### PR TITLE
fix(T11568): write commands hang at rc:124 — terminate brain-writer worker at CLI exit (P1 post-E6)

### DIFF
--- a/packages/cleo/src/cli/__tests__/process-exit-no-hang.test.ts
+++ b/packages/cleo/src/cli/__tests__/process-exit-no-hang.test.ts
@@ -1,0 +1,159 @@
+/**
+ * T11568 — regression: write-path commands must EXIT, not hang at rc:124.
+ *
+ * ## The bug
+ *
+ * The CLEO CLI success path does NOT call `process.exit()`; it emits the LAFS
+ * envelope and returns, relying on the libuv event loop draining naturally so
+ * the process exits rc:0 (see `runMainWithLafsEnvelope` in `../index.ts`).
+ *
+ * Post-E6, every hot-path `brain.db` write (`cleo memory observe`, decisions,
+ * the dialectic pipeline) was funneled through a `worker_threads.Worker`
+ * (T10351 single-writer chokepoint). That worker's `MessagePort` keeps the
+ * event loop alive forever, and its `process.on('exit')` shutdown can never run
+ * (the loop never drains to fire it). So `cleo memory observe` printed its
+ * success envelope and then **hung** until the shell timed it out (rc:124).
+ *
+ * The fix: the CLI success-path `finally` calls `shutdownCliRuntime()` (core),
+ * which terminates the brain-writer worker thread + pino-roll transport worker
+ * + closes DB handles, AFTER the envelope is written. The loop then drains and
+ * the process exits rc:0.
+ *
+ * ## What this test proves
+ *
+ * Spawns the COMPILED CLI as a subprocess with a hard timeout. `spawnSync`
+ * surfaces a hang as `status: null` + `signal: 'SIGTERM'`. We assert the
+ * process exits on its own (status is a number, signal is null) — i.e. it did
+ * NOT have to be killed. A pre-fix binary fails this assertion; the fixed
+ * binary exits rc:0.
+ *
+ * This is a subprocess test (not the inline brain-writer unit test) on purpose:
+ * the worker only spawns when `brain-writer-worker.js` is resolvable on disk,
+ * which is true for the shipped dist but not inside the vitest worker. Only a
+ * real CLI subprocess exercises the exact hang.
+ *
+ * @task T11568
+ * @epic T11249 (E6)
+ * @saga T11242
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Absolute path to `packages/cleo/` root. */
+const PKG_ROOT = resolve(__dirname, '..', '..', '..');
+
+/** Path to the compiled CLI entry point. */
+const CLI_DIST = resolve(PKG_ROOT, 'dist', 'cli', 'index.js');
+
+/** True when the compiled CLI dist bundle exists and can be spawned. */
+const CLI_DIST_AVAILABLE = existsSync(CLI_DIST);
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+/**
+ * Run the compiled CLI as a subprocess against an isolated tmp project root +
+ * global data home. A 20s hard timeout converts a hang into a `SIGTERM` kill so
+ * the assertion can distinguish "exited on its own" from "had to be killed".
+ */
+function runCli(args: readonly string[], projectRoot: string, dataHome: string): CliResult {
+  const env = {
+    ...process.env,
+    CLEO_PROJECT_ROOT: projectRoot,
+    CLEO_ROOT: projectRoot,
+    CLEO_DIR: join(projectRoot, '.cleo'),
+    XDG_DATA_HOME: dataHome,
+    CLEO_OUTPUT_FORMAT: 'json',
+  };
+  const result = spawnSync('node', [CLI_DIST, ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+    timeout: 20_000,
+    cwd: projectRoot,
+    env,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+    signal: result.signal ?? null,
+  };
+}
+
+let projectRoot: string;
+let dataHome: string;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(join(tmpdir(), 'cleo-T11568-'));
+  dataHome = await mkdtemp(join(tmpdir(), 'cleo-T11568-xdg-'));
+  await mkdir(join(projectRoot, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true }).catch(() => undefined);
+  await rm(dataHome, { recursive: true, force: true }).catch(() => undefined);
+});
+
+describe.skipIf(!CLI_DIST_AVAILABLE)('T11568 — write commands exit, never hang (rc:124)', () => {
+  it('cleo init then `memory observe` exits on its own (not killed by timeout)', () => {
+    const init = runCli(['init'], projectRoot, dataHome);
+    expect(init.signal, `init was killed (hang); stderr:\n${init.stderr}`).toBeNull();
+
+    const observe = runCli(
+      ['memory', 'observe', 'process exits cleanly', '--title', 'T11568 regression'],
+      projectRoot,
+      dataHome,
+    );
+
+    // The core regression assertion: a hang manifests as a SIGTERM kill from
+    // the spawnSync timeout. The process MUST exit on its own.
+    expect(
+      observe.signal,
+      `memory observe was KILLED by the timeout (process hang regression).\nstdout:\n${observe.stdout}\nstderr:\n${observe.stderr}`,
+    ).toBeNull();
+    expect(observe.status).toBe(0);
+
+    // Sanity: it actually did the write (success envelope on stdout).
+    expect(observe.stdout).toContain('"success":true');
+    expect(observe.stdout).toContain('"operation":"memory.observe"');
+  }, 60_000);
+
+  it('a second `memory observe` in the same project also exits cleanly', () => {
+    runCli(['init'], projectRoot, dataHome);
+    runCli(['memory', 'observe', 'first', '--title', 'first'], projectRoot, dataHome);
+    const second = runCli(
+      ['memory', 'observe', 'second', '--title', 'second'],
+      projectRoot,
+      dataHome,
+    );
+
+    expect(
+      second.signal,
+      `second memory observe was killed (hang).\nstderr:\n${second.stderr}`,
+    ).toBeNull();
+    expect(second.status).toBe(0);
+  }, 60_000);
+
+  it('a read-path command (`find`) also exits on its own (control — never hangs)', () => {
+    runCli(['init'], projectRoot, dataHome);
+    const find = runCli(['find', 'anything'], projectRoot, dataHome);
+    // The regression property is "exits on its own", not a specific code:
+    // `find` with no matches conventionally exits 100, which is still a clean
+    // self-exit (signal === null), NOT a timeout kill. Assert non-hang only.
+    expect(find.signal, `find was killed (hang).\nstderr:\n${find.stderr}`).toBeNull();
+    expect(typeof find.status).toBe('number');
+  }, 60_000);
+});

--- a/packages/cleo/src/cli/index.ts
+++ b/packages/cleo/src/cli/index.ts
@@ -392,6 +392,10 @@ async function runMainWithLafsEnvelope(
     try {
       await runCommand(cmd, { rawArgs });
     } catch (err) {
+      // NOTE: every branch in this catch ends with `process.exit(1)`, which
+      // terminates immediately and bypasses the `finally` below. That is the
+      // intended error contract — a hard exit releases all handles. Only the
+      // SUCCESS path (no exit) needs the coordinated teardown in `finally`.
       const { cliError } = await import('./renderers/index.js');
       // Citty's CLIError extends Error with a string `code` (e.g. 'EARG') and
       // sets `name === 'CLIError'`. Narrow without lying to the type system.
@@ -413,6 +417,19 @@ async function runMainWithLafsEnvelope(
       const message = err instanceof Error ? err.message : String(err);
       cliError(message, 1, { name: 'E_CLI_UNCAUGHT' });
       process.exit(1);
+    } finally {
+      // T11568 — the success path does NOT call process.exit(); it emits the
+      // LAFS envelope and returns, relying on the event loop draining so the
+      // process exits rc:0. Process-lifetime worker threads (the BRAIN
+      // single-writer worker behind `cleo memory observe` / brain.db writes, and
+      // the pino-roll log transport) own a `MessagePort` that keeps the loop
+      // alive forever — so without coordinated teardown the command printed its
+      // success envelope and then HUNG (rc:124). Tear those down here, AFTER the
+      // envelope has been written, so the loop drains and the process exits.
+      // The error branches above already `process.exit(1)` (which bypasses this
+      // finally), so this runs only on the success path.
+      const { shutdownCliRuntime } = await import('@cleocode/core/internal');
+      await shutdownCliRuntime();
     }
   });
 }

--- a/packages/core/src/__tests__/shutdown.test.ts
+++ b/packages/core/src/__tests__/shutdown.test.ts
@@ -1,0 +1,30 @@
+/**
+ * T11568 — unit coverage for the coordinated CLI teardown aggregator.
+ *
+ * The end-to-end "does the process actually exit" assertion lives in the CLI
+ * subprocess test (`packages/cleo/src/cli/__tests__/process-exit-no-hang.test.ts`),
+ * because the brain-writer worker thread only spawns when its compiled worker
+ * file is resolvable on disk — which is true for the shipped dist but not inside
+ * the vitest worker. This unit test guards the aggregator's CONTRACT so a future
+ * refactor cannot silently drop one of the teardown steps:
+ *
+ *   - `shutdownCliRuntime` is exported and callable.
+ *   - It is best-effort + idempotent: calling it twice never throws, even with
+ *     no subsystem initialized.
+ *
+ * @task T11568
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shutdownCliRuntime } from '../shutdown.js';
+
+describe('shutdownCliRuntime — coordinated CLI teardown (T11568)', () => {
+  it('is callable and resolves with nothing initialized (best-effort)', async () => {
+    await expect(shutdownCliRuntime()).resolves.toBeUndefined();
+  });
+
+  it('is idempotent — a second call never throws', async () => {
+    await shutdownCliRuntime();
+    await expect(shutdownCliRuntime()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2537,6 +2537,10 @@ export {
   pruneOrphanTempDirs,
   pruneOrphanWorktrees,
 } from './gc/cleanup.js';
+// T11568 — coordinated CLI teardown: terminates the brain-writer worker thread
+// + pino-roll transport + DB handles so short-lived commands exit rc:0 instead
+// of hanging on a live MessagePort.
+export { shutdownCliRuntime } from './shutdown.js';
 // Store — project detection (used by cleo init tests)
 export { detectProjectType } from './store/project-detect.js';
 export { closeAllDatabases, closeDb, resetDbState } from './store/sqlite.js';

--- a/packages/core/src/shutdown.ts
+++ b/packages/core/src/shutdown.ts
@@ -1,0 +1,108 @@
+/**
+ * Coordinated process-lifetime teardown for short-lived CLI invocations.
+ *
+ * ## Why this exists (T11568 — post-E6 process hang)
+ *
+ * The CLEO CLI's success path does NOT call `process.exit()` — it emits the
+ * LAFS envelope and returns, relying on the libuv event loop draining naturally
+ * so the process exits with code 0 (see `runMainWithLafsEnvelope` in
+ * `packages/cleo/src/cli/index.ts`). That contract only holds while every
+ * resource opened during the command is released by the time the handler
+ * resolves.
+ *
+ * Two process-lifetime singletons violate that contract because they own a
+ * `worker_threads.Worker` whose `MessagePort` keeps the event loop alive:
+ *
+ *   1. **The BRAIN single-writer worker** ({@link shutdownBrainWriter}). Every
+ *      hot-path write to `brain.db` (`cleo memory observe`, decisions, the
+ *      dialectic pipeline) is funneled through a `worker_threads.Worker`
+ *      (T10351). The worker is created lazily on first write and registered for
+ *      a `process.on('exit')` flush — but that exit handler can never fire
+ *      because the worker's `MessagePort` is itself what keeps the loop alive,
+ *      so a `cleo memory observe` printed its success envelope and then hung
+ *      (rc:124) until the shell timed it out.
+ *   2. **The pino-roll log transport** ({@link closeLogger}). `pino.transport()`
+ *      backs a worker thread too; its rotation timer + port keep the loop alive
+ *      in the same way once `initLogger` has run.
+ *
+ * Installed builds where the worker file was not resolvable fell back to the
+ * inline executor (no worker) and exited cleanly — masking the defect until the
+ * E6 build shipped a resolvable `brain-writer-worker.js`.
+ *
+ * {@link shutdownCliRuntime} is the single chokepoint the CLI calls from its
+ * success-path `finally` (after the envelope has been written to stdout) so the
+ * loop can drain and the process exits rc:0. It is best-effort and idempotent:
+ * every teardown is wrapped so one failure cannot mask another, and calling it
+ * twice is a no-op for already-closed handles.
+ *
+ * This is NOT a `process.exit()` band-aid: the established CLI exit contract is
+ * "drain the loop, then exit". Forcing teardown of the long-lived handles
+ * restores that contract instead of papering over it. Mid-operation handles
+ * (shared dual-scope `cleo.db`) are released here too, honoring the L4/L5
+ * shared-handle rule that they close at PROCESS EXIT, not mid-operation.
+ *
+ * @module
+ * @task T11568
+ */
+
+import { closeLogger } from './logger.js';
+import { shutdownBrainWriter } from './memory/brain-writer-thread.js';
+import { closeAllDatabases } from './store/sqlite.js';
+
+/**
+ * Run a teardown step, swallowing any error so a single failure cannot abort
+ * the remaining teardown steps. Best-effort by design.
+ */
+async function safely(step: () => Promise<void> | void): Promise<void> {
+  try {
+    await step();
+  } catch {
+    // Best-effort teardown — never let cleanup throw out of the CLI exit path.
+  }
+}
+
+/**
+ * Tear down every process-lifetime resource that would otherwise keep the libuv
+ * event loop alive after a short-lived CLI command resolves.
+ *
+ * Call this from the CLI's success-path `finally`, AFTER the command's LAFS
+ * envelope has been emitted to stdout. The CLI does not `process.exit()` on
+ * success (ADR-039 / T9633), so without this the brain-writer worker thread
+ * (T10351) or the pino-roll transport worker can keep the process hanging at
+ * rc:124.
+ *
+ * Order:
+ *   1. {@link shutdownBrainWriter} — terminate the BRAIN single-writer worker
+ *      thread (the `MessagePort` proven to hang `cleo memory observe`).
+ *   2. {@link closeAllDatabases} — close the dual-scope `cleo.db` + brain/nexus
+ *      native handles (releases file locks; required on Windows).
+ *   3. {@link closeLogger} — flush + terminate the pino-roll transport worker.
+ *
+ * Every step is best-effort and idempotent — safe to call once per process at
+ * exit, and harmless if a given subsystem was never initialized.
+ *
+ * @returns A promise that resolves once all teardown steps have settled.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await runCommand(cmd, { rawArgs });
+ * } finally {
+ *   await shutdownCliRuntime();
+ * }
+ * ```
+ *
+ * @task T11568
+ */
+export async function shutdownCliRuntime(): Promise<void> {
+  // 1. BRAIN single-writer worker thread — the live MessagePort that hangs
+  //    `cleo memory observe` / `cleo docs add` / any brain.db write path.
+  await safely(() => shutdownBrainWriter());
+
+  // 2. Close DB singletons (dual-scope cleo.db + brain/nexus native handles).
+  //    Releases SQLite file handles — required before tmpdir cleanup on Windows.
+  await safely(() => closeAllDatabases());
+
+  // 3. Flush + terminate the pino-roll transport worker thread.
+  await safely(() => closeLogger());
+}


### PR DESCRIPTION
## Summary
P1 post-E6 regression: \`cleo memory observe\` and any \`brain.db\` write path printed their success envelope then **hung (rc:124)** instead of exiting. Installed v2026.5.130 exits clean → new regression.

## Root cause (proven)
The live handle keeping the event loop alive is the **BRAIN single-writer \`worker_threads.Worker\`** (T10351). Every hot-path \`brain.db\` write (\`memory observe\`, decisions, the dialectic pipeline) is funneled through this worker; its \`MessagePort\` keeps the libuv loop alive forever.

The CLI success path does **not** \`process.exit()\` — it emits the LAFS envelope and returns, relying on the loop draining (ADR-039 / T9633). With the worker live (post-E6, \`brain-writer-worker.js\` is now resolvable in dist; previously it fell back to the inline executor with no worker, masking the defect), the loop never drains so the command hangs. The worker's own \`process.on('exit')\` flush can never fire for the same reason.

Probe of \`process._getActiveHandles()\` after the command resolved: \`["Socket","MessagePort"]\` — the \`MessagePort\` is the brain-writer Worker. Pino-roll's transport worker is the same class of leak once \`initLogger\` runs.

## Fix (root cause, not a band-aid)
New core aggregator \`shutdownCliRuntime()\` tears down all process-lifetime handles **after the envelope is written**, restoring the "drain the loop, then exit" contract:
1. \`shutdownBrainWriter()\` — terminate the brain-writer worker thread.
2. \`closeAllDatabases()\` — close dual-scope \`cleo.db\` + brain/nexus native handles (L4/L5 shared-handle rule: close at process exit).
3. \`closeLogger()\` — flush + terminate the pino-roll transport worker.

Called from the CLI success-path \`finally\` in \`runMainWithLafsEnvelope\`. Error branches already \`process.exit(1)\` (hard exit, bypasses the finally) — intended.

## Evidence
On a fresh build of this branch:
- \`cleo memory observe "x" --title "y"\` → **rc=0** (was rc=124)
- \`cleo docs add <task> note.md --type note --slug hp\` → **rc=0** (dialectic.no_backend WARN fires right before, as the smoke described — confirms the dialectic path also routes through the same worker)
- \`find\`, \`session end\`, second \`memory observe\` → exit on their own
- \`cleo check arch\` → 5/5 gates pass (DB Open Guard green)

## Tests
- \`packages/cleo/src/cli/__tests__/process-exit-no-hang.test.ts\` — spawns the compiled CLI; a hang manifests as a \`SIGTERM\` timeout kill, so it asserts \`signal === null\` (exited on its own) + \`status === 0\`. A pre-fix binary fails; the fixed binary passes.
- \`packages/core/src/__tests__/shutdown.test.ts\` — aggregator contract (callable, idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)