### PR TITLE
fix(T11569): route project resolver to consolidated cleo.db — docs fetch works post-E6 (P1)

### DIFF
--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -600,7 +600,8 @@ describe('resolveCanonicalCleoDir', () => {
   });
 
   function seedNexusDb(rows: Array<{ project_id: string; project_path: string }>) {
-    const dbPath = join(tmpHome, 'nexus.db');
+    // T11569: registry lives in the consolidated GLOBAL `cleo.db` (E6-L4/T11524).
+    const dbPath = join(tmpHome, 'cleo.db');
     const db = new DatabaseSync(dbPath);
     db.exec(
       'CREATE TABLE IF NOT EXISTS project_registry (project_id TEXT PRIMARY KEY, project_path TEXT NOT NULL)',
@@ -633,7 +634,7 @@ describe('resolveCanonicalCleoDir', () => {
     expect(() => resolveCanonicalCleoDir('nonexistent')).toThrow('E_PROJECT_NOT_FOUND');
   });
 
-  it('throws E_PROJECT_NOT_FOUND when nexus.db does not exist', () => {
+  it('throws E_PROJECT_NOT_FOUND when the consolidated cleo.db does not exist', () => {
     expect(() => resolveCanonicalCleoDir('any-id')).toThrow('E_PROJECT_NOT_FOUND');
   });
 
@@ -866,7 +867,8 @@ describe('resolveProjectByCwd', () => {
   }
 
   function seedNexusDb(rows: Array<{ project_id: string; project_path: string }>) {
-    const dbPath = join(tmpHome, 'nexus.db');
+    // T11569: registry lives in the consolidated GLOBAL `cleo.db` (E6-L4/T11524).
+    const dbPath = join(tmpHome, 'cleo.db');
     const db = new DatabaseSync(dbPath);
     db.exec(
       'CREATE TABLE IF NOT EXISTS project_registry (project_id TEXT PRIMARY KEY, project_path TEXT NOT NULL)',
@@ -1029,7 +1031,8 @@ describe('ID-Aware Path Resolver — resolveProjectByCwd + resolveCanonicalCleoD
   }
 
   function seedNexusDb(rows: Array<{ project_id: string; project_path: string }>) {
-    const dbPath = join(tmpHome, 'nexus.db');
+    // T11569: registry lives in the consolidated GLOBAL `cleo.db` (E6-L4/T11524).
+    const dbPath = join(tmpHome, 'cleo.db');
     const db = new DatabaseSync(dbPath);
     db.exec(
       'CREATE TABLE IF NOT EXISTS project_registry (project_id TEXT PRIMARY KEY, project_path TEXT NOT NULL)',
@@ -1174,8 +1177,8 @@ describe('ID-Aware Path Resolver — resolveProjectByCwd + resolveCanonicalCleoD
     expect(() => resolveCanonicalCleoDir('unknown-id')).toThrow('E_PROJECT_NOT_FOUND');
   });
 
-  it('resolveCanonicalCleoDir throws when nexus.db does not exist (AC7)', () => {
-    // No seedNexusDb call — nexus.db doesn't exist
+  it('resolveCanonicalCleoDir throws when the consolidated cleo.db does not exist (AC7)', () => {
+    // No seedNexusDb call — the consolidated cleo.db registry doesn't exist
 
     expect(() => resolveCanonicalCleoDir('any-id')).toThrow('E_PROJECT_NOT_FOUND');
   });
@@ -1193,7 +1196,7 @@ describe('ID-Aware Path Resolver — resolveProjectByCwd + resolveCanonicalCleoD
     // T11023: projectId is canonical 12-hex hash — use it for nexus lookup
     expect(projectId).toMatch(/^[0-9a-f]{12}$/);
 
-    // Register the canonical hash in nexus.db (not the raw UUID)
+    // Register the canonical hash in the consolidated cleo.db (not the raw UUID)
     seedNexusDb([{ project_id: projectId, project_path: projDir }]);
 
     const cleoDir = resolveCanonicalCleoDir(projectId);

--- a/packages/core/src/__tests__/t11031-it.test.ts
+++ b/packages/core/src/__tests__/t11031-it.test.ts
@@ -32,7 +32,8 @@ function createTempProject(baseDir: string, opts?: { projectId?: string; project
 }
 
 function seedNexusDb(cleoHome: string, rows: Array<{ project_id: string; project_path: string }>) {
-  const dbPath = join(cleoHome, 'nexus.db');
+  // T11569: registry lives in the consolidated GLOBAL `cleo.db` (E6-L4/T11524).
+  const dbPath = join(cleoHome, 'cleo.db');
   const db = new DatabaseSync(dbPath);
   db.exec(
     'CREATE TABLE IF NOT EXISTS project_registry (project_id TEXT PRIMARY KEY, project_path TEXT NOT NULL)',
@@ -47,7 +48,8 @@ function seedNexusDb(cleoHome: string, rows: Array<{ project_id: string; project
 }
 
 function countRegistryRows(cleoHome: string): number {
-  const dbPath = join(cleoHome, 'nexus.db');
+  // T11569: registry lives in the consolidated GLOBAL `cleo.db` (E6-L4/T11524).
+  const dbPath = join(cleoHome, 'cleo.db');
   try {
     const db = new DatabaseSync(dbPath, { readOnly: true });
     const row = db.prepare('SELECT COUNT(*) as cnt FROM project_registry').get() as { cnt: number };

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -532,23 +532,29 @@ export function resolveCanonicalCleoDir(projectId: string): string {
 }
 
 /**
- * Walk up from cwd looking for a match in the global nexus.db project_registry
- * by project_path. Falls back when no `.cleo/project-info.json` is found locally.
+ * Walk up from cwd looking for a match in the consolidated GLOBAL `cleo.db`
+ * `project_registry` by project_path. Falls back when no
+ * `.cleo/project-info.json` is found locally.
+ *
+ * T11569: reads `<cleoHome>/cleo.db` (the registry moved out of the now-gone
+ * `nexus.db` at E6-L4/T11524). The bare `project_registry` table inside
+ * `cleo.db` is the live runtime registry SSoT.
  *
  * @internal
  * @task T11013
+ * @task T11569
  */
 function _resolveProjectByCwdFromNexus(cwd?: string): string | null {
   try {
     const cleoHome = getCleoHome();
-    const nexusDbPath = join(cleoHome, 'nexus.db');
-    if (!existsSync(nexusDbPath)) return null;
+    const globalDbPath = join(cleoHome, 'cleo.db');
+    if (!existsSync(globalDbPath)) return null;
 
     const start = resolve(cwd ?? process.cwd());
     let current = start;
 
     const DatabaseSync = _getDatabaseSyncCtor();
-    const db = new DatabaseSync(nexusDbPath, { readOnly: true }); // db-open-allowed: bootstrap path resolver cannot import core DB chokepoint without a cycle
+    const db = new DatabaseSync(globalDbPath, { readOnly: true }); // db-open-allowed: bootstrap path resolver cannot import core DB chokepoint without a cycle
     try {
       const stmt = db.prepare(
         'SELECT project_id FROM project_registry WHERE project_path = ? LIMIT 1',

--- a/packages/paths/src/__tests__/cleo-paths.test.ts
+++ b/packages/paths/src/__tests__/cleo-paths.test.ts
@@ -390,8 +390,10 @@ describe('cleo-paths', () => {
       );
       mkdirSync(tempCleoHome, { recursive: true });
 
-      const nexusDbPath = join(tempCleoHome, 'nexus.db');
-      const db = new DatabaseSync(nexusDbPath);
+      // T11569: the cross-project registry lives in the consolidated GLOBAL
+      // `cleo.db` (E6-L4/T11524), no longer the standalone `nexus.db`.
+      const globalDbPath = join(tempCleoHome, 'cleo.db');
+      const db = new DatabaseSync(globalDbPath);
       db.exec(
         'CREATE TABLE IF NOT EXISTS project_registry (project_id TEXT PRIMARY KEY, project_path TEXT NOT NULL UNIQUE)',
       );
@@ -443,7 +445,7 @@ describe('cleo-paths', () => {
       expect(resolveCanonicalCleoDir('nonexistent-uuid')).toBeNull();
     });
 
-    it('returns null when nexus.db does not exist', () => {
+    it('returns null when the consolidated cleo.db does not exist', () => {
       const emptyHome = join(tmpdir(), 'cleo-empty-' + Date.now());
       mkdirSync(emptyHome, { recursive: true });
       process.env['CLEO_HOME'] = emptyHome;

--- a/packages/paths/src/cleo-paths.ts
+++ b/packages/paths/src/cleo-paths.ts
@@ -411,13 +411,27 @@ export function resolveProjectByCwd(cwd?: string): ResolvedProject | null {
 /**
  * Resolve the canonical `.cleo` directory for a project given its `projectId`.
  *
- * Looks up the project in the global `nexus.db` registry (`project_registry`
- * table) to find the project's root path, then returns the `.cleo/` directory
- * under that root.
+ * Looks up the project in the consolidated GLOBAL `cleo.db` registry
+ * (`project_registry` table) to find the project's root path, then returns the
+ * `.cleo/` directory under that root.
+ *
+ * **Post-E6 consolidation (T11569):** The cross-project registry moved from the
+ * standalone `<cleoHome>/nexus.db` into the consolidated dual-scope
+ * `<cleoHome>/cleo.db` (SG-DB-SUBSTRATE-V2 · E6-L4, T11524). On a fresh post-E6
+ * install `nexus.db` is never created, so opening it here returned `null` and
+ * the core wrapper threw `E_PROJECT_NOT_FOUND` even for registered projects (the
+ * read path had diverged from the write path — same class as #909/T11562). This
+ * resolver now opens `cleo.db`. The live runtime registry table inside `cleo.db`
+ * is the bare `project_registry` (materialized by the legacy `drizzle-nexus`
+ * migrations via `establishLegacyNexusSchema`); the prefixed
+ * `nexus_project_registry` is the consolidated-migration existence sentinel and
+ * stays empty until the exodus cutover (T11248/T11553).
  *
  * **Legacy ID support (T11023 AC4):** If the `projectId` is not found in
  * `project_registry`, also checks the `project_id_aliases` table for a
- * legacy→canonical mapping before returning `null`.
+ * legacy→canonical mapping before returning `null`. The path-derived canonical
+ * 12-hex id is recorded as an alias of the immutable registry id (T11281), so a
+ * canonical id supplied by `resolveProjectByCwd` resolves through this fallback.
  *
  * This enables cross-project lookups: given a stable project ID, resolve where
  * that project lives on disk without walking from a working directory.
@@ -425,21 +439,25 @@ export function resolveProjectByCwd(cwd?: string): ResolvedProject | null {
  * @param projectId - The project ID to look up. Can be a canonical 12-hex-char
  *   ID, a legacy UUID, or a legacy base64url(path) ID.
  * @returns Absolute path to the `.cleo/` directory, or `null` if the
- *   projectId is not found in the nexus registry (or its alias table).
+ *   projectId is not found in the consolidated registry (or its alias table).
  *
  * @task T11008
  * @task T11023
+ * @task T11569
  */
 export function resolveCanonicalCleoDir(projectId: string): string | null {
   const cleoHome = getCleoHome();
-  const nexusDbPath = join(cleoHome, 'nexus.db');
+  // T11569: read the consolidated GLOBAL `cleo.db` (the registry moved out of
+  // the now-gone `nexus.db` at E6-L4/T11524). The bare `project_registry` table
+  // inside `cleo.db` is the live runtime registry SSoT.
+  const globalDbPath = join(cleoHome, 'cleo.db');
 
-  if (!existsSync(nexusDbPath)) return null;
+  if (!existsSync(globalDbPath)) return null;
 
   let db: DatabaseSyncType | undefined;
   try {
     const DatabaseSync = getDatabaseSyncCtor();
-    db = new DatabaseSync(nexusDbPath, { readOnly: true }); // db-open-allowed: leaf path package cannot depend on core DB chokepoint
+    db = new DatabaseSync(globalDbPath, { readOnly: true }); // db-open-allowed: leaf path package cannot depend on core DB chokepoint
 
     // Try direct project_registry lookup first.
     const directStmt = db.prepare(


### PR DESCRIPTION
## Summary

Post-E6 (SG-DB-SUBSTRATE-V2 · T11524/E6-L4) the cross-project registry moved out of the standalone `<cleoHome>/nexus.db` into the consolidated dual-scope `<cleoHome>/cleo.db`. On a **fresh** post-E6 install `nexus.db` is never created, so the registry-reading resolvers still opened the gone `nexus.db`, returned null, and the core wrapper threw `E_PROJECT_NOT_FOUND` for projects that ARE registered — the read path had diverged from the write path (same class as #909/T11562). `cleo docs fetch <slug>` (`docs.ts:798 → resolveCanonicalCleoDir`) was the user-visible break.

## Bug #1 — resolver opened the gone nexus.db
- `resolveCanonicalCleoDir` (`packages/paths` leaf) and `_resolveProjectByCwdFromNexus` (`packages/core`) now open `<cleoHome>/cleo.db`.
- The leaf stays **zero-dep** — `cleo.db` is just a sibling filename under cleoHome; no core chokepoint import needed. `db-open-allowed` comments retained (Gate 2 passes).
- `resolveProjectById` already gated on `getNexusDbPath()` (= cleo.db) → untouched.

## Bug #2 — registry SSoT (verified against running code)
The **live** runtime registry table inside `cleo.db` is the **bare `project_registry`** (init writes 1 row to it; 79 runtime callsites use the `projectRegistry` drizzle table; `establishLegacyNexusSchema` keeps the runtime on legacy bare names — the same deferred-exodus pattern brain/conduit/signaldock follow). The prefixed `nexus_project_registry` (0 rows) is **NOT** safe to drop — it is the `existenceTable('global')` sentinel that dual-scope-db migration reconciliation probes.

So the single live SSoT that the write path **and all readers** (incl. this resolver) align on is `project_registry`. The prefixed→bare cutover is the exodus job (T11248/T11553), out of scope for this P1. **No table is dropped** (dropping either breaks 79 callsites or the migration sentinel).

## Proof
Fresh `XDG_DATA_HOME` init creates only `cleo.db` (no `nexus.db`); the chain `resolveProjectByCwd → resolveCanonicalCleoDir` resolves the `.cleo` dir (canonical 12-hex id → `project_id_aliases` → `project_path`); `cleo docs fetch` returns **success** with a resolved storage path (was `E_PROJECT_NOT_FOUND`).

## Tests / gates
- 3 fixture helpers reseeded to write/read `cleo.db` (cleo-paths.test, paths.test ×3, t11031-it.test seed + count).
- FULL `@cleocode/core`: **zero NEW failures** — the worktree-merge failures are the pre-existing worktree-napi `"integrateWorktree not available in test fallback"` env flake, proven identical on the stashed origin/main baseline.
- FULL `@cleocode/runtime`: **120/120 pass**.
- `cleo check arch`: **5/5** (Gate 2 no-direct-db-open honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)