### PR TITLE
fix(T10538): agent-trust completion — cancelled-child waiver (DP4) + add-under-done reopen (DP5)

### DIFF
--- a/.changeset/pmcore-donetrust-agent-trust.md
+++ b/.changeset/pmcore-donetrust-agent-trust.md
@@ -1,0 +1,18 @@
+---
+id: pmcore-donetrust-agent-trust
+tasks: [T10538]
+kind: fix
+summary: PM-Core V2 agent-trust completion — cancelled children require a waiver (DP4) and add-under-done-parent reopens the ancestor (DP5)
+---
+
+Fixes two PM-Core V2 "agent-trust" completion defects flagged by the saga T10538 audit. Both let a parent be marked `done` while the work was not actually done, eroding trust in task state.
+
+**Design-point 4 — cancelled children no longer silently satisfy parent completion.**
+The premature-close guard and the epic / coordination-parent auto-rollup paths previously filtered `cancelled` children out of the completion check, so a parent completed as if the cancelled work had shipped. Completing a parent that has an un-waived `cancelled` child is now rejected with `E_CANCELLED_CHILD_NO_WAIVER` (exit 109); the auto-rollup paths no longer auto-close such a parent. To close it, supply `cleo complete <parentId> --waive-cancelled-children "<reason>"` (cite a replacement task id when applicable) — the waiver is audited to `.cleo/audit/cancelled-child-waiver.jsonl`. The existing T10554 `evaluateCompletion` waiver/replacement model was written but unwired; this change wires the equivalent runtime gate into `completeTask`.
+
+**Design-point 5 — adding a child under a `done` parent reopens the ancestor chain.**
+`cleo add --parent <doneEpic>` injected an unsatisfied `child_task` AC into a completed parent with no ancestor reopen, leaving a silently-stale `done` parent. Now the done parent (and any done ancestors) are reopened to `pending` — reusing the canonical `coreTaskReopen` semantics (clear `completedAt`, preserve completion history in notes) — and the reopen is surfaced on the add result as `reopenedAncestors` plus a warning.
+
+The CleoError code/details/fix from these gates are now preserved end-to-end (the `taskComplete` / `completeTaskStrict` catches route through `cleoErrorToEngineResult` instead of flattening every guard rejection to `E_INTERNAL`, which also restores fidelity for the pre-existing `E_EPIC_HAS_PENDING_CHILDREN` guard).
+
+New tests in `packages/core/src/tasks/__tests__/agent-trust-completion.test.ts` cover both design points (block + waiver-success + audit + reopen). Four existing tests that encoded the old broken behavior (cancelled-sibling auto-close / ignore) were updated to the design-point-correct behavior.

--- a/packages/cleo/src/cli/commands/complete.ts
+++ b/packages/cleo/src/cli/commands/complete.ts
@@ -76,6 +76,12 @@ export const completeCommand = defineCommand({
       description:
         'Mandatory justification text for --waive-ac. Captured verbatim in the audit row.',
     },
+    // T10538 — cancelled-child waiver gate (PM-Core V2 agent-trust)
+    'waive-cancelled-children': {
+      type: 'string',
+      description:
+        'Reason for completing a parent that has cancelled children. Cancelled work does not silently satisfy completion; the reason is audited to .cleo/audit/cancelled-child-waiver.jsonl.',
+    },
   },
   async run({ args }) {
     const response = await dispatchRaw('mutate', 'tasks', 'complete', {
@@ -88,6 +94,8 @@ export const completeCommand = defineCommand({
       // T10509 — AC-coverage gate waiver path
       waiveAc: args['waive-ac'] as string | undefined,
       waiveReason: args['waive-reason'] as string | undefined,
+      // T10538 — cancelled-child waiver (PM-Core V2 agent-trust)
+      cancelledChildWaiverReason: args['waive-cancelled-children'] as string | undefined,
     });
 
     if (!response.success) {

--- a/packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts
@@ -756,11 +756,16 @@ describe('TasksHandler', () => {
 
       expect(result.success).toBe(true);
       // T832/ADR-051: completeTaskStrict no longer accepts the force parameter.
-      // T1632: notes/overrideReason/acknowledgeRisk now passed as options object.
+      // T1632: notes/overrideReason/acknowledgeRisk passed as options object.
+      // T10509: waiveAc/waiveReason (AC-coverage gate waiver).
+      // T10538: cancelledChildWaiverReason (cancelled-child waiver, agent-trust).
       expect(completeTaskStrict).toHaveBeenCalledWith('/mock/project', 'T001', {
         notes: 'Done',
         overrideReason: undefined,
         acknowledgeRisk: undefined,
+        waiveAc: undefined,
+        waiveReason: undefined,
+        cancelledChildWaiverReason: undefined,
       });
     });
 

--- a/packages/cleo/src/dispatch/domains/tasks.ts
+++ b/packages/cleo/src/dispatch/domains/tasks.ts
@@ -439,6 +439,8 @@ const _tasksTypedHandler = defineTypedHandler<TasksOps>('tasks', {
       // T10509 — AC-coverage gate waiver path
       waiveAc: params.waiveAc,
       waiveReason: params.waiveReason,
+      // T10538 — cancelled-child waiver (PM-Core V2 agent-trust)
+      cancelledChildWaiverReason: params.cancelledChildWaiverReason,
     });
     // T994: Track memory usage on task completion (fire-and-forget; must not block).
     // SSoT-EXEMPT: fire-and-forget side-effect that must not block the complete flow

--- a/packages/contracts/src/exit-codes.ts
+++ b/packages/contracts/src/exit-codes.ts
@@ -247,6 +247,26 @@ export enum ExitCode {
    * @adr ADR-079-r4
    */
   AC_COVERAGE_INCOMPLETE = 108,
+
+  /**
+   * E_CANCELLED_CHILD_NO_WAIVER — `cleo complete <parentId>` was rejected
+   * because the parent has one or more `cancelled` children that have NOT been
+   * waived or replaced. A cancelled child represents work that was NOT done;
+   * silently treating it as satisfied lets a parent complete as if cancelled
+   * work had shipped (PM-Core V2 design-point 4 — agent-trust completion).
+   *
+   * `error.details.cancelledChildIds` lists the offending children. Recovery:
+   *   1. Record an audited waiver for the cancelled children via
+   *      `cleo complete <parentId> --waive-cancelled-children "<reason>"`
+   *      (logged to `.cleo/audit/cancelled-child-waiver.jsonl`).
+   *   2. Re-open and finish the work (the child stops being cancelled).
+   *   3. Replace the cancelled work with a new done child and waive the
+   *      original, citing the replacement task id in the reason.
+   *
+   * @codeName E_CANCELLED_CHILD_NO_WAIVER
+   * @saga T10538 (PM-Core V2 agent-trust)
+   */
+  CANCELLED_CHILD_NO_WAIVER = 109,
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/contracts/src/operations/tasks.ts
+++ b/packages/contracts/src/operations/tasks.ts
@@ -1449,6 +1449,16 @@ export interface TasksCompleteQueryParams {
    * @task T10509
    */
   waiveReason?: string;
+  /**
+   * Reason for waiving the `E_CANCELLED_CHILD_NO_WAIVER` gate (PM-Core V2
+   * design-point 4). When the parent has `cancelled` children, completion is
+   * blocked unless this waiver is supplied — a cancelled child is abandoned
+   * work and must not silently satisfy parent completion. Recorded to
+   * `.cleo/audit/cancelled-child-waiver.jsonl`.
+   *
+   * @saga T10538 (PM-Core V2 agent-trust)
+   */
+  cancelledChildWaiverReason?: string;
 }
 /**
  * Result of `tasks.complete` — completion confirmation with unblocked tasks.

--- a/packages/core/src/dispatch/mutate-projection.ts
+++ b/packages/core/src/dispatch/mutate-projection.ts
@@ -175,6 +175,21 @@ export const MUTATE_PROJECTION_PLANS: Readonly<Record<string, MutateProjectionPl
       }
       if (data['duplicate'] === true) envelope['duplicate'] = true;
       if (data['dryRun'] === true) envelope['dryRun'] = true;
+      // T089 — surface non-blocking validation warnings (e.g. duplicate-similar)
+      // and the T10538 ancestor-reopen notice so `cleo add` callers see them.
+      const warnings = data['warnings'];
+      if (Array.isArray(warnings) && warnings.length > 0) {
+        envelope['warnings'] = warnings.filter(
+          (entry): entry is string => typeof entry === 'string',
+        );
+      }
+      // T10538 / design-point 5 — report any done ancestors reopened by this add.
+      const reopenedAncestors = data['reopenedAncestors'];
+      if (Array.isArray(reopenedAncestors) && reopenedAncestors.length > 0) {
+        envelope['reopenedAncestors'] = reopenedAncestors.filter(
+          (entry): entry is string => typeof entry === 'string',
+        );
+      }
       return envelope;
     },
   },

--- a/packages/core/src/tasks/__tests__/agent-trust-completion.test.ts
+++ b/packages/core/src/tasks/__tests__/agent-trust-completion.test.ts
@@ -1,0 +1,292 @@
+/**
+ * PM-Core V2 agent-trust completion semantics (saga T10538).
+ *
+ * Covers two completion-trust defects flagged by the agent-trust audit:
+ *
+ * Design-point 4 — "Cancelled children should NOT automatically satisfy parent
+ *   completion. They require waiver/replacement evidence."
+ *   A parent with an un-waived `cancelled` child is REJECTED with
+ *   `E_CANCELLED_CHILD_NO_WAIVER`; supplying `cancelledChildWaiverReason`
+ *   records an audit and allows completion.
+ *
+ * Design-point 5 — "Silent stale 'done' parents destroy agent trust."
+ *   Adding a child under a `done` parent reopens the done parent (and any done
+ *   ancestors) so it never silently holds an unsatisfied child.
+ *
+ * @saga T10538
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
+import type { DataAccessor } from '../../store/data-accessor.js';
+import { resetDbState } from '../../store/sqlite.js';
+import { addTask } from '../add.js';
+import { completeTask } from '../complete.js';
+
+const permissiveConfig = JSON.stringify({
+  enforcement: {
+    session: { requiredForMutate: false },
+    acceptance: { mode: 'off' },
+  },
+  lifecycle: { mode: 'off' },
+  verification: { enabled: false },
+});
+
+const now = new Date().toISOString();
+
+function makeEpic(id: string, status: 'active' | 'done' = 'active') {
+  return {
+    id,
+    title: `Epic ${id}`,
+    type: 'epic' as const,
+    status,
+    priority: 'medium' as const,
+    acceptance: ['AC1'],
+    createdAt: now,
+    updatedAt: now,
+    ...(status === 'done' ? { completedAt: now } : {}),
+  };
+}
+
+function makeChild(
+  id: string,
+  parentId: string,
+  status: 'pending' | 'active' | 'done' | 'cancelled' = 'pending',
+) {
+  return {
+    id,
+    title: `Child ${id}`,
+    type: 'task' as const,
+    status,
+    priority: 'medium' as const,
+    parentId,
+    acceptance: ['AC1'],
+    createdAt: now,
+    updatedAt: now,
+    ...(status === 'done' ? { completedAt: now } : {}),
+    ...(status === 'cancelled' ? { cancelledAt: now } : {}),
+  };
+}
+
+describe('T10538: agent-trust completion semantics', () => {
+  let env: TestDbEnv;
+  let accessor: DataAccessor;
+
+  beforeEach(async () => {
+    env = await createTestDb();
+    accessor = env.accessor;
+    process.env['CLEO_DIR'] = env.cleoDir;
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(env.cleoDir, 'config.json'), permissiveConfig);
+  });
+
+  afterEach(async () => {
+    delete process.env['CLEO_DIR'];
+    resetDbState();
+    await env.cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // Design-point 4 — cancelled children require a waiver
+  // -------------------------------------------------------------------------
+
+  describe('design-point 4: cancelled children require waiver/replacement', () => {
+    it('REJECTS completing a parent with an un-waived cancelled child', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'done'),
+        makeChild('T003', 'E001', 'cancelled'),
+      ]);
+
+      await expect(completeTask({ taskId: 'E001' }, env.tempDir, accessor)).rejects.toMatchObject({
+        code: ExitCode.CANCELLED_CHILD_NO_WAIVER,
+        message: expect.stringContaining('T003'),
+      });
+
+      const epic = await accessor.loadSingleTask('E001');
+      expect(epic?.status).not.toBe('done');
+    });
+
+    it('surfaces the offending cancelled child ids in error.details', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'cancelled'),
+        makeChild('T003', 'E001', 'cancelled'),
+      ]);
+
+      await expect(completeTask({ taskId: 'E001' }, env.tempDir, accessor)).rejects.toMatchObject({
+        code: ExitCode.CANCELLED_CHILD_NO_WAIVER,
+        details: { cancelledChildIds: expect.arrayContaining(['T002', 'T003']) },
+      });
+    });
+
+    it('ALLOWS completion when a cancelled-child waiver is supplied', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'done'),
+        makeChild('T003', 'E001', 'cancelled'),
+      ]);
+
+      const result = await completeTask(
+        { taskId: 'E001', cancelledChildWaiverReason: 'replaced by T999 — out of scope' },
+        env.tempDir,
+        accessor,
+      );
+      expect(result.task.status).toBe('done');
+    });
+
+    it('writes the waiver to .cleo/audit/cancelled-child-waiver.jsonl', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'done'),
+        makeChild('T003', 'E001', 'cancelled'),
+      ]);
+
+      await completeTask(
+        { taskId: 'E001', cancelledChildWaiverReason: 'incident-42 replacement T999' },
+        env.tempDir,
+        accessor,
+      );
+
+      const auditPath = join(env.tempDir, '.cleo', 'audit', 'cancelled-child-waiver.jsonl');
+      const raw = await readFile(auditPath, 'utf8');
+      const entries = raw
+        .trim()
+        .split('\n')
+        .map(
+          (l) =>
+            JSON.parse(l) as {
+              parentId: string;
+              cancelledChildIds: string[];
+              waiverReason: string;
+              timestamp: string;
+              agent: string;
+            },
+        );
+
+      expect(entries).toHaveLength(1);
+      const [entry] = entries;
+      expect(entry.parentId).toBe('E001');
+      expect(entry.cancelledChildIds).toContain('T003');
+      expect(entry.waiverReason).toBe('incident-42 replacement T999');
+      expect(entry.timestamp).toBeTruthy();
+      expect(entry.agent).toBeTruthy();
+    });
+
+    it('does NOT write an audit entry when the gate blocks (no waiver)', async () => {
+      await seedTasks(accessor, [makeEpic('E001'), makeChild('T002', 'E001', 'cancelled')]);
+
+      await expect(completeTask({ taskId: 'E001' }, env.tempDir, accessor)).rejects.toMatchObject({
+        code: ExitCode.CANCELLED_CHILD_NO_WAIVER,
+      });
+
+      const auditPath = join(env.tempDir, '.cleo', 'audit', 'cancelled-child-waiver.jsonl');
+      await expect(readFile(auditPath, 'utf8')).rejects.toThrow();
+    });
+
+    it('completes normally when there are no cancelled children', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'done'),
+        makeChild('T003', 'E001', 'done'),
+      ]);
+
+      const result = await completeTask({ taskId: 'E001' }, env.tempDir, accessor);
+      expect(result.task.status).toBe('done');
+    });
+
+    it('does NOT auto-close a parent when the last live sibling completes but a sibling is cancelled', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'cancelled'),
+        makeChild('T003', 'E001', 'active'),
+      ]);
+
+      // Completing the last active child must NOT auto-roll the epic to done —
+      // the cancelled sibling is un-waived abandoned work.
+      const result = await completeTask({ taskId: 'T003' }, env.tempDir, accessor);
+      expect(result.task.status).toBe('done');
+      expect(result.autoCompleted ?? []).not.toContain('E001');
+
+      const epic = await accessor.loadSingleTask('E001');
+      expect(epic?.status).not.toBe('done');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Design-point 5 — add under a done parent reopens the ancestor chain
+  // -------------------------------------------------------------------------
+
+  describe('design-point 5: add under a done parent reopens the ancestor', () => {
+    // addTask validates parent ids match the T### format, so the parent epic
+    // is seeded as T001 here (not the E### alias used in the completion tests).
+    it('reopens a done parent when a child is added under it', async () => {
+      await seedTasks(accessor, [makeEpic('T001', 'done')]);
+
+      const result = await addTask(
+        {
+          title: 'Late child',
+          description: 'work added after the parent was completed',
+          parentId: 'T001',
+        },
+        env.tempDir,
+        accessor,
+      );
+
+      // The new child exists.
+      expect(result.task.parentId).toBe('T001');
+      // The done parent was reopened and reported on the result.
+      expect(result.reopenedAncestors).toEqual(['T001']);
+
+      const parent = await accessor.loadSingleTask('T001');
+      expect(parent?.status).toBe('pending');
+      expect(parent?.completedAt).toBeUndefined();
+    });
+
+    it('surfaces a warning describing the reopen', async () => {
+      await seedTasks(accessor, [makeEpic('T001', 'done')]);
+
+      const result = await addTask(
+        { title: 'Late child', description: 'late work under done parent', parentId: 'T001' },
+        env.tempDir,
+        accessor,
+      );
+
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings?.some((w) => w.includes('T001') && /Reopen/i.test(w))).toBe(true);
+    });
+
+    it('preserves the prior completion timestamp in the parent notes', async () => {
+      await seedTasks(accessor, [makeEpic('T001', 'done')]);
+
+      await addTask(
+        { title: 'Late child', description: 'late work', parentId: 'T001' },
+        env.tempDir,
+        accessor,
+      );
+
+      const parent = await accessor.loadSingleTask('T001');
+      const notes = parent?.notes ?? [];
+      expect(notes.some((n) => n.includes('completion-history'))).toBe(true);
+      expect(notes.some((n) => /Reopened by add of child/i.test(n))).toBe(true);
+    });
+
+    it('does NOT reopen a parent that is not done', async () => {
+      await seedTasks(accessor, [makeEpic('T001', 'active')]);
+
+      const result = await addTask(
+        { title: 'Child', description: 'child under active parent', parentId: 'T001' },
+        env.tempDir,
+        accessor,
+      );
+
+      expect(result.reopenedAncestors).toBeUndefined();
+
+      const parent = await accessor.loadSingleTask('T001');
+      expect(parent?.status).toBe('active');
+    });
+  });
+});

--- a/packages/core/src/tasks/__tests__/coordination-parent-rollup.test.ts
+++ b/packages/core/src/tasks/__tests__/coordination-parent-rollup.test.ts
@@ -239,7 +239,12 @@ describe('coordination parent rollup (T9040)', () => {
   // All-cancelled siblings: treated as terminal → parent rolls up
   // -------------------------------------------------------------------------
 
-  it('auto-rolls-up when the last active child completes and all others are cancelled', async () => {
+  // T10538 / design-point 4 (agent-trust): a cancelled child is NOT done work,
+  // so it must NOT silently auto-roll-up the coordination parent. This test
+  // previously asserted the parent auto-completed despite an un-waived cancelled
+  // child — that was the defect. The corrected behavior leaves the parent open
+  // until the cancelled child is waived/replaced.
+  it('does NOT auto-roll-up when the last active child completes but a sibling is cancelled (un-waived)', async () => {
     await seedTasks(accessor, [
       {
         id: 'P005',
@@ -269,11 +274,14 @@ describe('coordination parent rollup (T9040)', () => {
 
     const result = await completeTask({ taskId: 'C010' }, env.tempDir, accessor);
 
+    // The completed child itself goes done.
     expect(result.task.status).toBe('done');
-    expect(result.autoCompleted).toContain('P005');
+    // But the coordination parent must NOT auto-close — the cancelled sibling
+    // is un-waived abandoned work.
+    expect(result.autoCompleted ?? []).not.toContain('P005');
 
     const parent = await accessor.loadSingleTask('P005');
-    expect(parent?.status).toBe('done');
+    expect(parent?.status).not.toBe('done');
   });
 });
 

--- a/packages/core/src/tasks/__tests__/epic-auto-complete.test.ts
+++ b/packages/core/src/tasks/__tests__/epic-auto-complete.test.ts
@@ -166,7 +166,12 @@ describe('epic auto-complete', () => {
     expect(epic?.status).not.toBe('done');
   });
 
-  it('auto-completes epic when all remaining subtasks are cancelled', async () => {
+  // T10538 / design-point 4 (agent-trust): a cancelled subtask is NOT done
+  // work, so it must NOT silently auto-complete the epic. This test previously
+  // asserted the epic auto-completed despite an un-waived cancelled child —
+  // that was the defect. The corrected behavior leaves the epic open until the
+  // cancelled child is waived/replaced via `cleo complete --waive-cancelled-children`.
+  it('does NOT auto-complete epic when a remaining subtask is cancelled (un-waived)', async () => {
     await seedTasks(accessor, [
       {
         id: 'T001',
@@ -199,11 +204,13 @@ describe('epic auto-complete', () => {
 
     const result = await completeTask({ taskId: 'T002' }, env.tempDir, accessor);
 
+    // The completed subtask itself goes done.
     expect(result.task.status).toBe('done');
-    expect(result.autoCompleted).toContain('T001');
+    // But the epic must NOT auto-close while a cancelled sibling is un-waived.
+    expect(result.autoCompleted ?? []).not.toContain('T001');
 
     const epic = await accessor.loadSingleTask('T001');
-    expect(epic?.status).toBe('done');
+    expect(epic?.status).not.toBe('done');
   });
 
   it('does NOT auto-complete epic when getChildren returns an empty list (vacuous truth guard, T585)', async () => {

--- a/packages/core/src/tasks/__tests__/epic-closure-enforcement.test.ts
+++ b/packages/core/src/tasks/__tests__/epic-closure-enforcement.test.ts
@@ -384,7 +384,12 @@ describe('epic closure enforcement (strict mode, integration)', () => {
     expect(result.task.status).toBe('done');
   });
 
-  it('ALLOWS: epic where remaining non-cancelled child is done+verified (cancelled sibling ignored)', async () => {
+  // T10538 / design-point 4 (agent-trust): the T1404 evidence gate is satisfied
+  // by the done+verified child, but a cancelled sibling is NOT done work, so the
+  // cancelled-child gate now blocks closure until the cancelled child is
+  // waived/replaced. This test previously asserted the cancelled sibling was
+  // silently ignored — that was the defect.
+  it('REJECTS: epic with a done+verified child but an un-waived cancelled sibling', async () => {
     await seedTasks(accessor, [
       makeEpic('T001'),
       makeChild('T002', 'T001', {
@@ -394,7 +399,27 @@ describe('epic closure enforcement (strict mode, integration)', () => {
       makeChild('T003', 'T001', { status: 'cancelled' }),
     ]);
 
-    const result = await completeTask({ taskId: 'T001' }, env.tempDir, accessor);
+    await expect(completeTask({ taskId: 'T001' }, env.tempDir, accessor)).rejects.toMatchObject({
+      code: ExitCode.CANCELLED_CHILD_NO_WAIVER,
+      message: expect.stringContaining('T003'),
+    });
+  });
+
+  it('ALLOWS: same epic once the cancelled-child waiver is supplied', async () => {
+    await seedTasks(accessor, [
+      makeEpic('T001'),
+      makeChild('T002', 'T001', {
+        status: 'done',
+        verification: makePassedVerification(),
+      }),
+      makeChild('T003', 'T001', { status: 'cancelled' }),
+    ]);
+
+    const result = await completeTask(
+      { taskId: 'T001', cancelledChildWaiverReason: 'T003 superseded by T002 scope' },
+      env.tempDir,
+      accessor,
+    );
     expect(result.task.status).toBe('done');
   });
 });

--- a/packages/core/src/tasks/__tests__/epic-pending-children-guard.test.ts
+++ b/packages/core/src/tasks/__tests__/epic-pending-children-guard.test.ts
@@ -118,7 +118,12 @@ describe('T1632: epic pending-children guard', () => {
       expect(epic?.completedAt).toBeDefined();
     });
 
-    it('auto-closes parent epic when all remaining siblings are cancelled', async () => {
+    // T10538 / design-point 4 (agent-trust): a cancelled sibling is NOT done
+    // work, so it must NOT silently auto-close the epic. Previously this test
+    // asserted the epic auto-closed; that was the "cancelled children silently
+    // auto-satisfy parent completion" defect. The corrected behavior leaves the
+    // epic open until the cancelled child is waived/replaced.
+    it('does NOT auto-close parent epic when a remaining sibling is cancelled (un-waived)', async () => {
       await seedTasks(accessor, [
         makeEpic('E001'),
         makeChild('T002', 'E001', 'cancelled'),
@@ -127,8 +132,13 @@ describe('T1632: epic pending-children guard', () => {
 
       const result = await completeTask({ taskId: 'T003' }, env.tempDir, accessor);
 
+      // The completed child itself still goes done.
       expect(result.task.status).toBe('done');
-      expect(result.autoCompleted).toContain('E001');
+      // But the epic must NOT auto-close — the cancelled sibling needs a waiver.
+      expect(result.autoCompleted ?? []).not.toContain('E001');
+
+      const epic = await accessor.loadSingleTask('E001');
+      expect(epic?.status).not.toBe('done');
     });
 
     it('does NOT auto-close when siblings still have pending children', async () => {
@@ -192,11 +202,45 @@ describe('T1632: epic pending-children guard', () => {
       });
     });
 
-    it('ALLOWS direct complete on epic when all children are done or cancelled', async () => {
+    // T10538 / design-point 4: an un-waived cancelled child now BLOCKS direct
+    // completion (E_CANCELLED_CHILD_NO_WAIVER). The pre-fix behavior — allowing
+    // the epic to complete as if the cancelled work had shipped — was the defect.
+    it('REJECTS direct complete on epic with an un-waived cancelled child', async () => {
       await seedTasks(accessor, [
         makeEpic('E001'),
         makeChild('T002', 'E001', 'done'),
         makeChild('T003', 'E001', 'cancelled'),
+      ]);
+
+      await expect(completeTask({ taskId: 'E001' }, env.tempDir, accessor)).rejects.toMatchObject({
+        code: ExitCode.CANCELLED_CHILD_NO_WAIVER,
+        message: expect.stringContaining('T003'),
+      });
+
+      const epic = await accessor.loadSingleTask('E001');
+      expect(epic?.status).not.toBe('done');
+    });
+
+    it('ALLOWS direct complete on epic with a cancelled child when the waiver is supplied', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'done'),
+        makeChild('T003', 'E001', 'cancelled'),
+      ]);
+
+      const result = await completeTask(
+        { taskId: 'E001', cancelledChildWaiverReason: 'replaced by T999; out of scope' },
+        env.tempDir,
+        accessor,
+      );
+      expect(result.task.status).toBe('done');
+    });
+
+    it('ALLOWS direct complete on epic when all children are done (no cancelled)', async () => {
+      await seedTasks(accessor, [
+        makeEpic('E001'),
+        makeChild('T002', 'E001', 'done'),
+        makeChild('T003', 'E001', 'done'),
       ]);
 
       const result = await completeTask({ taskId: 'E001' }, env.tempDir, accessor);

--- a/packages/core/src/tasks/add.ts
+++ b/packages/core/src/tasks/add.ts
@@ -114,6 +114,14 @@ export interface AddTaskResult {
   };
   /** Non-blocking warnings emitted during validation. @task T089 */
   warnings?: string[];
+  /**
+   * IDs of done ancestors that were reopened because this child was added under
+   * a `done` parent (PM-Core V2 design-point 5 — a done parent must never
+   * silently hold an unsatisfied child). Empty/absent when nothing was reopened.
+   *
+   * @saga T10538 (PM-Core V2 agent-trust)
+   */
+  reopenedAncestors?: string[];
 }
 
 /** Normalize AC arrays once so legacy JSON, AC rows, and projections stay aligned. */
@@ -1271,8 +1279,32 @@ export async function addTask(
     }
   }
 
+  // ---- T10538 / PM-Core V2 design-point 5: never silently hold a stale done parent ----
+  // Adding a child under a `done` parent injects an unsatisfied `child_task` AC
+  // into that parent (the projection write below). Leaving the parent `done`
+  // makes it lie: it is marked complete while holding work that is not done.
+  // Per the agent-trust design-point 5 — "silent stale 'done' parents destroy
+  // agent trust" — reopen the done parent and any done ancestors so the
+  // hierarchy honestly reflects the new unsatisfied child. This reuses the same
+  // reopen semantics as `coreTaskReopen` (status→pending, clear completedAt,
+  // preserve completion history in notes). The reopen is reported on the result
+  // so the `add` caller sees what happened.
+  const ancestorsToReopen: Task[] = [];
+  if (parentId && parentTaskForProjection) {
+    const reopenCandidates: Task[] = [
+      parentTaskForProjection,
+      ...(await dataAccessor.getAncestorChain(parentId)),
+    ];
+    for (const candidate of reopenCandidates) {
+      if (candidate.status === 'done') {
+        ancestorsToReopen.push(candidate);
+      }
+    }
+  }
+
   // Wrap all writes in a transaction for TOCTOU safety (T023)
   const createdAcceptanceCriteriaIds: string[] = [];
+  const reopenedAncestorIds: string[] = [];
   await dataAccessor.transaction(async (tx: TransactionAccessor) => {
     // Position shuffling via bulk SQL update (T025)
     if (options.position !== undefined) {
@@ -1333,6 +1365,27 @@ export async function addTask(
       });
     }
 
+    // T10538 / design-point 5: reopen any done ancestor so it never silently
+    // holds the unsatisfied child injected above. Mirrors coreTaskReopen:
+    // status→pending, clear completedAt, preserve completion history in notes.
+    for (const ancestor of ancestorsToReopen) {
+      const reopened: Task = {
+        ...ancestor,
+        status: 'pending',
+        completedAt: undefined,
+        updatedAt: now,
+        notes: [
+          ...(ancestor.notes ?? []),
+          ...(ancestor.completedAt
+            ? [`[${now}] completion-history: completedAt=${ancestor.completedAt}`]
+            : []),
+          `[${now}] Reopened by add of child ${taskId} (done parent gained an unsatisfied child)`,
+        ],
+      };
+      await tx.upsertSingleTask(reopened);
+      reopenedAncestorIds.push(ancestor.id);
+    }
+
     // Update project metadata if a new phase was created
     if (options.addPhase && phase && updatedProjectMeta?.phases?.[phase]) {
       await tx.setMetaValue('project_meta', updatedProjectMeta);
@@ -1350,6 +1403,18 @@ export async function addTask(
       after: { title: options.title, status, priority },
     });
   });
+
+  // T10538 / design-point 5: surface the ancestor reopen on the add result so
+  // the operator is never surprised by a parent silently transitioning out of
+  // `done`. The reopen itself already happened inside the transaction above.
+  if (reopenedAncestorIds.length > 0) {
+    warnings.push(
+      `Reopened ${reopenedAncestorIds.length} done ancestor` +
+        `${reopenedAncestorIds.length === 1 ? '' : 's'} (${reopenedAncestorIds.join(', ')}) ` +
+        `because new child ${taskId} added unsatisfied work under a completed parent. ` +
+        `Re-complete the ancestor(s) once ${taskId} is done.`,
+    );
+  }
 
   // T945 Stage A — mint a `task:T###` brain graph node at creation, not at
   // completion. Prior to this hook, addTask never wrote to the graph, so new
@@ -1394,5 +1459,6 @@ export async function addTask(
     task,
     createdIds: { tasks: [taskId], acceptanceCriteria: createdAcceptanceCriteriaIds },
     ...(warnings.length > 0 && { warnings }),
+    ...(reopenedAncestorIds.length > 0 && { reopenedAncestors: reopenedAncestorIds }),
   };
 }

--- a/packages/core/src/tasks/cancelled-child-waiver-audit.ts
+++ b/packages/core/src/tasks/cancelled-child-waiver-audit.ts
@@ -1,0 +1,64 @@
+/**
+ * Cancelled-child-waiver audit trail.
+ *
+ * Records waiver entries to `.cleo/audit/cancelled-child-waiver.jsonl` when a
+ * caller completes a parent that has `cancelled` children by supplying
+ * `--waive-cancelled-children "<reason>"` to bypass the
+ * `E_CANCELLED_CHILD_NO_WAIVER` gate.
+ *
+ * Pattern mirrors `premature-close-audit.ts` (T1632) — one JSONL file per audit
+ * concern, created on demand, appended atomically.
+ *
+ * @saga T10538 (PM-Core V2 agent-trust)
+ */
+
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getProjectRoot } from '../paths.js';
+
+/**
+ * A single entry in the cancelled-child-waiver audit file.
+ *
+ * Written whenever `cleo complete <parentId>` is called while the parent has
+ * one or more `cancelled` children AND the caller supplies
+ * `--waive-cancelled-children` to bypass the gate.
+ */
+export interface CancelledChildWaiverAuditEntry {
+  /** Parent task ID that was completed despite having cancelled children. */
+  parentId: string;
+  /**
+   * IDs of the cancelled children whose abandoned work was waived. Captured
+   * for post-mortem traceability so a reviewer can confirm the cancelled work
+   * was genuinely waivable or replaced.
+   */
+  cancelledChildIds: string[];
+  /** Human-readable reason supplied by the caller for waiving the cancelled children. */
+  waiverReason: string;
+  /** ISO-8601 timestamp of the waiver. */
+  timestamp: string;
+  /** Agent / user identity that performed the completion. */
+  agent: string;
+}
+
+/**
+ * Append a cancelled-child-waiver entry to the audit file.
+ *
+ * Creates `.cleo/audit/` if it does not exist and atomically appends a
+ * single-line JSON record to `.cleo/audit/cancelled-child-waiver.jsonl`.
+ *
+ * @param entry - The audit entry to append.
+ * @param projectRoot - Absolute path to the project root (defaults to `getProjectRoot()`).
+ */
+export async function appendCancelledChildWaiverAudit(
+  entry: CancelledChildWaiverAuditEntry,
+  projectRoot?: string,
+): Promise<void> {
+  const root = projectRoot ?? getProjectRoot();
+  const auditDir = join(root, '.cleo', 'audit');
+
+  await mkdir(auditDir, { recursive: true });
+
+  const auditFile = join(auditDir, 'cancelled-child-waiver.jsonl');
+  const line = JSON.stringify(entry);
+  await appendFile(auditFile, `${line}\n`, { encoding: 'utf8' });
+}

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -10,6 +10,7 @@ import { ExitCode } from '@cleocode/contracts';
 import { getRawConfigValue, loadConfig } from '../config.js';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { CleoError } from '../errors.js';
+import { cleoErrorToEngineResult } from '../errors-to-engine.js';
 import { getIvtrState, type IvtrPhase } from '../lifecycle/ivtr-loop.js';
 import { getLogger } from '../logger.js';
 import {
@@ -88,6 +89,19 @@ export interface CompleteTaskOptions {
    * @task T10509
    */
   waiveReason?: string;
+  /**
+   * Reason for waiving the `E_CANCELLED_CHILD_NO_WAIVER` gate (PM-Core V2
+   * design-point 4). When a parent has `cancelled` children, completion is
+   * blocked unless this waiver is supplied: a cancelled child represents work
+   * that was NOT done, so it must not silently satisfy parent completion.
+   *
+   * When set, the waiver is audited to `.cleo/audit/cancelled-child-waiver.jsonl`.
+   * Cite a replacement task id in the reason when the cancelled work was
+   * superseded by other done work.
+   *
+   * @saga T10538 (PM-Core V2 agent-trust)
+   */
+  cancelledChildWaiverReason?: string;
 }
 
 /**
@@ -591,6 +605,64 @@ export async function completeTask(
     }
   }
 
+  // ---- T10538 / PM-Core V2 design-point 4: cancelled children require a waiver ----
+  // A cancelled child is NOT done work — it was abandoned. The legacy premature-
+  // close guard above filtered `cancelled` out of `pendingChildren`, which let a
+  // parent complete as if the cancelled work had shipped (the "cancelled children
+  // silently auto-satisfy parent completion" defect). Per the plan's agent-trust
+  // design-point 4, completing a parent that has cancelled children REQUIRES a
+  // waiver or replacement evidence for those children. The waiver is an audited
+  // `--waive-cancelled-children "<reason>"` bypass (mirrors `--override-reason`).
+  //
+  // This gate applies to any parent with children (not just epics), because the
+  // child_task AC projection is written for every parent → child edge.
+  const cancelledChildren = children.filter((c) => c.status === 'cancelled');
+  if (cancelledChildren.length > 0) {
+    const waiverReason = options.cancelledChildWaiverReason?.trim();
+    if (!waiverReason) {
+      throw new CleoError(
+        ExitCode.CANCELLED_CHILD_NO_WAIVER,
+        `Task ${options.taskId} has ${cancelledChildren.length} cancelled ` +
+          `child${cancelledChildren.length === 1 ? '' : 'ren'} that must be waived or ` +
+          `replaced before completion: ${cancelledChildren.map((c) => c.id).join(', ')}`,
+        {
+          fix:
+            `Cancelled children represent work that was NOT done — they cannot silently ` +
+            `satisfy parent completion. Either re-open and finish the work, replace it with ` +
+            `a done child, or record an audited waiver: ` +
+            `'cleo complete ${options.taskId} --waive-cancelled-children "<reason>"' ` +
+            `(cite the replacement task id in the reason when applicable; ` +
+            `audited to .cleo/audit/cancelled-child-waiver.jsonl).`,
+          details: {
+            field: 'cancelledChildIds',
+            cancelledChildIds: cancelledChildren.map((c) => c.id),
+          },
+        },
+      );
+    }
+
+    // Waiver supplied — audit the decision before proceeding.
+    try {
+      const { appendCancelledChildWaiverAudit } = await import('./cancelled-child-waiver-audit.js');
+      await appendCancelledChildWaiverAudit(
+        {
+          parentId: options.taskId,
+          cancelledChildIds: cancelledChildren.map((c) => c.id),
+          waiverReason,
+          timestamp: new Date().toISOString(),
+          agent: process.env['CLEO_AGENT_ID'] ?? 'cleo',
+        },
+        cwd,
+      );
+    } catch (err) {
+      // Audit write failure must not block the completion — warn only.
+      console.warn(
+        '[complete] failed to write cancelled-child-waiver audit:',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
   const now = new Date().toISOString();
   const before = { ...task };
 
@@ -719,7 +791,21 @@ export async function completeTask(
               siblings.every(
                 (c) => c.id === task.id || c.status === 'done' || c.status === 'cancelled',
               );
-            if (allDone) {
+            // T10538 / design-point 4: a cancelled sibling is NOT done work, so
+            // it must not silently roll the epic up to done. When un-waived
+            // cancelled children exist, suppress auto-close and leave the epic
+            // open — the operator must run `cleo complete <epic>
+            // --waive-cancelled-children "<reason>"` to close it with an audit.
+            const hasCancelledSibling = siblings.some(
+              (c) => c.id !== task.id && c.status === 'cancelled',
+            );
+            if (allDone && hasCancelledSibling) {
+              getLogger('engine:complete').info(
+                { epicId: parent.id, completedChild: task.id },
+                '[complete] suppressing epic auto-close: un-waived cancelled children require `cleo complete --waive-cancelled-children`',
+              );
+            }
+            if (allDone && !hasCancelledSibling) {
               // T1632: When enforcement is strict + verification enabled, only
               // auto-close if the epic's evidence gates are satisfied.
               // `verifyEpicHasEvidence` returns true when:
@@ -798,7 +884,18 @@ export async function completeTask(
               const allCpDone = cpChildren.every(
                 (c) => c.id === task.id || c.status === 'done' || c.status === 'cancelled',
               );
-              if (allCpDone) {
+              // T10538 / design-point 4: un-waived cancelled children must not
+              // silently roll a coordination parent up to done.
+              const cpHasCancelledChild = cpChildren.some(
+                (c) => c.id !== task.id && c.status === 'cancelled',
+              );
+              if (allCpDone && cpHasCancelledChild) {
+                getLogger('engine:complete').info(
+                  { parentId: coordinationParent.id, completedChild: task.id },
+                  '[complete] suppressing coordination-parent auto-close: un-waived cancelled children require `cleo complete --waive-cancelled-children`',
+                );
+              }
+              if (allCpDone && !cpHasCancelledChild) {
                 // Synthesize verification evidence from children's gate state.
                 // The overlay adds the current task (not yet in DB) as done so
                 // buildRollupEvidence sees the post-write view.
@@ -1075,7 +1172,7 @@ export async function completeTask(
 // EngineResult-returning wrappers (T1568 / ADR-057 / ADR-058)
 // ---------------------------------------------------------------------------
 
-type CompleteEngineResult = EngineResult<{
+interface CompleteEngineSuccess {
   task: TaskRecord;
   autoCompleted?: string[];
   unblockedTasks?: Array<{ id: string; title: string }>;
@@ -1090,7 +1187,9 @@ type CompleteEngineResult = EngineResult<{
    * @task T9548
    */
   worktreeAutoComplete?: AutoCompleteWorktreeResult;
-}>;
+}
+
+type CompleteEngineResult = EngineResult<CompleteEngineSuccess>;
 
 /**
  * Options forwarded through the EngineResult-returning wrappers.
@@ -1125,6 +1224,12 @@ export interface TaskCompleteEngineOptions {
    * @task T10509
    */
   waiveReason?: string;
+  /**
+   * Reason for waiving the `E_CANCELLED_CHILD_NO_WAIVER` gate.
+   * @see CompleteTaskOptions.cancelledChildWaiverReason
+   * @saga T10538 (PM-Core V2 agent-trust)
+   */
+  cancelledChildWaiverReason?: string;
 }
 
 /**
@@ -1159,6 +1264,7 @@ export async function taskComplete(
         acknowledgeRisk: opts.acknowledgeRisk,
         waiveAc: opts.waiveAc,
         waiveReason: opts.waiveReason,
+        cancelledChildWaiverReason: opts.cancelledChildWaiverReason,
       },
       projectRoot,
       accessor,
@@ -1207,8 +1313,14 @@ export async function taskComplete(
       worktreeAutoComplete,
     });
   } catch (err: unknown) {
-    const e = err as { message?: string };
-    return engineError('E_INTERNAL', e?.message ?? 'Failed to complete task');
+    // T10538: preserve CleoError LAFS codes (E_EPIC_HAS_PENDING_CHILDREN,
+    // E_CANCELLED_CHILD_NO_WAIVER, …) + their `fix`/`details` instead of
+    // flattening every guard rejection to a contextless E_INTERNAL.
+    return cleoErrorToEngineResult<CompleteEngineSuccess>(
+      err,
+      'E_INTERNAL',
+      'Failed to complete task',
+    );
   }
 }
 
@@ -1396,7 +1508,11 @@ export async function completeTaskStrict(
     // No IVTR state, or lifecycle not strict, or already released — delegate normally.
     return taskComplete(projectRoot, taskId, opts);
   } catch (err: unknown) {
-    const e = err as { message?: string };
-    return engineError('E_INTERNAL', e?.message ?? 'Failed to complete task (strict mode)');
+    // T10538: preserve CleoError LAFS codes/details on strict-path pre-check throws.
+    return cleoErrorToEngineResult<CompleteEngineSuccess>(
+      err,
+      'E_INTERNAL',
+      'Failed to complete task (strict mode)',
+    );
   }
 }

--- a/packages/core/src/tasks/session-scope.ts
+++ b/packages/core/src/tasks/session-scope.ts
@@ -139,7 +139,17 @@ export async function addTaskWithSessionScope(
     forceDuplicate?: boolean;
   },
 ): Promise<
-  EngineResult<{ task: TaskRecord; duplicate: boolean; dryRun?: boolean; warnings?: string[] }>
+  EngineResult<{
+    task: TaskRecord;
+    duplicate: boolean;
+    dryRun?: boolean;
+    warnings?: string[];
+    /**
+     * IDs of done ancestors reopened because this child was added under a done
+     * parent (PM-Core V2 design-point 5). @saga T10538
+     */
+    reopenedAncestors?: string[];
+  }>
 > {
   try {
     const { resolvedParent, error } = await resolveParentFromSession(projectRoot, {
@@ -154,6 +164,7 @@ export async function addTaskWithSessionScope(
         duplicate: boolean;
         dryRun?: boolean;
         warnings?: string[];
+        reopenedAncestors?: string[];
       }>;
     }
 
@@ -187,6 +198,10 @@ export async function addTaskWithSessionScope(
       duplicate: result.duplicate ?? false,
       dryRun: params.dryRun,
       ...(result.warnings?.length && { warnings: result.warnings }),
+      // T10538 / design-point 5 — surface the ancestor reopen to the caller.
+      ...(result.reopenedAncestors?.length && {
+        reopenedAncestors: result.reopenedAncestors,
+      }),
     });
   } catch (err: unknown) {
     // T9940: preserve CleoError LAFS codes; non-CleoError falls through to


### PR DESCRIPTION
## Summary

Fixes two PM-Core V2 **agent-trust completion** defects flagged by the saga T10538 audit. Both let a parent be marked `done` while the work was not actually done.

### Defect ② (DP4) — cancelled children silently auto-satisfied parent completion

`packages/core/src/tasks/complete.ts` filtered `cancelled` children out of the premature-close guard **and** the epic / coordination-parent auto-rollup paths, so a parent completed as if the cancelled work had shipped.

**Fix:** a parent with an un-waived `cancelled` child is now rejected with `E_CANCELLED_CHILD_NO_WAIVER` (exit 109, with `details.cancelledChildIds` + an actionable `fix`); the auto-rollup paths no longer auto-close such a parent. To proceed, supply:

```
cleo complete <parentId> --waive-cancelled-children "<reason>"   # cite a replacement task id when applicable
```

The waiver is audited to `.cleo/audit/cancelled-child-waiver.jsonl`. The T10554 `evaluateCompletion` waiver/replacement model was written but **unwired**; this wires the equivalent runtime gate into the actual completion path.

### Defect ⑤ (DP5) — adding a child under a `done` parent left a silently-stale `done` parent

`cleo add --parent <doneEpic>` injected an unsatisfied `child_task` AC into a completed parent with **no ancestor reopen**.

**Fix:** the done parent (and any done ancestors) are reopened to `pending` — reusing the canonical `coreTaskReopen` semantics (clear `completedAt`, preserve completion history in notes) — and the reopen is surfaced on the add result as `reopenedAncestors` plus a warning.

### Error fidelity

`taskComplete` / `completeTaskStrict` catches now route through `cleoErrorToEngineResult`, preserving the CleoError code/details/fix instead of flattening every guard rejection to `E_INTERNAL` (also restores fidelity for the pre-existing `E_EPIC_HAS_PENDING_CHILDREN` guard).

## Verification

- Live end-to-end repro through the built CLI for both defects (block → waiver-success → audit; add-under-done → reopen).
- New `agent-trust-completion.test.ts` (11 tests) covers both design points.
- 4 existing tests that encoded the old broken behavior (cancelled-sibling auto-close / ignore) updated to the design-point-correct behavior.
- Full `@cleocode/core` suite: 0 new failures (the ~16-17 remaining are pre-existing git/worktree/release-integration env failures, unrelated to this change).
- `pnpm run typecheck` (tsc -b) clean · `biome check` clean · `cleo check arch` 5/5 gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)