### PR TITLE
fix(T11571): post-E6 smoke P2 polish — init agent-reg ordering + agent-list envelope + docs refCount

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/agent-list-global.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-list-global.test.ts
@@ -140,10 +140,14 @@ describe('cleo agent list', () => {
       includeDisabled: false,
     });
 
+    // T11572 (#5): `agent list` now passes the bare agent array to cliOutput —
+    // the renderer wraps it into the single-level LAFS envelope. The payload is
+    // therefore the array itself, NOT a `{ success, data }` object (which would
+    // have produced a double-nested envelope).
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].success).toBe(true);
-    expect(outputCall[0].data).toHaveLength(1);
-    expect(outputCall[0].data[0].agentId).toBe('agent-alpha');
+    expect(Array.isArray(outputCall[0])).toBe(true);
+    expect(outputCall[0]).toHaveLength(1);
+    expect(outputCall[0][0].agentId).toBe('agent-alpha');
   });
 
   it('TC-082: project with no project_agent_refs returns empty array', async () => {
@@ -153,8 +157,8 @@ describe('cleo agent list', () => {
     await run({ args: {}, rawArgs: [] });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].success).toBe(true);
-    expect(outputCall[0].data).toHaveLength(0);
+    expect(Array.isArray(outputCall[0])).toBe(true);
+    expect(outputCall[0]).toHaveLength(0);
   });
 
   it('TC-084: --global returns all global agents regardless of project refs', async () => {
@@ -171,8 +175,8 @@ describe('cleo agent list', () => {
     });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].success).toBe(true);
-    expect(outputCall[0].data).toHaveLength(2);
+    expect(Array.isArray(outputCall[0])).toBe(true);
+    expect(outputCall[0]).toHaveLength(2);
   });
 
   it('TC-085: --include-disabled includes detached (enabled=0) rows', async () => {
@@ -188,8 +192,8 @@ describe('cleo agent list', () => {
     });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].success).toBe(true);
-    expect(outputCall[0].data).toHaveLength(1);
+    expect(Array.isArray(outputCall[0])).toBe(true);
+    expect(outputCall[0]).toHaveLength(1);
   });
 
   it('TC-086: --global --include-disabled passes both opts to listAgentsForProject', async () => {
@@ -206,7 +210,8 @@ describe('cleo agent list', () => {
     });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].data).toHaveLength(2);
+    expect(Array.isArray(outputCall[0])).toBe(true);
+    expect(outputCall[0]).toHaveLength(2);
   });
 
   it('TC-087: attachment annotation is [attached] for attached agents', async () => {
@@ -217,7 +222,7 @@ describe('cleo agent list', () => {
     await run({ args: {}, rawArgs: [] });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].data[0].attachment).toBe('[attached]');
+    expect(outputCall[0][0].attachment).toBe('[attached]');
   });
 
   it('TC-087: attachment annotation is [global] for agents without a projectRef', async () => {
@@ -228,7 +233,7 @@ describe('cleo agent list', () => {
     await run({ args: { global: true }, rawArgs: [] });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].data[0].attachment).toBe('[global]');
+    expect(outputCall[0][0].attachment).toBe('[global]');
   });
 
   it('TC-087: attachment annotation is [disabled] for detached (enabled=0) agents', async () => {
@@ -239,7 +244,7 @@ describe('cleo agent list', () => {
     await run({ args: { 'include-disabled': true }, rawArgs: [] });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    expect(outputCall[0].data[0].attachment).toBe('[disabled]');
+    expect(outputCall[0][0].attachment).toBe('[disabled]');
   });
 
   it('output columns match spec §5.2: agentId, name, classification, transportType, isActive, lastUsedAt, attachment', async () => {
@@ -250,7 +255,7 @@ describe('cleo agent list', () => {
     await run({ args: {}, rawArgs: [] });
 
     const [outputCall] = mockCliOutput.mock.calls;
-    const row = outputCall[0].data[0] as Record<string, unknown>;
+    const row = outputCall[0][0] as Record<string, unknown>;
     expect(row).toHaveProperty('agentId');
     expect(row).toHaveProperty('name');
     expect(row).toHaveProperty('classification');
@@ -258,6 +263,27 @@ describe('cleo agent list', () => {
     expect(row).toHaveProperty('isActive');
     expect(row).toHaveProperty('lastUsedAt');
     expect(row).toHaveProperty('attachment');
+  });
+
+  it('T11572 (#5): passes a bare array to cliOutput — no double-nested {success,data} envelope', async () => {
+    // Regression guard for the post-E6 smoke #5: the handler previously passed
+    // `{ success: true, data: [...] }` to cliOutput, which is the envelope
+    // boundary and re-wraps its payload → emitted `{ data: { success, data } }`.
+    // The payload MUST be the agent array itself so the final LAFS envelope is
+    // single-level (`{ success, data: [...] }`).
+    const agent = makeAgent('agent-envelope', { projectRef: makeRef(1) });
+    mockListAgentsForProject.mockReturnValue([agent]);
+
+    const run = getAgentSubRun('list');
+    await run({ args: {}, rawArgs: [] });
+
+    const [outputCall] = mockCliOutput.mock.calls;
+    const payload = outputCall[0];
+    expect(Array.isArray(payload)).toBe(true);
+    // The bare array must NOT carry an inner `success`/`data` wrapper.
+    expect(payload).not.toHaveProperty('success');
+    expect(payload).not.toHaveProperty('data');
+    expect(payload[0].agentId).toBe('agent-envelope');
   });
 
   it('outputs success=false with E_LIST on listAgentsForProject error', async () => {

--- a/packages/cleo/src/cli/commands/agent.ts
+++ b/packages/cleo/src/cli/commands/agent.ts
@@ -1084,23 +1084,25 @@ const listCommand = defineCommand({
       // Apply legacy --active filter only when NOT in global mode
       const filtered = !includeGlobal && args.active ? agents.filter((a) => a.isActive) : agents;
 
+      // `cliOutput` is the envelope boundary — it wraps the payload it is given
+      // in `{ success, data, meta }` (formatSuccess). Passing an already-wrapped
+      // `{ success, data }` here produced a DOUBLE-NESTED envelope
+      // (`{ data: { success, data: [...] } }`). Pass the agent array directly as
+      // the payload so the emitted LAFS envelope is single-level.
       cliOutput(
-        {
-          success: true,
-          data: filtered.map((a) => ({
-            agentId: a.agentId,
-            name: a.displayName,
-            classification: a.classification ?? null,
-            transportType: a.transportType,
-            isActive: a.isActive,
-            lastUsedAt: a.lastUsedAt ?? null,
-            attachment: a.projectRef
-              ? a.projectRef.enabled === 1
-                ? '[attached]'
-                : '[disabled]'
-              : '[global]',
-          })),
-        },
+        filtered.map((a) => ({
+          agentId: a.agentId,
+          name: a.displayName,
+          classification: a.classification ?? null,
+          transportType: a.transportType,
+          isActive: a.isActive,
+          lastUsedAt: a.lastUsedAt ?? null,
+          attachment: a.projectRef
+            ? a.projectRef.enabled === 1
+              ? '[attached]'
+              : '[disabled]'
+            : '[global]',
+        })),
         { command: 'agent list' },
       );
     } catch (err) {

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -542,7 +542,9 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         description: undefined,
         labels: undefined,
         createdAt: doc.createdAt,
-        refCount: 0,
+        // Surface the real attachment ref_count (T11572) so `docs list` agrees
+        // with the `docs add` response — both now read the same source of truth.
+        refCount: doc.refCount,
         ...(doc.slug ? { slug: doc.slug } : {}),
         ...(doc.kind ? { type: doc.kind as DocsType } : {}),
         ownerId: doc.ownerId,
@@ -597,7 +599,8 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       description: undefined,
       labels: undefined,
       createdAt: doc.createdAt,
-      refCount: 0,
+      // Surface the real attachment ref_count (T11572) — see project-scope note.
+      refCount: doc.refCount,
       ...(doc.slug ? { slug: doc.slug } : {}),
       ...(doc.kind ? { type: doc.kind as DocsType } : {}),
     }));

--- a/packages/core/src/agents/seed-install.ts
+++ b/packages/core/src/agents/seed-install.ts
@@ -693,33 +693,35 @@ export async function forceInstallProjectTierAgents(
     );
   }
 
-  try {
-    for (const filename of cantFiles) {
-      const cantPath = join(scannedDir, filename);
-      try {
-        const result = installAgentFromCant(db, {
-          cantSource: cantPath,
-          targetTier: 'project',
-          installedFrom: 'seed',
-          projectRoot,
-          force: true,
-        });
-        installed.push({
-          agentId: result.agentId,
-          cantPath: result.cantPath,
-          inserted: result.inserted,
-          skillsAttached: result.skillsAttached,
-          warnings: result.warnings,
-        });
-      } catch (err) {
-        failed.push({
-          cantPath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
+  // NOTE: `db` is the SHARED dual-scope GLOBAL `cleo.db` handle owned by
+  // openDualScopeDb('global') and co-owned by the nexus / skills domains
+  // (E6-L5 · T11525). We MUST NOT `.close()` it here — its lifecycle belongs
+  // to openDualScopeDb. Closing it would tear the handle out from under
+  // sibling domains and any later in-process consumer (e.g. `cleo init`'s
+  // earlier installTemplatesAtProjectTier() shares the same singleton).
+  for (const filename of cantFiles) {
+    const cantPath = join(scannedDir, filename);
+    try {
+      const result = installAgentFromCant(db, {
+        cantSource: cantPath,
+        targetTier: 'project',
+        installedFrom: 'seed',
+        projectRoot,
+        force: true,
+      });
+      installed.push({
+        agentId: result.agentId,
+        cantPath: result.cantPath,
+        inserted: result.inserted,
+        skillsAttached: result.skillsAttached,
+        warnings: result.warnings,
+      });
+    } catch (err) {
+      failed.push({
+        cantPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
-  } finally {
-    db.close();
   }
 
   return { installed, failed, scannedDir };

--- a/packages/core/src/docs/docs-read-model.ts
+++ b/packages/core/src/docs/docs-read-model.ts
@@ -82,6 +82,13 @@ export interface ResolvedDoc {
   readonly blobName: string;
   /** Byte size of the stored content. */
   readonly sizeBytes: number;
+  /**
+   * Number of owners referencing this doc, sourced from `attachments.ref_count`
+   * in tasks.db. Zero for manifest-only blobs (which have no ref-count concept)
+   * and for freshly-added docs not yet attached to an owner. Surfacing the real
+   * value keeps `docs list` consistent with the `docs add` response (T11572).
+   */
+  readonly refCount: number;
   /** IANA MIME type, when known. */
   readonly mimeType: string | null;
   /** Human-readable summary from attachments.summary. */
@@ -578,6 +585,7 @@ export class DocsReadModel {
         ownerType: row.ownerType,
         blobName: name ?? row.slug ?? row.metadata.id,
         sizeBytes: size,
+        refCount: row.metadata.refCount,
         mimeType: mime,
         summary: row.summary,
         lifecycleStatus: row.lifecycleStatus,
@@ -666,6 +674,9 @@ export class DocsReadModel {
       ownerType: detectOwnerType(ownerId),
       blobName: entry.name,
       sizeBytes: entry.sizeBytes,
+      // manifest.db blobs are the content SSoT, not the ref-counted attachment
+      // store — there is no per-owner ref_count to surface here.
+      refCount: 0,
       mimeType: entry.mimeType ?? null,
       summary: null,
       lifecycleStatus: 'active',
@@ -723,6 +734,7 @@ export class DocsReadModel {
       ownerType: detectOwnerType(ownerId),
       blobName: blobName ?? extras.slug ?? meta.id,
       sizeBytes: size,
+      refCount: meta.refCount,
       mimeType: mime,
       summary: extras.summary,
       lifecycleStatus: extras.lifecycleStatus ?? 'active',

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -274,32 +274,34 @@ export async function installTemplatesAtProjectTier(
   const installed: TemplateInstallEntry[] = [];
   const failed: Array<{ cantPath: string; error: string }> = [];
 
-  try {
-    const { installAgentFromCant } = await import('./store/agent-install.js');
-    for (const filename of cantFiles) {
-      const cantPath = join(templatesDir, filename);
-      try {
-        const result = installAgentFromCant(db, {
-          cantSource: cantPath,
-          targetTier: 'project',
-          installedFrom: 'seed',
-          projectRoot,
-          force: true,
-        });
-        installed.push({
-          agentId: result.agentId,
-          cantPath: result.cantPath,
-          inserted: result.inserted,
-        });
-      } catch (err) {
-        failed.push({
-          cantPath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
+  // NOTE: `db` is the SHARED dual-scope GLOBAL `cleo.db` handle owned by
+  // openDualScopeDb('global') and co-owned by the nexus / skills domains
+  // (E6-L5 · T11525). We MUST NOT `.close()` it here — doing so tears the
+  // handle out from under sibling domains AND breaks the subsequent
+  // forceInstallProjectTierAgents() call in `cleo init`, which re-uses the
+  // same singleton and would otherwise hit "database is not open".
+  const { installAgentFromCant } = await import('./store/agent-install.js');
+  for (const filename of cantFiles) {
+    const cantPath = join(templatesDir, filename);
+    try {
+      const result = installAgentFromCant(db, {
+        cantSource: cantPath,
+        targetTier: 'project',
+        installedFrom: 'seed',
+        projectRoot,
+        force: true,
+      });
+      installed.push({
+        agentId: result.agentId,
+        cantPath: result.cantPath,
+        inserted: result.inserted,
+      });
+    } catch (err) {
+      failed.push({
+        cantPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
-  } finally {
-    db.close();
   }
 
   return { installed, failed, templatesDir };


### PR DESCRIPTION
Three P2 integration-polish fixes found by the post-E6 smoke (`post-e6-integration-smoke-2026-06-01`). Tracking task: T11571.

## #4 — `cleo init` "database is not open" warning
`installTemplatesAtProjectTier` (init.ts) and `forceInstallProjectTierAgents` (seed-install.ts) both called `db.close()` on the **shared dual-scope global `cleo.db` handle** (E6-L5 · T11525 — co-owned by nexus/skills, callers must NEVER close it). The first close broke the second agent-registration pass → `warnings: ["project-tier agent registration failed: database is not open"]` while `created` optimistically claimed success. Removed both `db.close()` calls. Both registration passes now succeed; `warnings: []`.

## #5 — `cleo agent list` double-nested envelope
The handler passed an already-wrapped `{ success: true, data: [...] }` object to `cliOutput`, which is the envelope boundary and re-wraps its payload → `{ data: { success: true, data: [] } }`. Now passes the bare agent array so the emitted LAFS envelope is single-level `{ success, data: [...] }`. Updated `agent-list-global` tests to the corrected shape and added a regression guard asserting the payload is a bare array (no inner `success`/`data`).

## #6 — `docs add` refCount:1 vs `docs list` refCount:0
The `docs.list` dispatch projection hardcoded `refCount: 0` for every row. Added a `refCount` field to `ResolvedDoc`, populated from `attachments.ref_count` in the tasks-db resolution paths (`0` for manifest-only blobs, which have no ref-count concept), and surfaced `doc.refCount` in both list projections. `add` and `list` now report the same truthful value.

## Verification (fresh XDG_DATA_HOME + fresh build)
- `cleo init` → `warnings: []`, both agent passes register 5 templates
- `cleo agent list` → top keys `[success, data, meta]`, `data` is a list (no nested `success`)
- `cleo docs add` refCount=1 → `cleo docs list --task` / `--project` refCount=1

Typecheck (`tsc -b`) clean; biome clean; full build green. Local vitest path-filters for `@cleocode/cleo` are environment-broken (documented gotcha) — trusting CI for that package; core changes covered (init-install-templates 7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)