### PR TITLE
feat(T11540): move telemetry to global cleo.db scope (ADR-090 residency)

### DIFF
--- a/.changeset/t11540-telemetry-residency-global.md
+++ b/.changeset/t11540-telemetry-residency-global.md
@@ -1,0 +1,8 @@
+---
+id: t11540-telemetry-residency-global
+tasks: [T11540]
+kind: feat
+summary: Move telemetry_events + telemetry_schema_meta from PROJECT to GLOBAL cleo.db scope — telemetry residency correction (ADR-090 §2.3)
+---
+
+Relocates the consolidated `telemetry_*` target-shape family (`telemetry_events`, `telemetry_schema_meta`) from the PROJECT-scope `cleo.db` schema (`cleo-project/telemetry.ts`) to the GLOBAL-scope `cleo.db` schema (`cleo-global/telemetry.ts`), completing the deferred residency move recorded in ADR-090 §2.3. Machine-wide command telemetry is a cross-project signal and belongs in the global `$XDG_DATA_HOME/cleo/cleo.db`, not the per-project file. The physical DDL is preserved byte-for-byte so the exodus cutover (T11248) emits zero drift versus the prior project-scope shape; the two telemetry CREATE TABLE blocks plus their five indexes are moved from the `drizzle-cleo-project` consolidation migration to the `drizzle-cleo-global` one accordingly. `telemetry_schema_meta` now uses the shared `makeSchemaMetaTable()` factory (T11543) for the canonical `{ key TEXT PRIMARY KEY, value TEXT NOT NULL }` KV shape, eliminating its last inline duplicate. The project/global schema barrels, drizzle scope configs, and the consolidated-schema-parity round-trip suite are updated to reflect the new residency (project 87→85 tables, global 49→51 tables). The standalone runtime `telemetry.db` (`telemetry/sqlite.ts`, already global via `getCleoHome()`) and its runtime schema module (`store/schema/telemetry-schema.ts`) are unchanged — the consolidated modules are target-shape authoring, not the live substrate until exodus.

--- a/drizzle/cleo-global.config.ts
+++ b/drizzle/cleo-global.config.ts
@@ -11,11 +11,14 @@
  * single-file-per-scope, domain-prefixed tables):
  *   `nexus_*` (cross-project code index) / `skills_*` / `signaldock_*`
  *   (global agent identity — folded here per D1, no standalone `signaldock.db`
- *   survives) / `brain_*` (the global cross-project memory store).
+ *   survives) / `telemetry_*` (machine-wide command telemetry — relocated here
+ *   from PROJECT scope by T11540 per ADR-090 §2.3) / `brain_*` (the global
+ *   cross-project memory store).
  *
  * Re-derived count (against the lifecycle split, superseding the prior 48/550
- * domain-split figure): **49 tables / 555 columns** — nexus 10t/109c +
- * skills 4t/36c + signaldock 13t/133c + brain (memory) 22t/277c. The `brain_*`
+ * domain-split figure): **51 tables / 567 columns** — nexus 10t/109c +
+ * skills 4t/36c + signaldock 13t/133c + telemetry 2t/12c + brain (memory)
+ * 22t/277c. The `brain_*`
  * schema modules are SHARED with the project config — same DDL, two DB files,
  * data partitioned by scope (global = cross-project memory). Project-tier
  * `tasks_*` (releases, provenance, lifecycle, playbooks) are intentionally NOT

--- a/drizzle/cleo-project.config.ts
+++ b/drizzle/cleo-project.config.ts
@@ -9,12 +9,15 @@
  *
  * Project `cleo.db` holds every **project-tier** domain (Pattern A —
  * single-file-per-scope, domain-prefixed tables):
- *   `tasks_*` / `brain_*` (this project's memory) / `conduit_*` / `docs_*` /
- *   `telemetry_*` (+ lifecycle / provenance / chain / playbooks / agents).
+ *   `tasks_*` / `brain_*` (this project's memory) / `conduit_*` / `docs_*`
+ *   (+ lifecycle / provenance / chain / playbooks / agents). The `telemetry_*`
+ *   pair was relocated to GLOBAL scope by T11540 per ADR-090 §2.3 (machine-wide
+ *   command telemetry is a cross-project signal).
  *
  * Re-derived count (against the lifecycle split, superseding the prior 66/631
- * domain-split figure): **87 tables / 903 columns** — tasks-core 45t/450c +
- * conduit 14t/116c + docs 4t/48c + telemetry 2t/12c + brain (memory) 22t/277c.
+ * domain-split figure): **85 tables / 891 columns** — tasks-core 45t/450c +
+ * conduit 14t/116c + docs 4t/48c + brain (memory) 22t/277c (telemetry 2t/12c
+ * moved to GLOBAL per T11540).
  * The `brain_*` schema modules are SHARED with the global config (the global
  * brain holds cross-project memory; this project brain holds project-local
  * memory) — same DDL, two DB files, data partitioned by scope.

--- a/packages/core/migrations/drizzle-cleo-global/20260531000001_t11363-consolidation-cleo-global/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260531000001_t11363-consolidation-cleo-global/migration.sql
@@ -939,6 +939,24 @@ CREATE TABLE `skills_skills` (
 	CHECK ("archived_at" IS NULL OR "archived_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
 );
 --> statement-breakpoint
+CREATE TABLE `telemetry_events` (
+	`id` text PRIMARY KEY,
+	`anonymous_id` text NOT NULL,
+	`domain` text NOT NULL,
+	`gateway` text NOT NULL,
+	`operation` text NOT NULL,
+	`command` text NOT NULL,
+	`exit_code` integer DEFAULT 0 NOT NULL,
+	`duration_ms` integer NOT NULL,
+	`error_code` text,
+	`timestamp` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `telemetry_schema_meta` (
+	`key` text PRIMARY KEY,
+	`value` text NOT NULL
+);
+--> statement-breakpoint
 CREATE INDEX `idx_brain_attention_scope` ON `brain_attention` (`scope_kind`,`scope_id`);--> statement-breakpoint
 CREATE INDEX `idx_brain_attention_session` ON `brain_attention` (`session_id`);--> statement-breakpoint
 CREATE INDEX `idx_brain_attention_status_expires` ON `brain_attention` (`status`,`expires_at`);--> statement-breakpoint
@@ -1142,4 +1160,9 @@ CREATE INDEX `idx_skills_skill_reviews_outcome` ON `skills_skill_reviews` (`outc
 CREATE INDEX `idx_skills_skill_usage_name_observed` ON `skills_skill_usage` (`skill_name`,`observed_at`);--> statement-breakpoint
 CREATE INDEX `idx_skills_skill_usage_kind` ON `skills_skill_usage` (`event_kind`);--> statement-breakpoint
 CREATE INDEX `idx_skills_skills_state` ON `skills_skills` (`lifecycle_state`);--> statement-breakpoint
-CREATE INDEX `idx_skills_skills_source` ON `skills_skills` (`source_type`);
+CREATE INDEX `idx_skills_skills_source` ON `skills_skills` (`source_type`);--> statement-breakpoint
+CREATE INDEX `idx_telemetry_command` ON `telemetry_events` (`command`);--> statement-breakpoint
+CREATE INDEX `idx_telemetry_domain` ON `telemetry_events` (`domain`);--> statement-breakpoint
+CREATE INDEX `idx_telemetry_exit_code` ON `telemetry_events` (`exit_code`);--> statement-breakpoint
+CREATE INDEX `idx_telemetry_timestamp` ON `telemetry_events` (`timestamp`);--> statement-breakpoint
+CREATE INDEX `idx_telemetry_duration` ON `telemetry_events` (`duration_ms`);

--- a/packages/core/migrations/drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project/migration.sql
@@ -1594,24 +1594,6 @@ CREATE TABLE `tasks_task_labels` (
 	CONSTRAINT `tasks_task_labels_pk` PRIMARY KEY(`task_id`, `label`)
 );
 --> statement-breakpoint
-CREATE TABLE `telemetry_events` (
-	`id` text PRIMARY KEY,
-	`anonymous_id` text NOT NULL,
-	`domain` text NOT NULL,
-	`gateway` text NOT NULL,
-	`operation` text NOT NULL,
-	`command` text NOT NULL,
-	`exit_code` integer DEFAULT 0 NOT NULL,
-	`duration_ms` integer NOT NULL,
-	`error_code` text,
-	`timestamp` text DEFAULT (datetime('now')) NOT NULL
-);
---> statement-breakpoint
-CREATE TABLE `telemetry_schema_meta` (
-	`key` text PRIMARY KEY,
-	`value` text NOT NULL
-);
---> statement-breakpoint
 CREATE INDEX `idx_brain_attention_scope` ON `brain_attention` (`scope_kind`,`scope_id`);--> statement-breakpoint
 CREATE INDEX `idx_brain_attention_session` ON `brain_attention` (`session_id`);--> statement-breakpoint
 CREATE INDEX `idx_brain_attention_status_expires` ON `brain_attention` (`status`,`expires_at`);--> statement-breakpoint
@@ -1908,9 +1890,4 @@ CREATE UNIQUE INDEX `uq_tasks_evidence_ac_bindings_atom_ac_type` ON `tasks_evide
 CREATE INDEX `idx_tasks_evidence_ac_bindings_ac_id` ON `tasks_evidence_ac_bindings` (`ac_id`);--> statement-breakpoint
 CREATE INDEX `idx_tasks_evidence_ac_bindings_evidence_atom_id` ON `tasks_evidence_ac_bindings` (`evidence_atom_id`);--> statement-breakpoint
 CREATE INDEX `idx_tasks_experiments_merged` ON `tasks_experiments` (`merged_at`);--> statement-breakpoint
-CREATE INDEX `idx_tasks_task_labels_label` ON `tasks_task_labels` (`label`);--> statement-breakpoint
-CREATE INDEX `idx_telemetry_command` ON `telemetry_events` (`command`);--> statement-breakpoint
-CREATE INDEX `idx_telemetry_domain` ON `telemetry_events` (`domain`);--> statement-breakpoint
-CREATE INDEX `idx_telemetry_exit_code` ON `telemetry_events` (`exit_code`);--> statement-breakpoint
-CREATE INDEX `idx_telemetry_timestamp` ON `telemetry_events` (`timestamp`);--> statement-breakpoint
-CREATE INDEX `idx_telemetry_duration` ON `telemetry_events` (`duration_ms`);
+CREATE INDEX `idx_tasks_task_labels_label` ON `tasks_task_labels` (`label`);

--- a/packages/core/src/store/__tests__/consolidated-schema-parity-fk.test.ts
+++ b/packages/core/src/store/__tests__/consolidated-schema-parity-fk.test.ts
@@ -8,8 +8,8 @@
  *
  * The consolidated D1″ lifecycle split collapses the CLEO SQLite fleet into two
  * `cleo.db` files: a PROJECT-scope DB (`tasks_*` / `conduit_*` / `docs_*` /
- * `telemetry_*` / `brain_*`) and a GLOBAL-scope DB (`nexus_*` / `skills_*` /
- * `signaldock_*` / `brain_*`). Two parallel artifacts describe that target shape:
+ * `brain_*`) and a GLOBAL-scope DB (`nexus_*` / `skills_*` / `signaldock_*` /
+ * `telemetry_*` / `brain_*`). Two parallel artifacts describe that target shape:
  *
  *   1. the Drizzle **schema families** under
  *      `packages/core/src/store/schema/cleo-{project,global,shared}/`, and
@@ -37,9 +37,9 @@
  *     `enumValues`, `_at` TEXT → ISO-8601 GLOB) so any drift between schema and
  *     migration fails here.
  *   - **AC3 — typed round-trip.** Inserts representative rows through the typed
- *     Drizzle writers for each domain (project: tasks/conduit/docs/telemetry/
- *     brain; global: nexus/skills/signaldock/brain), reads them back typed, and
- *     asserts equality — proving the migrated physical schema accepts and
+ *     Drizzle writers for each domain (project: tasks/conduit/docs/brain;
+ *     global: nexus/skills/signaldock/telemetry/brain), reads them back typed,
+ *     and asserts equality — proving the migrated physical schema accepts and
  *     returns exactly what the typed schema models.
  *   - **AC4 — ATTACH rejection re-asserted.** Re-proves, consistent with the
  *     spike, that a cross-FILE FK across the two scopes is unenforceable (no
@@ -572,7 +572,7 @@ describe('T11364 AC3 — typed round-trip through the consolidated schema', () =
     globalDb.close();
   });
 
-  it('project: tasks/conduit/docs/telemetry/brain round-trip equal', async () => {
+  it('project: tasks/conduit/docs/brain round-trip equal', async () => {
     const db = drizzle({ client: projectDb });
 
     // tasks domain — root row referenced by intra-domain FKs.
@@ -617,25 +617,6 @@ describe('T11364 AC3 — typed round-trip through the consolidated schema', () =
     expect(att.sha256).toBe('a'.repeat(64));
     expect(att.refCount).toBe(0); // default
 
-    // telemetry domain
-    await db.insert(projectSchema.telemetryEvents).values({
-      id: 'E-rt-1',
-      anonymousId: 'anon-1',
-      domain: 'tasks',
-      gateway: 'query',
-      operation: 'show',
-      command: 'tasks.show',
-      durationMs: 42,
-      timestamp: '2026-05-31T00:00:00Z',
-    });
-    const [evt] = await db
-      .select()
-      .from(projectSchema.telemetryEvents)
-      .where(eq(projectSchema.telemetryEvents.id, 'E-rt-1'));
-    expect(evt.id).toBe('E-rt-1');
-    expect(evt.durationMs).toBe(42);
-    expect(evt.exitCode).toBe(0); // default
-
     // brain domain (mirrored) — enum value 'discovery' satisfies the CHECK.
     await db.insert(projectSchema.brainObservations).values({
       id: 'O-rt-1',
@@ -652,7 +633,7 @@ describe('T11364 AC3 — typed round-trip through the consolidated schema', () =
     expect(obs.verified).toBe(false); // boolean default — proves mode:'boolean' round-trip
   });
 
-  it('global: nexus/skills/signaldock/brain round-trip equal', async () => {
+  it('global: nexus/skills/signaldock/telemetry/brain round-trip equal', async () => {
     const db = drizzle({ client: globalDb });
 
     // nexus domain
@@ -696,6 +677,36 @@ describe('T11364 AC3 — typed round-trip through the consolidated schema', () =
     expect(cap.slug).toBe('code-review');
     expect(cap.name).toBe('Code Review');
     expect(cap.category).toBe('engineering');
+
+    // telemetry domain — machine-wide command telemetry, relocated to GLOBAL
+    // scope by T11540 per ADR-090 §2.3.
+    await db.insert(globalSchema.telemetryEvents).values({
+      id: 'E-rt-1',
+      anonymousId: 'anon-1',
+      domain: 'tasks',
+      gateway: 'query',
+      operation: 'show',
+      command: 'tasks.show',
+      durationMs: 42,
+      timestamp: '2026-05-31T00:00:00Z',
+    });
+    const [evt] = await db
+      .select()
+      .from(globalSchema.telemetryEvents)
+      .where(eq(globalSchema.telemetryEvents.id, 'E-rt-1'));
+    expect(evt.id).toBe('E-rt-1');
+    expect(evt.durationMs).toBe(42);
+    expect(evt.exitCode).toBe(0); // default
+    // telemetry_schema_meta — KV table built from the makeSchemaMetaTable factory.
+    await db
+      .insert(globalSchema.telemetrySchemaMeta)
+      .values({ key: 'schema_version', value: '1.0.0' });
+    const [tMeta] = await db
+      .select()
+      .from(globalSchema.telemetrySchemaMeta)
+      .where(eq(globalSchema.telemetrySchemaMeta.key, 'schema_version'));
+    expect(tMeta.key).toBe('schema_version');
+    expect(tMeta.value).toBe('1.0.0');
 
     // brain domain (mirrored — same module as project scope)
     await db

--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -11,12 +11,13 @@
  * GLOBAL-scope DB (`$XDG_DATA_HOME/cleo/cleo.db`). The GLOBAL-scope DB holds
  * every CROSS-PROJECT domain — `nexus_*` (code-intelligence index) / `skills_*`
  * (installed-skills registry) / `signaldock_*` (global agent identity — folded
- * here per D1, no standalone `signaldock.db`) / `brain_*` (cross-project
- * memory) — as domain-prefixed Pattern-A tables.
+ * here per D1, no standalone `signaldock.db`) / `telemetry_*` (machine-wide
+ * command telemetry — relocated here from PROJECT scope by T11540 per ADR-090
+ * §2.3) / `brain_*` (cross-project memory) — as domain-prefixed Pattern-A tables.
  *
  * Per the canonical typing report §1 (D1″), the GLOBAL `cleo.db` is
- * **49 tables / 555 columns** = nexus 10 + skills 4 + signaldock 13 + brain 22
- * (MIRRORED). This barrel composes exactly that set.
+ * **51 tables / 567 columns** = nexus 10 + skills 4 + signaldock 13 +
+ * telemetry 2 + brain 22 (MIRRORED). This barrel composes exactly that set.
  *
  * Modules under this directory author the **target shape**: domain-prefixed
  * `sqliteTable` definitions with the E10 strict typing applied per
@@ -46,9 +47,9 @@
  * `nexus_project_registry`, `code_index` → `nexus_code_index`, `skills` →
  * `skills_skills`, `agents` → `signaldock_agents`, …).
  *
- * ## Coverage (T11361 — global-exclusive authoring COMPLETE · 27 tables + 22 mirrored brain)
+ * ## Coverage (T11361 — global-exclusive authoring COMPLETE · 29 tables + 22 mirrored brain)
  *
- * **Global-exclusive (authored here · 27 tables):**
+ * **Global-exclusive (authored here · 29 tables):**
  *   - **nexus** (10 tables · `./nexus.ts`): nexus_project_registry ·
  *     nexus_project_id_aliases · nexus_audit_log · nexus_schema_meta ·
  *     nexus_nodes · nexus_relations · nexus_contracts · nexus_code_index ·
@@ -68,14 +69,19 @@
  *     `users.role` (`SIGNALDOCK_USER_ROLES`) and `agents.status`
  *     (`SIGNALDOCK_AGENT_STATUSES`). All FKs are intra-domain (single global
  *     file) → kept native `.references()` (AC4).
+ *   - **telemetry** (2 tables · `./telemetry.ts`): telemetry_events ·
+ *     telemetry_schema_meta. Relocated from PROJECT scope by T11540 per ADR-090
+ *     §2.3 (machine-wide command telemetry is a cross-project signal). No
+ *     boolean/enum/JSON columns; `telemetry_schema_meta` built from the shared
+ *     `makeSchemaMetaTable` factory (T11543) for zero KV-shape drift.
  *
  * **Mirrored (re-exported · 22 tables):** the `brain_*` family from
  * `../cleo-shared/index.ts` (same module the project barrel uses).
  *
- * **GLOBAL SCHEMA NOW COMPLETE.** 27 global-exclusive prefixed `sqliteTable`s +
- * 22 mirrored brain tables = the canonical 49 (nexus 10 + skills 4 +
- * signaldock 13 + brain 22). What remains for the saga is the exodus cutover
- * (T11248).
+ * **GLOBAL SCHEMA NOW COMPLETE.** 29 global-exclusive prefixed `sqliteTable`s +
+ * 22 mirrored brain tables = the canonical 51 (nexus 10 + skills 4 +
+ * signaldock 13 + telemetry 2 + brain 22). What remains for the saga is the
+ * exodus cutover (T11248).
  *
  * @task T11361
  * @epic T11245
@@ -90,3 +96,4 @@ export * from '../cleo-shared/index.js';
 export * from './nexus.js';
 export * from './signaldock.js';
 export * from './skills.js';
+export * from './telemetry.js';

--- a/packages/core/src/store/schema/cleo-global/telemetry.ts
+++ b/packages/core/src/store/schema/cleo-global/telemetry.ts
@@ -1,13 +1,19 @@
 /**
- * Project-scope `cleo.db` — consolidated **telemetry** domain.
+ * Global-scope `cleo.db` — consolidated **telemetry** domain.
  *
- * Part of the consolidated PROJECT-scope `cleo.db` target shape authored for
- * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11360). Target-shape
- * authoring only — physical names carry the `telemetry_` domain prefix (already
- * present in the source, so the idempotent prefixer is a no-op here: a table
- * already carrying a recognized domain prefix is NOT double-prefixed, per AC1).
- * The live runtime module `schema/telemetry-schema.ts` is unchanged until the
- * exodus migration (T11248) deploys this shape.
+ * Part of the consolidated GLOBAL-scope `cleo.db` target shape. Per ADR-090 §2.3
+ * the two telemetry tables (`telemetry_events`, `telemetry_schema_meta`) are
+ * machine-wide command telemetry — a CROSS-PROJECT signal — so they reside in the
+ * GLOBAL `cleo.db` (`$XDG_DATA_HOME/cleo/cleo.db`), not the per-project file. They
+ * were relocated here from `cleo-project/telemetry.ts` by T11540 (the deferred
+ * residency move recorded in ADR-090 §2.3); the physical DDL is unchanged so the
+ * exodus cutover (T11248) emits zero drift versus the prior project-scope shape.
+ *
+ * Physical names carry the `telemetry_` domain prefix (already present in the
+ * source, so the idempotent prefixer is a no-op here: a table already carrying a
+ * recognized domain prefix is NOT double-prefixed, per AC1). The live runtime
+ * module `schema/telemetry-schema.ts` (the standalone, already-global
+ * `telemetry.db`) is unchanged until the exodus migration deploys this shape.
  *
  * ## E10 typing applied
  *
@@ -15,23 +21,30 @@
  *   ISO8601 form (`datetime('now')`); no epoch non-conformer in this domain.
  * - **No boolean / enum / JSON columns** — `exit_code` is a numeric LAFS code
  *   (not a 0/1 boolean flag), so it stays plain `integer` per the audit.
+ * - **`telemetry_schema_meta`** is the canonical two-column KV shape, so it is
+ *   built from the shared {@link makeSchemaMetaTable} factory (T11543) — the
+ *   single source of the `{ key TEXT PK, value TEXT NOT NULL }` DDL across every
+ *   domain. The emitted DDL is byte-identical to the prior inline definition.
  *
- * @task T11360
- * @epic T11245
+ * @task T11540
+ * @epic T11535
  * @saga T11242
+ * @see .cleo/rcasd/adr-090-nexus-graph-residency-split.md §2.3 (telemetry → GLOBAL)
+ * @see ../schema-utils.ts — re-exported as {@link makeSchemaMetaTable} (T11543 factory)
  * @see docs/migration/sqlite-schema-canonical.md §1 (D1″) · §4
  * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
  */
 
 import { sql } from 'drizzle-orm';
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { makeSchemaMetaTable } from '../schema-utils.js';
 
 /**
  * `telemetry_events` — one row per command invocation captured by the
  * telemetry middleware (anonymous, opt-in). Already domain-prefixed; the
  * idempotent prefixer leaves the name as-is.
  *
- * @task T11360 (target shape) · T624 (original)
+ * @task T11540 (residency move · target shape) · T11360 (prior project-scope authoring) · T624 (original)
  */
 export const telemetryEvents = sqliteTable(
   'telemetry_events',
@@ -69,14 +82,13 @@ export const telemetryEvents = sqliteTable(
 /**
  * `telemetry_schema_meta` — key-value schema-version tracking (single row).
  *
- * @task T11360 (target shape) · T624 (original)
+ * Built from the shared {@link makeSchemaMetaTable} factory (T11543) so the
+ * canonical `{ key TEXT PRIMARY KEY, value TEXT NOT NULL }` shape never drifts
+ * across domains; the emitted DDL is identical to the prior inline definition.
+ *
+ * @task T11540 (residency move · target shape) · T11543 (factory) · T624 (original)
  */
-export const telemetrySchemaMeta = sqliteTable('telemetry_schema_meta', {
-  /** Config key. */
-  key: text('key').primaryKey(),
-  /** Config value. */
-  value: text('value').notNull(),
-});
+export const telemetrySchemaMeta = makeSchemaMetaTable('telemetry_schema_meta');
 
 // === TYPE EXPORTS ===
 

--- a/packages/core/src/store/schema/cleo-project/index.ts
+++ b/packages/core/src/store/schema/cleo-project/index.ts
@@ -10,8 +10,10 @@
  * (`<projectRoot>/.cleo/cleo.db`) and a GLOBAL-scope DB
  * (`$XDG_DATA_HOME/cleo/cleo.db`). The PROJECT-scope DB holds every project-tier
  * domain — `tasks_*` / `brain_*` (this project's memory) / `conduit_*` /
- * `docs_*` / `telemetry_*` — as domain-prefixed Pattern-A tables (87 tables /
- * 903 columns per the canonical typing report §1).
+ * `docs_*` — as domain-prefixed Pattern-A tables (85 tables / 891 columns
+ * per the canonical typing report §1, after the telemetry residency move). The
+ * `telemetry_*` family — machine-wide command telemetry, a cross-project signal —
+ * was relocated to GLOBAL scope by T11540 per ADR-090 §2.3.
  *
  * Modules under this directory author that **target shape**: domain-prefixed
  * `sqliteTable` definitions with the E10 strict typing applied per
@@ -86,15 +88,16 @@
  * E4 jsonb BLOB.
  *
  * **PROJECT SCHEMA NOW COMPLETE.** Every project-tier table is authored: the
- * canonical 87 (tasks-core 45 + conduit 14 + docs 4 + telemetry 2 + brain 22)
- * plus the 2 E4 junctions added on main since the audit (`tasks_task_labels`,
- * `brain_sticky_tags`) = 89 prefixed `sqliteTable`s across `cleo-project/` +
- * `cleo-shared/`. The two `_conduit_*` legacy meta tables are dropped at exodus
- * per §6b. **T11549 (zero-loss final mile)**: `tasks_agent_credentials` and
+ * canonical 85 (tasks-core 45 + conduit 14 + docs 4 + brain 22; the `telemetry_*`
+ * pair relocated to GLOBAL by T11540 per ADR-090 §2.3) plus the 2 E4 junctions
+ * added on main since the audit (`tasks_task_labels`, `brain_sticky_tags`) = 87
+ * prefixed `sqliteTable`s across `cleo-project/` + `cleo-shared/`. The two
+ * `_conduit_*` legacy meta tables are dropped at exodus per §6b. **T11549
+ * (zero-loss final mile)**: `tasks_agent_credentials` and
  * `tasks_brain_release_links` added in `provenance-orphans.ts` (2 tables, 11
- * rows recovered from legacy brain.db). Total = 91 prefixed tables.
- * What remains for the saga is the GLOBAL scope (T11361: nexus_* / skills_* /
- * signaldock_* + this same mirrored brain_*) and the exodus cutover (T11248).
+ * rows recovered from legacy brain.db). Total = 89 prefixed tables (before the
+ * T11538 nexus code-graph additions noted below).
+ * What remains for the saga is the exodus cutover (T11248).
  *
  * ## Nexus code-graph residency move (ADR-090 · T11538 — additive)
  *
@@ -127,4 +130,3 @@ export * from './provenance-rest.js';
 export * from './runtime.js';
 export * from './tasks-core.js';
 export * from './tasks-core-batch2.js';
-export * from './telemetry.js';


### PR DESCRIPTION
## Summary

Per ADR-090 §2.3, `telemetry_events` + `telemetry_schema_meta` are machine-wide command telemetry — a cross-project signal — and belong in the GLOBAL `cleo.db`, not the per-project file. This completes the deferred residency move (the schema-meta factory in T11543 explicitly deferred `telemetry_schema_meta` to this task).

## Changes
- **Moved** the telemetry target-shape module `cleo-project/telemetry.ts` → `cleo-global/telemetry.ts` (git rename, byte-identical DDL).
- **Barrels**: `cleo-project/index.ts` no longer exports telemetry; `cleo-global/index.ts` now does.
- **`telemetry_schema_meta`** now built from the shared `makeSchemaMetaTable()` factory (T11543) — zero KV-shape drift, last inline duplicate eliminated.
- **Migrations**: the two telemetry `CREATE TABLE` blocks + 5 indexes moved from the `drizzle-cleo-project` consolidation migration to `drizzle-cleo-global` (byte-identical → zero exodus drift). Snapshots left as drizzle-kit baseline, matching the T11538 precedent.
- **Docs/configs**: schema barrels + drizzle scope configs updated (project 87→85 tables, global 49→51 tables).
- **Test**: `consolidated-schema-parity-fk` telemetry round-trip moved from the project block to the global block (now also covers `telemetry_schema_meta`).
- **AC3**: `db-inventory.json` telemetry role already had `tier=global` (the standalone `telemetry.db` was always global) — no change required.

## Runtime note
The live runtime `telemetry.db` (`telemetry/sqlite.ts`, already global via `getCleoHome()`) and its runtime schema (`store/schema/telemetry-schema.ts`) are **unchanged** — the consolidated `cleo-{project,global}` modules are pre-exodus target-shape authoring, not the live substrate (T11248 cutover). No `openDualScopeDb` reroute is needed yet.

## Validation
- `pnpm biome check` clean (3459 files, 0 fixes)
- `pnpm run typecheck` (`tsc -b`) clean
- `node build.mjs` + CLI smoke pass
- Parity + migration suites: **55/55 pass** (incl. relocated telemetry round-trip + per-scope declared-table parity gate)
- db-inventory + manifest-idempotency: 13/13 pass
- `cleo check arch`: 5/5 gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)