### PR TITLE
feat(T11581): @cleocode/core submodule re-exports for internalized packages (R10-L2, additive)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -114,7 +114,21 @@ const SUBPATH_SUBDIRS = {
  * Root-level flat files in packages/core/src/ that need standalone entries
  * (in addition to index.ts which is always included).
  */
-const ROOT_FLATS = ['cleo.ts', 'contracts.ts', 'internal.ts'];
+const ROOT_FLATS = [
+  'cleo.ts',
+  'contracts.ts',
+  'internal.ts',
+  // R10-L2 (T11581) — thin submodule re-exports of internalized workspace
+  // packages, exposed as @cleocode/core/<pkg> subpaths (batteries-included
+  // prep). Each `export * from '@cleocode/<pkg>'` bundles to a flat dist file;
+  // validateCoreEntryPoints() asserts the matching package.json export entry.
+  'paths-export.ts',
+  'lafs-export.ts',
+  'skills-export.ts',
+  'caamp-export.ts',
+  'worktree-export.ts',
+  'git-shim-export.ts',
+];
 
 /**
  * Collect all @cleocode/core esbuild entry points by scanning the source

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/core",
   "version": "2026.5.126",
-  "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
+  "description": "CLEO core business logic kernel \u2014 tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -360,6 +360,36 @@
       "types": "./dist/llm/*.d.ts",
       "import": "./dist/llm/*.js",
       "require": "./dist/llm/*.js"
+    },
+    "./paths": {
+      "types": "./dist/paths-export.d.ts",
+      "import": "./dist/paths-export.js",
+      "require": "./dist/paths-export.js"
+    },
+    "./lafs": {
+      "types": "./dist/lafs-export.d.ts",
+      "import": "./dist/lafs-export.js",
+      "require": "./dist/lafs-export.js"
+    },
+    "./skills-lib": {
+      "types": "./dist/skills-export.d.ts",
+      "import": "./dist/skills-export.js",
+      "require": "./dist/skills-export.js"
+    },
+    "./caamp": {
+      "types": "./dist/caamp-export.d.ts",
+      "import": "./dist/caamp-export.js",
+      "require": "./dist/caamp-export.js"
+    },
+    "./worktree": {
+      "types": "./dist/worktree-export.d.ts",
+      "import": "./dist/worktree-export.js",
+      "require": "./dist/worktree-export.js"
+    },
+    "./git-shim": {
+      "types": "./dist/git-shim-export.d.ts",
+      "import": "./dist/git-shim-export.js",
+      "require": "./dist/git-shim-export.js"
     }
   },
   "scripts": {
@@ -379,6 +409,7 @@
     "@cleocode/agents": "workspace:*",
     "@cleocode/caamp": "workspace:*",
     "@cleocode/contracts": "workspace:*",
+    "@cleocode/git-shim": "workspace:*",
     "@cleocode/lafs": "workspace:*",
     "@cleocode/nexus": "workspace:*",
     "@cleocode/paths": "workspace:*",

--- a/packages/core/src/__tests__/subpath-contract.test.ts
+++ b/packages/core/src/__tests__/subpath-contract.test.ts
@@ -225,3 +225,69 @@ describe('@cleocode/core — subpath coverage sanity', () => {
     expect(STABLE_SUBPATHS.length).toBe(9);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 7. R10-L2 (T11581) — internalized-package submodule re-exports
+//
+// `@cleocode/core/<pkg>` thin re-exports of internalized workspace packages
+// (batteries-included prep). Each entry maps to a flat `dist/<base>.js`
+// produced from `src/<base>.ts` (`export * from '@cleocode/<pkg>'`).
+//
+// Scope note: only packages that (a) `@cleocode/core` depends on and (b)
+// resolve at core's tsc declaration-emit point are wired here. `adapters`
+// and `animations` are deferred (built after core / no standalone pre-core
+// dist build); `runtime`/`brain`/`cant`/`playbooks` are excluded (they
+// depend on `@cleocode/core` — a re-export would be circular).
+// ---------------------------------------------------------------------------
+
+const SUBMODULE_REEXPORTS: Array<{
+  subpath: string;
+  distBase: string;
+  expectedSymbol: string;
+}> = [
+  { subpath: './paths', distBase: 'paths-export', expectedSymbol: 'canonicalizePath' },
+  { subpath: './lafs', distBase: 'lafs-export', expectedSymbol: 'AGENT_ACTIONS' },
+  { subpath: './skills-lib', distBase: 'skills-export', expectedSymbol: 'listSkills' },
+  { subpath: './caamp', distBase: 'caamp-export', expectedSymbol: 'CANONICAL_HOOK_EVENTS' },
+  {
+    subpath: './worktree',
+    distBase: 'worktree-export',
+    expectedSymbol: 'WORKTREE_INDEX_RELATIVE_PATH',
+  },
+  { subpath: './git-shim', distBase: 'git-shim-export', expectedSymbol: 'GIT_OP_DENYLIST' },
+];
+
+describe('@cleocode/core — internalized-package submodule re-exports (T11581)', () => {
+  it('declares every submodule re-export subpath with types + import conditions', () => {
+    for (const { subpath, distBase } of SUBMODULE_REEXPORTS) {
+      const entry = pkg.exports[subpath];
+      expect(entry, `exports[${JSON.stringify(subpath)}] must be defined`).toBeTypeOf('object');
+      const cond = entry as ExportConditions;
+      expect(cond.types, `exports[${JSON.stringify(subpath)}].types`).toBe(
+        `./dist/${distBase}.d.ts`,
+      );
+      expect(cond.import, `exports[${JSON.stringify(subpath)}].import`).toBe(
+        `./dist/${distBase}.js`,
+      );
+    }
+  });
+
+  describe.skipIf(!hasDist)('built dist artifacts + runtime resolution', () => {
+    it('emits a .js and .d.ts file per submodule re-export', () => {
+      for (const { subpath, distBase } of SUBMODULE_REEXPORTS) {
+        const js = path.join(DIST_DIR, `${distBase}.js`);
+        const dts = path.join(DIST_DIR, `${distBase}.d.ts`);
+        expect(existsSync(js), `${subpath} -> ${js} must exist`).toBe(true);
+        expect(existsSync(dts), `${subpath} -> ${dts} must exist`).toBe(true);
+      }
+    });
+
+    it('each submodule re-export resolves and exposes its expected symbol', async () => {
+      for (const { subpath, distBase, expectedSymbol } of SUBMODULE_REEXPORTS) {
+        const modPath = path.join(DIST_DIR, `${distBase}.js`);
+        const mod = (await import(modPath)) as Record<string, unknown>;
+        expect(mod[expectedSymbol], `${subpath} must re-export '${expectedSymbol}'`).toBeDefined();
+      }
+    });
+  });
+});

--- a/packages/core/src/caamp-export.ts
+++ b/packages/core/src/caamp-export.ts
@@ -1,0 +1,18 @@
+/**
+ * @cleocode/core/caamp — Re-export of the @cleocode/caamp public surface.
+ *
+ * R10-L2 (T11581): batteries-included prep. This submodule lets SDK consumers
+ * import the internalized `@cleocode/caamp` package as a stable submodule of
+ * `@cleocode/core` (`import { … } from '@cleocode/core/caamp'`) instead of the
+ * soon-to-be-private bare `@cleocode/caamp` specifier.
+ *
+ * Additive re-export only — the standalone `@cleocode/caamp` package is
+ * unchanged and still published. Mirrors the `./contracts` shim pattern.
+ *
+ * @example
+ * import { … } from '@cleocode/core/caamp';
+ *
+ * @package @cleocode/core
+ */
+
+export * from '@cleocode/caamp';

--- a/packages/core/src/git-shim-export.ts
+++ b/packages/core/src/git-shim-export.ts
@@ -1,0 +1,18 @@
+/**
+ * @cleocode/core/git-shim — Re-export of the @cleocode/git-shim public surface.
+ *
+ * R10-L2 (T11581): batteries-included prep. This submodule lets SDK consumers
+ * import the internalized `@cleocode/git-shim` package as a stable submodule of
+ * `@cleocode/core` (`import { … } from '@cleocode/core/git-shim'`) instead of
+ * the soon-to-be-private bare `@cleocode/git-shim` specifier.
+ *
+ * Additive re-export only — the standalone `@cleocode/git-shim` package is
+ * unchanged and still published. Mirrors the `./contracts` shim pattern.
+ *
+ * @example
+ * import { … } from '@cleocode/core/git-shim';
+ *
+ * @package @cleocode/core
+ */
+
+export * from '@cleocode/git-shim';

--- a/packages/core/src/lafs-export.ts
+++ b/packages/core/src/lafs-export.ts
@@ -1,0 +1,18 @@
+/**
+ * @cleocode/core/lafs — Re-export of the @cleocode/lafs public surface.
+ *
+ * R10-L2 (T11581): batteries-included prep. This submodule lets SDK consumers
+ * import the internalized `@cleocode/lafs` package as a stable submodule of
+ * `@cleocode/core` (`import { … } from '@cleocode/core/lafs'`) instead of the
+ * soon-to-be-private bare `@cleocode/lafs` specifier.
+ *
+ * Additive re-export only — the standalone `@cleocode/lafs` package is
+ * unchanged and still published. Mirrors the `./contracts` shim pattern.
+ *
+ * @example
+ * import { … } from '@cleocode/core/lafs';
+ *
+ * @package @cleocode/core
+ */
+
+export * from '@cleocode/lafs';

--- a/packages/core/src/paths-export.ts
+++ b/packages/core/src/paths-export.ts
@@ -1,0 +1,18 @@
+/**
+ * @cleocode/core/paths — Re-export of the @cleocode/paths public surface.
+ *
+ * R10-L2 (T11581): batteries-included prep. This submodule lets SDK consumers
+ * import the internalized `@cleocode/paths` package as a stable submodule of
+ * `@cleocode/core` (`import { … } from '@cleocode/core/paths'`) instead of the
+ * soon-to-be-private bare `@cleocode/paths` specifier.
+ *
+ * Additive re-export only — the standalone `@cleocode/paths` package is
+ * unchanged and still published. Mirrors the `./contracts` shim pattern.
+ *
+ * @example
+ * import { resolveCleoDir } from '@cleocode/core/paths';
+ *
+ * @package @cleocode/core
+ */
+
+export * from '@cleocode/paths';

--- a/packages/core/src/skills-export.ts
+++ b/packages/core/src/skills-export.ts
@@ -1,0 +1,23 @@
+/**
+ * @cleocode/core/skills-lib — Re-export of the @cleocode/skills public surface.
+ *
+ * R10-L2 (T11581): batteries-included prep. This submodule lets SDK consumers
+ * import the internalized `@cleocode/skills` package as a stable submodule of
+ * `@cleocode/core` (`import { … } from '@cleocode/core/skills-lib'`) instead of
+ * the soon-to-be-private bare `@cleocode/skills` specifier.
+ *
+ * Exposed under `./skills-lib` (not `./skills`) because `./skills/*` is already
+ * a distinct wildcard subpath mapping into core's own `dist/skills/` tree
+ * (skill-root, etc.). This dedicated entry re-exports the standalone skills
+ * library surface (listSkills, getSkill, manifest, …).
+ *
+ * Additive re-export only — the standalone `@cleocode/skills` package is
+ * unchanged and still published. Mirrors the `./contracts` shim pattern.
+ *
+ * @example
+ * import { listSkills, getSkill } from '@cleocode/core/skills-lib';
+ *
+ * @package @cleocode/core
+ */
+
+export * from '@cleocode/skills';

--- a/packages/core/src/worktree-export.ts
+++ b/packages/core/src/worktree-export.ts
@@ -1,0 +1,18 @@
+/**
+ * @cleocode/core/worktree — Re-export of the @cleocode/worktree public surface.
+ *
+ * R10-L2 (T11581): batteries-included prep. This submodule lets SDK consumers
+ * import the internalized `@cleocode/worktree` package as a stable submodule of
+ * `@cleocode/core` (`import { … } from '@cleocode/core/worktree'`) instead of
+ * the soon-to-be-private bare `@cleocode/worktree` specifier.
+ *
+ * Additive re-export only — the standalone `@cleocode/worktree` package is
+ * unchanged and still published. Mirrors the `./contracts` shim pattern.
+ *
+ * @example
+ * import { … } from '@cleocode/core/worktree';
+ *
+ * @package @cleocode/core
+ */
+
+export * from '@cleocode/worktree';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "ES2025",
     "module": "NodeNext",
-    "lib": ["ES2025"],
+    "lib": [
+      "ES2025"
+    ],
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
@@ -24,14 +26,38 @@
     "composite": true
   },
   "references": [
-    { "path": "../contracts" },
-    { "path": "../lafs" },
-    { "path": "../caamp" },
-    { "path": "../nexus" },
-    { "path": "../paths" },
-    { "path": "../utils" },
-    { "path": "../worktree" }
+    {
+      "path": "../contracts"
+    },
+    {
+      "path": "../lafs"
+    },
+    {
+      "path": "../caamp"
+    },
+    {
+      "path": "../nexus"
+    },
+    {
+      "path": "../paths"
+    },
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../worktree"
+    },
+    {
+      "path": "../git-shim"
+    }
   ],
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/__tests__", "src/**/*.test.ts"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__",
+    "src/**/*.test.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@cleocode/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@cleocode/git-shim':
+        specifier: workspace:*
+        version: link:../git-shim
       '@cleocode/lafs':
         specifier: workspace:*
         version: link:../lafs


### PR DESCRIPTION
## R10-L2 (T11581) — batteries-included prep

Adds thin submodule re-exports so SDK consumers can import internalized workspace packages as `@cleocode/core/<pkg>` instead of the soon-to-be-private bare `@cleocode/<pkg>` specifier. Mirrors the existing `./contracts` shim pattern.

### Wired (6 submodules)
| subpath | re-export module | source pkg |
|---|---|---|
| `./paths` | `src/paths-export.ts` | `@cleocode/paths` |
| `./lafs` | `src/lafs-export.ts` | `@cleocode/lafs` |
| `./skills-lib` | `src/skills-export.ts` | `@cleocode/skills` |
| `./caamp` | `src/caamp-export.ts` | `@cleocode/caamp` |
| `./worktree` | `src/worktree-export.ts` | `@cleocode/worktree` |
| `./git-shim` | `src/git-shim-export.ts` | `@cleocode/git-shim` |

Each module is `export * from '@cleocode/<pkg>'`. Wiring per submodule: `package.json` `exports` entry (`types`+`import`+`require` → `dist/<pkg>-export.js`), `build.mjs` `ROOT_FLATS` (cold build emits a dist file each), and `subpath-contract.test.ts` §7 asserts each path resolves + exposes a known symbol.

`./skills-lib` (not `./skills`) avoids the existing `./skills/*` wildcard that maps into core's own `dist/skills/` tree.

### Deferred / excluded (with reasons)
- **Deferred:** `./adapters` (built in Wave 6 *after* core — transitively deps core via `@cleocode/playbooks`), `./animations` (no standalone pre-core dist build; only inlined into the cleo bundle).
- **Excluded:** `./runtime` `./brain` `./cant` `./playbooks` — these depend on `@cleocode/core`, so a re-export would be circular.

### Additive — zero publish-surface change
- Publish surface unchanged (18 packages; Gate 9 green).
- No private flips, no `release.yml`/`EXPECTED_PUBLISH_COUNT` edits.
- Standalone `@cleocode/<pkg>` packages untouched.
- `@cleocode/git-shim` added as a runtime dep of core (others were already core deps); `../git-shim` added as a tsconfig project reference.

### Validation
- `node build.mjs` cold build green — all 6 `dist/<pkg>-export.{js,d.ts}` emitted.
- `pnpm run typecheck` (`tsc -b`) green.
- All 6 submodule imports resolve at runtime and expose real symbols.
- `cleo check arch` 5/5; Gates 8/9/11 green.
- `vitest run subpath-contract.test.ts` 14/14. Full core suite failures are the known `createTestDb` tmpdir-race env flakes (the 2 observed files pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)