### PR TITLE
feat(T11580): shared postinstall picker resolves worktree-napi (R10-L1, additive)

### DIFF
--- a/.github/workflows/core-tarball-size.yml
+++ b/.github/workflows/core-tarball-size.yml
@@ -1,16 +1,18 @@
 name: Core Tarball Size Gate
 
 # @task T11342 — SG-RUNTIME-UNIFICATION R1 (T11252).
+# @task T11580 — R10-L1: worktree-napi joins the supervisor picker.
 #
 # Asserts the packed @cleocode/core tarball stays <= 25 MB and bundles ONLY the
-# linux-x64-gnu cleo-supervisor fallback binary (Pattern P1). Fails the build
-# with a largest-contributors message when the budget is exceeded or an extra
-# platform binary sneaks in.
+# linux-x64-gnu fallback for each CLEO-managed native binary family
+# (cleo-supervisor + worktree-napi, Pattern P1). Fails the build with a
+# largest-contributors message when the budget is exceeded or an extra platform
+# binary sneaks in.
 #
 # Runs at RELEASE-TAG time (and on-demand), NOT on PRs/main: the assertion is only
-# meaningful once the cross-compiled linux-x64-gnu fallback binary has been produced
-# by cleo-supervisor-prebuild.yml (tag-triggered) and bundled into the packed tarball.
-# On PRs the fallback is a placeholder, so the gate would false-fail (T11252 integration).
+# meaningful once the cross-compiled linux-x64-gnu fallback binaries have been
+# produced and bundled into the packed tarball. On PRs the fallbacks are
+# placeholders, so the gate would false-fail (T11252 integration).
 
 on:
   push:
@@ -56,6 +58,25 @@ jobs:
           node packages/core/scripts/gen-supervisor-manifest.mjs \
             --bin-dir /tmp/sup-bin \
             --out packages/core/binaries/cleo-supervisor-manifest.json
+
+      # Stage the P1 worktree-napi fallback addon + manifest so the gate measures
+      # the REAL shipped layout for the worktree-napi family too (T11580 · R10-L1).
+      # Only the linux-x64-gnu .node is bundled; the manifest pins all triples for
+      # the postinstall P2 picker.
+      - name: Build + stage linux-x64-gnu worktree-napi fallback
+        run: |
+          set -euo pipefail
+          cargo build --release -p worktree-napi
+          # cargo emits the cdylib as libworktree_napi.so; rename to the .node
+          # triple name the loader + manifest expect.
+          mkdir -p packages/core/binaries/fallback /tmp/napi-bin
+          cp target/release/libworktree_napi.so \
+            packages/core/binaries/fallback/worktree-napi.linux-x64-gnu.node
+          cp target/release/libworktree_napi.so \
+            /tmp/napi-bin/worktree-napi.linux-x64-gnu.node
+          node packages/core/scripts/gen-napi-manifest.mjs \
+            --bin-dir /tmp/napi-bin \
+            --out packages/core/binaries/worktree-napi-manifest.json
 
       - name: Assert tarball size + fallback policy
         run: node packages/core/scripts/check-core-tarball-size.mjs

--- a/packages/core/binaries/README.md
+++ b/packages/core/binaries/README.md
@@ -1,51 +1,73 @@
-# cleo-supervisor native binary distribution (T11340 · SG-RUNTIME-UNIFICATION R1)
+# CLEO native binary distribution (T11340 · SG-RUNTIME-UNIFICATION R1 · T11580 · R10-L1)
 
-This directory carries the **distribution metadata + P1 fallback** for the
-`cleo-supervisor` native binary (`crates/cleo-supervisor`). The supervisor is a
-standalone executable distributed via the worktree-napi-style packaging pattern
-(decision D14′), **not** a napi `.node` addon and **not** a Bun process (D8′).
+This directory carries the **distribution metadata + P1 fallback** for the two
+CLEO-managed native binaries, both distributed via the same packaging pattern
+(decision D14′) through the single `@cleocode/core` postinstall picker:
+
+- **`cleo-supervisor`** — a standalone executable (`crates/cleo-supervisor`).
+  **Not** a napi `.node` addon and **not** a Bun process (D8′).
+- **`worktree-napi`** — the napi-rs Node-API addon (`crates/worktree-napi`)
+  consumed by `@cleocode/worktree`. As of R10-L1 (T11580) the host-triple
+  `.node` is resolved by the SAME picker so `@cleocode/worktree` no longer has
+  to bundle all four `.node` files in its own tarball.
 
 ## Layout
 
 | Path | Produced by | Shipped in tarball? |
 |------|-------------|---------------------|
 | `cleo-supervisor-manifest.json` | CI (`gen-supervisor-manifest.mjs`) at publish time | **Yes** (Pattern P2 — pinned, not fetched) |
+| `worktree-napi-manifest.json` | CI (`gen-napi-manifest.mjs`) at publish time | **Yes** (Pattern P2 — pinned, not fetched) |
 | `fallback/cleo-supervisor` | CI (`cargo build --release` linux-x64-gnu) | **Yes** (Pattern P1 — `--ignore-scripts` installs) |
+| `fallback/worktree-napi.linux-x64-gnu.node` | CI (`cargo build --release` linux-x64-gnu) | **Yes** (Pattern P1 — `--ignore-scripts` installs) |
 | `fallback/.gitkeep` | repo | n/a (placeholder so the dir is tracked) |
 
-Neither the manifest nor the fallback binary is committed to git — both are
-generated/staged in CI. They are listed in `packages/core/package.json`
-`files` so they land in the published `@cleocode/core` tarball.
+Neither the manifests nor the fallback binaries are committed to git — all four
+are generated/staged in CI. The `binaries/` directory is listed in
+`packages/core/package.json` `files` so they land in the published
+`@cleocode/core` tarball.
 
 ## Pattern P2 — postinstall download + sha256 verify (primary)
 
-1. CI cross-compiles 5 targets (`linux-x64-gnu`, `linux-arm64-gnu`,
-   `darwin-x64`, `darwin-arm64`, `win32-x64-msvc`) in
-   `.github/workflows/cleo-supervisor-prebuild.yml`.
-2. CI attaches the 5 binaries to the **GitHub Release** for the matching
+The shared picker module is `scripts/napi-binary-picker.mjs`, driven for both
+binaries by the `postinstall` entrypoint `scripts/install-supervisor-binary.mjs`.
+
+1. CI cross-compiles the supported targets:
+   - `cleo-supervisor`: 5 triples (`linux-x64-gnu`, `linux-arm64-gnu`,
+     `darwin-x64`, `darwin-arm64`, `win32-x64-msvc`) in
+     `.github/workflows/cleo-supervisor-prebuild.yml`.
+   - `worktree-napi`: 4 triples (`linux-x64-gnu`, `linux-arm64-gnu`,
+     `darwin-arm64`, `win32-x64-msvc`; `darwin-x64` dropped per T10479) in the
+     release prebuild matrix.
+2. CI attaches the binaries to the **GitHub Release** for the matching
    `@cleocode/core` version using `GITHUB_TOKEN` only — **ZERO new OIDC trust
-   configs** (no `@cleocode/cleo-supervisor-*` npm packages).
-3. CI generates `cleo-supervisor-manifest.json` (per-triple sha256 + Release
-   base URL) and checks it **into the tarball**.
-4. On `npm install`, `scripts/install-supervisor-binary.mjs` (the package
-   `postinstall`) resolves the host triple (platform + arch + libc), downloads
-   the matching binary from the Release, **verifies the sha256 fail-closed**,
-   and caches it under `~/.cache/cleo/napi-bin/<version>/` with `chmod +x`
-   written atomically (tmp-then-rename).
+   configs** (no `@cleocode/cleo-supervisor-*` / `@cleocode/worktree-napi-*`
+   npm packages).
+3. CI generates the per-binary manifest (per-triple sha256 + Release base URL)
+   and checks it **into the tarball**.
+4. On `npm install`, the `postinstall` picker resolves the host triple
+   (platform + arch + libc), downloads the matching binary from the Release,
+   **verifies the sha256 fail-closed**, and caches it under
+   `~/.cache/cleo/napi-bin/<version>/` written atomically (tmp-then-rename;
+   `chmod +x` for the supervisor executable, no exec bit for the `.node` addon).
 5. `CLEO_NAPI_BINARY_MIRROR` overrides the download base URL for corporate
-   proxies / air-gapped mirrors.
+   proxies / air-gapped mirrors (shared by both binaries).
+
+At runtime `@cleocode/worktree`'s loader (`src/napi-binding.ts`) resolves, in
+order: the bundled `native/worktree-napi.cjs`, the repo-local crate loader, then
+the **core-managed cached `.node`** written by the picker (newest version first).
 
 ## Pattern P1 — bundled linux-x64-gnu fallback
 
 For `npm install --ignore-scripts` (postinstall never runs) or an offline /
 mirror-outage download failure, the picker falls back to the bundled
-`fallback/cleo-supervisor` **iff** the host triple is `linux-x64-gnu`. Only one
-fallback binary is bundled to keep the tarball under the 25 MB budget enforced
-by `scripts/check-core-tarball-size.mjs` (T11342).
+`fallback/cleo-supervisor` / `fallback/worktree-napi.linux-x64-gnu.node`
+**iff** the host triple is `linux-x64-gnu`. Only one fallback per binary is
+bundled to keep the tarball under the 25 MB budget enforced by
+`scripts/check-core-tarball-size.mjs` (T11342 / T11580).
 
-## Tarball size budget (T11342)
+## Tarball size budget (T11342 · T11580)
 
-Only the `linux-x64-gnu` fallback is bundled. The CI gate
+Only the `linux-x64-gnu` fallback is bundled for each binary family. The CI gate
 `scripts/check-core-tarball-size.mjs` fails the build if the packed
 `@cleocode/core` tarball exceeds **25 MB** or if more than one platform binary
-is found bundled.
+of either family is found bundled (or one targets a non-`linux-x64-gnu` triple).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -462,6 +462,7 @@
     "templates",
     "binaries",
     "scripts/install-supervisor-binary.mjs",
+    "scripts/napi-binary-picker.mjs",
     "README.md",
     "STABILITY.md"
   ],

--- a/packages/core/scripts/check-core-tarball-size.mjs
+++ b/packages/core/scripts/check-core-tarball-size.mjs
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
 /**
  * CI gate: assert the packed `@cleocode/core` tarball stays within budget and
- * bundles ONLY the linux-x64-gnu supervisor fallback binary
- * (T11342 — SG-RUNTIME-UNIFICATION R1).
+ * bundles ONLY the linux-x64-gnu fallback for each CLEO-managed native binary
+ * (T11342 — SG-RUNTIME-UNIFICATION R1; extended T11580 — R10-L1).
  *
- * Rationale: Distribution Pattern P1 bundles exactly ONE supervisor binary
- * (linux-x64-gnu) into the tarball; the other four targets are downloaded at
+ * Rationale: Distribution Pattern P1 bundles exactly ONE binary per family
+ * (linux-x64-gnu) into the tarball; the other targets are downloaded at
  * postinstall (P2). If a future change bundles additional platform binaries,
  * the tarball bloats and `npm install` slows for everyone. This gate fails the
  * build (non-zero exit) when:
  *
  *   1. The packed tarball exceeds {@link MAX_CORE_TARBALL_BYTES}, OR
- *   2. More than one `cleo-supervisor.*` platform binary is bundled, OR a
- *      bundled binary targets a triple other than `linux-x64-gnu`.
+ *   2. More than one `cleo-supervisor.*` platform binary is bundled, or a
+ *      bundled one targets a triple other than `linux-x64-gnu`, OR
+ *   3. More than one `worktree-napi.*.node` platform addon is bundled, or a
+ *      bundled one targets a triple other than `linux-x64-gnu` (T11580).
  *
  * On failure it prints the largest contributors so the regression is obvious.
  *
@@ -20,6 +22,7 @@
  *   node packages/core/scripts/check-core-tarball-size.mjs
  *
  * @task T11342
+ * @task T11580
  */
 
 import { execFileSync } from 'node:child_process';
@@ -40,8 +43,16 @@ export const MAX_CORE_TARBALL_MB = 25;
 /** The threshold expressed in bytes for the size comparison. */
 export const MAX_CORE_TARBALL_BYTES = MAX_CORE_TARBALL_MB * 1024 * 1024;
 
-/** The ONLY supervisor platform binary permitted inside the bundled tarball. */
-export const ALLOWED_BUNDLED_SUPERVISOR_TRIPLE = 'linux-x64-gnu';
+/** The ONLY platform triple permitted bundled for each native-binary family. */
+export const ALLOWED_BUNDLED_TRIPLE = 'linux-x64-gnu';
+
+/**
+ * Back-compat alias — the supervisor-specific name kept for any external
+ * importer. Both families share the single allowed triple.
+ *
+ * @deprecated Use {@link ALLOWED_BUNDLED_TRIPLE}.
+ */
+export const ALLOWED_BUNDLED_SUPERVISOR_TRIPLE = ALLOWED_BUNDLED_TRIPLE;
 
 /**
  * Run `npm pack --dry-run --json` and parse the single package report.
@@ -84,6 +95,40 @@ function supervisorTripleFromPath(path) {
   return m[1];
 }
 
+/** Extract the platform triple from a bundled worktree-napi addon path, or null. */
+function worktreeNapiTripleFromPath(path) {
+  // Match `worktree-napi.<triple>.node`; never `worktree-napi-manifest.json`.
+  const m = /(?:^|\/)worktree-napi\.([a-z0-9-]+?)\.node$/.exec(path);
+  return m ? m[1] : null;
+}
+
+/**
+ * Assert a native-binary family bundles exactly one fallback, for the allowed
+ * triple. Pushes a message into `failures` per violation.
+ *
+ * @param {string} family - Human label, e.g. `supervisor` or `worktree-napi`.
+ * @param {Array<{ path: string }>} files - Packed tarball file entries.
+ * @param {(path: string) => string | null} tripleFromPath - Family extractor.
+ * @param {string[]} failures - Mutable failure sink.
+ */
+function assertSingleFallback(family, files, tripleFromPath, failures) {
+  const bundledTriples = files.map((f) => tripleFromPath(f.path)).filter((t) => t !== null);
+  for (const triple of bundledTriples) {
+    if (triple !== ALLOWED_BUNDLED_TRIPLE) {
+      failures.push(
+        `tarball bundles a non-fallback ${family} binary for '${triple}' — only ` +
+          `'${ALLOWED_BUNDLED_TRIPLE}' may be bundled (other targets download via P2)`,
+      );
+    }
+  }
+  if (bundledTriples.length > 1) {
+    failures.push(
+      `tarball bundles ${bundledTriples.length} ${family} binaries (${bundledTriples.join(', ')}) — ` +
+        `exactly one (${ALLOWED_BUNDLED_TRIPLE}) is allowed`,
+    );
+  }
+}
+
 function main() {
   const report = packReport();
 
@@ -98,23 +143,10 @@ function main() {
   }
 
   // 2. Bundled supervisor binaries — exactly one, linux-x64-gnu.
-  const bundledTriples = report.files
-    .map((f) => supervisorTripleFromPath(f.path))
-    .filter((t) => t !== null);
-  for (const triple of bundledTriples) {
-    if (triple !== ALLOWED_BUNDLED_SUPERVISOR_TRIPLE) {
-      failures.push(
-        `tarball bundles a non-fallback supervisor binary for '${triple}' — only ` +
-          `'${ALLOWED_BUNDLED_SUPERVISOR_TRIPLE}' may be bundled (other targets download via P2)`,
-      );
-    }
-  }
-  if (bundledTriples.length > 1) {
-    failures.push(
-      `tarball bundles ${bundledTriples.length} supervisor binaries (${bundledTriples.join(', ')}) — ` +
-        'exactly one (linux-x64-gnu) is allowed',
-    );
-  }
+  assertSingleFallback('supervisor', report.files, supervisorTripleFromPath, failures);
+
+  // 3. Bundled worktree-napi addons — exactly one, linux-x64-gnu (T11580).
+  assertSingleFallback('worktree-napi', report.files, worktreeNapiTripleFromPath, failures);
 
   // Always print the headline numbers + largest contributors.
   console.log(
@@ -129,7 +161,7 @@ function main() {
 
   if (failures.length > 0) {
     console.error('');
-    console.error('::error::@cleocode/core tarball gate FAILED (T11342):');
+    console.error('::error::@cleocode/core tarball gate FAILED (T11342 / T11580):');
     for (const f of failures) console.error(`  - ${f}`);
     process.exit(1);
   }

--- a/packages/core/scripts/gen-napi-manifest.mjs
+++ b/packages/core/scripts/gen-napi-manifest.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Generate the sha256 manifest for the cross-compiled worktree-napi `.node`
+ * addons (T11580 — R10-L1 · SG-PACKAGE-ARCH).
+ *
+ * Mirrors `gen-supervisor-manifest.mjs`. Distribution Pattern P2: the manifest
+ * is generated in CI from the `.node` binaries attached to a GitHub Release and
+ * CHECKED INTO the @cleocode/core tarball at publish time (NOT fetched at
+ * runtime). The shared postinstall picker (`napi-binary-picker.mjs`, driven by
+ * `install-supervisor-binary.mjs`) downloads the matching `.node` from the
+ * Release and verifies it against the pinned sha256 here, failing closed on a
+ * mismatch.
+ *
+ * The buildable worktree-napi matrix is FOUR triples (`linux-x64-gnu`,
+ * `linux-arm64-gnu`, `darwin-arm64`, `win32-x64-msvc`) — `darwin-x64` was
+ * dropped (T10479) because macos-13 Intel runners stall the release. This
+ * generator emits an entry for every `worktree-napi.<triple>.node` found in the
+ * bin dir, so it adapts if the matrix changes.
+ *
+ * Manifest schema (stable — the picker reads it; identical shape to the
+ * supervisor manifest so one picker consumes both):
+ *
+ * ```jsonc
+ * {
+ *   "version": "2026.5.130",
+ *   "generatedAt": "2026-05-30T01:23:45.678Z",
+ *   "baseUrl": "https://github.com/kryptobaseddev/cleo/releases/download/v2026.5.130",
+ *   "binaries": {
+ *     "linux-x64-gnu":   { "file": "worktree-napi.linux-x64-gnu.node",   "sha256": "…", "size": 1441472 },
+ *     "linux-arm64-gnu": { "file": "worktree-napi.linux-arm64-gnu.node", "sha256": "…", "size": 1400000 },
+ *     "darwin-arm64":    { "file": "worktree-napi.darwin-arm64.node",    "sha256": "…", "size": 1480000 },
+ *     "win32-x64-msvc":  { "file": "worktree-napi.win32-x64-msvc.node",  "sha256": "…", "size": 1600000 }
+ *   }
+ * }
+ * ```
+ *
+ * Usage:
+ *   node packages/core/scripts/gen-napi-manifest.mjs \
+ *     --bin-dir <dir-with-worktree-napi.*.node> \
+ *     --out <manifest.json> \
+ *     [--version <ver>] [--repo kryptobaseddev/cleo]
+ *
+ * @task T11580
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Filename prefix shared by every worktree-napi binary artifact. */
+const BIN_PREFIX = 'worktree-napi.';
+
+/** Filename suffix shared by every napi addon artifact. */
+const BIN_SUFFIX = '.node';
+
+/** Default GitHub repository slug for the release download base URL. */
+const DEFAULT_REPO = 'kryptobaseddev/cleo';
+
+/**
+ * Map an artifact filename to its platform triple.
+ *
+ * `worktree-napi.linux-x64-gnu.node`   -> `linux-x64-gnu`
+ * `worktree-napi.win32-x64-msvc.node`  -> `win32-x64-msvc`
+ *
+ * @param {string} file - The artifact basename.
+ * @returns {string | null} The triple, or null if the name is not a napi addon.
+ */
+function tripleFromFile(file) {
+  if (!file.startsWith(BIN_PREFIX) || !file.endsWith(BIN_SUFFIX)) return null;
+  const rest = file.slice(BIN_PREFIX.length, -BIN_SUFFIX.length);
+  return rest.length > 0 ? rest : null;
+}
+
+/**
+ * Compute the sha256 hex digest of a file via streaming.
+ *
+ * @param {string} path - Absolute file path.
+ * @returns {Promise<string>} Lowercase hex digest.
+ */
+function sha256File(path) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(path);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+/**
+ * Parse `--flag value` style CLI args into a plain object.
+ *
+ * @param {string[]} argv - Raw argv slice.
+ * @returns {Record<string, string>} Parsed flags.
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        out[key] = next;
+        i += 1;
+      } else {
+        out[key] = 'true';
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the version: explicit flag wins, else the root package.json version.
+ *
+ * @param {string | undefined} flag - Explicit `--version` value.
+ * @returns {string} The resolved version string.
+ */
+function resolveVersion(flag) {
+  if (flag) return flag;
+  const here = fileURLToPath(import.meta.url);
+  // packages/core/scripts/gen-napi-manifest.mjs -> repo root is ../../..
+  const rootPkg = join(here, '..', '..', '..', '..', 'package.json');
+  const pkg = JSON.parse(readFileSync(rootPkg, 'utf8'));
+  return pkg.version;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const binDir = args['bin-dir'];
+  const outPath = args.out;
+  if (!binDir || !outPath) {
+    console.error(
+      'usage: gen-napi-manifest.mjs --bin-dir <dir> --out <manifest.json> [--version <v>] [--repo <slug>]',
+    );
+    process.exit(2);
+  }
+  const version = resolveVersion(args.version);
+  const repo = args.repo ?? DEFAULT_REPO;
+  const baseUrl = `https://github.com/${repo}/releases/download/v${version}`;
+
+  /** @type {Record<string, { file: string; sha256: string; size: number }>} */
+  const binaries = {};
+  for (const entry of readdirSync(binDir)) {
+    const triple = tripleFromFile(basename(entry));
+    if (!triple) continue;
+    const full = join(binDir, entry);
+    const sha256 = await sha256File(full);
+    const size = readFileSync(full).length;
+    binaries[triple] = { file: entry, sha256, size };
+  }
+
+  const found = Object.keys(binaries);
+  if (found.length === 0) {
+    console.error(`no worktree-napi.*.node binaries found in ${binDir}`);
+    process.exit(1);
+  }
+
+  const manifest = {
+    version,
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    binaries,
+  };
+  writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  console.log(`wrote ${outPath} with ${found.length} binaries: ${found.join(', ')}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/core/scripts/install-supervisor-binary.mjs
+++ b/packages/core/scripts/install-supervisor-binary.mjs
@@ -1,229 +1,78 @@
 #!/usr/bin/env node
 /**
- * Postinstall picker for the cleo-supervisor native binary
- * (T11340 — SG-RUNTIME-UNIFICATION R1, Distribution Pattern P2/P1).
+ * Postinstall picker entrypoint for CLEO-managed native binaries
+ * (T11340 — SG-RUNTIME-UNIFICATION R1; extended T11580 — R10-L1).
  *
- * Resolution + verification flow:
+ * Historically this script resolved ONLY the `cleo-supervisor` executable. As
+ * of R10-L1 (T11580) it drives the SAME picker over BOTH CLEO-managed native
+ * binaries — `cleo-supervisor` and `worktree-napi` — via the shared
+ * {@link pickBinary} module. The resolution + verification flow (P2 download +
+ * sha256 fail-closed + `CLEO_NAPI_BINARY_MIRROR` override + idempotent cache
+ * reuse + P1 bundled fallback) is identical for both; only the manifest,
+ * fallback path, and cache filename differ per binary.
  *
- *   1. Resolve the platform triple from `process.platform` + `process.arch` +
- *      libc (gnu/musl on Linux). Supported: linux-x64-gnu, linux-arm64-gnu,
- *      darwin-x64, darwin-arm64, win32-x64-msvc.
- *   2. Read the sha256 manifest CHECKED INTO this package (P2 — pinned at
- *      publish time, never fetched). The manifest pins the GitHub Release
- *      base URL + per-triple sha256 + filename.
- *   3. If the binary is already cached + sha256-valid, reuse it (idempotent).
- *   4. Otherwise download `<baseUrl>/<file>` (base URL overridable via
- *      `CLEO_NAPI_BINARY_MIRROR`), verify sha256 against the manifest
- *      (FAIL CLOSED on mismatch), write atomically (tmp-then-rename), chmod +x.
- *   5. P1 fallback: when the download is unavailable (offline, `--ignore-scripts`
- *      so this never ran, or a mirror outage) AND the bundled
- *      `binaries/fallback/cleo-supervisor` matches the host triple
- *      (linux-x64-gnu), use it.
+ * The package `postinstall` invokes this once. Each binary is resolved
+ * independently and best-effort — a failure of one never blocks the other, and
+ * neither ever fails `npm install` (graceful degrade; the dependent feature is
+ * resolved on first use).
  *
- * postinstall MUST NOT fail the install — a missing supervisor binary degrades
- * gracefully (the daemon feature is unavailable until the binary is resolved on
- * first use). This script therefore exits 0 even on download failure, logging a
- * diagnostic. The fail-closed sha256 check applies to the BYTES (a tampered
- * download is rejected); it does not abort `npm install`.
+ * Standalone binary specs:
+ *
+ *   - `cleo-supervisor`: a single executable per triple, cached as
+ *     `cleo-supervisor<ext>` and chmod +x.
+ *   - `worktree-napi`: a napi-rs `.node` addon, cached as
+ *     `worktree-napi.<triple>.node` (no exec bit needed — it is `require()`d).
  *
  * @task T11340
+ * @task T11580
  */
 
-import { createHash } from 'node:crypto';
-import {
-  chmodSync,
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { homedir, platform as osPlatform } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { pickBinary } from './napi-binary-picker.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** Package root: packages/core (scripts/ is a direct child). */
 const PKG_ROOT = join(__dirname, '..');
 
-/** Path to the sha256 manifest checked into the tarball (P2). */
-const MANIFEST_PATH = join(PKG_ROOT, 'binaries', 'cleo-supervisor-manifest.json');
-
-/** Bundled P1 fallback binary (linux-x64-gnu only). */
-const FALLBACK_BIN = join(PKG_ROOT, 'binaries', 'fallback', 'cleo-supervisor');
-
-/** The single triple the P1 fallback binary targets. */
-const FALLBACK_TRIPLE = 'linux-x64-gnu';
+/** Directory holding the checked-in manifests + bundled P1 fallbacks. */
+const BINARIES_DIR = join(PKG_ROOT, 'binaries');
 
 /**
- * Resolve the platform triple for the current host.
- *
- * @returns {{ triple: string; ext: string } | null} Triple + binary extension,
- *   or null if the host platform/arch is unsupported.
+ * The CLEO-managed native binaries resolved at postinstall. Each entry is a
+ * {@link import('./napi-binary-picker.mjs').BinarySpec}.
  */
-function resolveTriple() {
-  const p = process.platform;
-  const a = process.arch;
-  if (p === 'linux' && a === 'x64') return { triple: 'linux-x64-gnu', ext: '' };
-  if (p === 'linux' && a === 'arm64') return { triple: 'linux-arm64-gnu', ext: '' };
-  if (p === 'darwin' && a === 'x64') return { triple: 'darwin-x64', ext: '' };
-  if (p === 'darwin' && a === 'arm64') return { triple: 'darwin-arm64', ext: '' };
-  if (p === 'win32' && a === 'x64') return { triple: 'win32-x64-msvc', ext: '.exe' };
-  return null;
-}
-
-/**
- * Detect whether the Linux host uses musl libc (Alpine et al.). The published
- * Linux binaries are gnu-only; a musl host has no matching prebuild and falls
- * through to the descriptive "unsupported" path.
- *
- * @returns {boolean} True when the host appears to be musl-based.
- */
-function isMuslLinux() {
-  if (osPlatform() !== 'linux') return false;
-  try {
-    // The simplest robust signal available without spawning: the ldd report
-    // embedded in process.report (Node exposes glibc/musl there on Linux).
-    const report =
-      typeof process.report?.getReport === 'function' ? process.report.getReport() : null;
-    const glibc = report?.header?.glibcVersionRuntime;
-    // glibcVersionRuntime present => glibc; absent on musl.
-    return !glibc;
-  } catch {
-    return false;
-  }
-}
-
-/** Compute the sha256 hex digest of a buffer. */
-function sha256(buf) {
-  return createHash('sha256').update(buf).digest('hex');
-}
-
-/** Cache directory for the resolved binary: `<cache>/cleo/napi-bin/<version>/`. */
-function cacheDir(version) {
-  // Mirror env-paths('cleo', {suffix:''}).cache without importing @cleocode/paths
-  // (this script runs in postinstall where workspace deps may not be linked yet).
-  const p = process.platform;
-  if (p === 'win32') {
-    const local = process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local');
-    return join(local, 'cleo', 'Cache', 'napi-bin', version);
-  }
-  if (p === 'darwin') {
-    return join(homedir(), 'Library', 'Caches', 'cleo', 'napi-bin', version);
-  }
-  const xdg = process.env.XDG_CACHE_HOME;
-  const base = xdg && xdg.startsWith('/') ? xdg : join(homedir(), '.cache');
-  return join(base, 'cleo', 'napi-bin', version);
-}
-
-/** Write `buf` to `dest` atomically (tmp-then-rename) and chmod +x. */
-function writeBinaryAtomic(dest, buf) {
-  mkdirSync(dirname(dest), { recursive: true });
-  const tmp = `${dest}.${process.pid}.tmp`;
-  writeFileSync(tmp, buf);
-  chmodSync(tmp, 0o755);
-  renameSync(tmp, dest);
-}
-
-/** Use the bundled P1 fallback if it matches the host triple. */
-function tryFallback(triple, dest) {
-  if (triple !== FALLBACK_TRIPLE || !existsSync(FALLBACK_BIN)) return false;
-  try {
-    mkdirSync(dirname(dest), { recursive: true });
-    const tmp = `${dest}.${process.pid}.fallback.tmp`;
-    copyFileSync(FALLBACK_BIN, tmp);
-    chmodSync(tmp, 0o755);
-    renameSync(tmp, dest);
-    console.log(`[cleo-supervisor] using bundled P1 fallback for ${triple}`);
-    return true;
-  } catch (err) {
-    console.warn(`[cleo-supervisor] fallback copy failed: ${err?.message ?? err}`);
-    return false;
-  }
-}
+const BINARY_SPECS = [
+  {
+    label: 'cleo-supervisor',
+    manifestPath: join(BINARIES_DIR, 'cleo-supervisor-manifest.json'),
+    fallbackPath: join(BINARIES_DIR, 'fallback', 'cleo-supervisor'),
+    executable: true,
+    cachedName: (_triple, ext) => `cleo-supervisor${ext}`,
+  },
+  {
+    label: 'worktree-napi',
+    manifestPath: join(BINARIES_DIR, 'worktree-napi-manifest.json'),
+    fallbackPath: join(BINARIES_DIR, 'fallback', 'worktree-napi.linux-x64-gnu.node'),
+    executable: false,
+    cachedName: (triple) => `worktree-napi.${triple}.node`,
+  },
+];
 
 async function main() {
-  const resolved = resolveTriple();
-  if (!resolved) {
-    console.warn(
-      `[cleo-supervisor] no prebuilt binary for ${process.platform}/${process.arch}` +
-        (isMuslLinux() ? ' (musl libc — only gnu Linux prebuilds are published)' : '') +
-        ' — daemon features will be unavailable.',
-    );
-    return; // graceful: do not fail install
-  }
-  const { triple, ext } = resolved;
-
-  if (!existsSync(MANIFEST_PATH)) {
-    console.warn(
-      `[cleo-supervisor] manifest missing at ${MANIFEST_PATH} — skipping binary install` +
-        ' (development checkout or --ignore-scripts publish).',
-    );
-    return;
-  }
-
-  /** @type {{version:string; baseUrl:string; binaries:Record<string,{file:string; sha256:string; size:number}>}} */
-  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
-  const entry = manifest.binaries?.[triple];
-  if (!entry) {
-    console.warn(`[cleo-supervisor] manifest has no entry for ${triple} — skipping.`);
-    return;
-  }
-
-  const dest = join(cacheDir(manifest.version), `cleo-supervisor${ext}`);
-
-  // Idempotent: reuse a cached binary that already matches the pinned sha256.
-  if (existsSync(dest)) {
-    try {
-      if (sha256(readFileSync(dest)) === entry.sha256) {
-        console.log(`[cleo-supervisor] cached binary OK at ${dest}`);
-        return;
-      }
-    } catch {
-      // fall through to re-download
-    }
-  }
-
-  // CLEO_NAPI_BINARY_MIRROR overrides the download base URL (corporate proxies).
-  const mirror = process.env.CLEO_NAPI_BINARY_MIRROR?.replace(/\/+$/, '');
-  const base = mirror ?? manifest.baseUrl;
-  const url = `${base}/${entry.file}`;
-
-  try {
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} for ${url}`);
-    }
-    const buf = Buffer.from(await res.arrayBuffer());
-    const digest = sha256(buf);
-    if (digest !== entry.sha256) {
-      // FAIL CLOSED on the bytes — never install a tampered binary.
-      throw new Error(
-        `sha256 mismatch for ${triple}: expected ${entry.sha256}, got ${digest} — refusing to install`,
-      );
-    }
-    writeBinaryAtomic(dest, buf);
-    console.log(`[cleo-supervisor] installed ${triple} -> ${dest} (sha256 verified)`);
-  } catch (err) {
-    console.warn(`[cleo-supervisor] download failed: ${err?.message ?? err}`);
-    if (tryFallback(triple, dest)) return;
-    // Clean a partial cache entry, then degrade gracefully.
-    try {
-      rmSync(dest, { force: true });
-    } catch {
-      /* ignore */
-    }
-    console.warn(
-      `[cleo-supervisor] binary unavailable for ${triple}; daemon features deferred until first use.`,
-    );
-  }
+  // Resolve each binary independently — one failure must not block the other.
+  await Promise.all(
+    BINARY_SPECS.map((spec) =>
+      pickBinary(spec).catch((err) => {
+        console.warn(`[${spec.label}] picker error (non-fatal): ${err?.message ?? err}`);
+      }),
+    ),
+  );
 }
 
 main().catch((err) => {
   // postinstall must never break `npm install`.
-  console.warn(`[cleo-supervisor] postinstall picker error (non-fatal): ${err?.message ?? err}`);
+  console.warn(`[cleo-napi] postinstall picker error (non-fatal): ${err?.message ?? err}`);
   process.exit(0);
 });

--- a/packages/core/scripts/napi-binary-picker.mjs
+++ b/packages/core/scripts/napi-binary-picker.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Shared postinstall picker for CLEO-managed native binaries
+ * (T11580 — R10-L1 · SG-PACKAGE-ARCH; generalizes the T11340 supervisor picker).
+ *
+ * Two binaries flow through this single picker:
+ *
+ *   - `cleo-supervisor` — the standalone process supervisor executable
+ *     (`crates/cleo-supervisor`). A single exec per triple.
+ *   - `worktree-napi`    — the napi-rs Node-API addon (`crates/worktree-napi`)
+ *     consumed by `@cleocode/worktree`. The host-triple `.node` is cached so the
+ *     worktree loader resolves a core-managed path instead of bundling all four
+ *     `.node` files in the `@cleocode/worktree` tarball.
+ *
+ * Both follow Distribution Pattern P2 (primary) + P1 (fallback):
+ *
+ *   1. Resolve the platform triple from `process.platform` + `process.arch` +
+ *      libc (gnu/musl on Linux).
+ *   2. Read the sha256 manifest CHECKED INTO this package (P2 — pinned at
+ *      publish time, never fetched). The manifest pins the GitHub Release base
+ *      URL + per-triple sha256 + filename.
+ *   3. If the binary is already cached + sha256-valid, reuse it (idempotent).
+ *   4. Otherwise download `<baseUrl>/<file>` (base URL overridable via
+ *      `CLEO_NAPI_BINARY_MIRROR`), verify sha256 against the manifest
+ *      (FAIL CLOSED on mismatch), write atomically (tmp-then-rename), chmod +x
+ *      for executables.
+ *   5. P1 fallback: when the download is unavailable (offline, `--ignore-scripts`
+ *      so this never ran, or a mirror outage) AND the bundled
+ *      `binaries/fallback/<fallbackFile>` matches the host triple
+ *      (linux-x64-gnu), use it.
+ *
+ * postinstall MUST NOT fail the install — a missing binary degrades gracefully
+ * (the dependent feature is resolved on first use). Callers therefore exit 0
+ * even on download failure, logging a diagnostic. The fail-closed sha256 check
+ * applies to the BYTES (a tampered download is rejected); it does not abort
+ * `npm install`.
+ *
+ * @task T11580
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir, platform as osPlatform } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** The single triple every P1 fallback binary targets. */
+export const FALLBACK_TRIPLE = 'linux-x64-gnu';
+
+/**
+ * Resolve the platform triple for the current host.
+ *
+ * @returns {{ triple: string; ext: string } | null} Triple + executable
+ *   extension (`.exe` on Windows, `''` elsewhere), or null if the host
+ *   platform/arch is unsupported. `ext` only applies to standalone
+ *   executables; napi `.node` addons ignore it.
+ */
+export function resolveTriple() {
+  const p = process.platform;
+  const a = process.arch;
+  if (p === 'linux' && a === 'x64') return { triple: 'linux-x64-gnu', ext: '' };
+  if (p === 'linux' && a === 'arm64') return { triple: 'linux-arm64-gnu', ext: '' };
+  if (p === 'darwin' && a === 'x64') return { triple: 'darwin-x64', ext: '' };
+  if (p === 'darwin' && a === 'arm64') return { triple: 'darwin-arm64', ext: '' };
+  if (p === 'win32' && a === 'x64') return { triple: 'win32-x64-msvc', ext: '.exe' };
+  return null;
+}
+
+/**
+ * Detect whether the Linux host uses musl libc (Alpine et al.). The published
+ * Linux binaries are gnu-only; a musl host has no matching prebuild and falls
+ * through to the descriptive "unsupported" path.
+ *
+ * @returns {boolean} True when the host appears to be musl-based.
+ */
+export function isMuslLinux() {
+  if (osPlatform() !== 'linux') return false;
+  try {
+    // The simplest robust signal available without spawning: the ldd report
+    // embedded in process.report (Node exposes glibc/musl there on Linux).
+    const report =
+      typeof process.report?.getReport === 'function' ? process.report.getReport() : null;
+    const glibc = report?.header?.glibcVersionRuntime;
+    // glibcVersionRuntime present => glibc; absent on musl.
+    return !glibc;
+  } catch {
+    return false;
+  }
+}
+
+/** Compute the sha256 hex digest of a buffer. */
+export function sha256(buf) {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Cache directory for resolved native binaries:
+ * `<cache>/cleo/napi-bin/<version>/`.
+ *
+ * Mirrors `env-paths('cleo', {suffix:''}).cache` without importing
+ * `@cleocode/paths` (this runs in postinstall where workspace deps may not be
+ * linked yet).
+ *
+ * @param {string} version - The manifest version segment.
+ * @returns {string} Absolute cache directory path.
+ */
+export function cacheDir(version) {
+  const p = process.platform;
+  if (p === 'win32') {
+    const local = process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local');
+    return join(local, 'cleo', 'Cache', 'napi-bin', version);
+  }
+  if (p === 'darwin') {
+    return join(homedir(), 'Library', 'Caches', 'cleo', 'napi-bin', version);
+  }
+  const xdg = process.env.XDG_CACHE_HOME;
+  const base = xdg && xdg.startsWith('/') ? xdg : join(homedir(), '.cache');
+  return join(base, 'cleo', 'napi-bin', version);
+}
+
+/**
+ * Write `buf` to `dest` atomically (tmp-then-rename). Executables are chmod'd
+ * +x; napi `.node` addons are loaded by `require()` and need no exec bit.
+ *
+ * @param {string} dest - Destination path.
+ * @param {Buffer} buf - Bytes to write.
+ * @param {boolean} executable - Whether to chmod 0o755.
+ */
+function writeBinaryAtomic(dest, buf, executable) {
+  mkdirSync(dirname(dest), { recursive: true });
+  const tmp = `${dest}.${process.pid}.tmp`;
+  writeFileSync(tmp, buf);
+  if (executable) chmodSync(tmp, 0o755);
+  renameSync(tmp, dest);
+}
+
+/**
+ * Copy the bundled P1 fallback into the cache if it matches the host triple.
+ *
+ * @param {object} spec - The binary spec (see {@link pickBinary}).
+ * @param {string} triple - The resolved host triple.
+ * @param {string} dest - Cache destination path.
+ * @returns {boolean} True when the fallback was used.
+ */
+function tryFallback(spec, triple, dest) {
+  if (triple !== FALLBACK_TRIPLE || !existsSync(spec.fallbackPath)) return false;
+  try {
+    mkdirSync(dirname(dest), { recursive: true });
+    const tmp = `${dest}.${process.pid}.fallback.tmp`;
+    copyFileSync(spec.fallbackPath, tmp);
+    if (spec.executable) chmodSync(tmp, 0o755);
+    renameSync(tmp, dest);
+    console.log(`[${spec.label}] using bundled P1 fallback for ${triple}`);
+    return true;
+  } catch (err) {
+    console.warn(`[${spec.label}] fallback copy failed: ${err?.message ?? err}`);
+    return false;
+  }
+}
+
+/**
+ * @typedef {object} BinarySpec
+ * @property {string} label - Diagnostic label, e.g. `cleo-supervisor`.
+ * @property {string} manifestPath - Absolute path to the checked-in sha256
+ *   manifest (P2).
+ * @property {string} fallbackPath - Absolute path to the bundled P1 fallback
+ *   binary (linux-x64-gnu).
+ * @property {boolean} executable - Whether the resolved binary is a standalone
+ *   executable (`true` → chmod +x) or a napi `.node` addon (`false`).
+ * @property {(triple: string, ext: string) => string} cachedName - The basename
+ *   the binary is cached under in `<cache>/napi-bin/<version>/`. Supervisor uses
+ *   `cleo-supervisor<ext>`; worktree-napi uses `worktree-napi.<triple>.node`.
+ */
+
+/**
+ * Resolve a single CLEO-managed native binary into the shared cache following
+ * Distribution Pattern P2 (download + sha256) with a P1 (bundled fallback) safety
+ * net. Never throws to the caller for install-failure conditions — degrades
+ * gracefully and logs.
+ *
+ * @param {BinarySpec} spec - The per-binary distribution spec.
+ * @returns {Promise<void>}
+ */
+export async function pickBinary(spec) {
+  const resolved = resolveTriple();
+  if (!resolved) {
+    console.warn(
+      `[${spec.label}] no prebuilt binary for ${process.platform}/${process.arch}` +
+        (isMuslLinux() ? ' (musl libc — only gnu Linux prebuilds are published)' : '') +
+        ' — feature unavailable until resolved on first use.',
+    );
+    return; // graceful: do not fail install
+  }
+  const { triple, ext } = resolved;
+
+  if (!existsSync(spec.manifestPath)) {
+    console.warn(
+      `[${spec.label}] manifest missing at ${spec.manifestPath} — skipping binary install` +
+        ' (development checkout or --ignore-scripts publish).',
+    );
+    return;
+  }
+
+  /** @type {{version:string; baseUrl:string; binaries:Record<string,{file:string; sha256:string; size:number}>}} */
+  const manifest = JSON.parse(readFileSync(spec.manifestPath, 'utf8'));
+  const entry = manifest.binaries?.[triple];
+  if (!entry) {
+    console.warn(`[${spec.label}] manifest has no entry for ${triple} — skipping.`);
+    return;
+  }
+
+  const dest = join(cacheDir(manifest.version), spec.cachedName(triple, ext));
+
+  // Idempotent: reuse a cached binary that already matches the pinned sha256.
+  if (existsSync(dest)) {
+    try {
+      if (sha256(readFileSync(dest)) === entry.sha256) {
+        console.log(`[${spec.label}] cached binary OK at ${dest}`);
+        return;
+      }
+    } catch {
+      // fall through to re-download
+    }
+  }
+
+  // CLEO_NAPI_BINARY_MIRROR overrides the download base URL (corporate proxies).
+  const mirror = process.env.CLEO_NAPI_BINARY_MIRROR?.replace(/\/+$/, '');
+  const base = mirror ?? manifest.baseUrl;
+  const url = `${base}/${entry.file}`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} for ${url}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    const digest = sha256(buf);
+    if (digest !== entry.sha256) {
+      // FAIL CLOSED on the bytes — never install a tampered binary.
+      throw new Error(
+        `sha256 mismatch for ${triple}: expected ${entry.sha256}, got ${digest} — refusing to install`,
+      );
+    }
+    writeBinaryAtomic(dest, buf, spec.executable);
+    console.log(`[${spec.label}] installed ${triple} -> ${dest} (sha256 verified)`);
+  } catch (err) {
+    console.warn(`[${spec.label}] download failed: ${err?.message ?? err}`);
+    if (tryFallback(spec, triple, dest)) return;
+    // Clean a partial cache entry, then degrade gracefully.
+    try {
+      rmSync(dest, { force: true });
+    } catch {
+      /* ignore */
+    }
+    console.warn(
+      `[${spec.label}] binary unavailable for ${triple}; feature deferred until first use.`,
+    );
+  }
+}

--- a/packages/worktree/src/napi-binding.ts
+++ b/packages/worktree/src/napi-binding.ts
@@ -11,11 +11,27 @@
  * package import napi functions from THIS module, never directly from the
  * native loader.
  *
+ * Resolution order (first hit wins):
+ *
+ *   1. Bundled loader at `../native/worktree-napi.cjs` (published
+ *      `@cleocode/worktree` tarball).
+ *   2. Repo-local crate loader at `../../../crates/worktree-napi/index.cjs`
+ *      (source-tree execution after a local napi build).
+ *   3. **Core-managed cache** (T11580 · R10-L1): the host-triple `.node`
+ *      resolved by the shared `@cleocode/core` postinstall picker under
+ *      `<cache>/cleo/napi-bin/<version>/worktree-napi.<triple>.node`. This is
+ *      the Distribution Pattern P2 runtime hand-off — the picker downloads +
+ *      sha256-verifies the addon; this loader simply `require()`s the cached
+ *      file (the `.node` exports `module.exports = nativeBinding`, so no `.cjs`
+ *      wrapper is needed). Picked newest-version-first.
+ *
  * @task T9982
+ * @task T11580
  */
 
-import { cpSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -26,6 +42,69 @@ const bundledNativeLoaderPath = fileURLToPath(
 const repoLocalNativeLoaderPath = fileURLToPath(
   new URL('../../../crates/worktree-napi/index.cjs', import.meta.url),
 );
+
+/**
+ * Resolve the platform triple for the current host, mirroring the napi loader's
+ * `tripleName()` and the core picker's `resolveTriple()`. Returns `null` for
+ * unsupported platform/arch (e.g. macOS x64, for which no prebuild ships).
+ *
+ * @returns The host triple, or `null` when unsupported.
+ */
+function resolveHostTriple(): string | null {
+  const { platform, arch } = process;
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64-gnu';
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64-gnu';
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64';
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64-msvc';
+  return null;
+}
+
+/**
+ * Base cache directory holding the per-version `napi-bin` subdirs that the
+ * `@cleocode/core` picker writes to. Mirrors `cacheDir()` in
+ * `packages/core/scripts/napi-binary-picker.mjs` (env-paths('cleo').cache /
+ * napi-bin) without importing `@cleocode/core` (a devDependency only).
+ *
+ * @returns Absolute path to `<cache>/cleo/napi-bin`.
+ */
+function napiBinCacheRoot(): string {
+  const p = process.platform;
+  if (p === 'win32') {
+    const local = process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local');
+    return join(local, 'cleo', 'Cache', 'napi-bin');
+  }
+  if (p === 'darwin') {
+    return join(homedir(), 'Library', 'Caches', 'cleo', 'napi-bin');
+  }
+  const xdg = process.env.XDG_CACHE_HOME;
+  const base = xdg?.startsWith('/') ? xdg : join(homedir(), '.cache');
+  return join(base, 'cleo', 'napi-bin');
+}
+
+/**
+ * Find the core-managed cached `worktree-napi.<triple>.node` for the host,
+ * preferring the newest version directory. Returns `null` when no cached addon
+ * exists (the common case in a fully-bundled install — tiers 1/2 win first).
+ *
+ * @returns Absolute path to the cached `.node`, or `null`.
+ */
+function resolveCoreManagedNapiPath(): string | null {
+  const triple = resolveHostTriple();
+  if (triple === null) return null;
+  const root = napiBinCacheRoot();
+  if (!existsSync(root)) return null;
+  let versions: string[];
+  try {
+    versions = readdirSync(root).sort().reverse();
+  } catch {
+    return null;
+  }
+  for (const version of versions) {
+    const candidate = join(root, version, `worktree-napi.${triple}.node`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
 
 interface CopyOptsNapi {
   /** Overwrite existing entries at the destination. */
@@ -260,6 +339,29 @@ function getNative(): WorktreeNapiModule {
     }
   }
 
+  // Tier 3 (T11580 · R10-L1): the core-managed cached `.node` resolved by the
+  // shared @cleocode/core postinstall picker (Distribution Pattern P2). The
+  // cached file is a raw addon exporting `module.exports = nativeBinding`, so
+  // it is `require()`d directly — no `.cjs` wrapper.
+  const coreManagedNapiPath = resolveCoreManagedNapiPath();
+  if (coreManagedNapiPath !== null) {
+    try {
+      nativeBinding = require_(coreManagedNapiPath) as WorktreeNapiModule;
+      return nativeBinding;
+    } catch {
+      if (isTestRuntime()) {
+        nativeBinding = createTestFallbackNativeModule();
+        return nativeBinding;
+      }
+
+      throw new Error(
+        `@cleocode/worktree: failed to load core-managed native addon at ${coreManagedNapiPath}. ` +
+          'The @cleocode/core postinstall picker resolved a cached binary that could not be loaded — ' +
+          'reinstall @cleocode/core or clear the napi-bin cache.',
+      );
+    }
+  }
+
   if (isTestRuntime()) {
     nativeBinding = createTestFallbackNativeModule();
     return nativeBinding;
@@ -267,7 +369,8 @@ function getNative(): WorktreeNapiModule {
 
   throw new Error(
     `@cleocode/worktree: missing bundled native loader at ${bundledNativeLoaderPath}. ` +
-      'The release package must include native/worktree-napi.cjs and worktree-napi.<triple>.node files.',
+      'The release package must include native/worktree-napi.cjs and worktree-napi.<triple>.node files, ' +
+      'or @cleocode/core must resolve worktree-napi via its postinstall picker (Pattern P2).',
   );
 }
 


### PR DESCRIPTION
## What

R10-L1 (SG-PACKAGE-ARCH). Generalizes the `@cleocode/core` postinstall binary picker so the SAME P2/P1 distribution flow that resolves `cleo-supervisor` (T11340) also resolves the `worktree-napi` napi-rs addon. **Additive — supervisor resolution behaviorally unchanged; ZERO publish-surface change.**

### VERIFY result: real work (not verify-close)
Before this PR, worktree-napi shipped ALL 4 `.node` triples bundled into `@cleocode/worktree/native` (Pattern P1-for-all). There was no core-managed picker, no sha256 manifest, no GitHub-Release fetch, and no `CLEO_NAPI_BINARY_MIRROR` path for it — the `release.yml` comment claiming a "Pattern P2 fetched from GitHub Release" path for worktree-napi was aspirational, not implemented. This PR makes it real.

## Acceptance criteria

- **AC1** — `packages/core/scripts/gen-napi-manifest.mjs`: sha256 manifest generator for worktree-napi, mirroring `gen-supervisor-manifest.mjs`. Emits one entry per `worktree-napi.<triple>.node` found (adapts to the 4-triple buildable matrix; `darwin-x64` dropped per T10479).
- **AC2** — `packages/core/scripts/napi-binary-picker.mjs`: shared picker extracted from `install-supervisor-binary.mjs` (DRY). P2 download + sha256 **fail-closed** + `CLEO_NAPI_BINARY_MIRROR` override + idempotent cache reuse. `install-supervisor-binary.mjs` now drives **both** binaries via a per-binary spec table.
- **AC3** — P1 `linux-x64-gnu` `worktree-napi.<triple>.node` fallback staged in CI (`core-tarball-size.yml`), consistent with the supervisor fallback (CI-staged, not committed; `binaries/` ships in the tarball).
- **AC4** — `check-core-tarball-size.mjs` asserts exactly ONE worktree-napi fallback (linux-x64-gnu) and no extra napi triples bundled.
- **AC5** — `@cleocode/worktree` napi loader (`napi-binding.ts`) adds **Tier-3** resolution of the core-managed cached `.node` (newest version first); existing bundled + repo-local tiers unchanged; postinstall exits 0 on download failure (graceful degrade).

Also ships `scripts/napi-binary-picker.mjs` in `@cleocode/core` `files[]` so the postinstall import resolves in the published tarball.

## Validation

- `pnpm run typecheck` (tsc -b oracle) — clean
- `node build.mjs` — clean
- `npx vitest run --project @cleocode/worktree` — 14 files / 83 tests pass
- `cleo check arch` — 5/5 gates pass; publish-surface / tools-skills / contracts-purity lints pass
- Picker smoke (local HTTP server): P2 download, sha256 verify, idempotent reuse, **fail-closed tamper-reject → P1 fallback**, `CLEO_NAPI_BINARY_MIRROR` override — all pass
- Supervisor parity smoke: still cached as `cleo-supervisor`, chmod +x — unchanged
- `npm pack --dry-run` confirms picker module ships + postinstall entrypoint exits 0 on missing manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)