### PR TITLE
fix(T11572): exodus parity gate over-aborts — FTS/meta exclusion + source-orphan tolerance + journal-rollback reconcile

### DIFF
--- a/packages/contracts/src/migration-parity.ts
+++ b/packages/contracts/src/migration-parity.ts
@@ -71,9 +71,11 @@ export interface MigrationTableParity {
  * child `table`, the offending `rowid`, the referenced `parent` table, and the
  * `fkid` (the index of the foreign-key constraint within that table).
  *
- * A non-empty list means the migrated data has genuine referential orphans —
- * NOT copy-order artifacts (the migration copies with `foreign_keys=OFF` and
- * checks afterward). The parity gate treats any orphan as a failure.
+ * A non-empty list means the migrated data has referential orphans — NOT
+ * copy-order artifacts (the migration copies with `foreign_keys=OFF` and checks
+ * afterward). The parity gate fails only on orphans the migration *introduced*
+ * (those absent from the source); pre-existing source orphans are carried
+ * forward losslessly and tolerated (T11572).
  *
  * @public
  */
@@ -130,7 +132,8 @@ export const MIGRATION_ENUM_DRIFT_SAMPLE_LIMIT = 20 as const;
  * a single source→target migration verification pass.
  *
  * `ok === true` IFF every table has `countMatch && hashMatch`, the
- * `foreignKeyViolations` list is empty, AND no {@link MigrationEnumDrift} was
+ * `introducedForeignKeyViolations` list is empty (pre-existing source orphans do
+ * NOT fail the strict check — T11572), AND no {@link MigrationEnumDrift} was
  * detected. When `ok === false`, `error` is ALWAYS populated with a
  * human-readable failure summary (the false-pass guard from T11531).
  *
@@ -141,8 +144,30 @@ export interface VerifyMigrationResult {
   readonly ok: boolean;
   /** Per-table row-count + checksum parity entries. */
   readonly tables: readonly MigrationTableParity[];
-  /** Orphan rows from `PRAGMA foreign_key_check` on the consolidated target. */
+  /**
+   * ALL orphan rows from `PRAGMA foreign_key_check` on the consolidated target —
+   * both pre-existing (already orphaned in the SOURCE) and migration-introduced.
+   *
+   * NOTE: this list is NOT, on its own, a data-loss signal. A legacy source DB
+   * can carry pre-existing orphans (rows whose parent was deleted before the
+   * migration); those copy through faithfully (zero loss) and are NOT a migration
+   * failure. Use {@link introducedForeignKeyViolations} for the data-loss gate.
+   */
   readonly foreignKeyViolations: readonly MigrationForeignKeyViolation[];
+  /**
+   * Orphans present on the consolidated TARGET that the SOURCE did NOT already
+   * have — i.e. referential integrity the migration *worsened* (a parent row the
+   * migration dropped). This is the FK class that indicates genuine data loss and
+   * is the one the cutover parity gate fails on. Empty when the migration only
+   * carried forward pre-existing source orphans (T11572).
+   */
+  readonly introducedForeignKeyViolations: readonly MigrationForeignKeyViolation[];
+  /**
+   * Orphans that ALREADY existed in the SOURCE before migration (a data-hygiene
+   * pre-condition, not a migration defect). Carried forward as-is (zero loss);
+   * surfaced as a WARN for a follow-up clean-up, never an abort (T11572).
+   */
+  readonly preExistingForeignKeyViolations: readonly MigrationForeignKeyViolation[];
   /** Enum/type-drift findings (source values outside the target CHECK enum). */
   readonly enumDrift: readonly MigrationEnumDrift[];
   /**

--- a/packages/core/src/store/__tests__/exodus-on-open.test.ts
+++ b/packages/core/src/store/__tests__/exodus-on-open.test.ts
@@ -32,6 +32,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildRepresentativeFixture,
   FIXTURE_EXPECTED_ROWS,
+  FIXTURE_HAZARD_EXPECTED_ROWS,
+  type RepresentativeFixtureOptions,
 } from '../exodus/__fixtures__/representative-fixture.js';
 import type { ExodusPlan, LegacyDbDescriptor } from '../exodus/types.js';
 
@@ -69,14 +71,17 @@ function countRows(dbPath: string, table: string): number {
  * mock `buildExodusPlan` so the hook's plan points at the fixture sources +
  * targets. The REAL migrate + verify engines run unmocked.
  */
-async function armFixture(tmpDir: string): Promise<{
+async function armFixture(
+  tmpDir: string,
+  fixtureOpts: RepresentativeFixtureOptions = {},
+): Promise<{
   fx: ReturnType<typeof buildRepresentativeFixture>;
   sources: LegacyDbDescriptor[];
   plan: ExodusPlan;
   projectDb: DatabaseSyncType;
   globalDb: DatabaseSyncType;
 }> {
-  const fx = buildRepresentativeFixture(tmpDir);
+  const fx = buildRepresentativeFixture(tmpDir, fixtureOpts);
 
   const projectDb = new DatabaseSync(fx.projectDbPath);
   const globalDb = new DatabaseSync(fx.globalDbPath);
@@ -239,6 +244,8 @@ describe('exodus-on-open data-continuity (T11553)', () => {
         },
       ],
       foreignKeyViolations: [],
+      introducedForeignKeyViolations: [],
+      preExistingForeignKeyViolations: [],
       enumDrift: [],
       error: 'FORCED count deficit for abort test',
     });
@@ -389,5 +396,124 @@ describe('exodus-on-open data-continuity (T11553)', () => {
     expect(result.outcome).toBe('migrated');
     // Flag is always cleared in the finally block, even across the nested opens.
     expect(onOpen._isExodusInProgress()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // T11572 — parity gate over-abort fixes, end-to-end through the REAL engines.
+  // -------------------------------------------------------------------------
+
+  it('T11572 BLOCKER 1: a fixture WITH FTS5 + _conduit_meta shadow tables migrates GREEN', async () => {
+    const { fx, projectDb, globalDb } = await armFixture(tmpDir, {
+      withDerivedAndInternalTables: true,
+    });
+    openProjectDb = projectDb;
+    openGlobalDb = globalDb;
+
+    // Sanity: the source carries the derived FTS shadow + internal meta tables.
+    expect(countRows(fx.brainDbPath, 'brain_decisions_fts_data')).toBeGreaterThan(0);
+    expect(countRows(fx.brainDbPath, '_conduit_meta')).toBe(1);
+
+    const { maybeRunExodusOnOpen } = await import('../exodus/on-open.js');
+    const result = await maybeRunExodusOnOpen('project', fx.projectDbPath, projectDb, tmpDir);
+
+    // The presence of FTS5 + meta shadow tables must NOT abort the cutover.
+    expect(result.outcome, `unexpected outcome: ${result.reason}`).toBe('migrated');
+
+    // Every BASE table — including the FTS5 content table brain_decisions — has
+    // exact row parity. The derived/meta tables were skipped (no consolidated
+    // home), not counted as deficits.
+    for (const [table, expected] of Object.entries(FIXTURE_EXPECTED_ROWS)) {
+      expect(countRows(fx.projectDbPath, table), `${table} parity`).toBe(expected);
+    }
+    expect(countRows(fx.projectDbPath, 'brain_decisions')).toBe(
+      FIXTURE_HAZARD_EXPECTED_ROWS.brain_decisions,
+    );
+  });
+
+  it('T11572 BLOCKER 2: a fixture with a pre-existing SOURCE FK orphan migrates GREEN (orphan preserved)', async () => {
+    const { fx, projectDb, globalDb } = await armFixture(tmpDir, {
+      withPreExistingSourceOrphan: true,
+    });
+    openProjectDb = projectDb;
+    openGlobalDb = globalDb;
+
+    // Sanity: the source already has the 6 task_relations rows (4 clean + 2 orphan).
+    expect(countRows(fx.tasksDbPath, 'task_relations')).toBe(
+      FIXTURE_HAZARD_EXPECTED_ROWS.tasks_task_relations,
+    );
+
+    const { maybeRunExodusOnOpen } = await import('../exodus/on-open.js');
+    const result = await maybeRunExodusOnOpen('project', fx.projectDbPath, projectDb, tmpDir);
+
+    // The pre-existing source orphan must NOT abort the cutover.
+    expect(result.outcome, `unexpected outcome: ${result.reason}`).toBe('migrated');
+
+    // The orphan row is PRESERVED (zero loss) — all 6 relation rows copied,
+    // including the 2 that reference deleted tasks.
+    expect(countRows(fx.projectDbPath, 'tasks_task_relations')).toBe(
+      FIXTURE_HAZARD_EXPECTED_ROWS.tasks_task_relations,
+    );
+    // Base parity unaffected.
+    for (const [table, expected] of Object.entries(FIXTURE_EXPECTED_ROWS)) {
+      expect(countRows(fx.projectDbPath, table), `${table} parity`).toBe(expected);
+    }
+  });
+
+  it('T11572 BLOCKER 3: retry after a FORCED abort RE-COPIES and succeeds (no permanent abort loop)', async () => {
+    const { fx, projectDb, globalDb } = await armFixture(tmpDir);
+    openProjectDb = projectDb;
+    openGlobalDb = globalDb;
+
+    const verifyMod = await import('../exodus/index.js');
+    const { maybeRunExodusOnOpen } = await import('../exodus/on-open.js');
+
+    // --- Attempt 1: force a genuine deficit so the cutover aborts + rolls back. ---
+    const verifySpy = vi.spyOn(verifyMod, 'verifyMigration').mockReturnValue({
+      ok: false,
+      tables: [
+        {
+          sourceTable: 'tasks',
+          targetTable: 'tasks_tasks',
+          scope: 'project',
+          sourceCount: 30,
+          targetCount: 12, // forced deficit
+          sourceHash: 'aaaa',
+          targetHash: 'bbbb',
+          countMatch: false,
+          hashMatch: false,
+        },
+      ],
+      foreignKeyViolations: [],
+      introducedForeignKeyViolations: [],
+      preExistingForeignKeyViolations: [],
+      enumDrift: [],
+      error: 'FORCED count deficit for retry test',
+    });
+
+    const aborted = await maybeRunExodusOnOpen('project', fx.projectDbPath, projectDb, tmpDir);
+    expect(aborted.outcome).toBe('aborted');
+    // Consolidated rolled back to empty; legacy intact.
+    expect(countRows(fx.projectDbPath, 'tasks_tasks')).toBe(0);
+    expect(countRows(fx.tasksDbPath, 'tasks')).toBe(FIXTURE_EXPECTED_ROWS.tasks_tasks);
+
+    // The journal MUST have been cleared on abort so the retry re-copies. Before
+    // the fix, the journal still marked every table 'done' and the retry copied
+    // NOTHING (permanent abort loop).
+    const stagingDir = join(tmpDir, 'staging');
+    expect(
+      existsSync(join(stagingDir, 'exodus-journal.json')),
+      'migrate journal must be cleared after abort/rollback so retry re-copies',
+    ).toBe(false);
+
+    // --- Attempt 2: restore real verify; the retry must RE-COPY and migrate GREEN. ---
+    verifySpy.mockRestore();
+
+    const retried = await maybeRunExodusOnOpen('project', fx.projectDbPath, projectDb, tmpDir);
+    expect(retried.outcome, `retry should re-copy and succeed: ${retried.reason}`).toBe('migrated');
+
+    // The retry actually re-copied every row (not a no-op resume over an empty DB).
+    for (const [table, expected] of Object.entries(FIXTURE_EXPECTED_ROWS)) {
+      expect(countRows(fx.projectDbPath, table), `${table} re-copied on retry`).toBe(expected);
+    }
   });
 });

--- a/packages/core/src/store/__tests__/verify-migration.test.ts
+++ b/packages/core/src/store/__tests__/verify-migration.test.ts
@@ -24,6 +24,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseSync as DatabaseSyncType } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isDerivedOrInternalTable } from '../exodus/table-name-map.js';
 import type { LegacyDbDescriptor } from '../exodus/types.js';
 import { verifyMigration } from '../exodus/verify-migration.js';
 
@@ -256,7 +257,219 @@ describe('verifyMigration — PRAGMA foreign_key_check', () => {
 
     expect(r.foreignKeyViolations.length).toBeGreaterThan(0);
     expect(r.foreignKeyViolations.some((v) => v.table === 'children')).toBe(true);
+    // This orphan is INTRODUCED by the migration (source had a clean pair) → fail.
+    expect(r.introducedForeignKeyViolations.some((v) => v.table === 'children')).toBe(true);
+    expect(r.preExistingForeignKeyViolations).toHaveLength(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain('fk');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BLOCKER 1 (T11572) — FTS5 + internal/meta shadow tables are NOT deficits.
+// ---------------------------------------------------------------------------
+
+describe('verifyMigration — FTS5 + internal/meta shadow-table exclusion (T11572)', () => {
+  let tmpDir: string;
+  let sourcePath: string;
+  let projectPath: string;
+  let globalPath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourcePath = join(tmpDir, 'brain.db');
+    projectPath = join(tmpDir, 'cleo-project.db');
+    globalPath = join(tmpDir, 'cleo-global.db');
+    new DatabaseSync(globalPath).close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('isDerivedOrInternalTable classifies FTS5 + meta tables, not base tables', () => {
+    // FTS5 virtual table + its full shadow family.
+    expect(isDerivedOrInternalTable('brain_decisions_fts')).toBe(true);
+    expect(isDerivedOrInternalTable('brain_observations_fts')).toBe(true);
+    expect(isDerivedOrInternalTable('messages_fts')).toBe(true);
+    expect(isDerivedOrInternalTable('brain_decisions_fts_data')).toBe(true);
+    expect(isDerivedOrInternalTable('brain_decisions_fts_idx')).toBe(true);
+    expect(isDerivedOrInternalTable('brain_decisions_fts_docsize')).toBe(true);
+    expect(isDerivedOrInternalTable('brain_decisions_fts_config')).toBe(true);
+    expect(isDerivedOrInternalTable('messages_fts_content')).toBe(true);
+    // Internal bookkeeping.
+    expect(isDerivedOrInternalTable('_conduit_meta')).toBe(true);
+    expect(isDerivedOrInternalTable('_conduit_migrations')).toBe(true);
+    // Base data tables — must NOT be excluded.
+    expect(isDerivedOrInternalTable('brain_decisions')).toBe(false);
+    expect(isDerivedOrInternalTable('tasks')).toBe(false);
+    expect(isDerivedOrInternalTable('conduit_messages')).toBe(false);
+    // A non-FTS table that merely contains "fts" mid-name must not be caught.
+    expect(isDerivedOrInternalTable('drafts')).toBe(false);
+  });
+
+  it('GREEN: a source with FTS5 shadow + _conduit_meta tables verifies ok (no N→0 deficit)', () => {
+    // Source: a real base table (brain_decisions, 20 rows) PLUS an FTS5 virtual
+    // table + its full shadow family + a _conduit_meta bookkeeping table — the
+    // exact set the real-data dry-run aborted on.
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(
+        `CREATE TABLE "brain_decisions" (id INTEGER PRIMARY KEY, decision TEXT, rationale TEXT)`,
+      );
+      for (let i = 1; i <= 20; i++) {
+        src.exec(`INSERT INTO "brain_decisions" VALUES (${i}, 'd-${i}', 'why-${i}')`);
+      }
+      // Real FTS5 index over brain_decisions — this materialises
+      // brain_decisions_fts + _data/_idx/_docsize/_config shadow tables, all of
+      // which carry rows that do NOT correspond 1:1 to base rows.
+      src.exec(
+        `CREATE VIRTUAL TABLE "brain_decisions_fts" USING fts5(decision, rationale, content="brain_decisions", content_rowid="id")`,
+      );
+      src.exec(`INSERT INTO "brain_decisions_fts"("brain_decisions_fts") VALUES('rebuild')`);
+      // Internal bookkeeping table (no consolidated home).
+      src.exec(`CREATE TABLE "_conduit_meta" (key TEXT PRIMARY KEY, value TEXT)`);
+      src.exec(`INSERT INTO "_conduit_meta" VALUES ('schema_version', '7')`);
+    } finally {
+      src.close();
+    }
+
+    // Target: ONLY the consolidated base table exists, with all 20 rows. The FTS
+    // index + meta table have NO consolidated counterpart (rebuilt at runtime).
+    const tgt = new DatabaseSync(projectPath);
+    try {
+      tgt.exec(
+        `CREATE TABLE "brain_decisions" (id INTEGER PRIMARY KEY, decision TEXT, rationale TEXT)`,
+      );
+      for (let i = 1; i <= 20; i++) {
+        tgt.exec(`INSERT INTO "brain_decisions" VALUES (${i}, 'd-${i}', 'why-${i}')`);
+      }
+    } finally {
+      tgt.close();
+    }
+
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'brain (project)', path: sourcePath, targetScope: 'project' },
+    ];
+    const r = verifyMigration(sources, projectPath, globalPath);
+
+    // The base table parity holds and the derived/meta tables were SKIPPED — no
+    // spurious N→0 deficit, no abort.
+    expect(r.ok, r.error ?? '').toBe(true);
+    // The FTS/meta tables must NOT appear as a parity row (they were skipped).
+    expect(r.tables.some((t) => t.targetTable.includes('_fts'))).toBe(false);
+    expect(r.tables.some((t) => t.targetTable === '_conduit_meta')).toBe(false);
+    // The base table IS verified.
+    const base = r.tables.find((t) => t.targetTable === 'brain_decisions');
+    expect(base?.countMatch).toBe(true);
+    expect(base?.sourceCount).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BLOCKER 2 (T11572) — pre-existing SOURCE FK orphans are tolerated.
+// ---------------------------------------------------------------------------
+
+describe('verifyMigration — pre-existing source FK orphans tolerated (T11572)', () => {
+  let tmpDir: string;
+  let sourcePath: string;
+  let projectPath: string;
+  let globalPath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourcePath = join(tmpDir, 'tasks.db');
+    projectPath = join(tmpDir, 'cleo-project.db');
+    globalPath = join(tmpDir, 'cleo-global.db');
+    new DatabaseSync(globalPath).close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('GREEN: an orphan that ALREADY exists in the source migrates ok (carried forward, not a deficit)', () => {
+    // Source: a parent/child pair where the child references a parent that does
+    // NOT exist (parent_id=99) — a pre-existing orphan, exactly like the 2 real
+    // tasks_task_relations rows pointing at deleted tasks. FK enforcement OFF so
+    // the orphan can be seeded.
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(`PRAGMA foreign_keys = OFF`);
+      src.exec(`CREATE TABLE "parents" (id INTEGER PRIMARY KEY)`);
+      src.exec(
+        `CREATE TABLE "children" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "parents"(id))`,
+      );
+      src.exec(`INSERT INTO "parents" VALUES (1)`);
+      src.exec(`INSERT INTO "children" VALUES (1, 1)`); // clean
+      src.exec(`INSERT INTO "children" VALUES (2, 99)`); // PRE-EXISTING orphan
+    } finally {
+      src.close();
+    }
+
+    // Target: the SAME data copied faithfully — the orphan travels with the row
+    // (zero loss). FK declared; orphan present on target too.
+    const tgt = new DatabaseSync(projectPath);
+    try {
+      tgt.exec(`PRAGMA foreign_keys = OFF`);
+      tgt.exec(`CREATE TABLE "parents" (id INTEGER PRIMARY KEY)`);
+      tgt.exec(
+        `CREATE TABLE "children" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "parents"(id))`,
+      );
+      tgt.exec(`INSERT INTO "parents" VALUES (1)`);
+      tgt.exec(`INSERT INTO "children" VALUES (1, 1)`);
+      tgt.exec(`INSERT INTO "children" VALUES (2, 99)`); // same orphan carried forward
+    } finally {
+      tgt.close();
+    }
+
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'fixture', path: sourcePath, targetScope: 'project' },
+    ];
+    const r = verifyMigration(sources, projectPath, globalPath);
+
+    // The orphan is detected on the target...
+    expect(r.foreignKeyViolations.some((v) => v.table === 'children')).toBe(true);
+    // ...but classified as PRE-EXISTING (it was in the source too) → tolerated.
+    expect(r.preExistingForeignKeyViolations.some((v) => v.table === 'children')).toBe(true);
+    expect(r.introducedForeignKeyViolations).toHaveLength(0);
+    // Row counts match → no deficit. The migration is OK (zero loss).
+    expect(r.ok, r.error ?? '').toBe(true);
+  });
+
+  it('STILL ABORTS: an orphan present ONLY on the target (source clean) is a genuine introduced loss', () => {
+    // Source: a CLEAN parent/child pair (no orphan).
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(`CREATE TABLE "parents" (id INTEGER PRIMARY KEY)`);
+      src.exec(`CREATE TABLE "children" (id INTEGER PRIMARY KEY, parent_id INTEGER)`);
+      src.exec(`INSERT INTO "parents" VALUES (1)`);
+      src.exec(`INSERT INTO "children" VALUES (1, 1)`);
+    } finally {
+      src.close();
+    }
+
+    // Target: an orphan the source never had (the migration dropped the parent).
+    const tgt = new DatabaseSync(projectPath);
+    try {
+      tgt.exec(`PRAGMA foreign_keys = OFF`);
+      tgt.exec(`CREATE TABLE "parents" (id INTEGER PRIMARY KEY)`);
+      tgt.exec(
+        `CREATE TABLE "children" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "parents"(id))`,
+      );
+      // parent missing → introduced orphan
+      tgt.exec(`INSERT INTO "children" VALUES (1, 1)`);
+    } finally {
+      tgt.close();
+    }
+
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'fixture', path: sourcePath, targetScope: 'project' },
+    ];
+    const r = verifyMigration(sources, projectPath, globalPath);
+
+    expect(r.introducedForeignKeyViolations.some((v) => v.table === 'children')).toBe(true);
+    expect(r.preExistingForeignKeyViolations).toHaveLength(0);
+    expect(r.ok).toBe(false);
   });
 });

--- a/packages/core/src/store/exodus/__fixtures__/representative-fixture.ts
+++ b/packages/core/src/store/exodus/__fixtures__/representative-fixture.ts
@@ -60,11 +60,54 @@ export const FIXTURE_EXPECTED_ROWS = {
 } as const;
 
 /**
+ * Options for {@link buildRepresentativeFixture} that inject the derived/internal
+ * + pre-existing-orphan hazards the T11572 parity-gate fixes guard. Default off
+ * so the base zero-loss parity test is unaffected.
+ *
+ * @public
+ */
+export interface RepresentativeFixtureOptions {
+  /**
+   * When `true`, the legacy `brain.db` source also gets a real FTS5 virtual
+   * table (`brain_decisions_fts` + its `_data/_idx/_docsize/_config` shadow
+   * tables) and the `_conduit_meta` / `_conduit_migrations` internal bookkeeping
+   * tables — none of which have a consolidated counterpart. A correct migration
+   * SKIPS them (no N→0 deficit). The consolidated target schema additionally
+   * gains a `brain_decisions` base table so the FTS source has real base data.
+   * (T11572 BLOCKER 1.)
+   */
+  readonly withDerivedAndInternalTables?: boolean;
+  /**
+   * When `true`, the legacy `tasks.db` source gets a `task_relations` table
+   * carrying a PRE-EXISTING FK orphan (a row referencing a `tasks.id` that does
+   * not exist — like the real `tasks_task_relations` rows pointing at deleted
+   * tasks). The same orphan is faithfully copied to the target (zero loss); the
+   * parity gate must TOLERATE it. (T11572 BLOCKER 2.)
+   */
+  readonly withPreExistingSourceOrphan?: boolean;
+}
+
+/**
+ * Base-table rows for the optional hazard tables (only seeded when the matching
+ * {@link RepresentativeFixtureOptions} flag is set). Exposed so a test that
+ * enables the hazards can assert exact parity on them too.
+ *
+ * @public
+ */
+export const FIXTURE_HAZARD_EXPECTED_ROWS = {
+  /** brain_decisions base rows (content table behind the FTS5 index). */
+  brain_decisions: 20,
+  /** task_relations rows: 4 clean + 2 pre-existing orphans = 6. */
+  tasks_task_relations: 6,
+} as const;
+
+/**
  * Build the legacy `tasks.db` source fixture with representative drift.
  *
  * @param path - Absolute path for the legacy tasks source DB.
+ * @param opts - Optional hazard injection (T11572).
  */
-function buildTasksSource(path: string): void {
+function buildTasksSource(path: string, opts: RepresentativeFixtureOptions = {}): void {
   const db = new DatabaseSync(path);
   try {
     // --- tasks (unprefixed → tasks_tasks) with a self-referential FK + epoch ms ---
@@ -102,6 +145,34 @@ function buildTasksSource(path: string): void {
     for (let i = 1; i <= FIXTURE_EXPECTED_ROWS.tasks_token_usage; i++) {
       db.exec(`INSERT INTO "token_usage" VALUES (${i}, '${transports[i % transports.length]}')`);
     }
+
+    // --- task_relations with a PRE-EXISTING source FK orphan (T11572 BLOCKER 2) ---
+    // Mirrors the real `tasks_task_relations` rows that reference deleted tasks.
+    // 4 clean rows (parent + child both real) + 2 orphan rows (to_id is a task id
+    // that was never inserted). FK enforcement is OFF so the orphans can be
+    // seeded; the orphan travels with the row on copy (zero loss).
+    if (opts.withPreExistingSourceOrphan) {
+      db.exec(`PRAGMA foreign_keys = OFF`);
+      db.exec(
+        `CREATE TABLE "task_relations" (
+          id INTEGER PRIMARY KEY,
+          from_id TEXT REFERENCES "tasks"(id),
+          to_id TEXT REFERENCES "tasks"(id),
+          kind TEXT
+        )`,
+      );
+      // 4 clean rows referencing real tasks T1..T5.
+      for (let i = 1; i <= 4; i++) {
+        db.exec(`INSERT INTO "task_relations" VALUES (${i}, 'T${i}', 'T${i + 1}', 'related')`);
+      }
+      // 2 PRE-EXISTING orphans: to_id points at tasks that do NOT exist.
+      db.exec(
+        `INSERT INTO "task_relations" VALUES (5, 'T1', 'T-RECONCILE-FOLLOWUP-v2026.5.38-2', 'related')`,
+      );
+      db.exec(
+        `INSERT INTO "task_relations" VALUES (6, 'T2', 'T-RECONCILE-FOLLOWUP-v2026.5.38-3', 'related')`,
+      );
+    }
   } finally {
     db.close();
   }
@@ -111,8 +182,9 @@ function buildTasksSource(path: string): void {
  * Build the legacy `brain.db` source fixture with representative drift.
  *
  * @param path - Absolute path for the legacy brain source DB.
+ * @param opts - Optional hazard injection (T11572).
  */
-function buildBrainSource(path: string): void {
+function buildBrainSource(path: string, opts: RepresentativeFixtureOptions = {}): void {
   const db = new DatabaseSync(path);
   try {
     // brain_observations already domain-prefixed (identity map) with legacy
@@ -126,6 +198,32 @@ function buildBrainSource(path: string): void {
       db.exec(
         `INSERT INTO "brain_observations" VALUES (${i}, '${types[i % types.length]}', ${ms})`,
       );
+    }
+
+    // --- DERIVED (FTS5) + INTERNAL (conduit meta) tables (T11572 BLOCKER 1) ---
+    // These have NO consolidated counterpart; a correct migration SKIPS them
+    // rather than counting them as an N→0 deficit.
+    if (opts.withDerivedAndInternalTables) {
+      // brain_decisions: the FTS5 content table (real base data).
+      db.exec(
+        `CREATE TABLE "brain_decisions" (id INTEGER PRIMARY KEY, decision TEXT, rationale TEXT)`,
+      );
+      for (let i = 1; i <= FIXTURE_HAZARD_EXPECTED_ROWS.brain_decisions; i++) {
+        db.exec(`INSERT INTO "brain_decisions" VALUES (${i}, 'decision-${i}', 'rationale-${i}')`);
+      }
+      // Real FTS5 index → materialises brain_decisions_fts + _data/_idx/_docsize/
+      // _config shadow tables (rows that do NOT map 1:1 to base rows).
+      db.exec(
+        `CREATE VIRTUAL TABLE "brain_decisions_fts" USING fts5(decision, rationale, content="brain_decisions", content_rowid="id")`,
+      );
+      db.exec(`INSERT INTO "brain_decisions_fts"("brain_decisions_fts") VALUES('rebuild')`);
+      // Internal bookkeeping tables (conduit-sqlite's schema-version + ledger).
+      db.exec(`CREATE TABLE "_conduit_meta" (key TEXT PRIMARY KEY, value TEXT)`);
+      db.exec(`INSERT INTO "_conduit_meta" VALUES ('schema_version', '7')`);
+      db.exec(
+        `CREATE TABLE "_conduit_migrations" (id INTEGER PRIMARY KEY, name TEXT, applied_at TEXT)`,
+      );
+      db.exec(`INSERT INTO "_conduit_migrations" VALUES (1, 'init', '2026-01-01T00:00:00Z')`);
     }
   } finally {
     db.close();
@@ -141,8 +239,15 @@ function buildBrainSource(path: string): void {
  *
  * @param projectPath - Absolute path for the consolidated project cleo.db.
  * @param globalPath  - Absolute path for the consolidated global cleo.db.
+ * @param opts        - Optional hazard injection (T11572) — adds the matching
+ *   target tables (`tasks_task_relations`, `brain_decisions`) so the hazard
+ *   source data has a consolidated home to copy INTO.
  */
-function buildTargetSchema(projectPath: string, globalPath: string): void {
+function buildTargetSchema(
+  projectPath: string,
+  globalPath: string,
+  opts: RepresentativeFixtureOptions = {},
+): void {
   const db = new DatabaseSync(projectPath);
   try {
     // tasks_tasks: created_at is text + ISO GLOB; self-FK on parent_id.
@@ -177,6 +282,29 @@ function buildTargetSchema(projectPath: string, globalPath: string): void {
         created_at TEXT CHECK ("created_at" IS NULL OR "created_at" GLOB ${ISO_GLOB})
       )`,
     );
+
+    // tasks_task_relations: self-FK to tasks_tasks via from_id/to_id. The
+    // pre-existing source orphan (to_id pointing at a missing task) copies
+    // through and surfaces under PRAGMA foreign_key_check — but is tolerated
+    // because the SOURCE already had it (T11572 BLOCKER 2).
+    if (opts.withPreExistingSourceOrphan) {
+      db.exec(
+        `CREATE TABLE "tasks_task_relations" (
+          id INTEGER PRIMARY KEY,
+          from_id TEXT REFERENCES "tasks_tasks"(id),
+          to_id TEXT REFERENCES "tasks_tasks"(id),
+          kind TEXT
+        )`,
+      );
+    }
+    // brain_decisions: consolidated home for the FTS5 content table. The derived
+    // FTS shadow tables + _conduit_meta have NO target — they are skipped, not
+    // migrated (T11572 BLOCKER 1).
+    if (opts.withDerivedAndInternalTables) {
+      db.exec(
+        `CREATE TABLE "brain_decisions" (id INTEGER PRIMARY KEY, decision TEXT, rationale TEXT)`,
+      );
+    }
   } finally {
     db.close();
   }
@@ -188,12 +316,19 @@ function buildTargetSchema(projectPath: string, globalPath: string): void {
  * Materialise the full representative fixture: two legacy source DBs and the
  * consolidated target DBs with production-grade CHECK/GLOB/FK constraints.
  *
- * @param dir - Directory the fixture files are written into. Must already exist.
+ * @param dir  - Directory the fixture files are written into. Must already exist.
+ * @param opts - Optional T11572 hazard injection (FTS5/meta derived tables +
+ *   pre-existing source FK orphan). Omitting it preserves the original
+ *   zero-loss base fixture exactly.
  * @returns Absolute paths of every fixture artifact.
  *
  * @task T11551 (DHQ-045 · AC3)
+ * @task T11572 (parity-gate hazards — FTS5/meta exclusion + source-orphan tolerance)
  */
-export function buildRepresentativeFixture(dir: string): {
+export function buildRepresentativeFixture(
+  dir: string,
+  opts: RepresentativeFixtureOptions = {},
+): {
   readonly tasksDbPath: string;
   readonly brainDbPath: string;
   readonly projectDbPath: string;
@@ -205,9 +340,9 @@ export function buildRepresentativeFixture(dir: string): {
   const projectDbPath = join(dir, 'cleo-project.db');
   const globalDbPath = join(dir, 'cleo-global.db');
 
-  buildTasksSource(tasksDbPath);
-  buildBrainSource(brainDbPath);
-  buildTargetSchema(projectDbPath, globalDbPath);
+  buildTasksSource(tasksDbPath, opts);
+  buildBrainSource(brainDbPath, opts);
+  buildTargetSchema(projectDbPath, globalDbPath, opts);
 
   return { tasksDbPath, brainDbPath, projectDbPath, globalDbPath };
 }

--- a/packages/core/src/store/exodus/index.ts
+++ b/packages/core/src/store/exodus/index.ts
@@ -9,10 +9,11 @@
  * @saga T11242
  */
 
-export { runExodusMigrate } from './migrate.js';
+export { clearExodusJournal, runExodusMigrate } from './migrate.js';
 export { buildExodusPlan, deriveStagingDirName, sourcesPresent } from './plan.js';
 export { runExodusStatus } from './status.js';
 export {
+  isDerivedOrInternalTable,
   resolveConsolidatedTableName,
   reverseLookup,
   type TableNameResolution,

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -203,6 +203,56 @@ function readJournal(stagingDir: string): ExodusJournal | null {
 }
 
 /**
+ * Invalidate the migrate journal after an aborted/rolled-back migration so a
+ * post-abort retry RE-COPIES every table from scratch (T11572).
+ *
+ * ## Why this is required for retry correctness
+ *
+ * `runExodusMigrate` is resumable (AC5): after each table copy it writes a
+ * journal entry with `status: 'done'`, and a subsequent run SKIPS any table
+ * already marked `done`. That resume optimisation is correct only while the
+ * consolidated rows it copied still EXIST. When the parity gate aborts, the
+ * exodus-on-open hook truncates the consolidated tables back to EMPTY
+ * (`rollbackConsolidatedToEmpty`) — but the on-disk journal still says every
+ * table is `done`. The next open therefore re-triggers (consolidated empty),
+ * runs `runExodusMigrate` again, finds every table `done` in the journal, copies
+ * NOTHING, re-verifies the still-empty target, and re-aborts — a permanent loop
+ * that pays the full migrate+verify cost on every open.
+ *
+ * Deleting the journal file forces `runExodusMigrate` to `initJournal()` afresh,
+ * so the retry actually re-copies. Idempotent and best-effort: a missing journal
+ * (or a missing staging dir) is a no-op. The staging backups are intentionally
+ * LEFT in place (they are the legacy source-of-truth snapshots — harmless to
+ * keep, valuable for forensics); only the progress journal is cleared.
+ *
+ * @param stagingDir - The staging directory whose `exodus-journal.json` to clear.
+ * @returns `true` if a journal file was removed, `false` if there was nothing to
+ *   remove.
+ *
+ * @task T11572 (abort/rollback must invalidate journal so retry re-copies)
+ * @epic T11249 (E6)
+ * @saga T11242
+ */
+export function clearExodusJournal(stagingDir: string): boolean {
+  const journalPath = join(stagingDir, JOURNAL_FILENAME);
+  try {
+    if (!existsSync(journalPath)) return false;
+    unlinkSync(journalPath);
+    log.info(
+      { stagingDir },
+      'exodus: cleared migrate journal after abort/rollback — a retry will RE-COPY all tables',
+    );
+    return true;
+  } catch (err) {
+    log.warn(
+      { err, stagingDir },
+      'exodus: failed to clear migrate journal after rollback (a retry may skip already-"done" tables)',
+    );
+    return false;
+  }
+}
+
+/**
  * Initialise a fresh journal object.
  */
 function initJournal(sqliteVersion: string): ExodusJournal {

--- a/packages/core/src/store/exodus/on-open.ts
+++ b/packages/core/src/store/exodus/on-open.ts
@@ -33,15 +33,26 @@
  *
  * After the copy, `verifyMigration` (T11551) compares row counts + canonical
  * digests + FK integrity + enum drift legacy↔consolidated. The data-continuity
- * gate is **row-count parity + zero FK orphans** (hash/enum drift are the
- * expected normalisation diagnostics — see {@link isDataContinuityOk}). If a
- * genuine deficit/orphan is detected the hook **aborts the cutover**: it rolls
- * the half-migrated consolidated tables back to EMPTY (`DELETE FROM` every user
- * table — see {@link rollbackConsolidatedToEmpty}) so the legacy DBs remain the
- * source of truth, no half-migrated `cleo.db` is exposed, and there are no silent
- * `INSERT OR IGNORE` row drops. The file is never unlinked; the chokepoint
- * re-opens a fresh handle afterwards (the migrate engine closes the handles it
- * opened, so the rollback re-opens the scope before truncating it).
+ * gate is **row-count parity + zero migration-INTRODUCED FK orphans** (hash/enum
+ * drift are the expected normalisation diagnostics, and pre-existing SOURCE FK
+ * orphans are tolerated as zero-loss — see {@link isDataContinuityOk}). If a
+ * genuine deficit/introduced-orphan is detected the hook **aborts the cutover**:
+ * it rolls the half-migrated consolidated tables back to EMPTY (`DELETE FROM`
+ * every user table — see {@link rollbackConsolidatedToEmpty}) so the legacy DBs
+ * remain the source of truth, no half-migrated `cleo.db` is exposed, and there
+ * are no silent `INSERT OR IGNORE` row drops. The file is never unlinked; the
+ * chokepoint re-opens a fresh handle afterwards (the migrate engine closes the
+ * handles it opened, so the rollback re-opens the scope before truncating it).
+ *
+ * ## Retry correctness — journal invalidation on abort (T11572)
+ *
+ * `runExodusMigrate` is resumable: it journals each table `done` and SKIPS
+ * already-`done` tables on a re-run. On abort we truncate the consolidated rows
+ * back to empty, so a stale `done` journal would make the next open re-trigger
+ * (target empty), copy NOTHING (journal says done), re-verify the still-empty
+ * target, and re-abort — a permanent loop. The abort path therefore also calls
+ * `clearExodusJournal(plan.stagingDir)` so a post-abort retry RE-COPIES from
+ * scratch.
  *
  * ## Concurrency safety (AC6 · reconcile with T11554 / R13-T11278)
  *
@@ -240,20 +251,33 @@ async function rollbackBothScopes(scope: DualScope): Promise<void> {
  *
  *   1. every data-bearing base table copied with EXACT row-count parity
  *      (`countMatch === true`), AND
- *   2. NO genuine referential orphans on the consolidated target
- *      (`foreignKeyViolations` empty).
+ *   2. NO referential orphans the migration INTRODUCED on the consolidated
+ *      target (`introducedForeignKeyViolations` empty).
+ *
+ * ## Pre-existing source orphans are tolerated (T11572)
+ *
+ * A legacy source DB can already contain referential orphans (e.g. a
+ * `tasks_task_relations` row pointing at a task that was deleted long before the
+ * migration). Those rows copy through faithfully — that is ZERO loss, not a
+ * migration defect — so they appear on BOTH sides and `verifyMigration`
+ * classifies them as `preExistingForeignKeyViolations`. Gating on the *total*
+ * orphan set (`foreignKeyViolations`) would permanently abort every real cutover
+ * over a defect the data already had. The gate therefore fails ONLY on
+ * `introducedForeignKeyViolations` — orphans present on the target that the
+ * source did not have (i.e. the migration dropped a parent row). Pre-existing
+ * orphans are logged as a WARN for a data-hygiene follow-up.
  *
  * Hash mismatch + source enum-drift are surfaced as WARN diagnostics (a true
- * content corruption would normally also show up as an FK orphan or a count
- * deficit), but they do NOT, on their own, indicate data loss.
+ * content corruption would normally also show up as an introduced FK orphan or a
+ * count deficit), but they do NOT, on their own, indicate data loss.
  *
  * @param result - The {@link VerifyMigrationResult} from `verifyMigration`.
- * @returns `true` when row-count parity holds for every table and there are no
- *   FK orphans — i.e. the cutover is safe.
+ * @returns `true` when row-count parity holds for every table and the migration
+ *   introduced no new FK orphans — i.e. the cutover is safe.
  */
 function isDataContinuityOk(result: VerifyMigrationResult): boolean {
   const allCountsMatch = result.tables.every((t) => t.countMatch);
-  return allCountsMatch && result.foreignKeyViolations.length === 0;
+  return allCountsMatch && result.introducedForeignKeyViolations.length === 0;
 }
 
 /**
@@ -322,7 +346,9 @@ export async function maybeRunExodusOnOpen(
 
   // Lazy-load the exodus engine via dynamic import to break the import cycle
   // (exodus/migrate.ts imports openDualScopeDb from dual-scope-db.ts).
-  const { buildExodusPlan, runExodusMigrate, verifyMigration } = await import('./index.js');
+  const { buildExodusPlan, runExodusMigrate, verifyMigration, clearExodusJournal } = await import(
+    './index.js'
+  );
 
   const plan = buildExodusPlan(cwd);
 
@@ -375,6 +401,9 @@ export async function maybeRunExodusOnOpen(
           // rolling the consolidated tables back to empty IN PLACE (handle stays
           // open; legacy DBs remain the source of truth).
           await rollbackBothScopes(scope);
+          // T11572: invalidate the journal so the NEXT open re-copies instead of
+          // resuming a half-done journal against the now-empty target (abort loop).
+          clearExodusJournal(migrateResult.stagingDir);
           const reason = `migration failed: ${migrateResult.error ?? 'unknown error'} — legacy DBs kept as source`;
           log.error({ scope, error: migrateResult.error }, `exodus-on-open: ${reason}`);
           return { outcome: 'aborted', reason };
@@ -410,18 +439,23 @@ export async function maybeRunExodusOnOpen(
           // source of truth. Never expose a lossy consolidated DB; never close the
           // caller's handle.
           await rollbackBothScopes(scope);
+          // T11572: invalidate the journal so a retry re-copies (see above).
+          clearExodusJournal(plan.stagingDir);
           const deficits = verifyResult.tables
             .filter((t) => !t.countMatch)
             .map((t) => `${t.targetTable}(${t.sourceCount}→${t.targetCount})`);
           const reason =
             `parity verification failed — cutover aborted, legacy DBs kept as source. ` +
             `count deficits: [${deficits.join(', ')}]; ` +
-            `fk orphans: ${verifyResult.foreignKeyViolations.length}. ${verifyResult.error ?? ''}`.trim();
+            `INTRODUCED fk orphans: ${verifyResult.introducedForeignKeyViolations.length} ` +
+            `(pre-existing source orphans tolerated: ${verifyResult.preExistingForeignKeyViolations.length}). ` +
+            `${verifyResult.error ?? ''}`.trim();
           log.error(
             {
               scope,
               countDeficits: deficits,
-              fkViolations: verifyResult.foreignKeyViolations.length,
+              introducedFkViolations: verifyResult.introducedForeignKeyViolations.length,
+              preExistingFkViolations: verifyResult.preExistingForeignKeyViolations.length,
             },
             'exodus-on-open: data-continuity FAILED — consolidated cleo.db rolled back to empty, legacy kept',
           );

--- a/packages/core/src/store/exodus/table-name-map.ts
+++ b/packages/core/src/store/exodus/table-name-map.ts
@@ -415,6 +415,88 @@ function inferSourceKind(sourceName: string): SourceKind | null {
 }
 
 // ---------------------------------------------------------------------------
+// Derived / internal table classification (T11572)
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal bookkeeping tables that exist in a legacy source DB but have NO
+ * consolidated counterpart and carry no user data — they are recreated by the
+ * runtime, not migrated. Matched by EXACT name.
+ *
+ * - `_conduit_meta` / `_conduit_migrations` — conduit-sqlite's own
+ *   schema-version + migration-ledger tables (see `conduit-sqlite.ts`). They
+ *   describe HOW the legacy conduit.db was built, not message payload data, and
+ *   the consolidated `cleo.db` has its own Drizzle journal (`__drizzle_*`) for
+ *   the same purpose. Row-comparing them would count internal ledger rows as a
+ *   user-data deficit and abort the cutover.
+ *
+ * @task T11572 (parity gate over-abort — internal/meta exclusion)
+ */
+const INTERNAL_BOOKKEEPING_TABLES: ReadonlySet<string> = new Set([
+  '_conduit_meta',
+  '_conduit_migrations',
+]);
+
+/**
+ * FTS5 shadow-table suffixes. A full-text index `<base>_fts` (an `fts5` VIRTUAL
+ * TABLE — e.g. `brain_decisions_fts`, `messages_fts`) materialises a family of
+ * backing tables `<base>_fts_data`, `<base>_fts_idx`, `<base>_fts_docsize`,
+ * `<base>_fts_config`, and (for `content=`-less indexes) `<base>_fts_content`.
+ *
+ * These are DERIVED from their content table and are REBUILT post-migration
+ * (`brain-search.ts` issues `INSERT INTO <base>_fts(<base>_fts) VALUES('rebuild')`).
+ * Their row counts do NOT correspond 1:1 to user rows, so comparing them against
+ * an absent consolidated target produces a spurious N→0 deficit. They must be
+ * excluded from the row-count-parity gate, not migrated.
+ *
+ * @task T11572 (parity gate over-abort — FTS5 shadow-table exclusion)
+ */
+const FTS5_SHADOW_SUFFIXES: readonly string[] = [
+  '_fts_data',
+  '_fts_idx',
+  '_fts_docsize',
+  '_fts_config',
+  '_fts_content',
+] as const;
+
+/**
+ * Return `true` if `tableName` is a DERIVED or INTERNAL table that must be
+ * EXCLUDED from the exodus row-count-parity gate (and from the copy path).
+ *
+ * This is the single, named, documented classification consumed by BOTH the
+ * migrate copy loop and the `verifyMigration` parity check, so the two never
+ * disagree about which tables carry migratable user data. It recognises:
+ *
+ *   1. **FTS5 virtual tables** — a bare `*_fts` name (e.g. `brain_decisions_fts`,
+ *      `messages_fts`). The virtual table itself cannot be `INSERT … SELECT`-ed
+ *      and is rebuilt from its content table after migration.
+ *   2. **FTS5 shadow/backing tables** — `*_fts_data`, `*_fts_idx`,
+ *      `*_fts_docsize`, `*_fts_config`, `*_fts_content` (see
+ *      {@link FTS5_SHADOW_SUFFIXES}). Derived; rebuilt post-migration.
+ *   3. **Internal bookkeeping** — `_conduit_meta`, `_conduit_migrations` (see
+ *      {@link INTERNAL_BOOKKEEPING_TABLES}). Schema-version ledgers with no
+ *      consolidated home.
+ *
+ * A migration is "safe" iff every BASE-DATA row survives; these derived/internal
+ * tables are NOT base data, so a 0-row consolidated counterpart for them is
+ * expected and correct — not data loss.
+ *
+ * @param tableName - Physical table name from a legacy source DB.
+ * @returns `true` when the table is derived/internal and must be skipped.
+ *
+ * @task T11572 (exodus parity gate: exclude FTS5 + internal/meta shadow tables)
+ * @epic T11249 (E6)
+ * @saga T11242
+ */
+export function isDerivedOrInternalTable(tableName: string): boolean {
+  if (INTERNAL_BOOKKEEPING_TABLES.has(tableName)) return true;
+  // Bare FTS5 virtual table (e.g. `brain_decisions_fts`, `messages_fts`).
+  if (tableName.endsWith('_fts')) return true;
+  // FTS5 backing/shadow tables (`*_fts_data`, `*_fts_idx`, …).
+  return FTS5_SHADOW_SUFFIXES.some((suffix) => tableName.endsWith(suffix));
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -443,6 +525,20 @@ export function resolveConsolidatedTableName(
   sourceName: string,
   legacyTable: string,
 ): TableNameResolution {
+  // T11572: derived (FTS5 shadow) + internal (conduit meta/migrations) tables
+  // are excluded BEFORE any per-source map lookup. They carry no migratable base
+  // data — comparing them against an absent consolidated target would count an
+  // N→0 "deficit" and abort the cutover. This guard is source-kind-agnostic so
+  // it covers FTS shadow tables in any DB (brain/conduit/…).
+  if (isDerivedOrInternalTable(legacyTable)) {
+    return {
+      kind: 'skip',
+      reason: legacyTable.includes('_fts')
+        ? `derived FTS5 table — rebuilt post-migration from its content table, not row-compared`
+        : `internal bookkeeping table — no consolidated home (recreated by runtime)`,
+    };
+  }
+
   const kind = inferSourceKind(sourceName);
 
   if (kind === null) {

--- a/packages/core/src/store/exodus/verify-migration.ts
+++ b/packages/core/src/store/exodus/verify-migration.ts
@@ -188,6 +188,22 @@ function listTables(db: DatabaseSync): string[] {
   return rows.map((r) => r.name);
 }
 
+/**
+ * Return `true` if `tableName` exists in `db`. Used to route an FK-orphan row to
+ * the scope DB that actually declares its child table (T11572).
+ */
+function tableExists(db: DatabaseSync, tableName: string): boolean {
+  try {
+    const escaped = tableName.replace(/'/g, "''");
+    return (
+      db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='${escaped}'`).get() !==
+      undefined
+    );
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Enum/type-drift detection
 // ---------------------------------------------------------------------------
@@ -357,6 +373,126 @@ function foreignKeyCheck(db: DatabaseSync, scope: string): MigrationForeignKeyVi
   }
 }
 
+/**
+ * Compute a **migration-stable, name-mapping-stable signature** for one FK
+ * orphan so the same dangling row can be matched between the legacy SOURCE and
+ * the consolidated TARGET — despite (a) a different `rowid` after the copy AND
+ * (b) the legacy→consolidated table RENAME (`task_relations`→`tasks_task_relations`,
+ * parent `tasks`→`tasks_tasks`).
+ *
+ * `PRAGMA foreign_key_check` returns `{ table, rowid, parent, fkid }`. We key the
+ * orphan on:
+ *   - the CONSOLIDATED child-table name (source names are mapped via
+ *     {@link resolveConsolidatedTableName} so both sides agree),
+ *   - the CONSOLIDATED parent-table name (same mapping),
+ *   - the actual VALUES of the foreign-key child columns for that row (read via
+ *     `PRAGMA foreign_key_list` + the row at `rowid`) — these travel with the row
+ *     unchanged, so the dangling reference is identical on both sides.
+ *
+ * `fkid` is intentionally EXCLUDED — the consolidated table may declare its FKs
+ * in a different order than the legacy one, so the per-table fkid is not stable.
+ * The (consolidated child, consolidated parent, dangling FK column values) triple
+ * uniquely identifies the orphan reference.
+ *
+ * Falls back to a column-name-only shape if the child columns can't be read
+ * (best-effort — a fallback only ever makes two orphans compare as *different*,
+ * which biases toward treating an orphan as "introduced", the SAFE/strict
+ * direction).
+ *
+ * @param db         - DB handle the orphan was found in.
+ * @param v          - One `PRAGMA foreign_key_check` row.
+ * @param sourceName - When set, the orphan is on the SOURCE side and its
+ *   `table`/`parent` names are mapped to their consolidated equivalents so the
+ *   signature matches the target side. Omit for the already-consolidated target.
+ * @returns A stable string signature.
+ */
+function orphanSignature(
+  db: DatabaseSync,
+  v: { table: string; rowid: number | null; parent: string; fkid: number },
+  sourceName?: string,
+): string {
+  // Map both child + parent table names to their CONSOLIDATED form so the source
+  // and target signatures agree across the legacy→consolidated rename.
+  const mapName = (name: string): string => {
+    if (sourceName === undefined) return name; // already consolidated (target side)
+    const res = resolveConsolidatedTableName(sourceName, name);
+    return res.kind === 'skip' ? name : res.targetName;
+  };
+  const childTable = mapName(v.table);
+  const parentTable = mapName(v.parent);
+
+  // Resolve the child→parent column mapping for this specific FK (matched by
+  // fkid via PRAGMA foreign_key_list ordering).
+  let childCols: string[] = [];
+  try {
+    const fkList = db.prepare(`PRAGMA foreign_key_list("${v.table}")`).all() as Array<{
+      id: number;
+      from: string;
+    }>;
+    childCols = fkList.filter((r) => r.id === v.fkid).map((r) => r.from);
+  } catch {
+    // ignore — fall through to rowid-based fallback
+  }
+
+  if (v.rowid !== null && childCols.length > 0) {
+    try {
+      const sel = childCols.map((c) => `"${c}"`).join(', ');
+      const row = db.prepare(`SELECT ${sel} FROM "${v.table}" WHERE rowid = ?`).get(v.rowid) as
+        | Record<string, unknown>
+        | undefined;
+      if (row) {
+        // Order the FK column values deterministically by column name.
+        const vals = childCols
+          .slice()
+          .sort()
+          .map((c) => `${c}=${JSON.stringify(row[c])}`)
+          .join('&');
+        return `${childTable}|${parentTable}|${vals}`;
+      }
+    } catch {
+      // ignore — fall through to rowid-based fallback
+    }
+  }
+
+  // Fallback: rowid-qualified signature (only collides with itself).
+  return `${childTable}|${parentTable}|rowid:${v.rowid ?? '?'}`;
+}
+
+/**
+ * Collect the set of {@link orphanSignature}s for every FK orphan in a SOURCE DB.
+ *
+ * Used to compute SOURCE-side orphan signatures so the parity gate can subtract
+ * pre-existing orphans from the target's orphan set and fail only on the orphans
+ * the migration INTRODUCED (T11572). The signatures are mapped to consolidated
+ * table names so they compare equal to the target-side signatures.
+ *
+ * @param db         - SOURCE DB handle to scan.
+ * @param sourceName - `LegacyDbDescriptor.name` (for table-name mapping).
+ * @param scope      - Scope label for diagnostics.
+ * @returns A set of name-mapping-stable orphan signatures.
+ */
+function sourceOrphanSignatures(db: DatabaseSync, sourceName: string, scope: string): Set<string> {
+  const sigs = new Set<string>();
+  try {
+    const rows = db.prepare('PRAGMA foreign_key_check').all() as Array<{
+      table: string;
+      rowid: number | null;
+      parent: string;
+      fkid: number;
+    }>;
+    for (const r of rows) sigs.add(orphanSignature(db, r, sourceName));
+    if (rows.length > 0) {
+      log.warn(
+        { scope, count: rows.length, sample: rows.slice(0, 5) },
+        `verifyMigration: source already has ${rows.length} pre-existing FK orphan(s) — these are tolerated (carried forward losslessly, flagged for data-hygiene)`,
+      );
+    }
+  } catch (err) {
+    log.warn({ scope, err }, 'verifyMigration: source PRAGMA foreign_key_check failed (non-fatal)');
+  }
+  return sigs;
+}
+
 // ---------------------------------------------------------------------------
 // Public primitive
 // ---------------------------------------------------------------------------
@@ -396,13 +532,23 @@ export function verifyMigration(
   const tables: MigrationTableParity[] = [];
   const enumDrift: MigrationEnumDrift[] = [];
   const foreignKeyViolations: MigrationForeignKeyViolation[] = [];
+  const introducedForeignKeyViolations: MigrationForeignKeyViolation[] = [];
+  const preExistingForeignKeyViolations: MigrationForeignKeyViolation[] = [];
   const failureLines: string[] = [];
+  /**
+   * Signatures of FK orphans ALREADY present in the legacy SOURCE DBs (T11572).
+   * Target orphans whose signature is in this set are pre-existing — carried
+   * forward losslessly — and do NOT fail the parity gate.
+   */
+  const sourceOrphanSigs = new Set<string>();
 
   if (!existsSync(projectDbPath)) {
     return {
       ok: false,
       tables: [],
       foreignKeyViolations: [],
+      introducedForeignKeyViolations: [],
+      preExistingForeignKeyViolations: [],
       enumDrift: [],
       error: `Consolidated project cleo.db not found at ${projectDbPath}. Run 'cleo exodus migrate' first.`,
     };
@@ -412,6 +558,8 @@ export function verifyMigration(
       ok: false,
       tables: [],
       foreignKeyViolations: [],
+      introducedForeignKeyViolations: [],
+      preExistingForeignKeyViolations: [],
       enumDrift: [],
       error: `Consolidated global cleo.db not found at ${globalDbPath}. Run 'cleo exodus migrate' first.`,
     };
@@ -430,6 +578,16 @@ export function verifyMigration(
       const srcSnap = openCleoDbSnapshot(src.path, { readOnly: true });
 
       try {
+        // T11572: record FK orphans that already exist in THIS source DB so the
+        // gate can distinguish pre-existing orphans (tolerated, zero-loss) from
+        // orphans the migration introduces (genuine loss → abort). Done while the
+        // source snapshot is open; signatures are migration-stable (content, not
+        // rowid). FK enforcement on the source is irrelevant — foreign_key_check
+        // scans regardless.
+        for (const sig of sourceOrphanSignatures(srcSnap.db, src.name, `source:${src.name}`)) {
+          sourceOrphanSigs.add(sig);
+        }
+
         const sourceTables = listTables(srcSnap.db);
         // Pre-compute the table set for each consolidated scope once; the
         // per-table scope override (ADR-090 nexus graph residency, T11539) means
@@ -539,17 +697,54 @@ export function verifyMigration(
     }
 
     // --- Foreign-key integrity on each distinct target DB ---
-    foreignKeyViolations.push(...foreignKeyCheck(projectSnap.db, 'project'));
-    foreignKeyViolations.push(...foreignKeyCheck(globalSnap.db, 'global'));
-    for (const fk of foreignKeyViolations) {
-      failureLines.push(
-        `[fk] ${fk.table}.rowid=${fk.rowid ?? '?'} references missing ${fk.parent} (fkid=${fk.fkid})`,
+    // Collect ALL target orphans, then partition into pre-existing (already
+    // orphaned in the source — tolerated, zero-loss) vs migration-introduced
+    // (genuine loss → gate failure). Match by migration-stable signature so a
+    // faithfully-copied pre-existing orphan is recognised despite a new rowid.
+    const targetOrphans: MigrationForeignKeyViolation[] = [];
+    targetOrphans.push(...foreignKeyCheck(projectSnap.db, 'project'));
+    targetOrphans.push(...foreignKeyCheck(globalSnap.db, 'global'));
+    foreignKeyViolations.push(...targetOrphans);
+
+    for (const fk of targetOrphans) {
+      // Recompute the orphan signature on the TARGET side (same content key as
+      // the source side) to test membership in the pre-existing source set. The
+      // orphan lives in whichever scope DB declares the child table.
+      const orphanDb = tableExists(projectSnap.db, fk.table) ? projectSnap.db : globalSnap.db;
+      const sig = orphanSignature(orphanDb, fk);
+      const preExisting = sourceOrphanSigs.has(sig);
+      if (preExisting) {
+        preExistingForeignKeyViolations.push(fk);
+      } else {
+        introducedForeignKeyViolations.push(fk);
+        // ONLY migration-INTRODUCED orphans fail the gate (T11572).
+        failureLines.push(
+          `[fk] ${fk.table}.rowid=${fk.rowid ?? '?'} references missing ${fk.parent} (fkid=${fk.fkid}) — INTRODUCED by migration`,
+        );
+      }
+    }
+
+    if (preExistingForeignKeyViolations.length > 0) {
+      log.warn(
+        {
+          count: preExistingForeignKeyViolations.length,
+          sample: preExistingForeignKeyViolations.slice(0, 5),
+        },
+        `verifyMigration: ${preExistingForeignKeyViolations.length} pre-existing source FK orphan(s) carried forward losslessly — tolerated (flag for data-hygiene follow-up, NOT a migration failure)`,
       );
     }
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'verifyMigration failed');
-    return { ok: false, tables, foreignKeyViolations, enumDrift, error };
+    return {
+      ok: false,
+      tables,
+      foreignKeyViolations,
+      introducedForeignKeyViolations,
+      preExistingForeignKeyViolations,
+      enumDrift,
+      error,
+    };
   } finally {
     projectSnap.close();
     globalSnap.close();
@@ -560,8 +755,23 @@ export function verifyMigration(
       .map((l) => `  • ${l}`)
       .join('\n')}`;
     log.error({ failureCount: failureLines.length }, error);
-    return { ok: false, tables, foreignKeyViolations, enumDrift, error };
+    return {
+      ok: false,
+      tables,
+      foreignKeyViolations,
+      introducedForeignKeyViolations,
+      preExistingForeignKeyViolations,
+      enumDrift,
+      error,
+    };
   }
 
-  return { ok: true, tables, foreignKeyViolations, enumDrift };
+  return {
+    ok: true,
+    tables,
+    foreignKeyViolations,
+    introducedForeignKeyViolations,
+    preExistingForeignKeyViolations,
+    enumDrift,
+  };
 }


### PR DESCRIPTION
## Summary

The exodus real-data cutover dry-run aborted on three gate-correctness bugs. The safety net worked (zero data loss), but the cutover could never succeed until the parity gate distinguished REAL data loss from benign differences. This fixes all three without weakening genuine-loss detection.

**Principle:** a migration is safe iff every base-data row in the source is present in the target; derived/internal/FTS tables and pre-existing source defects are NOT loss.

### BLOCKER 1 — FTS5 + meta shadow tables counted as deficits
- New named SSoT predicate `isDerivedOrInternalTable(name)` in `table-name-map.ts`: FTS5 `*_fts` virtual tables + `*_fts_{data,idx,docsize,config,content}` shadow tables, and `_conduit_meta`/`_conduit_migrations` bookkeeping.
- Wired into `resolveConsolidatedTableName` → `kind:'skip'` BEFORE any per-source map lookup, so BOTH the migrate copy loop AND `verifyMigration` exclude them. FTS indexes are rebuilt post-migration; meta tables have no consolidated home.

### BLOCKER 2 — pre-existing SOURCE FK orphans abort
- `verifyMigration` now scans each SOURCE DB with `PRAGMA foreign_key_check` and computes name-mapping-stable orphan signatures (consolidated child+parent table names + dangling FK column values).
- Target orphans are partitioned into `preExistingForeignKeyViolations` (already in source → tolerated, carried forward losslessly, logged WARN for data-hygiene) vs `introducedForeignKeyViolations` (migration dropped a parent → genuine loss).
- `isDataContinuityOk` gates ONLY on introduced orphans.

### BLOCKER 3 — abort→retry permanent loop
- `clearExodusJournal(stagingDir)` deletes the migrate journal on both abort paths so a post-abort retry RE-COPIES instead of resuming a stale `done` journal against the rolled-back empty target.

## Tests (89 exodus tests green)
- FTS5+`_conduit_meta` fixture migrates GREEN (verify-level + full migrate)
- pre-existing source FK orphan migrates GREEN, orphan preserved
- genuine count deficit STILL aborts; introduced orphan STILL aborts
- retry-after-forced-abort re-copies and succeeds

## Data-hygiene follow-up
The 2 real `tasks_task_relations` orphan rows (referencing deleted `T-RECONCILE-FOLLOWUP-v2026.5.38-2/-3`) migrate as-is and are flagged for a separate clean-up task — they no longer block the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)