### PR TITLE
fix(T11563): drizzle-conduit migration applies cleanly on fresh cleo.db (attachments collision)

### DIFF
--- a/.changeset/t11563-conduit-attachments-collision.md
+++ b/.changeset/t11563-conduit-attachments-collision.md
@@ -1,0 +1,8 @@
+---
+id: t11563-conduit-attachments-collision
+tasks: [T11563]
+kind: fix
+summary: Fix conduit drizzle-conduit migration crash on a fresh cleo.db — prefix the conduit attachment-family tables to avoid colliding with the docs-domain bare attachments table
+---
+
+The conduit forward migration (introduced by E6-L3 #900) created a bare `attachments` table that collided with the docs-domain bare `attachments` table once conduit was routed into the consolidated `cleo.db`. The conduit `CREATE TABLE IF NOT EXISTS attachments` silently no-opped against the docs table, then `CREATE INDEX attachments_conversation_idx ON attachments(conversation_id)` crashed with `no such column: conversation_id`, breaking `cleo agent list` and every `cleo conduit *` command on a fresh build. The four conduit attachment-family tables (`attachments`, `attachment_versions`, `attachment_approvals`, `attachment_contributors`) now carry the `conduit_` prefix so they are physically disjoint from the docs `attachments` table, matching the consolidated schema and the exodus rename-map target. The signaldock→conduit one-shot migration maps the legacy bare source names to the prefixed destination names.

--- a/packages/core/migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql
+++ b/packages/core/migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql
@@ -150,8 +150,21 @@ CREATE INDEX IF NOT EXISTS idx_pins_agent ON message_pins(pinned_by);
 
 -- -------------------------------------------------------------------------
 -- File/blob attachments associated with messages.
+--
+-- T11563: the conduit attachment-family tables carry the `conduit_` prefix so
+-- they are PHYSICALLY DISJOINT from the docs-domain bare `attachments` table
+-- (store/schema/attachments.ts) that ALSO lives in the consolidated `cleo.db`.
+-- Before E6-L3 (#900) the conduit domain had its own `conduit.db` file, so the
+-- bare names `attachments` / `attachment_versions` / `attachment_approvals` /
+-- `attachment_contributors` did not collide. Routing conduit into `cleo.db`
+-- (#900) put them in the same physical DB as the docs `attachments` table; the
+-- bare `CREATE TABLE IF NOT EXISTS attachments` then silently no-opped against
+-- the docs table and the `conversation_id` index crashed (no such column). The
+-- `conduit_`-prefixed names match the consolidated schema (cleo-project/conduit.ts)
+-- and the exodus rename map target (table-name-map.ts: `attachments` →
+-- `conduit_attachments`), restoring the intended "disjoint physical names".
 -- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachments (
+CREATE TABLE IF NOT EXISTS conduit_attachments (
     slug TEXT PRIMARY KEY,
     conversation_id TEXT NOT NULL,
     from_agent_id TEXT NOT NULL,
@@ -170,17 +183,17 @@ CREATE TABLE IF NOT EXISTS attachments (
     created_at INTEGER NOT NULL
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS attachments_conversation_idx ON attachments(conversation_id);
+CREATE INDEX IF NOT EXISTS conduit_attachments_conversation_idx ON conduit_attachments(conversation_id);
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS attachments_agent_idx ON attachments(from_agent_id);
+CREATE INDEX IF NOT EXISTS conduit_attachments_agent_idx ON conduit_attachments(from_agent_id);
 --> statement-breakpoint
 
 -- -------------------------------------------------------------------------
 -- Version history for attachments (collaborative editing).
 -- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachment_versions (
+CREATE TABLE IF NOT EXISTS conduit_attachment_versions (
     id TEXT PRIMARY KEY,
-    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
+    slug TEXT NOT NULL REFERENCES conduit_attachments(slug) ON DELETE CASCADE,
     version_number INTEGER NOT NULL,
     author_agent_id TEXT NOT NULL,
     change_type TEXT NOT NULL DEFAULT 'patch',
@@ -198,17 +211,17 @@ CREATE TABLE IF NOT EXISTS attachment_versions (
     UNIQUE(slug, version_number)
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_attachment_versions_slug ON attachment_versions(slug);
+CREATE INDEX IF NOT EXISTS idx_conduit_attachment_versions_slug ON conduit_attachment_versions(slug);
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_attachment_versions_author ON attachment_versions(author_agent_id);
+CREATE INDEX IF NOT EXISTS idx_conduit_attachment_versions_author ON conduit_attachment_versions(author_agent_id);
 --> statement-breakpoint
 
 -- -------------------------------------------------------------------------
 -- Approval records for attachment content review.
 -- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachment_approvals (
+CREATE TABLE IF NOT EXISTS conduit_attachment_approvals (
     id TEXT PRIMARY KEY,
-    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
+    slug TEXT NOT NULL REFERENCES conduit_attachments(slug) ON DELETE CASCADE,
     reviewer_agent_id TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
     comment TEXT,
@@ -218,14 +231,14 @@ CREATE TABLE IF NOT EXISTS attachment_approvals (
     UNIQUE(slug, reviewer_agent_id)
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_attachment_approvals_slug ON attachment_approvals(slug);
+CREATE INDEX IF NOT EXISTS idx_conduit_attachment_approvals_slug ON conduit_attachment_approvals(slug);
 --> statement-breakpoint
 
 -- -------------------------------------------------------------------------
 -- Contributor statistics per attachment (who edited, how much).
 -- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS attachment_contributors (
-    slug TEXT NOT NULL REFERENCES attachments(slug) ON DELETE CASCADE,
+CREATE TABLE IF NOT EXISTS conduit_attachment_contributors (
+    slug TEXT NOT NULL REFERENCES conduit_attachments(slug) ON DELETE CASCADE,
     agent_id TEXT NOT NULL,
     version_count INTEGER NOT NULL DEFAULT 0,
     total_tokens_added INTEGER NOT NULL DEFAULT 0,

--- a/packages/core/src/store/__tests__/conduit-sqlite.test.ts
+++ b/packages/core/src/store/__tests__/conduit-sqlite.test.ts
@@ -55,19 +55,26 @@ import { _resetDualScopeDbCache, resolveDualScopeDbPath } from '../dual-scope-db
 // ---------------------------------------------------------------------------
 
 /**
- * The legacy BARE conduit tables the forward migration creates. These now live
- * INSIDE the consolidated `cleo.db` alongside the prefixed `conduit_*` tables and
- * the `tasks_*` / `brain_*` domains, so we assert PRESENCE (arrayContaining)
- * rather than equality. `_conduit_meta` / `_conduit_migrations` are the two legacy
- * meta tables.
+ * The legacy conduit tables the forward migration creates. These now live INSIDE
+ * the consolidated `cleo.db` alongside the prefixed `conduit_*` tables and the
+ * `tasks_*` / `brain_*` domains, so we assert PRESENCE (arrayContaining) rather
+ * than equality. `_conduit_meta` / `_conduit_migrations` are the two legacy meta
+ * tables.
+ *
+ * T11563: the attachment-family tables carry the `conduit_` prefix
+ * (`conduit_attachments`, `conduit_attachment_versions`,
+ * `conduit_attachment_approvals`, `conduit_attachment_contributors`) so they are
+ * PHYSICALLY DISJOINT from the docs-domain bare `attachments` table that also
+ * lives in the consolidated `cleo.db` — the bare names collided once conduit was
+ * routed into `cleo.db` (#900), crashing the `conversation_id` index.
  */
 const EXPECTED_LEGACY_TABLES = [
   '_conduit_meta',
   '_conduit_migrations',
-  'attachment_approvals',
-  'attachment_contributors',
-  'attachment_versions',
-  'attachments',
+  'conduit_attachment_approvals',
+  'conduit_attachment_contributors',
+  'conduit_attachment_versions',
+  'conduit_attachments',
   'conversations',
   'dead_letters',
   'delivery_jobs',

--- a/packages/core/src/store/migrate-signaldock-to-conduit.ts
+++ b/packages/core/src/store/migrate-signaldock-to-conduit.ts
@@ -69,17 +69,28 @@ export interface MigrationResult {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Project-local tables to copy verbatim from legacy signaldock.db to conduit.db. */
+/**
+ * Project-local tables to copy from the legacy `signaldock.db` to the conduit DB.
+ *
+ * Each entry is a `{ src, dest }` pair. For most tables `src === dest`. The
+ * attachment-family tables differ: the legacy `signaldock.db` stored them under
+ * the BARE names (`attachments`, `attachment_versions`, …), but the consolidated
+ * conduit forward migration now creates them under the `conduit_`-prefixed names
+ * (T11563 — disjoint from the docs-domain bare `attachments` table that also
+ * lives in the consolidated `cleo.db`). The copy must therefore map the legacy
+ * source name to the prefixed destination name, otherwise rows would be inserted
+ * into the unrelated docs `attachments` table.
+ */
 const PROJECT_TIER_TABLES = [
-  'messages',
-  'conversations',
-  'delivery_jobs',
-  'dead_letters',
-  'message_pins',
-  'attachments',
-  'attachment_versions',
-  'attachment_approvals',
-  'attachment_contributors',
+  { src: 'messages', dest: 'messages' },
+  { src: 'conversations', dest: 'conversations' },
+  { src: 'delivery_jobs', dest: 'delivery_jobs' },
+  { src: 'dead_letters', dest: 'dead_letters' },
+  { src: 'message_pins', dest: 'message_pins' },
+  { src: 'attachments', dest: 'conduit_attachments' },
+  { src: 'attachment_versions', dest: 'conduit_attachment_versions' },
+  { src: 'attachment_approvals', dest: 'conduit_attachment_approvals' },
+  { src: 'attachment_contributors', dest: 'conduit_attachment_contributors' },
 ] as const;
 
 /** Global-identity tables to copy using INSERT OR IGNORE from legacy to global signaldock.db. */
@@ -166,24 +177,31 @@ function getTableColumns(db: DatabaseSync, tableName: string): string[] {
 }
 
 /**
- * Copy all rows from `tableName` in `srcDb` to the same table in `destDb`.
+ * Copy all rows from `srcTableName` in `srcDb` to `destTableName` in `destDb`.
  * Only columns that exist in both source and destination are copied (schema safety).
  * Uses INSERT OR IGNORE to handle unique constraint conflicts gracefully.
  *
+ * Source and destination table names may differ (T11563): the conduit
+ * attachment-family tables were renamed to `conduit_`-prefixed names in the
+ * consolidated `cleo.db`, while the legacy `signaldock.db` source still uses the
+ * bare names.
+ *
  * @param srcDb - Source database (legacy signaldock.db).
  * @param destDb - Destination database (conduit.db or global signaldock.db).
- * @param tableName - Table to copy.
+ * @param srcTableName - Table to read rows from in `srcDb`.
+ * @param destTableName - Table to write rows into in `destDb`. Defaults to `srcTableName`.
  * @param ignoreConflicts - When true uses INSERT OR IGNORE; when false uses INSERT.
  * @returns Number of rows found in source (not necessarily inserted — some may have been ignored).
  */
 function copyTableRows(
   srcDb: DatabaseSync,
   destDb: DatabaseSync,
-  tableName: string,
+  srcTableName: string,
+  destTableName: string = srcTableName,
   ignoreConflicts = false,
 ): number {
-  const srcCols = getTableColumns(srcDb, tableName);
-  const destCols = getTableColumns(destDb, tableName);
+  const srcCols = getTableColumns(srcDb, srcTableName);
+  const destCols = getTableColumns(destDb, destTableName);
   // Only copy columns that exist in both tables
   const cols = srcCols.filter((c) => destCols.includes(c));
   if (cols.length === 0) return 0;
@@ -191,9 +209,9 @@ function copyTableRows(
   const colList = cols.map((c) => `"${c}"`).join(', ');
   const placeholders = cols.map(() => '?').join(', ');
   const conflictClause = ignoreConflicts ? 'OR IGNORE' : '';
-  const insertSql = `INSERT ${conflictClause} INTO "${tableName}" (${colList}) VALUES (${placeholders})`;
+  const insertSql = `INSERT ${conflictClause} INTO "${destTableName}" (${colList}) VALUES (${placeholders})`;
 
-  const rows = srcDb.prepare(`SELECT ${colList} FROM "${tableName}"`).all() as Record<
+  const rows = srcDb.prepare(`SELECT ${colList} FROM "${srcTableName}"`).all() as Record<
     string,
     unknown
   >[];
@@ -387,10 +405,11 @@ export async function migrateSignaldockToConduit(projectRoot: string): Promise<M
   try {
     conduit.exec('BEGIN TRANSACTION');
 
-    // Copy project-local messaging tables verbatim
-    for (const tableName of PROJECT_TIER_TABLES) {
-      if (tableExistsInDb(legacy, tableName) && tableExistsInDb(conduit, tableName)) {
-        copyTableRows(legacy, conduit, tableName, false);
+    // Copy project-local messaging tables verbatim. Source/destination names may
+    // differ for the conduit attachment-family tables (T11563).
+    for (const { src, dest } of PROJECT_TIER_TABLES) {
+      if (tableExistsInDb(legacy, src) && tableExistsInDb(conduit, dest)) {
+        copyTableRows(legacy, conduit, src, dest, false);
       }
     }
 
@@ -538,10 +557,11 @@ export async function migrateSignaldockToConduit(projectRoot: string): Promise<M
   try {
     globalDb.exec('BEGIN TRANSACTION');
 
-    // Copy all global-identity tables using INSERT OR IGNORE
+    // Copy all global-identity tables using INSERT OR IGNORE. Source and
+    // destination share the same name for this tier.
     for (const tableName of GLOBAL_IDENTITY_TABLES) {
       if (tableExistsInDb(legacy, tableName) && tableExistsInDb(globalDb, tableName)) {
-        copyTableRows(legacy, globalDb, tableName, true /* ignoreConflicts */);
+        copyTableRows(legacy, globalDb, tableName, tableName, true /* ignoreConflicts */);
       }
     }
 

--- a/packages/core/src/store/schema/conduit-schema.ts
+++ b/packages/core/src/store/schema/conduit-schema.ts
@@ -197,10 +197,22 @@ export const messagePins = sqliteTable(
  *
  * `content` stores the compressed blob bytes inline (BLOB column).
  *
+ * ## T11563 — physical name `conduit_attachments` (collision fix)
+ *
+ * The physical table name carries the `conduit_` prefix so it is DISJOINT from
+ * the docs-domain bare `attachments` table (store/schema/attachments.ts) that
+ * also lives in the consolidated `cleo.db`. Pre-E6-L3 the conduit domain had its
+ * own `conduit.db`, so the bare `attachments` name did not collide; #900 routed
+ * conduit into `cleo.db` and the bare `CREATE TABLE IF NOT EXISTS attachments`
+ * silently no-opped against the docs table, crashing the `conversation_id` index.
+ * The prefixed name matches the consolidated schema (`cleo-project/conduit.ts`)
+ * and the exodus rename-map target (`attachments` → `conduit_attachments`).
+ *
  * @task T344
+ * @task T11563
  */
 export const attachments = sqliteTable(
-  'attachments',
+  'conduit_attachments',
   {
     slug: text('slug').primaryKey(),
     conversationId: text('conversation_id').notNull(),
@@ -221,8 +233,8 @@ export const attachments = sqliteTable(
     createdAt: integer('created_at').notNull(),
   },
   (table) => [
-    index('attachments_conversation_idx').on(table.conversationId),
-    index('attachments_agent_idx').on(table.fromAgentId),
+    index('conduit_attachments_conversation_idx').on(table.conversationId),
+    index('conduit_attachments_agent_idx').on(table.fromAgentId),
   ],
 );
 
@@ -232,7 +244,7 @@ export const attachments = sqliteTable(
  * @task T344
  */
 export const attachmentVersions = sqliteTable(
-  'attachment_versions',
+  'conduit_attachment_versions',
   {
     id: text('id').primaryKey(),
     slug: text('slug')
@@ -255,9 +267,9 @@ export const attachmentVersions = sqliteTable(
     createdAt: integer('created_at').notNull(),
   },
   (table) => [
-    unique('attachment_versions_slug_version_unique').on(table.slug, table.versionNumber),
-    index('idx_attachment_versions_slug').on(table.slug),
-    index('idx_attachment_versions_author').on(table.authorAgentId),
+    unique('conduit_attachment_versions_slug_version_unique').on(table.slug, table.versionNumber),
+    index('idx_conduit_attachment_versions_slug').on(table.slug),
+    index('idx_conduit_attachment_versions_author').on(table.authorAgentId),
   ],
 );
 
@@ -267,7 +279,7 @@ export const attachmentVersions = sqliteTable(
  * @task T344
  */
 export const attachmentApprovals = sqliteTable(
-  'attachment_approvals',
+  'conduit_attachment_approvals',
   {
     id: text('id').primaryKey(),
     slug: text('slug')
@@ -282,8 +294,11 @@ export const attachmentApprovals = sqliteTable(
     updatedAt: integer('updated_at').notNull(),
   },
   (table) => [
-    unique('attachment_approvals_slug_reviewer_unique').on(table.slug, table.reviewerAgentId),
-    index('idx_attachment_approvals_slug').on(table.slug),
+    unique('conduit_attachment_approvals_slug_reviewer_unique').on(
+      table.slug,
+      table.reviewerAgentId,
+    ),
+    index('idx_conduit_attachment_approvals_slug').on(table.slug),
   ],
 );
 
@@ -293,7 +308,7 @@ export const attachmentApprovals = sqliteTable(
  * @task T344
  */
 export const attachmentContributors = sqliteTable(
-  'attachment_contributors',
+  'conduit_attachment_contributors',
   {
     slug: text('slug')
       .notNull()


### PR DESCRIPTION
## Root cause (P1 — clean-build conduit/agent crash)

E6-L3 (#900) routed the conduit domain into the consolidated project `cleo.db`. That DB already contains the **docs-domain bare `attachments` table** (`id, sha256, attachment_json, ...`). The conduit forward migration's `CREATE TABLE IF NOT EXISTS attachments` (conduit shape: `slug, conversation_id, content BLOB, ...`) therefore **silently no-opped** against the docs table, and the next statement —

```sql
CREATE INDEX IF NOT EXISTS attachments_conversation_idx ON attachments(conversation_id);
```

— crashed with **`no such column: conversation_id`** (the docs `attachments` table has no `conversation_id`). This broke `cleo agent list` (`E_LIST: DrizzleError: Failed to run the query`) and every `cleo conduit *` command on a fresh build.

The per-leaf unit test passed because `ensureConduitDb` ran against an isolated tmp `cleo.db` where the docs `attachments` table was never created — the full CLI creates it first. The migration's own "disjoint physical names" comment was wrong: `attachments` is the **only** conduit bare name that collides (with the tasks/docs domain).

## Fix (root-cause, no integrity weakening)

Prefix the four conduit attachment-family tables/indexes/FK refs with `conduit_` so they are physically disjoint from the docs `attachments` table — matching the consolidated `cleo-project/conduit.ts` schema and the exodus rename-map target (`attachments` → `conduit_attachments`):

- `migration.sql` + `conduit-schema.ts`: rename `attachments`/`attachment_versions`/`attachment_approvals`/`attachment_contributors` (+ their indexes, unique constraints, FK references) to `conduit_*`.
- `migrate-signaldock-to-conduit.ts`: `PROJECT_TIER_TABLES` is now `{src, dest}` pairs; `copyTableRows` accepts a `destTableName` so the legacy bare source names map to the prefixed destination names (latent cascade bug for pre-T310 installs).
- `conduit-sqlite.test.ts`: `EXPECTED_LEGACY_TABLES` updated to the prefixed names.

## Verification

- Fresh `XDG_DATA_HOME`: `cleo agent list` → `{success:true, data:[]}` (was `E_LIST`); `cleo conduit status` reaches the app layer (`E_CONDUIT: no agent credential` — expected business response, not a migration crash).
- Migration replay proves the conduit migration now applies cleanly **alongside** a pre-existing docs `attachments` table; `conduit_attachments_conversation_idx` lands on `conversation_id`.
- `@cleocode/core` conduit suite (181 tests) + full `@cleocode/runtime` (120) green; the only core-suite failures are the pre-existing worktree-napi env failures (confirmed identical on clean `origin/main`).
- `cleo check arch` 5/5; `lint-migrations --fail-on=error` exit 0.

Closes T11563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)