### PR TITLE
feat(T11539): nexus graph tables global→project residency (10→6 + exodus routing) (ADR-090)

### DIFF
--- a/.changeset/t11539-nexus-graph-global-removal.md
+++ b/.changeset/t11539-nexus-graph-global-removal.md
@@ -1,0 +1,13 @@
+---
+id: t11539-nexus-graph-global-removal
+tasks: [T11539]
+prs: [917]
+kind: feat
+summary: Remove the four nexus code-graph tables from GLOBAL scope (10 → 6) and route them to PROJECT scope in exodus — nexus residency move step 2 (ADR-090)
+---
+
+Removes `nexus_nodes`, `nexus_relations`, `nexus_contracts`, and `nexus_code_index` (plus their in-module enum const arrays `NEXUS_NODE_KINDS`/`NEXUS_RELATION_TYPES`/`NEXUS_CONTRACT_TYPES`/`CODE_INDEX_KINDS` and the eight row-type exports) from `packages/core/src/store/schema/cleo-global/nexus.ts`, dropping the nexus GLOBAL table count from 10 to 6. The six registry/identity tables (`nexus_project_registry`, `nexus_project_id_aliases`, `nexus_audit_log`, `nexus_schema_meta`, `nexus_user_profile`, `nexus_sigils`) stay GLOBAL per ADR-090 Category B. No external module imported the removed symbols — the live runtime uses `schema/nexus-schema.ts` (untouched).
+
+The exodus `table-name-map.ts` gains `NEXUS_GRAPH_PROJECT_TABLES` + `resolveTableTargetScope()` — the single SSoT consumed by BOTH the migrate runner (`migrate.ts`, insert target) and the verifier (`verify-migration.ts`, verify target) so they never disagree — routing the four graph tables, still extracted from the legacy GLOBAL `nexus.db` source, into the PROJECT consolidated `cleo.db`. `copyTableFromAttached()` + `detectIsoGlobColumns()` gained a `targetSchema` parameter (default `main`); the global `migrateScope` pass cross-attaches the project DB and schema-qualifies the INSERT + introspection for those four tables. WAL-safe (the project pass already committed; the project handle is idle).
+
+This is step 2 of the residency move (T11538 #913 authored the project-scope schema). The live runtime is unaffected — graph tables are still created in the global `cleo.db` by the legacy `drizzle-nexus` migrations, and `getNexusDb` → `openDualScopeDb('global')` + the ADR-036 assert are untouched. The Studio `scope=all` fan-out is deferred to T11570 (depends on the larger E6 runtime cutover, not just this schema+exodus change). The Hebbian plasticity partition `nexus_relation_weights` (T11545) must land WITH the move.

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -127,11 +127,12 @@ import { getLogger } from '../../logger.js';
 import { getCleoVersion } from '../../scaffold/ensure-config.js';
 import { openDualScopeDb } from '../dual-scope-db.js';
 import { openCleoDbSnapshot } from '../open-cleo-db.js';
-import { resolveConsolidatedTableName } from './table-name-map.js';
+import { resolveConsolidatedTableName, resolveTableTargetScope } from './table-name-map.js';
 import type {
   ExodusJournal,
   ExodusMigrateResult,
   ExodusPlan,
+  ExodusScope,
   JournalTableEntry,
   LegacyDbDescriptor,
   TableCopyResult,
@@ -743,12 +744,20 @@ function buildEpochToIsoExpr(srcRef: string): string {
  *
  * @param db          - Target DB with the consolidated schema.
  * @param tableName   - Physical table name (consolidated, e.g. `conduit_messages`).
+ * @param targetSchema - Schema name the target table lives in (`'main'`, or an
+ *   ATTACH alias for cross-scope routing — ADR-090 nexus graph residency, T11539).
  * @returns Set of column names that require ISO GLOB validation.
  */
-function detectIsoGlobColumns(db: DatabaseSync, tableName: string): Set<string> {
+function detectIsoGlobColumns(
+  db: DatabaseSync,
+  tableName: string,
+  targetSchema = 'main',
+): Set<string> {
   const escapedTable = tableName.replace(/'/g, "''");
   const row = db
-    .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='${escapedTable}'`)
+    .prepare(
+      `SELECT sql FROM "${targetSchema}".sqlite_master WHERE type='table' AND name='${escapedTable}'`,
+    )
     .get() as { sql: string } | null;
 
   if (!row?.sql) return new Set();
@@ -886,11 +895,23 @@ function buildSelectExpr(
  * `ATTACH DATABASE '<path>' AS "<attachAlias>"` on `targetNativeDb`, and
  * `PRAGMA foreign_keys = OFF` has been set so FK ordering doesn't matter.
  *
+ * ## Cross-scope routing (ADR-090 · T11539)
+ *
+ * `targetSchema` defaults to `'main'` (the connection's own consolidated DB). For
+ * the four nexus code-graph tables, which are extracted from the GLOBAL `nexus.db`
+ * source but must land in the PROJECT consolidated `cleo.db`, the caller attaches
+ * the project DB under an alias on the SAME connection and passes that alias as
+ * `targetSchema`. All target-side introspection (`sqlite_master`, `PRAGMA
+ * table_info`) and the `INSERT OR IGNORE` are then schema-qualified to that
+ * attached DB instead of `main`.
+ *
  * @param targetNativeDb   - Writable target handle (mid-transaction, FK OFF).
  * @param srcNativeDb      - Read-only source snapshot (for metadata queries).
  * @param attachAlias      - Alias under which the source is attached.
  * @param legacyTableName  - Physical table name in the legacy source DB.
  * @param sourceName       - `LegacyDbDescriptor.name` (for name resolution).
+ * @param targetSchema     - Schema the consolidated target table lives in
+ *   (`'main'` by default, or an ATTACH alias for cross-scope routing).
  */
 function copyTableFromAttached(
   targetNativeDb: DatabaseSync,
@@ -898,6 +919,7 @@ function copyTableFromAttached(
   attachAlias: string,
   legacyTableName: string,
   sourceName: string,
+  targetSchema = 'main',
 ): CopyTableResult {
   // --- Step 1: Resolve the consolidated target table name (ROOT CAUSE 1) ---
   const resolution = resolveConsolidatedTableName(sourceName, legacyTableName);
@@ -930,21 +952,28 @@ function copyTableFromAttached(
   if (sourceCount === 0) return { rowsCopied: 0, skipped: false };
 
   // --- Step 4: Check the consolidated target table exists ---
+  // Schema-qualified so cross-scope routing (ADR-090 T11539) introspects the
+  // attached project DB, not `main`, for the four nexus graph tables.
   const escapedTarget = targetTableName.replace(/'/g, "''");
   const existsRow = targetNativeDb
-    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='${escapedTarget}'`)
+    .prepare(
+      `SELECT name FROM "${targetSchema}".sqlite_master WHERE type='table' AND name='${escapedTarget}'`,
+    )
     .get() as { name: string } | null;
 
   if (!existsRow) {
     // Target table absent — log and treat as explicit skip
     const reason = `consolidated target '${targetTableName}' not found (mapped from legacy '${legacyTableName}')`;
-    log.warn({ legacyTableName, targetTableName, sourceName, attachAlias }, `Exodus: ${reason}`);
+    log.warn(
+      { legacyTableName, targetTableName, sourceName, attachAlias, targetSchema },
+      `Exodus: ${reason}`,
+    );
     return { rowsCopied: 0, skipped: true, reason };
   }
 
   // --- Step 5: Compute column intersection (ROOT CAUSE 2 — T11532 + T11533) ---
   const tgtPragma = targetNativeDb
-    .prepare(`PRAGMA table_info("${targetTableName}")`)
+    .prepare(`PRAGMA "${targetSchema}".table_info("${targetTableName}")`)
     .all() as Array<{ name: string; type: string; notnull: number; dflt_value: string | null }>;
 
   // Build a lookup for target columns (type + notNull + dflt_value)
@@ -976,7 +1005,7 @@ function copyTableFromAttached(
   // T11549: the scale (seconds vs ms) is now detected per-row by magnitude heuristic
   // inside buildSelectExpr via buildEpochToIsoExpr — the per-source hint is kept for
   // logging only.
-  const isoGlobCols = detectIsoGlobColumns(targetNativeDb, targetTableName);
+  const isoGlobCols = detectIsoGlobColumns(targetNativeDb, targetTableName, targetSchema);
   const epochUnitHint = epochUnitForSource(sourceName);
 
   // Build a map of source column types for quick lookup in buildSelectExpr.
@@ -1065,8 +1094,10 @@ function copyTableFromAttached(
   // The source alias uses legacyTableName; the target uses consolidatedName.
   // OR IGNORE fires on PK/UNIQUE conflicts (safe for idempotent resume) AND
   // on CHECK constraint violations (dangerous — must detect and report).
+  // `targetSchema` is `main` by default; for cross-scope nexus graph tables
+  // (ADR-090 T11539) it is the ATTACH alias of the project consolidated cleo.db.
   const stmt = targetNativeDb.prepare(
-    `INSERT OR IGNORE INTO main."${targetTableName}" (${colList}) ` +
+    `INSERT OR IGNORE INTO "${targetSchema}"."${targetTableName}" (${colList}) ` +
       `SELECT ${selectList} FROM "${attachAlias}"."${legacyTableName}"`,
   );
   const result = stmt.run();
@@ -1152,7 +1183,7 @@ export async function runExodusMigrate(
   forceCrossVersion = false,
   onProgress?: (msg: string) => void,
 ): Promise<ExodusMigrateResult> {
-  const { sources, stagingDir, diskPreflight } = plan;
+  const { sources, stagingDir, diskPreflight, projectDbPath } = plan;
 
   // AC8: disk pre-flight
   if (!diskPreflight) {
@@ -1255,6 +1286,11 @@ export async function runExodusMigrate(
       allTableResults,
       onProgress,
     );
+    // Cross-scope routing (ADR-090 · T11539): the four nexus graph tables come
+    // from the GLOBAL `nexus.db` source but land in the PROJECT consolidated
+    // cleo.db. Pass the project DB path so the global pass can attach it and
+    // route those tables there. The project pass already committed + the project
+    // handle is idle, so the cross-attach write is the sole writer (WAL-safe).
     await migrateScope(
       'global',
       globalSources,
@@ -1263,6 +1299,7 @@ export async function runExodusMigrate(
       stagingDir,
       allTableResults,
       onProgress,
+      projectDbPath,
     );
 
     // Final journal update
@@ -1326,13 +1363,14 @@ export async function runExodusMigrate(
  *   PRAGMA foreign_keys = ON
  */
 async function migrateScope(
-  scope: string,
+  scope: ExodusScope,
   sources: LegacyDbDescriptor[],
   targetNativeDb: DatabaseSync,
   journal: ExodusJournal,
   stagingDir: string,
   allTableResults: TableCopyResult[],
   onProgress?: (msg: string) => void,
+  crossScopeTargetPath?: string,
 ): Promise<void> {
   if (sources.length === 0) return;
 
@@ -1354,6 +1392,19 @@ async function migrateScope(
       // The finally block below guarantees DETACH runs even on error.
       targetNativeDb.exec(`ATTACH DATABASE '${escapedPath}' AS "${attachAlias}"`);
       onProgress?.(`  [${src.name}] Attached as "${attachAlias}"`);
+
+      // Cross-scope routing (ADR-090 · T11539): the four nexus graph tables are
+      // extracted from the GLOBAL `nexus.db` source but land in PROJECT scope.
+      // When such tables exist for this source, ATTACH the cross-scope target
+      // consolidated `cleo.db` onto THIS connection so their INSERT … SELECT can
+      // schema-qualify the destination without a second connection/transaction.
+      let crossAlias: string | null = null;
+      if (crossScopeTargetPath) {
+        crossAlias = `_xscope_${attachAlias}`;
+        const escapedCrossPath = crossScopeTargetPath.replace(/'/g, "''");
+        targetNativeDb.exec(`ATTACH DATABASE '${escapedCrossPath}' AS "${crossAlias}"`);
+        onProgress?.(`  [${src.name}] Cross-scope target attached as "${crossAlias}"`);
+      }
 
       // Step 2: Open a read-only snapshot for metadata (column info, counts).
       const snap = openCleoDbSnapshot(src.path, { readOnly: true });
@@ -1394,12 +1445,25 @@ async function migrateScope(
               // Step 4: INSERT using the already-attached alias — no per-table ATTACH/DETACH.
               // FK enforcement is OFF (set at scope start), so copy order does not matter.
               // Pass src.name so copyTableFromAttached can resolve the consolidated target name.
+              //
+              // Cross-scope routing (ADR-090 · T11539): if this table's effective
+              // scope differs from the loop scope (the four nexus graph tables),
+              // direct the INSERT at the cross-scope target DB attached above.
+              const effectiveScope = resolveTableTargetScope(src.name, tableName, scope);
+              const targetSchema = effectiveScope !== scope && crossAlias ? crossAlias : 'main';
+              if (effectiveScope !== scope && !crossAlias) {
+                throw new Error(
+                  `Table '${tableName}' from '${src.name}' routes to ${effectiveScope} scope ` +
+                    `but no cross-scope target was attached for the ${scope} pass (ADR-090 T11539)`,
+                );
+              }
               const copyResult = copyTableFromAttached(
                 targetNativeDb,
                 snap.db,
                 attachAlias,
                 tableName,
                 src.name,
+                targetSchema,
               );
               rowsCopied = copyResult.rowsCopied;
               if (copyResult.skipped) {
@@ -1482,6 +1546,19 @@ async function migrateScope(
             { attachAlias, sourceDb: src.name, err: detachErr },
             'DETACH failed — alias will be released on DB close',
           );
+        }
+
+        // Detach the cross-scope target alias (ADR-090 · T11539), if attached.
+        if (crossAlias) {
+          try {
+            targetNativeDb.exec(`DETACH DATABASE "${crossAlias}"`);
+            onProgress?.(`  [${src.name}] Cross-scope target detached "${crossAlias}"`);
+          } catch (detachErr) {
+            log.warn(
+              { crossAlias, sourceDb: src.name, err: detachErr },
+              'Cross-scope DETACH failed — alias will be released on DB close',
+            );
+          }
         }
       }
     } // end for loop over sources

--- a/packages/core/src/store/exodus/table-name-map.ts
+++ b/packages/core/src/store/exodus/table-name-map.ts
@@ -30,14 +30,32 @@
  * both conduit.db and attachments.ts/tasks.db; `"sessions"` lives in both
  * tasks.db and signaldock.db).
  *
+ * ## Nexus code-graph residency move (ADR-090 · T11539)
+ *
+ * The four nexus code-graph tables — `nexus_nodes`, `nexus_relations`,
+ * `nexus_contracts`, `nexus_code_index` (ADR-090 "Category A") — were removed
+ * from the GLOBAL schema (`../schema/cleo-global/nexus.ts`) and now reside in
+ * PROJECT scope (`../schema/cleo-project/nexus-graph.ts`). They are still
+ * extracted from the legacy GLOBAL `nexus.db` source, but exodus MUST route them
+ * into the PROJECT-scope consolidated `cleo.db`, not the global one. The source
+ * descriptor `nexus` carries `targetScope: 'global'`, so a per-table scope
+ * override is required for these four tables — see
+ * {@link NEXUS_GRAPH_PROJECT_TABLES} and {@link resolveTableTargetScope}. The
+ * six registry/identity tables (`nexus_project_registry`,
+ * `nexus_project_id_aliases`, `nexus_audit_log`, `nexus_schema_meta`,
+ * `nexus_user_profile`, `nexus_sigils`) stay GLOBAL.
+ *
  * @task T11532 (ROOT CAUSE 1 — name-mapping gap)
  * @task T11533 (ROOT CAUSE 3 — signaldock skills mapping + brain_release_links skip +
  *               brain_session_narrative mapping)
  * @task T11546 (no-home-table fixes — schema_meta→tasks_schema_meta, brain_usage_log mapping,
  *               brain_schema_meta mapping)
+ * @task T11539 (nexus code-graph residency — route the 4 graph tables to PROJECT scope)
  * @epic T11248
  * @saga T11242
  */
+
+import type { ExodusScope } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Per-source legacy→consolidated mapping tables
@@ -242,6 +260,16 @@ const CONDUIT_DB_MAP: ReadonlyMap<string, string> = new Map([
  *
  * Some tables are ALREADY prefixed (`nexus_audit_log`, `nexus_nodes`, etc.) and
  * map identity. Others lack the prefix and gain `nexus_` in consolidated.
+ *
+ * ## Scope split (ADR-090 · T11539)
+ *
+ * The legacy `nexus.db` source descriptor carries `targetScope: 'global'`, but
+ * the four code-graph tables (`code_index`/`nexus_code_index`, `nexus_nodes`,
+ * `nexus_relations`, `nexus_contracts`) now live in PROJECT scope. Their
+ * consolidated NAME is unchanged (identity / `nexus_code_index`), but their
+ * destination DB is the PROJECT `cleo.db` — see {@link NEXUS_GRAPH_PROJECT_TABLES}
+ * and {@link resolveTableTargetScope}. The remaining six registry/identity
+ * tables stay GLOBAL.
  */
 const NEXUS_DB_MAP: ReadonlyMap<string, string> = new Map([
   // Unprefixed legacy names
@@ -249,15 +277,71 @@ const NEXUS_DB_MAP: ReadonlyMap<string, string> = new Map([
   ['project_id_aliases', 'nexus_project_id_aliases'],
   ['user_profile', 'nexus_user_profile'],
   ['sigils', 'nexus_sigils'],
+  // code_index → nexus_code_index: routed to PROJECT scope (ADR-090 §2.1).
   ['code_index', 'nexus_code_index'],
   // Already-prefixed names (identity)
   ['nexus_audit_log', 'nexus_audit_log'],
+  // The 3 graph tables below keep identity names but route to PROJECT scope (ADR-090).
   ['nexus_nodes', 'nexus_nodes'],
   ['nexus_relations', 'nexus_relations'],
   ['nexus_contracts', 'nexus_contracts'],
   // schema_meta tables created by consolidated schema bootstrap
   ['nexus_schema_meta', 'nexus_schema_meta'],
 ]);
+
+/**
+ * Legacy table names of the four nexus code-graph tables that moved from GLOBAL
+ * to PROJECT scope (ADR-090 · T11538/T11539).
+ *
+ * Keyed by the LEGACY physical name as it appears in `nexus.db`:
+ *   - `nexus_nodes`, `nexus_relations`, `nexus_contracts` — already prefixed.
+ *   - `code_index` — bare in legacy `nexus.db`; → `nexus_code_index` consolidated.
+ *
+ * Membership drives {@link resolveTableTargetScope}: exodus copies/verifies
+ * these against the PROJECT consolidated `cleo.db`, NOT the GLOBAL one, even
+ * though the `nexus` source descriptor's `targetScope` is `'global'`.
+ *
+ * @task T11539
+ * @epic T11248
+ * @saga T11242
+ * @see cleo docs fetch adr-090-nexus-graph-residency-split
+ */
+export const NEXUS_GRAPH_PROJECT_TABLES: ReadonlySet<string> = new Set([
+  'nexus_nodes',
+  'nexus_relations',
+  'nexus_contracts',
+  'code_index',
+]);
+
+/**
+ * Resolve the consolidated TARGET SCOPE for a legacy source table.
+ *
+ * Most tables share the scope of their source DB descriptor (`sourceScope`).
+ * The exception is the four nexus code-graph tables — they are extracted from
+ * the GLOBAL legacy `nexus.db` but land in PROJECT scope per ADR-090 (T11539).
+ *
+ * This is the SSoT consumed by BOTH the exodus migrate runner (insert target DB)
+ * and the exodus verifier (verify target DB) so the two never disagree.
+ *
+ * @param sourceName  - `LegacyDbDescriptor.name` (e.g. `"nexus"`, `"tasks"`).
+ * @param legacyTable - Physical table name in the legacy source DB.
+ * @param sourceScope - The source descriptor's `targetScope`.
+ * @returns The scope of the consolidated `cleo.db` this table copies into.
+ *
+ * @task T11539
+ * @epic T11248
+ * @saga T11242
+ */
+export function resolveTableTargetScope(
+  sourceName: string,
+  legacyTable: string,
+  sourceScope: ExodusScope,
+): ExodusScope {
+  if (inferSourceKind(sourceName) === 'nexus' && NEXUS_GRAPH_PROJECT_TABLES.has(legacyTable)) {
+    return 'project';
+  }
+  return sourceScope;
+}
 
 /**
  * signaldock.db (global) — tables from signaldock-schema.ts, all prefixed `signaldock_*`.

--- a/packages/core/src/store/exodus/verify-migration.ts
+++ b/packages/core/src/store/exodus/verify-migration.ts
@@ -48,7 +48,7 @@ import type {
 import { MIGRATION_ENUM_DRIFT_SAMPLE_LIMIT } from '@cleocode/contracts';
 import { getLogger } from '../../logger.js';
 import { openCleoDbSnapshot } from '../open-cleo-db.js';
-import { resolveConsolidatedTableName } from './table-name-map.js';
+import { resolveConsolidatedTableName, resolveTableTargetScope } from './table-name-map.js';
 import type { ExodusScope, LegacyDbDescriptor } from './types.js';
 
 const log = getLogger('verify-migration');
@@ -428,12 +428,14 @@ export function verifyMigration(
       }
 
       const srcSnap = openCleoDbSnapshot(src.path, { readOnly: true });
-      const targetSnap = src.targetScope === 'project' ? projectSnap : globalSnap;
-      const scope: ExodusScope = src.targetScope;
 
       try {
         const sourceTables = listTables(srcSnap.db);
-        const targetTables = new Set(listTables(targetSnap.db));
+        // Pre-compute the table set for each consolidated scope once; the
+        // per-table scope override (ADR-090 nexus graph residency, T11539) means
+        // a single source can verify against BOTH scope DBs.
+        const projectTables = new Set(listTables(projectSnap.db));
+        const globalTables = new Set(listTables(globalSnap.db));
 
         for (const legacyTableName of sourceTables) {
           onProgress?.(`Verifying ${src.name}.${legacyTableName}…`);
@@ -444,6 +446,17 @@ export function verifyMigration(
             continue;
           }
           const targetTableName = resolution.targetName;
+
+          // Per-table scope override (ADR-090 · T11539): the four nexus graph
+          // tables come from the GLOBAL `nexus.db` source but land in PROJECT
+          // scope. Pick the verify target DB by the effective per-table scope.
+          const scope: ExodusScope = resolveTableTargetScope(
+            src.name,
+            legacyTableName,
+            src.targetScope,
+          );
+          const targetSnap = scope === 'project' ? projectSnap : globalSnap;
+          const targetTables = scope === 'project' ? projectTables : globalTables;
 
           // --- Enum/type-drift report (diagnostic, only when target exists) ---
           if (targetTables.has(targetTableName)) {

--- a/packages/core/src/store/schema/cleo-global/nexus.ts
+++ b/packages/core/src/store/schema/cleo-global/nexus.ts
@@ -1,5 +1,5 @@
 /**
- * Global-scope `cleo.db` — consolidated **nexus** domain (10 tables).
+ * Global-scope `cleo.db` — consolidated **nexus registry/identity** domain (6 tables).
  *
  * Part of the consolidated GLOBAL-scope `cleo.db` target shape authored for
  * SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, task T11361). Target-shape
@@ -8,16 +8,25 @@
  * UNPREFIXED / partially-prefixed names until the exodus migration (T11248)
  * swaps the substrate to this shape.
  *
+ * ## Nexus code-graph residency move (ADR-090 · T11539 — REMOVED from here)
+ *
+ * The four per-project code/knowledge-graph tables — `nexus_nodes`,
+ * `nexus_relations`, `nexus_contracts`, `nexus_code_index` (ADR-090 "Category A")
+ * — were REMOVED from this GLOBAL module and now reside in PROJECT scope
+ * (`../cleo-project/nexus-graph.ts`, T11538), dropping the `project_id` column
+ * (scope is implicit in which project's `.cleo/cleo.db` is open). This reduces
+ * the nexus GLOBAL table count from 10 → 6. The six tables retained here are the
+ * genuinely-global "Category B" registry/identity tables (see below). Exodus
+ * routes the four graph tables to PROJECT scope per
+ * `../exodus/table-name-map.ts` (`NEXUS_GRAPH_PROJECT_TABLES`).
+ *
  * ## Idempotent prefixer (AC1)
  *
- * Five source tables already carry the recognized `nexus_` prefix and are NOT
- * double-prefixed: `nexus_audit_log` · `nexus_schema_meta` · `nexus_nodes` ·
- * `nexus_relations` · `nexus_contracts`. The remaining five bare tables gain the
- * domain prefix at exodus: `project_registry` → `nexus_project_registry` ·
- * `project_id_aliases` → `nexus_project_id_aliases` · `user_profile` →
- * `nexus_user_profile` · `sigils` → `nexus_sigils` · `code_index` →
- * `nexus_code_index` (the relocated tree-sitter symbol index, formerly in
- * `nexus.db` alongside the registry).
+ * The six retained tables: `nexus_audit_log` · `nexus_schema_meta` already carry
+ * the recognized `nexus_` prefix and are NOT double-prefixed. The remaining four
+ * bare tables gain the domain prefix at exodus: `project_registry` →
+ * `nexus_project_registry` · `project_id_aliases` → `nexus_project_id_aliases` ·
+ * `user_profile` → `nexus_user_profile` · `sigils` → `nexus_sigils`.
  *
  * ## E10 typing applied
  *
@@ -27,13 +36,11 @@
  *   (the 4 Date non-conformers in §4). They become canonical `text` ISO8601;
  *   the matching `CHECK (col GLOB 'YYYY-MM-DD*')` ships as raw DDL at exodus.
  * - **§5b enum-like bare TEXT → `{ enum }`:** `nexus_sigils.role` →
- *   `{ enum: SIGIL_ROLES }` and `nexus_code_index.kind` →
- *   `{ enum: CODE_INDEX_KINDS }`. The const arrays below are minted in-module
- *   (no cross-package contracts const exists for either) per §5b — the CHECK
- *   list derives from the identifier, never a hand-typed literal.
- * - **§3a already-conformant booleans:** `nexus_nodes.{is_exported,is_external}`
- *   and `nexus_code_index.exported` keep `{ mode:'boolean' }`; only the SQL
- *   `CHECK (col IN (0,1))` is added at exodus.
+ *   `{ enum: SIGIL_ROLES }`. The const array below is minted in-module (no
+ *   cross-package contracts const exists) per §5b — the CHECK list derives from
+ *   the identifier, never a hand-typed literal. (`nexus_code_index.kind` →
+ *   `{ enum: CODE_INDEX_KINDS }` moved with the graph tables to
+ *   `../cleo-project/nexus-graph.ts`.)
  *
  * ## FK reconciliation to single-file Pattern A (AC4)
  *
@@ -41,22 +48,23 @@
  * every cross-table reference; none crossed file boundaries via a real
  * `.references()`. Under the consolidated GLOBAL `cleo.db` they remain plain
  * `text` soft FKs:
- *   - intra-nexus refs (`nexus_nodes.project_id` → `nexus_project_registry`,
- *     `nexus_relations.{source_id,target_id}` → `nexus_nodes`, `parent_id`)
- *     stay soft because the source never declared them as enforced FKs and the
- *     graph stores unresolved external specifiers in the same column.
+ *   - `nexus_project_id_aliases.canonical_id` → `nexus_project_registry` and
+ *     `nexus_audit_log.project_id` → `nexus_project_registry` stay soft because
+ *     the source never declared them as enforced FKs.
  *   - cross-domain refs (`nexus_audit_log.session_id` → project-scope
  *     `tasks_sessions`, `nexus_user_profile.derived_from_message_id` →
  *     `conduit_session_messages`) point at the PROJECT-scope `cleo.db`, so they
  *     CANNOT be native FKs — they remain soft TEXT, resolved by the nexus
  *     accessor. No ATTACH; no cross-file FK.
  *
- * @task T11361
- * @epic T11245
+ * @task T11361 · T11539 (nexus graph residency removal)
+ * @epic T11245 · T11535 (nexus residency)
  * @saga T11242
+ * @see ../cleo-project/nexus-graph.ts (the PROJECT-scope home of the 4 graph tables)
  * @see docs/migration/sqlite-schema-canonical.md §1 (D1″ · global counts) · §4 · §5b
  * @see docs/migration/sqlite-schema-columns.json (per-column affinity SSoT)
  * @see ../nexus-schema.ts · ../code-index.ts (the runtime source modules)
+ * @see cleo docs fetch adr-090-nexus-graph-residency-split
  */
 
 import { sql } from 'drizzle-orm';
@@ -91,37 +99,6 @@ export const SIGIL_ROLES = [
 
 /** TypeScript union derived from {@link SIGIL_ROLES}. */
 export type SigilRole = (typeof SIGIL_ROLES)[number];
-
-/**
- * Legal `nexus_code_index.kind` values — tree-sitter symbol capture kinds.
- *
- * E10 §5b: `code_index.kind` was bare `text('kind')`. The legal set is the
- * symbol-kind taxonomy documented on the source column (the tree-sitter capture
- * groups): structural / module / callable / type-hierarchy / value-level
- * constructs. Kept as an in-module const so the exodus CHECK derives from this
- * identifier rather than a hand-typed literal.
- *
- * @task T11361
- */
-export const CODE_INDEX_KINDS = [
-  'function',
-  'method',
-  'class',
-  'interface',
-  'type',
-  'enum',
-  'variable',
-  'constant',
-  'module',
-  'import',
-  'export',
-  'struct',
-  'trait',
-  'impl',
-] as const;
-
-/** TypeScript union derived from {@link CODE_INDEX_KINDS}. */
-export type CodeIndexKind = (typeof CODE_INDEX_KINDS)[number];
 
 // ---------------------------------------------------------------------------
 // Registry + aliases
@@ -265,321 +242,6 @@ export const nexusAuditLog = sqliteTable(
 export const nexusSchemaMeta = makeSchemaMetaTable('nexus_schema_meta');
 
 // ---------------------------------------------------------------------------
-// Code-intelligence graph
-// ---------------------------------------------------------------------------
-
-/**
- * All node kind values — matches `GraphNodeKind` in `@cleocode/contracts`.
- * Kept as a const tuple for the Drizzle enum column. Ordering intentional:
- * structural → module → callable → type → value-level → language-specific →
- * graph-level → legacy.
- *
- * @task T11361 (target shape) · T529 (original)
- */
-export const NEXUS_NODE_KINDS = [
-  // Structural
-  'file',
-  'folder',
-  // Module-level
-  'module',
-  'namespace',
-  // Callable
-  'function',
-  'method',
-  'constructor',
-  // Type hierarchy
-  'class',
-  'interface',
-  'struct',
-  'trait',
-  'impl',
-  'type_alias',
-  'enum',
-  // Value-level
-  'property',
-  'constant',
-  'variable',
-  'static',
-  'record',
-  'delegate',
-  // Language-specific constructs
-  'macro',
-  'union',
-  'typedef',
-  'annotation',
-  'template',
-  // Graph-level (synthetic nodes from analysis phases)
-  'community',
-  'process',
-  'route',
-  // External references
-  'tool',
-  'section',
-  // Legacy (kept for T506 compatibility)
-  'import',
-  'export',
-  'type',
-] as const;
-
-/** TypeScript type derived from {@link NEXUS_NODE_KINDS}. */
-export type NexusNodeKind = (typeof NEXUS_NODE_KINDS)[number];
-
-/**
- * `nexus_nodes` — one row per symbol or structural element in the code
- * intelligence graph. Already domain-prefixed.
- *
- * @task T11361 (target shape) · T529 (original)
- */
-export const nexusNodes = sqliteTable(
-  'nexus_nodes',
-  {
-    /** Stable node ID (`<filePath>::<name>` / `<filePath>` / `community:<n>` / `process:<slug>`). */
-    id: text('id').primaryKey(),
-    /** Owning project (soft FK → nexus_project_registry.project_id). */
-    projectId: text('project_id').notNull(),
-    /** Node kind from {@link NEXUS_NODE_KINDS} (E10 §5a — already enum-typed). */
-    kind: text('kind', { enum: NEXUS_NODE_KINDS }).notNull(),
-    /** Human-readable display label. */
-    label: text('label').notNull(),
-    /** Symbol name as it appears in source; NULL for file/folder nodes. */
-    name: text('name'),
-    /** File path relative to project root; NULL for community/process nodes. */
-    filePath: text('file_path'),
-    /** Start line (1-based); NULL for structural nodes. */
-    startLine: integer('start_line'),
-    /** End line (1-based); NULL for structural nodes. */
-    endLine: integer('end_line'),
-    /** Source language (typescript, python, go, rust, …). */
-    language: text('language'),
-    /** Whether the symbol is publicly exported (E10 §3a — typed boolean). */
-    isExported: integer('is_exported', { mode: 'boolean' }).notNull().default(false),
-    /** Parent node id for nested symbols (intra-nexus soft FK → nexus_nodes.id). */
-    parentId: text('parent_id'),
-    /** JSON array of parameter name strings (serialized TEXT). */
-    parametersJson: text('parameters_json'),
-    /** Return-type annotation text. */
-    returnType: text('return_type'),
-    /** First line of the leading TSDoc/JSDoc comment. */
-    docSummary: text('doc_summary'),
-    /** Community membership id (soft FK → the community node's nexus_nodes.id). */
-    communityId: text('community_id'),
-    /** JSON blob for kind-specific metadata (serialized TEXT). */
-    metaJson: text('meta_json'),
-    /** Whether this node is an external/unresolved module (E10 §3a — typed boolean). */
-    isExternal: integer('is_external', { mode: 'boolean' }).notNull().default(false),
-    /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
-    indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
-  },
-  (table) => [
-    index('idx_nexus_nodes_project').on(table.projectId),
-    index('idx_nexus_nodes_kind').on(table.kind),
-    index('idx_nexus_nodes_file').on(table.filePath),
-    index('idx_nexus_nodes_name').on(table.name),
-    index('idx_nexus_nodes_project_kind').on(table.projectId, table.kind),
-    index('idx_nexus_nodes_project_file').on(table.projectId, table.filePath),
-    index('idx_nexus_nodes_community').on(table.communityId),
-    index('idx_nexus_nodes_parent').on(table.parentId),
-    index('idx_nexus_nodes_exported').on(table.isExported),
-    index('idx_nexus_nodes_is_external').on(table.isExternal),
-  ],
-);
-
-/**
- * All relation type values — matches `GraphRelationType` in `@cleocode/contracts`.
- *
- * @task T11361 (target shape) · T529 (original)
- */
-export const NEXUS_RELATION_TYPES = [
-  // Structural
-  'contains',
-  // Definition / usage
-  'defines',
-  'imports',
-  'accesses',
-  // Callable
-  'calls',
-  // Type hierarchy
-  'extends',
-  'implements',
-  'method_overrides',
-  'method_implements',
-  // Class structure
-  'has_method',
-  'has_property',
-  // Graph-level (synthetic, from analysis phases)
-  'member_of',
-  'step_in_process',
-  // Web / API
-  'handles_route',
-  'fetches',
-  // Tool / agent
-  'handles_tool',
-  'entry_point_of',
-  // Wrapping / delegation
-  'wraps',
-  // Data access
-  'queries',
-  // Cross-graph (brain link)
-  'documents',
-  'applies_to',
-  // Plasticity co-access relations (T998)
-  'co_changed',
-  'co_cited_in_task',
-] as const;
-
-/** TypeScript type derived from {@link NEXUS_RELATION_TYPES}. */
-export type NexusRelationType = (typeof NEXUS_RELATION_TYPES)[number];
-
-/**
- * `nexus_relations` — one row per directed graph edge. Already domain-prefixed.
- *
- * @task T11361 (target shape) · T529 (original)
- */
-export const nexusRelations = sqliteTable(
-  'nexus_relations',
-  {
-    /** UUID v4 row identifier. */
-    id: text('id').primaryKey(),
-    /** Owning project (soft FK → nexus_project_registry.project_id). */
-    projectId: text('project_id').notNull(),
-    /** Source node id (intra-nexus soft FK → nexus_nodes.id). */
-    sourceId: text('source_id').notNull(),
-    /** Target node id or raw module specifier (intra-nexus soft FK → nexus_nodes.id). */
-    targetId: text('target_id').notNull(),
-    /** Semantic relation type from {@link NEXUS_RELATION_TYPES} (E10 §5a). */
-    type: text('type', { enum: NEXUS_RELATION_TYPES }).notNull(),
-    /** Extractor confidence [0.0, 1.0]. */
-    confidence: real('confidence').notNull(),
-    /** Human-readable note explaining why this relation was emitted. */
-    reason: text('reason'),
-    /** Step index within an execution flow (for step_in_process relations). */
-    step: integer('step'),
-    /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
-    indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
-    /** Plasticity weight in [0.0, 1.0] (T998 Hebbian co-access strengthening). */
-    weight: real('weight').default(0.0),
-    /** ISO-8601 UTC last co-access strengthening instant; NULL until first strengthen. */
-    lastAccessedAt: text('last_accessed_at'),
-    /** Number of co-access strengthening events. */
-    coAccessedCount: integer('co_accessed_count').default(0),
-  },
-  (table) => [
-    index('idx_nexus_relations_project').on(table.projectId),
-    index('idx_nexus_relations_source').on(table.sourceId),
-    index('idx_nexus_relations_target').on(table.targetId),
-    index('idx_nexus_relations_type').on(table.type),
-    index('idx_nexus_relations_project_type').on(table.projectId, table.type),
-    index('idx_nexus_relations_source_type').on(table.sourceId, table.type),
-    index('idx_nexus_relations_target_type').on(table.targetId, table.type),
-    index('idx_nexus_relations_confidence').on(table.confidence),
-    index('idx_nexus_relations_last_accessed').on(table.lastAccessedAt),
-  ],
-);
-
-/**
- * All contract type values for cross-project API extraction.
- *
- * @task T11361 (target shape) · T1065 (original)
- */
-export const NEXUS_CONTRACT_TYPES = ['http', 'grpc', 'topic'] as const;
-
-/** TypeScript type derived from {@link NEXUS_CONTRACT_TYPES}. */
-export type NexusContractType = (typeof NEXUS_CONTRACT_TYPES)[number];
-
-/**
- * `nexus_contracts` — cross-project HTTP/gRPC/topic contract registry. Already
- * domain-prefixed.
- *
- * @task T11361 (target shape) · T1065 (original)
- */
-export const nexusContracts = sqliteTable(
-  'nexus_contracts',
-  {
-    /** Unique contract id. Primary key. */
-    contractId: text('contract_id').primaryKey(),
-    /** Owning project (soft FK → nexus_project_registry.project_id). */
-    projectId: text('project_id').notNull(),
-    /** Contract type from {@link NEXUS_CONTRACT_TYPES} (E10 §5a). */
-    type: text('type', { enum: NEXUS_CONTRACT_TYPES }).notNull(),
-    /** Path or endpoint identifier. */
-    path: text('path').notNull(),
-    /** HTTP/gRPC method; NULL for topics. */
-    method: text('method'),
-    /** Request schema as JSON string (serialized TEXT). */
-    requestSchemaJson: text('request_schema_json').notNull().default('{}'),
-    /** Response schema as JSON string (serialized TEXT). */
-    responseSchemaJson: text('response_schema_json').notNull().default('{}'),
-    /** Source symbol id (soft FK → nexus_nodes.id). */
-    sourceSymbolId: text('source_symbol_id'),
-    /** Route node id (soft FK → nexus_nodes.id). */
-    routeNodeId: text('route_node_id'),
-    /** Extraction confidence [0..1]. */
-    confidence: real('confidence').notNull().default(1.0),
-    /** Human-readable description. */
-    description: text('description'),
-    /** ISO-8601 UTC creation instant (canonical TEXT, §4). */
-    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
-    /** ISO-8601 UTC last-update instant (canonical TEXT, §4). */
-    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
-  },
-  (table) => [
-    index('idx_nexus_contracts_project').on(table.projectId),
-    index('idx_nexus_contracts_type').on(table.type),
-    index('idx_nexus_contracts_path').on(table.path),
-    index('idx_nexus_contracts_method').on(table.method),
-    index('idx_nexus_contracts_project_type').on(table.projectId, table.type),
-    index('idx_nexus_contracts_source_symbol').on(table.sourceSymbolId),
-    index('idx_nexus_contracts_created').on(table.createdAt),
-  ],
-);
-
-/**
- * `nexus_code_index` — persistent index of code symbols extracted by
- * tree-sitter (one row per symbol per file). Bare `code_index` →
- * `nexus_code_index` under the AC1 idempotent prefixer (the relocated
- * code-intelligence index that lived in `nexus.db` alongside the registry).
- *
- * @task T11361 (target shape) · original `code-index.ts`
- */
-export const nexusCodeIndex = sqliteTable(
-  'nexus_code_index',
-  {
-    /** Stable row identifier (UUID v4). Primary key. */
-    id: text('id').primaryKey(),
-    /** Owning project (soft FK → nexus_project_registry.project_id). */
-    projectId: text('project_id').notNull(),
-    /** Relative file path within the project root. */
-    filePath: text('file_path').notNull(),
-    /** Symbol name as extracted from the AST. */
-    symbolName: text('symbol_name').notNull(),
-    /** Symbol kind from {@link CODE_INDEX_KINDS} (E10 §5b — was bare TEXT). */
-    kind: text('kind', { enum: CODE_INDEX_KINDS }).notNull(),
-    /** Start line in the source file (1-based). */
-    startLine: integer('start_line').notNull(),
-    /** End line in the source file (1-based). */
-    endLine: integer('end_line').notNull(),
-    /** Source language detected from the file extension. */
-    language: text('language').notNull(),
-    /** Whether the symbol has an `export` modifier (E10 §3a — typed boolean). */
-    exported: integer('exported', { mode: 'boolean' }).default(false),
-    /** Parent symbol name for nested declarations; NULL at module scope. */
-    parent: text('parent'),
-    /** Return-type annotation extracted from the declaration. */
-    returnType: text('return_type'),
-    /** First line of the leading JSDoc/docstring comment. */
-    docSummary: text('doc_summary'),
-    /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
-    indexedAt: text('indexed_at').notNull(),
-  },
-  (table) => [
-    index('idx_nexus_code_index_project').on(table.projectId),
-    index('idx_nexus_code_index_file').on(table.filePath),
-    index('idx_nexus_code_index_symbol').on(table.symbolName),
-    index('idx_nexus_code_index_kind').on(table.kind),
-  ],
-);
-
-// ---------------------------------------------------------------------------
 // Global identity / preference layers
 // ---------------------------------------------------------------------------
 
@@ -686,22 +348,6 @@ export type NewNexusAuditLogRow = typeof nexusAuditLog.$inferInsert;
 export type NexusSchemaMetaRow = typeof nexusSchemaMeta.$inferSelect;
 /** Row type for `nexus_schema_meta` INSERT (target shape). */
 export type NewNexusSchemaMetaRow = typeof nexusSchemaMeta.$inferInsert;
-/** Row type for `nexus_nodes` SELECT (target shape). */
-export type NexusNodeRow = typeof nexusNodes.$inferSelect;
-/** Row type for `nexus_nodes` INSERT (target shape). */
-export type NewNexusNodeRow = typeof nexusNodes.$inferInsert;
-/** Row type for `nexus_relations` SELECT (target shape). */
-export type NexusRelationRow = typeof nexusRelations.$inferSelect;
-/** Row type for `nexus_relations` INSERT (target shape). */
-export type NewNexusRelationRow = typeof nexusRelations.$inferInsert;
-/** Row type for `nexus_contracts` SELECT (target shape). */
-export type NexusContractRow = typeof nexusContracts.$inferSelect;
-/** Row type for `nexus_contracts` INSERT (target shape). */
-export type NewNexusContractRow = typeof nexusContracts.$inferInsert;
-/** Row type for `nexus_code_index` SELECT (target shape). */
-export type NexusCodeIndexRow = typeof nexusCodeIndex.$inferSelect;
-/** Row type for `nexus_code_index` INSERT (target shape). */
-export type NewNexusCodeIndexRow = typeof nexusCodeIndex.$inferInsert;
 /** Row type for `nexus_user_profile` SELECT (target shape). */
 export type NexusUserProfileRow = typeof nexusUserProfile.$inferSelect;
 /** Row type for `nexus_user_profile` INSERT (target shape). */


### PR DESCRIPTION
## What (T11539 · ADR-090 nexus graph residency split · saga T11242)

Removes the four nexus **code-graph** tables from GLOBAL scope and finalizes their PROJECT residency in the exodus pipeline. Step 2 of the residency move (T11538 #913 authored the project-scope schema).

### Acceptance criteria
- **AC1/AC2** — `nexus_nodes` / `nexus_relations` / `nexus_contracts` / `nexus_code_index` (+ their in-module enum const arrays `NEXUS_NODE_KINDS`/`NEXUS_RELATION_TYPES`/`NEXUS_CONTRACT_TYPES`/`CODE_INDEX_KINDS` + 8 row-type exports) removed from `packages/core/src/store/schema/cleo-global/nexus.ts`. Nexus GLOBAL table count **10 → 6** (6 registry/identity tables stay GLOBAL per ADR-090 Category B). No external consumer imported these — verified (live runtime uses `schema/nexus-schema.ts`, untouched).
- **AC3** — `exodus/table-name-map.ts` gains `NEXUS_GRAPH_PROJECT_TABLES` + `resolveTableTargetScope()` (the SSoT) routing the four graph tables — extracted from the GLOBAL `nexus.db` source — into **PROJECT** scope.
- **AC4** — `pnpm biome check` + `tsc -b` clean.

## Runtime graph-vs-registry scope split (the "zero new failures" gate)
The exodus splits by `targetScope` per source DB; `nexus.db` is `targetScope: 'global'`. To send only the 4 graph tables to PROJECT scope:
- `resolveTableTargetScope()` is the single SSoT consumed by **both** `migrate.ts` (insert target) and `verify-migration.ts` (verify target) so they never disagree.
- `copyTableFromAttached()` + `detectIsoGlobColumns()` gained a `targetSchema` param (default `'main'`). The global `migrateScope` pass attaches the project consolidated `cleo.db` and schema-qualifies the INSERT + introspection for the 4 cross-scope tables. WAL-safe: the project pass already committed and the project handle is idle, so the cross-attach write is the sole writer.
- Registry/audit access stays GLOBAL (unchanged).

The **live runtime** is unaffected: graph tables are created in the global `cleo.db` by the legacy `drizzle-nexus` migrations (not the consolidated-target Drizzle modules). The `getNexusDb` → `openDualScopeDb('global')` accessor + ADR-036 assert are untouched — the full runtime residency cutover (reading graph from per-project DBs) is the larger E6 follow-up.

## Studio scope=all fan-out — DEFERRED → T11570
`studio/src/routes/api/search/+server.ts` `scope=all` reads the legacy global graph (`WHERE project_id = ?`), which still works at runtime today (graph physically still in global `cleo.db`). The fan-out over `nexus_project_registry` is only needed after the runtime graph physically moves per-project — filed as **T11570** (depends on the E6 runtime cutover, not just this schema+exodus change). Studio is not in the core release path.

## Validation
- `pnpm biome check` ✓ · `tsc -b` ✓ · `node build.mjs` ✓ · CLI runs ✓
- Exodus parity + verify-migration + exodus + consolidated-schema-parity-fk: **95 tests, twice, deterministic** ✓
- `cleo check arch` (5 SG-ARCH-SOLID gates + DB Open Guard) ✓ · `db:check` (Drizzle Kit Schema Check) ✓ · migration linter ✓
- **Fresh-DB nexus smoke**: `cleo init` → "NEXUS registration active"; `cleo nexus status` → `success, nodeCount:0`; `SELECT COUNT(*) FROM nexus_nodes` → `success, n:0`. No "no such table" / no global-assert throw.

## Note for T11545 (weights)
`nexus_relation_weights` (the Hebbian plasticity partition of `nexus_relations`, ADR-090 §5.3) lives in `cleo-project/nexus-graph.ts` and MUST land WITH the move. Until then the plasticity columns (`weight`, `last_accessed_at`, `co_accessed_count`) stay inline on `nexus_relations` in BOTH the old global source (now removed) and the new project-scope module. T11545 owns the JOIN rewrite in `nexus-plasticity.ts` / `plasticity-queries.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)