### PR TITLE
feat(T11545): partition nexus_relation_weights out of nexus_relations (Hebbian hot-path) — residency

### DIFF
--- a/packages/core/migrations/drizzle-cleo-project/20260601000002_t11538-project-nexus-graph/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260601000002_t11538-project-nexus-graph/migration.sql
@@ -1,4 +1,5 @@
--- T11538: Define the PROJECT-scope nexus code-graph schema (ADR-090 — residency step 1).
+-- T11538 + T11545: Define the PROJECT-scope nexus code-graph schema
+-- (ADR-090 — residency step 1 + plasticity partition §5.3).
 --
 -- The four per-project code/knowledge-graph tables (`nexus_nodes`,
 -- `nexus_relations`, `nexus_contracts`, `nexus_code_index`) move from GLOBAL
@@ -8,9 +9,16 @@
 -- move: it mirrors the global T11363 CREATE blocks for these four tables EXACTLY,
 -- minus the redundant `project_id` column (scope is implicit in the owning
 -- project DB, ADR-090 §2.1) and minus every `idx_*_project*` index that led with
--- `project_id`. The plasticity columns (`weight`, `last_accessed_at`,
--- `co_accessed_count`) stay inline on `nexus_relations` until T11545 partitions
--- them into the sibling `nexus_relation_weights` table.
+-- `project_id`.
+--
+-- T11545 (ADR-090 §5.3): the Hebbian plasticity columns (`weight`,
+-- `last_accessed_at`, `co_accessed_count`) are PARTITIONED into the sibling 1:1
+-- `nexus_relation_weights` table (keyed by `relation_id`) rather than living
+-- inline on `nexus_relations`. The consolidated project schema is authored to
+-- its FINAL shape directly here (no inline-then-drop dance — SQLite cannot DROP
+-- a column referenced by a CHECK without a full table rebuild), so this CREATE
+-- omits the three plasticity columns from `nexus_relations` and adds the weights
+-- table below.
 --
 -- CHECK constraints are derived from the schema enum/boolean/timestamp metadata —
 -- byte-identical to scripts/inject-consolidation-checks.mjs (T11363), never
@@ -53,12 +61,19 @@ CREATE TABLE `nexus_relations` (
 	`reason` text,
 	`step` integer,
 	`indexed_at` text DEFAULT (datetime('now')) NOT NULL,
-	`weight` real DEFAULT 0,
-	`last_accessed_at` text,
-	`co_accessed_count` integer DEFAULT 0,
 	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
 	CHECK ("type" IN ('contains', 'defines', 'imports', 'accesses', 'calls', 'extends', 'implements', 'method_overrides', 'method_implements', 'has_method', 'has_property', 'member_of', 'step_in_process', 'handles_route', 'fetches', 'handles_tool', 'entry_point_of', 'wraps', 'queries', 'documents', 'applies_to', 'co_changed', 'co_cited_in_task')),
-	CHECK ("indexed_at" IS NULL OR "indexed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+	CHECK ("indexed_at" IS NULL OR "indexed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+-- T11545 (ADR-090 §5.3): partitioned Hebbian plasticity weights, 1:1 with
+-- nexus_relations.id. relation_id is PK + intra-scope soft FK to nexus_relations.id.
+CREATE TABLE `nexus_relation_weights` (
+	`relation_id` text PRIMARY KEY NOT NULL,
+	`weight` real DEFAULT 0 NOT NULL,
+	`last_accessed_at` text,
+	`co_accessed_count` integer DEFAULT 0 NOT NULL,
+	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
 	CHECK ("last_accessed_at" IS NULL OR "last_accessed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
 );
 --> statement-breakpoint
@@ -113,7 +128,8 @@ CREATE INDEX `idx_nexus_relations_type` ON `nexus_relations` (`type`);--> statem
 CREATE INDEX `idx_nexus_relations_source_type` ON `nexus_relations` (`source_id`,`type`);--> statement-breakpoint
 CREATE INDEX `idx_nexus_relations_target_type` ON `nexus_relations` (`target_id`,`type`);--> statement-breakpoint
 CREATE INDEX `idx_nexus_relations_confidence` ON `nexus_relations` (`confidence`);--> statement-breakpoint
-CREATE INDEX `idx_nexus_relations_last_accessed` ON `nexus_relations` (`last_accessed_at`);--> statement-breakpoint
+CREATE INDEX `idx_nexus_relation_weights_last_accessed` ON `nexus_relation_weights` (`last_accessed_at`);--> statement-breakpoint
+CREATE INDEX `idx_nexus_relation_weights_weight` ON `nexus_relation_weights` (`weight`);--> statement-breakpoint
 CREATE INDEX `idx_nexus_contracts_type` ON `nexus_contracts` (`type`);--> statement-breakpoint
 CREATE INDEX `idx_nexus_contracts_path` ON `nexus_contracts` (`path`);--> statement-breakpoint
 CREATE INDEX `idx_nexus_contracts_method` ON `nexus_contracts` (`method`);--> statement-breakpoint

--- a/packages/core/migrations/drizzle-nexus/20260601000001_t11545-nexus-relation-weights-partition/migration.sql
+++ b/packages/core/migrations/drizzle-nexus/20260601000001_t11545-nexus-relation-weights-partition/migration.sql
@@ -1,0 +1,52 @@
+-- T11545: Partition the Hebbian plasticity columns out of `nexus_relations`
+-- into the sibling 1:1 table `nexus_relation_weights` (ADR-090 §5.3).
+--
+-- The write-heavy plasticity columns (`weight`, `last_accessed_at`,
+-- `co_accessed_count`) added by T998 are moved off the read-mostly structural
+-- graph row so structural queries scan a narrower row and the Hebbian hot path
+-- writes only the sibling table. A relation has at most one weights row, keyed
+-- by `relation_id` (soft FK -> `nexus_relations.id`). Rows are created lazily on
+-- the first co-access strengthening event, so absence == "never strengthened"
+-- (weight 0.0).
+--
+-- Forward migration order:
+--   1. CREATE the sibling table + indexes.
+--   2. Backfill: copy any relation that already carries non-default plasticity
+--      state (weight > 0, a recorded last_accessed_at, or co_accessed_count > 0)
+--      into the new table. Pristine rows are intentionally NOT copied (absence
+--      == weight 0.0), matching the lazy-create semantics.
+--   3. DROP the three legacy columns + the old index from `nexus_relations`.
+--      SQLite ALTER TABLE ... DROP COLUMN requires SQLite >= 3.35 (Node 24's
+--      bundled SQLite is 3.53+).
+--
+-- Legacy DBs where the T998 columns exist hit the backfill + drop path. Fresh
+-- DBs created after T11539's residency move never had the columns inline, but
+-- the backfill SELECT references them; the ensureNexusRelationWeights() safety
+-- net in nexus-sqlite.ts handles the column-absent path idempotently (the
+-- migration chain itself always runs on a DB where the prior T998 migration
+-- already added the columns, so the references resolve).
+CREATE TABLE IF NOT EXISTS `nexus_relation_weights` (
+	`relation_id` text PRIMARY KEY NOT NULL,
+	`weight` real DEFAULT 0.0 NOT NULL,
+	`last_accessed_at` text,
+	`co_accessed_count` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_nexus_relation_weights_last_accessed` ON `nexus_relation_weights` (`last_accessed_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_nexus_relation_weights_weight` ON `nexus_relation_weights` (`weight`);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `nexus_relation_weights` (`relation_id`, `weight`, `last_accessed_at`, `co_accessed_count`)
+SELECT `id`, COALESCE(`weight`, 0.0), `last_accessed_at`, COALESCE(`co_accessed_count`, 0)
+FROM `nexus_relations`
+WHERE COALESCE(`weight`, 0.0) > 0.0
+   OR `last_accessed_at` IS NOT NULL
+   OR COALESCE(`co_accessed_count`, 0) > 0;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_nexus_relations_last_accessed`;
+--> statement-breakpoint
+ALTER TABLE `nexus_relations` DROP COLUMN `weight`;
+--> statement-breakpoint
+ALTER TABLE `nexus_relations` DROP COLUMN `last_accessed_at`;
+--> statement-breakpoint
+ALTER TABLE `nexus_relations` DROP COLUMN `co_accessed_count`;

--- a/packages/core/src/memory/__tests__/nexus-plasticity.test.ts
+++ b/packages/core/src/memory/__tests__/nexus-plasticity.test.ts
@@ -45,8 +45,10 @@ vi.mock('../../store/nexus-sqlite.js', () => ({
 // ===========================================================================
 
 /**
- * Create a minimal in-memory SQLite DB that mimics nexus_relations after the
- * T998 migration (with plasticity columns).
+ * Create a minimal in-memory SQLite DB that mimics the T11545 partitioned shape:
+ * `nexus_relations` (structural, no plasticity columns) plus the sibling 1:1
+ * `nexus_relation_weights` table that carries `weight` / `last_accessed_at` /
+ * `co_accessed_count` (keyed by `relation_id`).
  */
 function createTestNexusDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
@@ -60,17 +62,24 @@ function createTestNexusDb(): DatabaseSync {
       confidence   REAL NOT NULL,
       reason       TEXT,
       step         INTEGER,
-      indexed_at   TEXT DEFAULT (datetime('now')) NOT NULL,
-      weight       REAL DEFAULT 0.0,
-      last_accessed_at TEXT,
-      co_accessed_count INTEGER DEFAULT 0
+      indexed_at   TEXT DEFAULT (datetime('now')) NOT NULL
+    );
+  `);
+  db.exec(`
+    CREATE TABLE nexus_relation_weights (
+      relation_id       TEXT PRIMARY KEY NOT NULL,
+      weight            REAL DEFAULT 0.0 NOT NULL,
+      last_accessed_at  TEXT,
+      co_accessed_count INTEGER DEFAULT 0 NOT NULL
     );
   `);
   return db;
 }
 
 /**
- * Create a DB WITHOUT the plasticity columns — simulates a pre-T998 database.
+ * Create a DB WITHOUT the partitioned weights table — simulates a pre-T11545
+ * database. The plasticity path must no-op gracefully when the sibling table is
+ * absent.
  */
 function createPreMigrationDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
@@ -90,7 +99,11 @@ function createPreMigrationDb(): DatabaseSync {
   return db;
 }
 
-/** Insert a row and return its id. */
+/**
+ * Insert a relation row. When `weight` or `coAccessedCount` are non-default a
+ * matching `nexus_relation_weights` row is also seeded — mirroring the
+ * lazy-create semantic (a pristine edge has no weights row).
+ */
 function insertEdge(
   db: DatabaseSync,
   id: string,
@@ -100,18 +113,36 @@ function insertEdge(
   coAccessedCount = 0,
 ): void {
   db.prepare(`
-    INSERT INTO nexus_relations (id, project_id, source_id, target_id, type, confidence, weight, co_accessed_count)
-    VALUES (?, 'proj-1', ?, ?, 'calls', 0.9, ?, ?)
-  `).run(id, sourceId, targetId, weight, coAccessedCount);
+    INSERT INTO nexus_relations (id, project_id, source_id, target_id, type, confidence)
+    VALUES (?, 'proj-1', ?, ?, 'calls', 0.9)
+  `).run(id, sourceId, targetId);
+  if (weight !== 0.0 || coAccessedCount !== 0) {
+    db.prepare(`
+      INSERT INTO nexus_relation_weights (relation_id, weight, co_accessed_count)
+      VALUES (?, ?, ?)
+    `).run(id, weight, coAccessedCount);
+  }
 }
 
-/** Read back a single row. */
+/**
+ * Read back the plasticity state for an edge via a LEFT JOIN onto the sibling
+ * weights table. An edge with no weights row reports the defaults (weight 0.0,
+ * co_accessed_count 0, last_accessed_at NULL) — identical to the pre-partition
+ * inline-column contract.
+ */
 function readEdge(
   db: DatabaseSync,
   id: string,
 ): { weight: number; co_accessed_count: number; last_accessed_at: string | null } {
   return db
-    .prepare('SELECT weight, co_accessed_count, last_accessed_at FROM nexus_relations WHERE id=?')
+    .prepare(
+      `SELECT COALESCE(w.weight, 0.0) AS weight,
+              COALESCE(w.co_accessed_count, 0) AS co_accessed_count,
+              w.last_accessed_at AS last_accessed_at
+         FROM nexus_relations r
+    LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
+        WHERE r.id = ?`,
+    )
     .get(id) as { weight: number; co_accessed_count: number; last_accessed_at: string | null };
 }
 
@@ -131,18 +162,27 @@ import {
 
 describe('T998 — NEXUS plasticity', () => {
   // -----------------------------------------------------------------------
-  // Test 1 — Schema: columns exist after migration
+  // Test 1 — Schema: T11545 plasticity columns are partitioned out of
+  // nexus_relations into the sibling nexus_relation_weights table.
   // -----------------------------------------------------------------------
-  describe('1. nexus_relations plasticity columns exist after migration', () => {
-    it('should have weight, last_accessed_at, co_accessed_count columns', () => {
+  describe('1. plasticity columns live on the partitioned nexus_relation_weights table', () => {
+    it('partitions weight, last_accessed_at, co_accessed_count off nexus_relations', () => {
       const db = createTestNexusDb();
-      const cols = db.prepare('PRAGMA table_info(nexus_relations)').all() as Array<{
-        name: string;
-      }>;
-      const names = cols.map((c) => c.name);
-      expect(names).toContain('weight');
-      expect(names).toContain('last_accessed_at');
-      expect(names).toContain('co_accessed_count');
+      // The structural relations table no longer carries the plasticity columns.
+      const relNames = (
+        db.prepare('PRAGMA table_info(nexus_relations)').all() as Array<{ name: string }>
+      ).map((c) => c.name);
+      expect(relNames).not.toContain('weight');
+      expect(relNames).not.toContain('last_accessed_at');
+      expect(relNames).not.toContain('co_accessed_count');
+      // The sibling weights table carries them, keyed by relation_id.
+      const wNames = (
+        db.prepare('PRAGMA table_info(nexus_relation_weights)').all() as Array<{ name: string }>
+      ).map((c) => c.name);
+      expect(wNames).toContain('relation_id');
+      expect(wNames).toContain('weight');
+      expect(wNames).toContain('last_accessed_at');
+      expect(wNames).toContain('co_accessed_count');
       db.close();
     });
 
@@ -578,9 +618,10 @@ describe('T998 — NEXUS plasticity', () => {
 
     it('applies decay to edges with last_accessed_at set', async () => {
       insertEdge(db, 'e-decay', 'nodeA', 'nodeB', 0.8, 10);
-      // Set last_accessed_at to a past date (simulating unused edge)
+      // Set last_accessed_at to a past date (simulating unused edge) — T11545:
+      // last_accessed_at now lives on the sibling nexus_relation_weights table.
       db.prepare(
-        "UPDATE nexus_relations SET last_accessed_at = datetime('now', '-7 days') WHERE id = ?",
+        "UPDATE nexus_relation_weights SET last_accessed_at = datetime('now', '-7 days') WHERE relation_id = ?",
       ).run('e-decay');
 
       const result = await applyPlasticityDecay();
@@ -595,7 +636,7 @@ describe('T998 — NEXUS plasticity', () => {
     it('respects CLEO_PLASTICITY_HALFLIFE_DAYS environment variable', async () => {
       insertEdge(db, 'e-env', 'nodeA', 'nodeB', 1.0, 5);
       db.prepare(
-        "UPDATE nexus_relations SET last_accessed_at = datetime('now', '-1 day') WHERE id = ?",
+        "UPDATE nexus_relation_weights SET last_accessed_at = datetime('now', '-1 day') WHERE relation_id = ?",
       ).run('e-env');
 
       // Set custom half-life: 2 days
@@ -618,9 +659,9 @@ describe('T998 — NEXUS plasticity', () => {
 
     it('clamps weight to 0.0 minimum (no negative weights)', async () => {
       insertEdge(db, 'e-clamp', 'nodeA', 'nodeB', 0.01, 5);
-      // Set to very old date (90 days)
+      // Set to very old date (90 days) on the sibling weights table (T11545).
       db.prepare(
-        "UPDATE nexus_relations SET last_accessed_at = datetime('now', '-90 days') WHERE id = ?",
+        "UPDATE nexus_relation_weights SET last_accessed_at = datetime('now', '-90 days') WHERE relation_id = ?",
       ).run('e-clamp');
 
       const result = await applyPlasticityDecay();

--- a/packages/core/src/memory/graph-memory-bridge.ts
+++ b/packages/core/src/memory/graph-memory-bridge.ts
@@ -1336,14 +1336,17 @@ export async function linkConduitMessagesToSymbols(
         label: string;
       }
 
+      // T11545: plasticity weight lives in the sibling nexus_relation_weights
+      // table — join it onto nexus_relations before aggregating per source.
       const topSymbols = typedAll<RawNexusSymbol>(
         nexusNative.prepare(`
           SELECT n.id, n.name, n.label
           FROM nexus_nodes n
           LEFT JOIN (
-            SELECT source_id, SUM(weight) AS total_weight
-            FROM nexus_relations
-            GROUP BY source_id
+            SELECT rel.source_id, SUM(w.weight) AS total_weight
+            FROM nexus_relations rel
+            JOIN nexus_relation_weights w ON w.relation_id = rel.id
+            GROUP BY rel.source_id
           ) r ON n.id = r.source_id
           WHERE n.name IS NOT NULL AND n.name != ''
           AND n.kind NOT IN ('community', 'process', 'folder')

--- a/packages/core/src/memory/nexus-plasticity.ts
+++ b/packages/core/src/memory/nexus-plasticity.ts
@@ -6,11 +6,17 @@
  * nexus_relations gain plasticity weight.  Weight is capped at 1.0 to prevent
  * runaway strengthening.
  *
+ * T11545 (ADR-090 §5.3) partitioned the plasticity columns (`weight`,
+ * `last_accessed_at`, `co_accessed_count`) out of `nexus_relations` into the
+ * sibling 1:1 `nexus_relation_weights` table (keyed by `relation_id`). Writes
+ * here UPSERT that sibling table; rows are created lazily on first strengthen.
+ *
  * Designed as Step 6b in runConsolidation (brain-lifecycle.ts) so every
  * nexus-backed read passively strengthens the code-graph edges that
  * participated in that retrieval.
  *
  * @task T998
+ * @task T11545
  * @epic T991
  */
 
@@ -63,18 +69,24 @@ export interface PlasticityDecayResult {
 /**
  * Strengthen nexus_relations edges for co-accessed node pairs.
  *
- * For each `{sourceId, targetId}` pair, performs:
+ * For each `{sourceId, targetId}` pair, UPSERTs into the partitioned
+ * `nexus_relation_weights` table (T11545 · ADR-090 §5.3) for every matching
+ * `nexus_relations.id`:
  * ```sql
- * UPDATE nexus_relations
- * SET weight          = MIN(1.0, weight + 0.05),
- *     co_accessed_count = co_accessed_count + 1,
- *     last_accessed_at  = datetime('now')
- * WHERE source_id = ? AND target_id = ?
+ * INSERT INTO nexus_relation_weights (relation_id, weight, last_accessed_at, co_accessed_count)
+ * SELECT id, MIN(1.0, 0.05), datetime('now'), 1
+ *   FROM nexus_relations
+ *  WHERE source_id = ? AND target_id = ?
+ * ON CONFLICT(relation_id) DO UPDATE SET
+ *   weight            = MIN(1.0, weight + 0.05),
+ *   co_accessed_count = co_accessed_count + 1,
+ *   last_accessed_at  = excluded.last_accessed_at
  * ```
  *
- * Only updates rows that already exist — never inserts.  This keeps the
- * plasticity pass additive and non-destructive: if a pair does not yet have
- * a code-graph edge, it is silently skipped (recorded in `result.skipped`).
+ * A weights row is created lazily on first strengthen and never for a pair that
+ * has no matching code-graph edge — when the SELECT is empty, zero rows change
+ * and the pair is silently skipped (recorded in `result.skipped`). This keeps
+ * the plasticity pass additive and non-destructive.
  *
  * This function is safe to call from any consolidation context.  It
  * gracefully no-ops when nexus.db has not been initialised (returns zeros).
@@ -100,12 +112,12 @@ export async function strengthenNexusCoAccess(
   const nativeDb = getNexusNativeDb();
   if (!nativeDb) return { strengthened: 0, skipped: 0 };
 
-  // Verify the plasticity columns exist before attempting updates (safety net
-  // for databases that haven't run the T998 migration yet).
+  // Verify the partitioned plasticity table exists before attempting writes
+  // (safety net for databases that haven't run the T11545 migration yet).
   try {
-    nativeDb.prepare('SELECT weight FROM nexus_relations LIMIT 1').get();
+    nativeDb.prepare('SELECT relation_id FROM nexus_relation_weights LIMIT 1').get();
   } catch {
-    // Column not present — migration hasn't run yet.  No-op gracefully.
+    // Table not present — migration hasn't run yet. No-op gracefully.
     return { strengthened: 0, skipped: 0 };
   }
 
@@ -113,12 +125,21 @@ export async function strengthenNexusCoAccess(
   let strengthened = 0;
   let skipped = 0;
 
+  // T11545: weights live in the sibling `nexus_relation_weights` table (1:1 on
+  // relation_id). UPSERT for every relation row matching the pair — rows are
+  // created lazily on first strengthen. INSERT ... SELECT ... ON CONFLICT keeps
+  // the original "never create a phantom edge" semantic: when no relation row
+  // matches the pair, the SELECT is empty, zero rows change, and the pair is
+  // recorded as skipped.
   const stmt = nativeDb.prepare(`
-    UPDATE nexus_relations
-    SET weight            = MIN(1.0, COALESCE(weight, 0.0) + ${WEIGHT_INCREMENT}),
-        co_accessed_count = COALESCE(co_accessed_count, 0) + 1,
-        last_accessed_at  = ?
-    WHERE source_id = ? AND target_id = ?
+    INSERT INTO nexus_relation_weights (relation_id, weight, last_accessed_at, co_accessed_count)
+    SELECT id, MIN(1.0, ${WEIGHT_INCREMENT}), ?, 1
+      FROM nexus_relations
+     WHERE source_id = ? AND target_id = ?
+    ON CONFLICT(relation_id) DO UPDATE SET
+      weight            = MIN(1.0, nexus_relation_weights.weight + ${WEIGHT_INCREMENT}),
+      co_accessed_count = nexus_relation_weights.co_accessed_count + 1,
+      last_accessed_at  = excluded.last_accessed_at
   `);
 
   for (const pair of pairs) {
@@ -200,11 +221,11 @@ export async function applyPlasticityDecay(): Promise<PlasticityDecayResult> {
   // This ensures weight = weight * 0.5 after halfLifeDays of decay.
   const decayPerDay = 1 - 0.5 ** (1 / halfLifeDays);
 
-  // Verify the plasticity columns exist before attempting updates.
+  // Verify the partitioned plasticity table exists before attempting updates.
   try {
-    nativeDb.prepare('SELECT weight, last_accessed_at FROM nexus_relations LIMIT 1').get();
+    nativeDb.prepare('SELECT weight, last_accessed_at FROM nexus_relation_weights LIMIT 1').get();
   } catch {
-    // Columns not present — migration hasn't run yet. No-op gracefully.
+    // Table not present — migration hasn't run yet. No-op gracefully.
     return {
       updated: 0,
       halfLifeDays,
@@ -212,12 +233,13 @@ export async function applyPlasticityDecay(): Promise<PlasticityDecayResult> {
     };
   }
 
+  // T11545: decay operates on the partitioned `nexus_relation_weights` table.
   // Apply decay to all edges with a non-NULL last_accessed_at.
   // SQLite's julianday('now') - julianday(last_accessed_at) gives days since access.
   // decay_factor = 0.5 ^ (days / halfLifeDays) = 2 ^ (-days / halfLifeDays)
   // This is implemented as: weight * EXP(LN(0.5) * julianday(...) / halfLifeDays)
   const stmt = nativeDb.prepare(`
-    UPDATE nexus_relations
+    UPDATE nexus_relation_weights
     SET weight = MAX(0.0, weight * EXP(LN(0.5) * (julianday('now') - julianday(last_accessed_at)) / ?))
     WHERE last_accessed_at IS NOT NULL AND weight > 0.001
   `);

--- a/packages/core/src/nexus/__tests__/living-brain.test.ts
+++ b/packages/core/src/nexus/__tests__/living-brain.test.ts
@@ -68,14 +68,21 @@ async function seedNexusData(nexusNative: ReturnType<typeof getNexusNativeDb>) {
       1,
     );
 
-  // Insert a calls relation: callerFunction -> testFunction
+  // Insert a calls relation: callerFunction -> testFunction.
+  // T11545: plasticity weight lives in the sibling nexus_relation_weights table.
   nexusNative
     .prepare(
       `INSERT OR IGNORE INTO nexus_relations
-       (id, project_id, source_id, target_id, type, confidence, weight)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+       (id, project_id, source_id, target_id, type, confidence)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     )
-    .run('rel-001', 'test-project', CALLER_ID, SYMBOL_ID, 'calls', 0.9, 2.0);
+    .run('rel-001', 'test-project', CALLER_ID, SYMBOL_ID, 'calls', 0.9);
+  nexusNative
+    .prepare(
+      `INSERT OR IGNORE INTO nexus_relation_weights (relation_id, weight, co_accessed_count)
+       VALUES (?, ?, ?)`,
+    )
+    .run('rel-001', 2.0, 1);
 }
 
 async function seedBrainData(brainNative: ReturnType<typeof getBrainNativeDb>) {

--- a/packages/core/src/nexus/impact.ts
+++ b/packages/core/src/nexus/impact.ts
@@ -136,13 +136,27 @@ export async function getSymbolImpact(
   }
 
   // Fetch project-scoped relations filtered by projectId and BFS-relevant types.
+  // T11545: plasticity `weight` lives in the sibling `nexus_relation_weights`
+  // table — LEFT JOIN it and flatten so downstream reads `r['weight']` (NULL
+  // when the edge has never been strengthened).
   let allRelations: Array<Record<string, unknown>> = [];
   try {
-    allRelations = db
+    const joined = db
       .select()
       .from(nexusSchema.nexusRelations)
+      .leftJoin(
+        nexusSchema.nexusRelationWeights,
+        eq(nexusSchema.nexusRelationWeights.relationId, nexusSchema.nexusRelations.id),
+      )
       .where(eq(nexusSchema.nexusRelations.projectId, projectId))
-      .all() as Array<Record<string, unknown>>;
+      .all() as Array<{
+      nexus_relations: Record<string, unknown>;
+      nexus_relation_weights: Record<string, unknown> | null;
+    }>;
+    allRelations = joined.map((row) => ({
+      ...row.nexus_relations,
+      weight: row.nexus_relation_weights?.['weight'] ?? null,
+    }));
   } catch {
     allRelations = [];
   }
@@ -337,12 +351,15 @@ export async function nexusImpact(
       });
     }
 
+    // T11545: plasticity weight lives in the sibling `nexus_relation_weights`
+    // table (LEFT JOIN — edges never strengthened have no weights row → NULL).
     const allRelations = db
       .prepare(
-        `SELECT source_id, target_id, type, weight
-           FROM nexus_relations
-          WHERE project_id = ?
-            AND type IN ('calls','imports','accesses')`,
+        `SELECT r.source_id AS source_id, r.target_id AS target_id, r.type AS type, w.weight AS weight
+           FROM nexus_relations r
+      LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
+          WHERE r.project_id = ?
+            AND r.type IN ('calls','imports','accesses')`,
       )
       .all(projectId || '') as Array<{
       source_id: string;

--- a/packages/core/src/nexus/living-brain.ts
+++ b/packages/core/src/nexus/living-brain.ts
@@ -67,7 +67,6 @@ interface RawNexusRelation {
   source_id: string;
   target_id: string;
   type: string;
-  weight: number | null;
 }
 
 interface RawBrainEdge {
@@ -203,10 +202,11 @@ export async function getSymbolFullContext(
       if (symbolNode) {
         resolvedSymbolId = symbolNode.id;
 
-        // Callers: relations where target_id = symbolNode.id
+        // Callers: relations where target_id = symbolNode.id.
+        // T11545: `weight` is no longer on nexus_relations and is unused here.
         const callerRelations = typedAll<RawNexusRelation>(
           nexusNative.prepare(
-            `SELECT r.source_id, r.target_id, r.type, r.weight
+            `SELECT r.source_id, r.target_id, r.type
              FROM nexus_relations r
              WHERE r.target_id = ?
                AND r.type IN ('calls', 'imports', 'accesses')
@@ -231,10 +231,11 @@ export async function getSymbolFullContext(
           };
         });
 
-        // Callees: relations where source_id = symbolNode.id
+        // Callees: relations where source_id = symbolNode.id.
+        // T11545: `weight` is no longer on nexus_relations and is unused here.
         const calleeRelations = typedAll<RawNexusRelation>(
           nexusNative.prepare(
-            `SELECT r.source_id, r.target_id, r.type, r.weight
+            `SELECT r.source_id, r.target_id, r.type
              FROM nexus_relations r
              WHERE r.source_id = ?
                AND r.type IN ('calls', 'imports', 'accesses')
@@ -281,14 +282,17 @@ export async function getSymbolFullContext(
           processes,
         };
 
-        // Plasticity: SUM of edge weights in nexus_relations
+        // Plasticity: SUM of edge weights — T11545 moved them to the sibling
+        // `nexus_relation_weights` table (LEFT JOIN; default 1.0 when an edge
+        // has no weights row, preserving the prior COALESCE(weight, 1.0) value).
         const plasticityRow = typedGet<{ total_weight: number | null; edge_count: number }>(
           nexusNative.prepare(
             `SELECT
-               SUM(COALESCE(weight, 1.0)) as total_weight,
+               SUM(COALESCE(w.weight, 1.0)) as total_weight,
                COUNT(*) as edge_count
-             FROM nexus_relations
-             WHERE source_id = ? OR target_id = ?`,
+             FROM nexus_relations r
+             LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
+             WHERE r.source_id = ? OR r.target_id = ?`,
           ),
           symbolNode.id,
           symbolNode.id,
@@ -617,16 +621,17 @@ export async function getTaskCodeImpact(
           ),
         );
 
+        // T11545: `weight` moved to the sibling nexus_relation_weights table and
+        // is unused by the GraphRelation mapping below — select only structural cols.
         const allRelations = typedAll<{
           id: string;
           source_id: string;
           target_id: string;
           type: string;
           confidence: number | null;
-          weight: number | null;
         }>(
           nexusNative.prepare(
-            `SELECT id, source_id, target_id, type, confidence, weight FROM nexus_relations LIMIT 200000`,
+            `SELECT id, source_id, target_id, type, confidence FROM nexus_relations LIMIT 200000`,
           ),
         );
 
@@ -1023,16 +1028,17 @@ export async function reasonImpactOfChange(
         ),
       );
 
+      // T11545: `weight` moved to the sibling nexus_relation_weights table and is
+      // unused by the GraphRelation mapping below — select only structural cols.
       const allRelations = typedAll<{
         id: string;
         source_id: string;
         target_id: string;
         type: string;
         confidence: number | null;
-        weight: number | null;
       }>(
         nexusNative.prepare(
-          `SELECT id, source_id, target_id, type, confidence, weight FROM nexus_relations LIMIT 200000`,
+          `SELECT id, source_id, target_id, type, confidence FROM nexus_relations LIMIT 200000`,
         ),
       );
 

--- a/packages/core/src/nexus/plasticity-queries.ts
+++ b/packages/core/src/nexus/plasticity-queries.ts
@@ -1,8 +1,10 @@
 /**
  * NEXUS plasticity queries (T1013 · fills wiring gap from T998 + T1006).
  *
- * Read-only queries over the plasticity columns that T998 added to
- * `nexus_relations` (`weight`, `last_accessed_at`, `co_accessed_count`).
+ * Read-only queries over the plasticity columns (`weight`, `last_accessed_at`,
+ * `co_accessed_count`) — added by T998 and partitioned by T11545 (ADR-090 §5.3)
+ * into the sibling `nexus_relation_weights` table (1:1 on `relation_id`). These
+ * queries JOIN that table back onto `nexus_relations`.
  *
  * - `getHotPaths`   — top-N relations by weight (strongest paths).
  * - `getHotNodes`   — top-N source symbols aggregated by weight (busiest hubs).
@@ -136,16 +138,19 @@ export async function getHotPaths(_projectRoot: string, limit = 20): Promise<Nex
   if (!db) {
     return emptyResult('paths', 'nexus database not initialised');
   }
+  // T11545: weights live in the sibling `nexus_relation_weights` table. INNER
+  // JOIN restricts to edges that have a weights row (i.e. have been strengthened).
   const stmt = sql`
-    SELECT source_id AS sourceId,
-           target_id AS targetId,
-           type AS type,
-           COALESCE(weight, 0.0) AS weight,
-           last_accessed_at AS lastAccessedAt,
-           COALESCE(co_accessed_count, 0) AS coAccessedCount
-      FROM nexus_relations
-     WHERE COALESCE(weight, 0.0) > 0.0
-  ORDER BY weight DESC
+    SELECT r.source_id AS sourceId,
+           r.target_id AS targetId,
+           r.type AS type,
+           COALESCE(w.weight, 0.0) AS weight,
+           w.last_accessed_at AS lastAccessedAt,
+           COALESCE(w.co_accessed_count, 0) AS coAccessedCount
+      FROM nexus_relations r
+      JOIN nexus_relation_weights w ON w.relation_id = r.id
+     WHERE COALESCE(w.weight, 0.0) > 0.0
+  ORDER BY w.weight DESC
      LIMIT ${limit}
   `;
   const rows = (await db.all(stmt)) as RawPathRow[];
@@ -173,16 +178,19 @@ export async function getHotNodes(_projectRoot: string, limit = 20): Promise<Nex
   if (!db) {
     return emptyResult('nodes', 'nexus database not initialised');
   }
+  // T11545: aggregate weights from the sibling `nexus_relation_weights` table.
+  // INNER JOIN restricts to strengthened edges (those with a weights row).
   const stmt = sql`
     SELECT r.source_id AS sourceId,
            COALESCE(n.label, r.source_id) AS label,
            n.file_path AS filePath,
            COALESCE(n.kind, 'unknown') AS kind,
-           SUM(COALESCE(r.weight, 0.0)) AS totalWeight,
+           SUM(COALESCE(w.weight, 0.0)) AS totalWeight,
            COUNT(*) AS pathCount
       FROM nexus_relations r
+      JOIN nexus_relation_weights w ON w.relation_id = r.id
  LEFT JOIN nexus_nodes n ON n.id = r.source_id
-     WHERE COALESCE(r.weight, 0.0) > 0.0
+     WHERE COALESCE(w.weight, 0.0) > 0.0
   GROUP BY r.source_id, n.label, n.file_path, n.kind
   ORDER BY totalWeight DESC
      LIMIT ${limit}
@@ -220,15 +228,19 @@ export async function getColdSymbols(
   // Cold = weak (maxWeight < 0.1) AND (never accessed OR older than cutoff).
   // thresholdDays=0 special-cases "any unaccessed symbol" — the cutoff is now
   // and we keep the NULL-allowed branch.
+  // T11545: cold = weak (maxWeight < 0.1) OR never strengthened (no weights
+  // row). LEFT JOIN the sibling `nexus_relation_weights` so edges without a
+  // weights row contribute weight 0.0 and last_accessed_at NULL.
   const stmt = sql`
     SELECT r.source_id AS sourceId,
            COALESCE(n.label, r.source_id) AS label,
            n.file_path AS filePath,
            COALESCE(n.kind, 'unknown') AS kind,
-           MAX(r.last_accessed_at) AS lastAccessedAt,
+           MAX(w.last_accessed_at) AS lastAccessedAt,
            COUNT(*) AS pathCount,
-           MAX(COALESCE(r.weight, 0.0)) AS maxWeight
+           MAX(COALESCE(w.weight, 0.0)) AS maxWeight
       FROM nexus_relations r
+ LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
  LEFT JOIN nexus_nodes n ON n.id = r.source_id
   GROUP BY r.source_id, n.label, n.file_path, n.kind
     HAVING maxWeight < 0.1

--- a/packages/core/src/nexus/query.ts
+++ b/packages/core/src/nexus/query.ts
@@ -371,26 +371,30 @@ export async function nexusTopEntries(params?: {
 
     try {
       const kind = params?.kind ? String(params.kind) : null;
+      // T11545: plasticity `weight` lives in the sibling `nexus_relation_weights`
+      // table — LEFT JOIN it (edges with no weights row contribute weight 0).
       const sql =
         kind === null
           ? `SELECT r.source_id,
-                    SUM(COALESCE(r.weight, 0)) AS totalWeight,
+                    SUM(COALESCE(w.weight, 0)) AS totalWeight,
                     COUNT(*)                   AS edgeCount,
                     n.label,
                     n.kind,
                     n.file_path
                FROM nexus_relations r
+               LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
                LEFT JOIN nexus_nodes n ON n.id = r.source_id
               GROUP BY r.source_id
               ORDER BY totalWeight DESC, edgeCount DESC
               LIMIT ?`
           : `SELECT r.source_id,
-                    SUM(COALESCE(r.weight, 0)) AS totalWeight,
+                    SUM(COALESCE(w.weight, 0)) AS totalWeight,
                     COUNT(*)                   AS edgeCount,
                     n.label,
                     n.kind,
                     n.file_path
                FROM nexus_relations r
+               LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
                LEFT JOIN nexus_nodes n ON n.id = r.source_id
               WHERE n.kind = ?
               GROUP BY r.source_id

--- a/packages/core/src/store/__tests__/migration-fresh-no-repair.nexus.test.ts
+++ b/packages/core/src/store/__tests__/migration-fresh-no-repair.nexus.test.ts
@@ -10,7 +10,9 @@
  *   3. Asserting that NO captured message contains "Adding missing column".
  *   4. Verifying via PRAGMA table_info that:
  *      - nexus_nodes contains `is_external`
- *      - nexus_relations contains `weight`, `last_accessed_at`, `co_accessed_count`
+ *      - nexus_relations NO LONGER carries the plasticity columns and the sibling
+ *        `nexus_relation_weights` table holds `weight`, `last_accessed_at`,
+ *        `co_accessed_count` (T11545 · ADR-090 §5.3 partition)
  *
  * If the "Adding missing column" warning reappears on a fresh DB it means a new
  * column was added to ensureColumns() without a corresponding forward migration —
@@ -145,14 +147,25 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
         const nodesColNames = nodesCols.map((c) => c.name);
         expect(nodesColNames).toContain('is_external');
 
-        // nexus_relations must have the three plasticity columns (T998 migration).
+        // T11545 (ADR-090 §5.3): the three plasticity columns are partitioned
+        // OUT of nexus_relations into the sibling nexus_relation_weights table.
         const relCols = nativeDb.prepare('PRAGMA table_info(nexus_relations)').all() as Array<{
           name: string;
         }>;
         const relColNames = relCols.map((c) => c.name);
-        expect(relColNames).toContain('weight');
-        expect(relColNames).toContain('last_accessed_at');
-        expect(relColNames).toContain('co_accessed_count');
+        expect(relColNames).not.toContain('weight');
+        expect(relColNames).not.toContain('last_accessed_at');
+        expect(relColNames).not.toContain('co_accessed_count');
+
+        // The sibling weights table exists and carries the partitioned columns.
+        const weightCols = nativeDb
+          .prepare('PRAGMA table_info(nexus_relation_weights)')
+          .all() as Array<{ name: string }>;
+        const weightColNames = weightCols.map((c) => c.name);
+        expect(weightColNames).toContain('relation_id');
+        expect(weightColNames).toContain('weight');
+        expect(weightColNames).toContain('last_accessed_at');
+        expect(weightColNames).toContain('co_accessed_count');
       } finally {
         nativeDb.close();
       }

--- a/packages/core/src/store/exodus/table-name-map.ts
+++ b/packages/core/src/store/exodus/table-name-map.ts
@@ -254,6 +254,8 @@ const NEXUS_DB_MAP: ReadonlyMap<string, string> = new Map([
   ['nexus_audit_log', 'nexus_audit_log'],
   ['nexus_nodes', 'nexus_nodes'],
   ['nexus_relations', 'nexus_relations'],
+  // T11545: partitioned Hebbian plasticity weights (1:1 with nexus_relations).
+  ['nexus_relation_weights', 'nexus_relation_weights'],
   ['nexus_contracts', 'nexus_contracts'],
   // schema_meta tables created by consolidated schema bootstrap
   ['nexus_schema_meta', 'nexus_schema_meta'],

--- a/packages/core/src/store/nexus-sqlite.ts
+++ b/packages/core/src/store/nexus-sqlite.ts
@@ -378,6 +378,60 @@ function ensureNexusFts5(nativeDb: DatabaseSync): void {
 }
 
 /**
+ * Idempotent safety net for `nexus_relation_weights` (T11545 · ADR-090 §5.3).
+ *
+ * The Hebbian plasticity columns were partitioned out of `nexus_relations` into
+ * this sibling 1:1 table. This safety net mirrors the prior T998 `ensureColumns`
+ * band-aid: it CREATEs the table (+ indexes) on existing nexus instances that
+ * predate the T11545 drizzle migration, and — when the legacy inline columns are
+ * still present on `nexus_relations` (pre-partition DBs whose migration chain has
+ * not yet reached T11545) — backfills any non-default plasticity state so the
+ * accessor never loses weights. Every statement is guarded; safe to re-run.
+ *
+ * @task T11545
+ */
+function ensureNexusRelationWeights(nativeDb: DatabaseSync): void {
+  // Only meaningful once the parent graph table exists.
+  if (!tableExists(nativeDb, 'nexus_relations')) return;
+
+  const alreadyExists = tableExists(nativeDb, 'nexus_relation_weights');
+
+  nativeDb.exec(`
+    CREATE TABLE IF NOT EXISTS nexus_relation_weights (
+      relation_id       TEXT PRIMARY KEY NOT NULL,
+      weight            REAL DEFAULT 0.0 NOT NULL,
+      last_accessed_at  TEXT,
+      co_accessed_count INTEGER DEFAULT 0 NOT NULL
+    )
+  `);
+  nativeDb.exec(
+    `CREATE INDEX IF NOT EXISTS idx_nexus_relation_weights_last_accessed ON nexus_relation_weights (last_accessed_at)`,
+  );
+  nativeDb.exec(
+    `CREATE INDEX IF NOT EXISTS idx_nexus_relation_weights_weight ON nexus_relation_weights (weight)`,
+  );
+
+  // Backfill from the legacy inline columns IFF they are still present and this
+  // is the first time the sibling table is created (avoids clobbering rows the
+  // running accessor may have written since the partition migration).
+  if (alreadyExists) return;
+  const relCols = nativeDb.prepare('PRAGMA table_info(nexus_relations)').all() as Array<{
+    name: string;
+  }>;
+  const hasInlinePlasticity = relCols.some((c) => c.name === 'weight');
+  if (!hasInlinePlasticity) return;
+
+  nativeDb.exec(`
+    INSERT OR IGNORE INTO nexus_relation_weights (relation_id, weight, last_accessed_at, co_accessed_count)
+    SELECT id, COALESCE(weight, 0.0), last_accessed_at, COALESCE(co_accessed_count, 0)
+      FROM nexus_relations
+     WHERE COALESCE(weight, 0.0) > 0.0
+        OR last_accessed_at IS NOT NULL
+        OR COALESCE(co_accessed_count, 0) > 0
+  `);
+}
+
+/**
  * Run drizzle migrations to create/update the legacy nexus tables inside the
  * consolidated GLOBAL `cleo.db`.
  *
@@ -424,19 +478,11 @@ function runNexusMigrations(
     }
   }
 
-  // T998: idempotent safety net for plasticity columns — covers pre-migration
-  // nexus instances that were created before the drizzle migration runs.
-  // ensureColumns is a no-op when the columns already exist.
-  ensureColumns(
-    nativeDb,
-    'nexus_relations',
-    [
-      { name: 'weight', ddl: 'real DEFAULT 0.0' },
-      { name: 'last_accessed_at', ddl: 'text' },
-      { name: 'co_accessed_count', ddl: 'integer DEFAULT 0' },
-    ],
-    'nexus',
-  );
+  // T11545: idempotent safety net for the partitioned plasticity table —
+  // covers pre-migration nexus instances created before the T11545 migration
+  // runs (it CREATEs the sibling table + backfills any legacy inline columns).
+  // No-op when the table already exists.
+  ensureNexusRelationWeights(nativeDb);
 
   // T1062: idempotent safety net for external module nodes — covers pre-migration
   // nexus instances that were created before the drizzle migration runs.

--- a/packages/core/src/store/schema/cleo-project/nexus-graph.ts
+++ b/packages/core/src/store/schema/cleo-project/nexus-graph.ts
@@ -291,11 +291,10 @@ export const nexusNodes = sqliteTable(
 /**
  * `nexus_relations` — one row per directed graph edge. PROJECT-scope:
  * `project_id` dropped (ADR-090 §2.1). The Hebbian plasticity columns
- * (`weight`, `last_accessed_at`, `co_accessed_count`) remain inline here until
- * T11545 partitions them into the sibling `nexus_relation_weights` table
- * (ADR-090 §5.3) — out of scope for T11538.
+ * (`weight`, `last_accessed_at`, `co_accessed_count`) were PARTITIONED out into
+ * the sibling {@link nexusRelationWeights} table by T11545 (ADR-090 §5.3).
  *
- * @task T11538 (project-scope target shape) · T11361 (global source) · T529 (original)
+ * @task T11545 (plasticity partition) · T11538 (project-scope target shape) · T11361 (global source) · T529 (original)
  */
 export const nexusRelations = sqliteTable(
   'nexus_relations',
@@ -316,12 +315,9 @@ export const nexusRelations = sqliteTable(
     step: integer('step'),
     /** ISO-8601 UTC last-indexed instant (canonical TEXT, §4). */
     indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
-    /** Plasticity weight in [0.0, 1.0] (T998 Hebbian co-access strengthening). */
-    weight: real('weight').default(0.0),
-    /** ISO-8601 UTC last co-access strengthening instant; NULL until first strengthen. */
-    lastAccessedAt: text('last_accessed_at'),
-    /** Number of co-access strengthening events. */
-    coAccessedCount: integer('co_accessed_count').default(0),
+    // T998 plasticity columns (`weight`, `last_accessed_at`, `co_accessed_count`)
+    // PARTITIONED out into the sibling `nexus_relation_weights` table by T11545
+    // (ADR-090 §5.3). See {@link nexusRelationWeights}.
   },
   (table) => [
     index('idx_nexus_relations_source').on(table.sourceId),
@@ -330,7 +326,41 @@ export const nexusRelations = sqliteTable(
     index('idx_nexus_relations_source_type').on(table.sourceId, table.type),
     index('idx_nexus_relations_target_type').on(table.targetId, table.type),
     index('idx_nexus_relations_confidence').on(table.confidence),
-    index('idx_nexus_relations_last_accessed').on(table.lastAccessedAt),
+  ],
+);
+
+/**
+ * `nexus_relation_weights` — plasticity weights for `nexus_relations` edges
+ * (Hebbian co-access, T998). PROJECT-scope sibling 1:1 table keyed by
+ * `relation_id`, partitioned out of `nexus_relations` by T11545 (ADR-090 §5.3)
+ * to keep the read-mostly structural graph row narrow and isolate the
+ * write-heavy plasticity hot path.
+ *
+ * A relation has at most one weights row; rows are created lazily on the first
+ * co-access strengthening event (UPSERT in `nexus-plasticity.ts`), so absence
+ * means "never strengthened" (treat as weight 0.0). `relation_id` is an
+ * intra-scope soft FK to `nexus_relations.id` (symmetric with the graph's
+ * soft-FK convention — no DB-level FK). Move-safe (no absolute paths, no
+ * cross-scope refs) per ADR-090 §4.
+ *
+ * @task T11545 (project-scope target shape) · T998 (original plasticity columns)
+ * @epic T11535
+ */
+export const nexusRelationWeights = sqliteTable(
+  'nexus_relation_weights',
+  {
+    /** Soft FK → `nexus_relations.id` (intra-scope). Primary key (1:1). */
+    relationId: text('relation_id').primaryKey(),
+    /** Plasticity weight in [0.0, 1.0] (T998 Hebbian co-access strengthening). */
+    weight: real('weight').notNull().default(0.0),
+    /** ISO-8601 UTC last co-access strengthening instant; NULL until first strengthen. */
+    lastAccessedAt: text('last_accessed_at'),
+    /** Number of co-access strengthening events. */
+    coAccessedCount: integer('co_accessed_count').notNull().default(0),
+  },
+  (table) => [
+    index('idx_nexus_relation_weights_last_accessed').on(table.lastAccessedAt),
+    index('idx_nexus_relation_weights_weight').on(table.weight),
   ],
 );
 
@@ -429,6 +459,10 @@ export type NewNexusNodeRow = typeof nexusNodes.$inferInsert;
 export type NexusRelationRow = typeof nexusRelations.$inferSelect;
 /** Row type for `nexus_relations` INSERT operations (project-scope target shape). */
 export type NewNexusRelationRow = typeof nexusRelations.$inferInsert;
+/** Row type for `nexus_relation_weights` SELECT queries (project-scope target shape). */
+export type NexusRelationWeightRow = typeof nexusRelationWeights.$inferSelect;
+/** Row type for `nexus_relation_weights` INSERT operations (project-scope target shape). */
+export type NewNexusRelationWeightRow = typeof nexusRelationWeights.$inferInsert;
 /** Row type for `nexus_contracts` SELECT queries (project-scope target shape). */
 export type NexusContractRow = typeof nexusContracts.$inferSelect;
 /** Row type for `nexus_contracts` INSERT operations (project-scope target shape). */

--- a/packages/core/src/store/schema/nexus-schema.ts
+++ b/packages/core/src/store/schema/nexus-schema.ts
@@ -390,14 +390,10 @@ export const nexusRelations = sqliteTable(
     /** ISO 8601 timestamp when this relation was last indexed. */
     indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
 
-    // T998: Plasticity columns for Hebbian co-access strengthening.
-    // Edges strengthen over time as nodes are accessed together during retrieval.
-    /** Plasticity weight in [0.0, 1.0]. Starts at 0.0; increments 0.05 per co-access; capped at 1.0. */
-    weight: real('weight').default(0.0),
-    /** ISO 8601 timestamp of the last co-access strengthening event. NULL until first strengthen. */
-    lastAccessedAt: text('last_accessed_at'),
-    /** Number of times this edge has been co-access strengthened. */
-    coAccessedCount: integer('co_accessed_count').default(0),
+    // T998 plasticity columns (`weight`, `last_accessed_at`, `co_accessed_count`)
+    // were PARTITIONED out into the sibling `nexus_relation_weights` table by
+    // T11545 (ADR-090 §5.3) to keep the read-mostly structural graph row narrow
+    // and isolate the write-heavy Hebbian hot path. See {@link nexusRelationWeights}.
   },
   (table) => [
     index('idx_nexus_relations_project').on(table.projectId),
@@ -408,8 +404,46 @@ export const nexusRelations = sqliteTable(
     index('idx_nexus_relations_source_type').on(table.sourceId, table.type),
     index('idx_nexus_relations_target_type').on(table.targetId, table.type),
     index('idx_nexus_relations_confidence').on(table.confidence),
-    // T998: index for plasticity decay queries and temporal access tracking
-    index('idx_nexus_relations_last_accessed').on(table.lastAccessedAt),
+  ],
+);
+
+// === NEXUS_RELATION_WEIGHTS TABLE (T11545 · ADR-090 §5.3) ===
+
+/**
+ * Plasticity weights for `nexus_relations` edges — Hebbian co-access (T998).
+ *
+ * Partitioned out of `nexus_relations` by T11545 (ADR-090 §5.3): the
+ * write-heavy plasticity columns (`weight`, `last_accessed_at`,
+ * `co_accessed_count`) live in this sibling 1:1 table keyed by `relation_id`,
+ * keeping the read-mostly structural graph row narrow. A relation has at most
+ * one weights row; rows are created lazily on the first co-access strengthening
+ * event (UPSERT in `nexus-plasticity.ts`), so absence means "never strengthened"
+ * (treat as weight 0.0).
+ *
+ * `relation_id` is an intra-scope soft FK to `nexus_relations.id` (no DB-level
+ * FK — symmetric with the rest of the graph's soft-FK convention).
+ *
+ * @task T11545
+ * @task T998
+ * @epic T11535
+ */
+export const nexusRelationWeights = sqliteTable(
+  'nexus_relation_weights',
+  {
+    /** Soft FK → `nexus_relations.id` (intra-scope). Primary key (1:1). */
+    relationId: text('relation_id').primaryKey(),
+    /** Plasticity weight in [0.0, 1.0]. Starts at 0.0; increments 0.05 per co-access; capped at 1.0. */
+    weight: real('weight').notNull().default(0.0),
+    /** ISO 8601 timestamp of the last co-access strengthening event. NULL until first strengthen. */
+    lastAccessedAt: text('last_accessed_at'),
+    /** Number of times this edge has been co-access strengthened. */
+    coAccessedCount: integer('co_accessed_count').notNull().default(0),
+  },
+  (table) => [
+    // Index for plasticity decay queries and temporal access tracking.
+    index('idx_nexus_relation_weights_last_accessed').on(table.lastAccessedAt),
+    // Index for hot-path queries ordering by weight DESC.
+    index('idx_nexus_relation_weights_weight').on(table.weight),
   ],
 );
 
@@ -654,6 +688,8 @@ export type NexusNodeRow = typeof nexusNodes.$inferSelect;
 export type NewNexusNodeRow = typeof nexusNodes.$inferInsert;
 export type NexusRelationRow = typeof nexusRelations.$inferSelect;
 export type NewNexusRelationRow = typeof nexusRelations.$inferInsert;
+export type NexusRelationWeightRow = typeof nexusRelationWeights.$inferSelect;
+export type NewNexusRelationWeightRow = typeof nexusRelationWeights.$inferInsert;
 export type NexusContractRow = typeof nexusContracts.$inferSelect;
 export type NewNexusContractRow = typeof nexusContracts.$inferInsert;
 export type UserProfileRow = typeof userProfile.$inferSelect;


### PR DESCRIPTION
## T11545 — last residency schema task (ADR-090 §5.3)

Partitions the write-heavy Hebbian plasticity columns (\`weight\`, \`last_accessed_at\`, \`co_accessed_count\`) out of the read-mostly structural \`nexus_relations\` row into a sibling 1:1 table \`nexus_relation_weights\` (PK + intra-scope soft FK \`relation_id\`). Weight rows are created **lazily** on first co-access strengthening (UPSERT), so absence == "never strengthened" (weight 0.0).

### Where the table landed (both modules, per AC1)
- **Runtime** — \`store/schema/nexus-schema.ts\` (where plasticity actually reads/writes via the GLOBAL consolidated \`cleo.db\`). \`nexusRelations\` stripped of the 3 columns + \`idx_nexus_relations_last_accessed\`; new \`nexusRelationWeights\` table + row-type exports.
- **Target** — \`store/schema/cleo-project/nexus-graph.ts\` (consolidated PROJECT-scope target, the table ADR-090 §5.3 names as its home). Same strip + add.

### Accessor rewrite (AC3)
- \`memory/nexus-plasticity.ts\` — \`strengthenNexusCoAccess\` UPSERTs \`nexus_relation_weights\` (INSERT…SELECT…ON CONFLICT, preserving the "never phantom-edge / skipped" semantic); \`applyPlasticityDecay\` decays the sibling table.
- \`nexus/plasticity-queries.ts\` — \`getHotPaths\`/\`getHotNodes\` INNER-JOIN, \`getColdSymbols\` LEFT-JOINs the weights table on \`relation_id\`.
- \`nexus/impact.ts\`, \`nexus/living-brain.ts\`, \`nexus/query.ts\`, \`memory/graph-memory-bridge.ts\` — every other \`nexus_relations.weight\` read now LEFT-JOINs \`nexus_relation_weights\` (absent row ⇒ 0.0/NULL); dead \`weight\` projections dropped.

### Migrations (AC5)
- \`drizzle-nexus/20260601000001\` — CREATE weights + backfill + DROP the 3 cols (runtime \`nexus_relations\` carries no CHECK, so DROP COLUMN is clean).
- \`drizzle-cleo-project\` parity folded into the T11538 \`nexus-graph\` CREATE to the **final shape** (SQLite can't DROP a CHECK-referenced column without a table rebuild).
- \`nexus-sqlite.ts\` \`ensureNexusRelationWeights\` safety-net (CREATE + one-time backfill) replaces the legacy T998 \`ensureColumns\` band-aid; exodus \`table-name-map\` identity entry added.

### Validation (AC4)
- **T998 co-access strengthening tests GREEN** (the forcing function).
- \`consolidated-schema-parity-fk\` (AC2 declared==written), \`migration-fresh-no-repair.nexus\`, \`exodus\`, \`verify-migration\`, \`plasticity-queries\`, \`living-brain\`, \`query\` all pass.
- \`pnpm biome check\`, \`pnpm run typecheck\` (\`tsc -b\`), \`node build.mjs\`, \`cleo check arch\` (5/5) all clean.
- 35 focused test files / 502 passed / 7 skipped — **identical across two consecutive runs** (zero flakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)