### PR TITLE
feat(T11578): tasks runtime read/write → prefixed tasks_* consolidated tables (AC1)

### DIFF
--- a/packages/core/src/doctor/__tests__/invariant-audit.test.ts
+++ b/packages/core/src/doctor/__tests__/invariant-audit.test.ts
@@ -70,7 +70,7 @@ function insertTask(
   const status = row.status ?? 'pending';
   const pipelineStage = status === 'done' ? 'contribution' : null;
   db.prepare(
-    'INSERT INTO tasks (id, title, type, status, parent_id, labels_json, pipeline_stage) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO tasks_tasks (id, title, type, status, parent_id, labels_json, pipeline_stage) VALUES (?, ?, ?, ?, ?, ?, ?)',
   ).run(
     row.id,
     row.title,

--- a/packages/core/src/doctor/__tests__/saga-audit.test.ts
+++ b/packages/core/src/doctor/__tests__/saga-audit.test.ts
@@ -82,7 +82,7 @@ function insertTask(
   const status = row.status ?? 'pending';
   const pipelineStage = status === 'done' ? 'contribution' : null;
   db.prepare(
-    'INSERT INTO tasks (id, title, type, status, parent_id, labels_json, pipeline_stage) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO tasks_tasks (id, title, type, status, parent_id, labels_json, pipeline_stage) VALUES (?, ?, ?, ?, ?, ?, ?)',
   ).run(
     row.id,
     row.title,
@@ -102,7 +102,7 @@ function insertTask(
  * saga for the I7 case).
  */
 function linkMember(db: NativeDbForTest, sagaId: string, memberId: string): void {
-  db.prepare('UPDATE tasks SET parent_id = ? WHERE id = ?').run(sagaId, memberId);
+  db.prepare('UPDATE tasks_tasks SET parent_id = ? WHERE id = ?').run(sagaId, memberId);
 }
 
 describe('auditSagaHierarchy (T10119)', () => {

--- a/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts
+++ b/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts
@@ -53,7 +53,10 @@ beforeEach(async () => {
       id: 'T999',
       title: 'Test Task',
       description: 'A task for IVTR testing',
-      status: 'in_progress',
+      // T11578 · AC1: 'in_progress' is NOT a valid TASK_STATUSES member — the
+      // legacy bare `tasks` table had no CHECK so it slipped through; the
+      // consolidated `tasks_tasks` CHECK rejects it. Canonical = 'active'.
+      status: 'active',
       priority: 'medium',
       depends: [],
     },

--- a/packages/core/src/lifecycle/__tests__/pipelinestage-unification.test.ts
+++ b/packages/core/src/lifecycle/__tests__/pipelinestage-unification.test.ts
@@ -48,7 +48,8 @@ afterEach(async () => {
 async function readTaskPipelineStage(taskId: string): Promise<string | null> {
   const { getNativeDb } = await import('../../store/sqlite.js');
   const db = getNativeDb()!;
-  const row = db.prepare('SELECT pipeline_stage FROM tasks WHERE id = ?').get(taskId) as
+  // T11578 · AC1: recordStageProgress now writes the PREFIXED consolidated table.
+  const row = db.prepare('SELECT pipeline_stage FROM tasks_tasks WHERE id = ?').get(taskId) as
     | { pipeline_stage: string | null }
     | undefined;
   return row?.pipeline_stage ?? null;

--- a/packages/core/src/lifecycle/effective-stage.ts
+++ b/packages/core/src/lifecycle/effective-stage.ts
@@ -158,7 +158,7 @@ export function fetchEpicProgressBatch(
       parent_id                                             AS parent_id,
       COUNT(*)                                              AS children_total,
       SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END)    AS children_done
-    FROM tasks
+    FROM tasks_tasks
     WHERE parent_id IN (${placeholders})
       AND status != 'archived'
     GROUP BY parent_id

--- a/packages/core/src/lifecycle/index.ts
+++ b/packages/core/src/lifecycle/index.ts
@@ -816,7 +816,7 @@ async function ensureLifecycleContext(
   const { getNativeDb } = await import('../store/sqlite.js');
   getNativeDb()!
     .prepare(
-      `INSERT OR IGNORE INTO tasks (id, title, status, priority, created_at) VALUES (?, ?, 'pending', 'medium', datetime('now'))`,
+      `INSERT OR IGNORE INTO tasks_tasks (id, title, status, priority, created_at) VALUES (?, ?, 'pending', 'medium', datetime('now'))`,
     )
     .run(epicId, `Task ${epicId}`);
 

--- a/packages/core/src/lifecycle/rollup.ts
+++ b/packages/core/src/lifecycle/rollup.ts
@@ -182,7 +182,7 @@ function fetchChildAggregates(taskIds: string[]): Map<string, { total: number; d
       parent_id           AS parent_id,
       COUNT(*)            AS children_total,
       SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) AS children_done
-    FROM tasks
+    FROM tasks_tasks
     WHERE parent_id IN (${placeholders})
       AND status != 'archived'
     GROUP BY parent_id

--- a/packages/core/src/memory/__tests__/brain-stdp-reward.test.ts
+++ b/packages/core/src/memory/__tests__/brain-stdp-reward.test.ts
@@ -61,7 +61,7 @@ function insertTestTask(
 
   nativeTasksDb
     .prepare(
-      `INSERT OR REPLACE INTO tasks
+      `INSERT OR REPLACE INTO tasks_tasks
        (id, title, status, session_id, verification_json, completed_at, cancelled_at,
         created_at, updated_at, priority, pipeline_stage)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'medium', ?)`,
@@ -87,7 +87,9 @@ function insertTestSession(
 ): void {
   const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
   nativeTasksDb
-    .prepare(`INSERT OR IGNORE INTO sessions (id, status, started_at) VALUES (?, 'active', ?)`)
+    .prepare(
+      `INSERT OR IGNORE INTO tasks_sessions (id, status, started_at) VALUES (?, 'active', ?)`,
+    )
     .run(sessionId, now);
 }
 

--- a/packages/core/src/release/__tests__/backfill.test.ts
+++ b/packages/core/src/release/__tests__/backfill.test.ts
@@ -103,8 +103,9 @@ async function insertTasks(projectRoot: string, taskIds: string[]): Promise<void
   const { getDb } = await import('../../store/sqlite.js');
   const db = await getDb(projectRoot);
   for (const id of taskIds) {
+    // T11578 · AC1: backfill reads the PREFIXED consolidated table; seed it.
     await db.run(
-      sql`INSERT OR IGNORE INTO tasks (id, title, status, priority, role, scope)
+      sql`INSERT OR IGNORE INTO tasks_tasks (id, title, status, priority, role, scope)
           VALUES (${id}, ${`Task ${id}`}, 'pending', 'medium', 'work', 'feature')`,
     );
   }

--- a/packages/core/src/release/__tests__/reconcile-v2.test.ts
+++ b/packages/core/src/release/__tests__/reconcile-v2.test.ts
@@ -108,8 +108,10 @@ async function insertTasks(projectRoot: string, taskIds: string[]): Promise<void
   const { sql } = await import('drizzle-orm');
   const db = await getDb(projectRoot);
   for (const id of taskIds) {
+    // T11578 · AC1: reconcile reads the PREFIXED consolidated table, so the
+    // fixture seeds tasks_tasks (created_at applies its NOT NULL default).
     await db.run(
-      sql`INSERT OR IGNORE INTO tasks (id, title, status, priority, role, scope)
+      sql`INSERT OR IGNORE INTO tasks_tasks (id, title, status, priority, role, scope)
           VALUES (${id}, ${`Task ${id}`}, 'pending', 'medium', 'work', 'feature')`,
     );
   }

--- a/packages/core/src/sagas/__tests__/migrate-containment.test.ts
+++ b/packages/core/src/sagas/__tests__/migrate-containment.test.ts
@@ -123,7 +123,7 @@ async function createRawTestDb(): Promise<{
 
 function seedSaga(db: DbHandle, id: string) {
   db.exec(
-    `INSERT INTO tasks (id, title, type, status) VALUES ('${id}', 'Saga ${id}', 'saga', 'active')`,
+    `INSERT INTO tasks_tasks (id, title, type, status) VALUES ('${id}', 'Saga ${id}', 'saga', 'active')`,
   );
 }
 
@@ -131,20 +131,20 @@ function seedSaga(db: DbHandle, id: string) {
 function seedEpicWithGroupsRelation(db: DbHandle, epicId: string, sagaId: string) {
   // Standalone Epic — no parent_id (legacy pattern: membership was via groups relation)
   db.exec(
-    `INSERT INTO tasks (id, title, type, status) VALUES ('${epicId}', 'Epic ${epicId}', 'epic', 'active')`,
+    `INSERT INTO tasks_tasks (id, title, type, status) VALUES ('${epicId}', 'Epic ${epicId}', 'epic', 'active')`,
   );
   // Legacy groups relation from Saga to Epic
   db.exec(
-    `INSERT INTO task_relations (task_id, related_to, relation_type) VALUES ('${sagaId}', '${epicId}', 'groups')`,
+    `INSERT INTO tasks_task_relations (task_id, related_to, relation_type) VALUES ('${sagaId}', '${epicId}', 'groups')`,
   );
 }
 
 function seedTaskWithGroupsRelation(db: DbHandle, taskId: string, sagaId: string) {
   db.exec(
-    `INSERT INTO tasks (id, title, type, status) VALUES ('${taskId}', 'Task ${taskId}', 'task', 'pending')`,
+    `INSERT INTO tasks_tasks (id, title, type, status) VALUES ('${taskId}', 'Task ${taskId}', 'task', 'pending')`,
   );
   db.exec(
-    `INSERT INTO task_relations (task_id, related_to, relation_type) VALUES ('${sagaId}', '${taskId}', 'groups')`,
+    `INSERT INTO tasks_task_relations (task_id, related_to, relation_type) VALUES ('${sagaId}', '${taskId}', 'groups')`,
   );
 }
 
@@ -152,12 +152,12 @@ function seedTaskWithGroupsRelation(db: DbHandle, taskId: string, sagaId: string
 
 function getRelations(db: DbHandle): Array<{ task_id: string; related_to: string }> {
   return db.all(
-    "SELECT task_id, related_to FROM task_relations WHERE relation_type = 'groups' ORDER BY task_id, related_to",
+    "SELECT task_id, related_to FROM tasks_task_relations WHERE relation_type = 'groups' ORDER BY task_id, related_to",
   ) as Array<{ task_id: string; related_to: string }>;
 }
 
 function getParentId(db: DbHandle, taskId: string): string | null {
-  const rows = db.all('SELECT parent_id FROM tasks WHERE id = ?', taskId) as Array<{
+  const rows = db.all('SELECT parent_id FROM tasks_tasks WHERE id = ?', taskId) as Array<{
     parent_id: string | null;
   }>;
   return rows[0]?.parent_id ?? null;
@@ -306,10 +306,10 @@ describe('migrateSagaContainment', () => {
     seedSaga(db, 'T100');
     // Epic already parented under Saga AND has legacy groups relation
     db.exec(
-      "INSERT INTO tasks (id, title, type, status, parent_id) VALUES ('T200', 'Epic T200', 'epic', 'active', 'T100')",
+      "INSERT INTO tasks_tasks (id, title, type, status, parent_id) VALUES ('T200', 'Epic T200', 'epic', 'active', 'T100')",
     );
     db.exec(
-      "INSERT INTO task_relations (task_id, related_to, relation_type) VALUES ('T100', 'T200', 'groups')",
+      "INSERT INTO tasks_task_relations (task_id, related_to, relation_type) VALUES ('T100', 'T200', 'groups')",
     );
 
     const result = await migrateSagaContainment(projectRoot, { sagaId: 'T100' });

--- a/packages/core/src/sagas/migrate-containment.ts
+++ b/packages/core/src/sagas/migrate-containment.ts
@@ -136,7 +136,7 @@ export async function migrateSagaContainment(
   const sagaArgs: unknown[] = sagaId ? [sagaId] : [];
 
   const sagas = db.all(
-    `SELECT DISTINCT p.id, p.title FROM tasks p WHERE p.type = 'saga' ${sagaFilter} ORDER BY p.id`,
+    `SELECT DISTINCT p.id, p.title FROM tasks_tasks p WHERE p.type = 'saga' ${sagaFilter} ORDER BY p.id`,
     ...sagaArgs,
   ) as Array<{ id: string; title: string }>;
 
@@ -157,9 +157,9 @@ export async function migrateSagaContainment(
 
   const epics = db.all(
     `SELECT t.id, t.title, t.parent_id as parentId, p.id as sagaId
-     FROM task_relations r
-     JOIN tasks p ON r.task_id = p.id
-     JOIN tasks t ON r.related_to = t.id
+     FROM tasks_task_relations r
+     JOIN tasks_tasks p ON r.task_id = p.id
+     JOIN tasks_tasks t ON r.related_to = t.id
      WHERE r.relation_type = 'groups'
        AND p.type = 'saga'
        AND t.type = 'epic'
@@ -171,9 +171,9 @@ export async function migrateSagaContainment(
   // 3. Find legacy groups relations whose target is not an Epic (conflicts).
   const tasks = db.all(
     `SELECT t.id, t.title, t.type, t.parent_id as parentId, p.id as sagaId
-     FROM task_relations r
-     JOIN tasks p ON r.task_id = p.id
-     JOIN tasks t ON r.related_to = t.id
+     FROM tasks_task_relations r
+     JOIN tasks_tasks p ON r.task_id = p.id
+     JOIN tasks_tasks t ON r.related_to = t.id
      WHERE r.relation_type = 'groups'
        AND p.type = 'saga'
        AND t.type != 'epic'

--- a/packages/core/src/sentient/__tests__/dedup.test.ts
+++ b/packages/core/src/sentient/__tests__/dedup.test.ts
@@ -51,7 +51,7 @@ afterEach(() => {
 function createTasksDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
   db.exec(`
-    CREATE TABLE tasks (
+    CREATE TABLE tasks_tasks (
       id TEXT PRIMARY KEY,
       parent_id TEXT,
       title TEXT NOT NULL,
@@ -69,7 +69,7 @@ function createTasksDb(): DatabaseSync {
   // T11356/T11357: dedup now joins the task_labels junction (Tier-2 membership)
   // and uses an exact json_extract on notes_json (no labels_json/notes_json LIKE).
   db.exec(`
-    CREATE TABLE task_labels (
+    CREATE TABLE tasks_task_labels (
       task_id TEXT NOT NULL,
       label TEXT NOT NULL,
       PRIMARY KEY (task_id, label)
@@ -103,7 +103,7 @@ function insertExistingProposal(
     dedupHash: args.dedupHash,
   });
   db.prepare(
-    `INSERT INTO tasks (
+    `INSERT INTO tasks_tasks (
       id, parent_id, title, description, status,
       labels_json, notes_json, created_at, role, scope
     ) VALUES (
@@ -121,7 +121,9 @@ function insertExistingProposal(
   });
   // T11356: mirror the junction the proposal inserters now maintain so the
   // Tier-2-membership join in checkDedupCollision sees this proposal.
-  const labelStmt = db.prepare('INSERT OR IGNORE INTO task_labels (task_id, label) VALUES (?, ?)');
+  const labelStmt = db.prepare(
+    'INSERT OR IGNORE INTO tasks_task_labels (task_id, label) VALUES (?, ?)',
+  );
   labelStmt.run(args.id, SENTIENT_TIER2_TAG);
   labelStmt.run(args.id, 'source:brain');
 }

--- a/packages/core/src/sentient/__tests__/hygiene-scan.test.ts
+++ b/packages/core/src/sentient/__tests__/hygiene-scan.test.ts
@@ -60,7 +60,7 @@ import { DEFAULT_SENTIENT_STATE, writeSentientState } from '../state.js';
 function createTestDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
   db.exec(`
-    CREATE TABLE tasks (
+    CREATE TABLE tasks_tasks (
       id TEXT PRIMARY KEY,
       parent_id TEXT,
       title TEXT NOT NULL DEFAULT '',
@@ -97,7 +97,7 @@ function insertTask(
   },
 ): void {
   db.prepare(`
-    INSERT INTO tasks (id, parent_id, type, status, acceptance_json, files_json, updated_at,
+    INSERT INTO tasks_tasks (id, parent_id, type, status, acceptance_json, files_json, updated_at,
       created_at, role, scope, title, description)
     VALUES (:id, :parentId, :type, :status, :acceptanceJson, :filesJson,
       COALESCE(:updatedAt, datetime('now')), datetime('now'), 'work', 'feature',

--- a/packages/core/src/sentient/__tests__/proposal-rate-limiter.test.ts
+++ b/packages/core/src/sentient/__tests__/proposal-rate-limiter.test.ts
@@ -25,7 +25,7 @@ import {
 function createTestDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
   db.exec(`
-    CREATE TABLE tasks (
+    CREATE TABLE tasks_tasks (
       id TEXT PRIMARY KEY,
       title TEXT NOT NULL,
       description TEXT,
@@ -51,7 +51,7 @@ function insertProposal(
   label = SENTIENT_TIER2_TAG,
 ) {
   db.prepare(
-    `INSERT INTO tasks (id, title, status, labels_json, created_at, role, scope)
+    `INSERT INTO tasks_tasks (id, title, status, labels_json, created_at, role, scope)
      VALUES (:id, :title, :status, :labelsJson, :createdAt, 'work', 'feature')`,
   ).run({
     id,
@@ -153,7 +153,7 @@ describe('isRateLimitExceeded', () => {
 
 describe('transactionalInsertProposal', () => {
   const insertSql = `
-    INSERT INTO tasks (id, title, status, labels_json, created_at, role, scope)
+    INSERT INTO tasks_tasks (id, title, status, labels_json, created_at, role, scope)
     VALUES (:id, :title, :status, :labelsJson, datetime('now'), 'work', 'feature')
   `;
 
@@ -259,10 +259,10 @@ describe('sentient proposal index (T11356)', () => {
     // the task_labels junction (idx_task_labels_label), not a JSON-LIKE scan.
     db.exec(`
       CREATE INDEX idx_tasks_created_date
-      ON tasks(date(created_at))
+      ON tasks_tasks(date(created_at))
     `);
 
-    const indexes = db.prepare('PRAGMA index_list(tasks)').all() as Array<{ name: string }>;
+    const indexes = db.prepare('PRAGMA index_list(tasks_tasks)').all() as Array<{ name: string }>;
     const idx = indexes.find((i) => i.name === 'idx_tasks_created_date');
     expect(idx).toBeDefined();
 

--- a/packages/core/src/sentient/__tests__/propose-tick.test.ts
+++ b/packages/core/src/sentient/__tests__/propose-tick.test.ts
@@ -28,7 +28,7 @@ let statePath: string;
 function createTestTasksDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
   db.exec(`
-    CREATE TABLE tasks (
+    CREATE TABLE tasks_tasks (
       id TEXT PRIMARY KEY,
       parent_id TEXT,
       title TEXT NOT NULL,
@@ -46,7 +46,7 @@ function createTestTasksDb(): DatabaseSync {
   // T11356/T11357: the propose-tick inserter writes Tier-2 membership into the
   // task_labels junction, and checkDedupCollision joins it. Mirror the table.
   db.exec(`
-    CREATE TABLE task_labels (
+    CREATE TABLE tasks_task_labels (
       task_id TEXT NOT NULL,
       label TEXT NOT NULL,
       PRIMARY KEY (task_id, label)
@@ -57,7 +57,7 @@ function createTestTasksDb(): DatabaseSync {
 
 function insertProposedTask(db: DatabaseSync, id: string) {
   db.prepare(
-    `INSERT INTO tasks (id, title, status, labels_json, created_at, role, scope)
+    `INSERT INTO tasks_tasks (id, title, status, labels_json, created_at, role, scope)
      VALUES (:id, :title, 'proposed', :labelsJson, datetime('now'), 'work', 'feature')`,
   ).run({
     id,
@@ -208,7 +208,7 @@ describe('runProposeTick', () => {
     // We need to actually insert a task to verify labels
     // Use the transactional insert directly for this check
     const { transactionalInsertProposal } = await import('../proposal-rate-limiter.js');
-    const sql = `INSERT INTO tasks (id, title, status, labels_json, created_at, role, scope)
+    const sql = `INSERT INTO tasks_tasks (id, title, status, labels_json, created_at, role, scope)
       VALUES (:id, '[T2-TEST] Test', 'proposed', :labelsJson, datetime('now'), 'work', 'feature')`;
     transactionalInsertProposal(db, sql, {
       id: 'T900',
@@ -216,7 +216,7 @@ describe('runProposeTick', () => {
     });
 
     expect(countTodayProposals(db)).toBe(1);
-    const row = db.prepare(`SELECT * FROM tasks WHERE id = 'T900'`).get() as {
+    const row = db.prepare(`SELECT * FROM tasks_tasks WHERE id = 'T900'`).get() as {
       status: string;
       labels_json: string;
     };

--- a/packages/core/src/sentient/__tests__/stage-drift.test.ts
+++ b/packages/core/src/sentient/__tests__/stage-drift.test.ts
@@ -37,7 +37,7 @@ import { DEFAULT_SENTIENT_STATE, writeSentientState } from '../state.js';
 function createTestDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:');
   db.exec(`
-    CREATE TABLE tasks (
+    CREATE TABLE tasks_tasks (
       id TEXT PRIMARY KEY,
       parent_id TEXT,
       title TEXT NOT NULL,
@@ -57,7 +57,7 @@ function createTestDb(): DatabaseSync {
   // T11356/T11357: the drift proposal inserter writes Tier-2 membership into the
   // task_labels junction, and checkDedupCollision joins it. Mirror the table.
   db.exec(`
-    CREATE TABLE task_labels (
+    CREATE TABLE tasks_task_labels (
       task_id TEXT NOT NULL,
       label TEXT NOT NULL,
       PRIMARY KEY (task_id, label)
@@ -72,7 +72,7 @@ function insertEpic(
   opts: { status?: string; pipelineStage?: string | null } = {},
 ): void {
   db.prepare(`
-    INSERT INTO tasks (id, title, status, type, pipeline_stage, created_at, role, scope)
+    INSERT INTO tasks_tasks (id, title, status, type, pipeline_stage, created_at, role, scope)
     VALUES (:id, :title, :status, 'epic', :pipelineStage, datetime('now'), 'work', 'project')
   `).run({
     id,
@@ -89,7 +89,7 @@ function insertTask(
   opts: { status?: string } = {},
 ): void {
   db.prepare(`
-    INSERT INTO tasks (id, title, parent_id, status, created_at, role, scope)
+    INSERT INTO tasks_tasks (id, title, parent_id, status, created_at, role, scope)
     VALUES (:id, :title, :parentId, :status, datetime('now'), 'work', 'feature')
   `).run({
     id,
@@ -359,7 +359,7 @@ describe('runStageDriftScan', () => {
     expect(outcome.proposalsWritten).toBe(1);
 
     // Verify proposal was inserted into DB.
-    const row = db.prepare(`SELECT id, title, status FROM tasks WHERE id = :id`).get({
+    const row = db.prepare(`SELECT id, title, status FROM tasks_tasks WHERE id = :id`).get({
       id: allocatedIds[0],
     }) as { id: string; title: string; status: string } | undefined;
 

--- a/packages/core/src/sentient/hygiene-scan.ts
+++ b/packages/core/src/sentient/hygiene-scan.ts
@@ -390,7 +390,7 @@ export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
 function queryRecentActivityTokens(db: DatabaseSync): Set<string> | null {
   const sql = `
     SELECT title, description
-    FROM tasks
+    FROM tasks_tasks
     WHERE status IN ('pending', 'active', 'blocked')
       AND updated_at >= datetime('now', '-30 days')
     LIMIT 200
@@ -817,7 +817,7 @@ function queryWorkingTasks(db: DatabaseSync): TaskRow[] {
     SELECT id, parent_id, type, status, acceptance_json, files_json, labels_json,
            COALESCE(title, '') as title, COALESCE(description, '') as description,
            updated_at
-    FROM tasks
+    FROM tasks_tasks
     WHERE type != 'epic'
       AND status NOT IN ('done', 'cancelled')
       AND status != 'proposed'
@@ -839,7 +839,7 @@ function queryRecentlyDoneTasks(db: DatabaseSync): TaskRow[] {
     SELECT id, parent_id, type, status, acceptance_json, files_json, labels_json,
            COALESCE(title, '') as title, COALESCE(description, '') as description,
            updated_at
-    FROM tasks
+    FROM tasks_tasks
     WHERE type != 'epic'
       AND status = 'done'
       AND parent_id IS NOT NULL
@@ -858,7 +858,7 @@ function queryRecentlyDoneTasks(db: DatabaseSync): TaskRow[] {
  * Look up the status of a parent task. Returns null if not found.
  */
 function queryParentStatus(db: DatabaseSync, parentId: string): string | null {
-  const sql = `SELECT id, status FROM tasks WHERE id = :id LIMIT 1`;
+  const sql = `SELECT id, status FROM tasks_tasks WHERE id = :id LIMIT 1`;
   try {
     const row = db.prepare(sql).get({ id: parentId }) as ParentStatusRow | undefined;
     return row ? row.status : null;
@@ -873,7 +873,7 @@ function queryParentStatus(db: DatabaseSync, parentId: string): string | null {
 function countActiveSiblings(db: DatabaseSync, parentId: string, excludeTaskId: string): number {
   const sql = `
     SELECT COUNT(*) as cnt
-    FROM tasks
+    FROM tasks_tasks
     WHERE parent_id = :parentId
       AND id != :excludeId
       AND status IN ('pending', 'active', 'blocked')
@@ -1004,7 +1004,7 @@ async function scanTopLevelOrphanTasks(
     SELECT id, parent_id, type, status, acceptance_json, files_json, labels_json,
            COALESCE(title, '') as title, COALESCE(description, '') as description,
            updated_at
-    FROM tasks
+    FROM tasks_tasks
     WHERE parent_id IS NULL
       AND type = 'task'
       AND status NOT IN ('done', 'cancelled', 'proposed')

--- a/packages/core/src/sentient/proposal-dedup.ts
+++ b/packages/core/src/sentient/proposal-dedup.ts
@@ -229,8 +229,8 @@ export function checkDedupCollision(opts: DedupCheckOptions): DedupCheckResult {
   // exact value — no substring matching, no cross-field false positives.
   const baseSql = `
     SELECT id
-    FROM tasks
-    WHERE id IN (SELECT task_id FROM task_labels WHERE label = :tier2Label)
+    FROM tasks_tasks
+    WHERE id IN (SELECT task_id FROM tasks_task_labels WHERE label = :tier2Label)
       AND json_extract(json_extract(notes_json, '$[0]'), '$.dedupHash') = :dedupHash
       ${windowHours > 0 ? `AND datetime(created_at) >= datetime('now', :windowSpec)` : ''}
       AND ${parentKey === null ? 'parent_id IS NULL' : 'parent_id = :parentId'}

--- a/packages/core/src/sentient/proposal-rate-limiter.ts
+++ b/packages/core/src/sentient/proposal-rate-limiter.ts
@@ -71,7 +71,7 @@ export function countTodayProposals(nativeDb: DatabaseSync | null): number {
 
   const stmt = nativeDb.prepare(`
     SELECT COUNT(*) as cnt
-    FROM tasks
+    FROM tasks_tasks
     WHERE labels_json LIKE :labelPattern
       AND date(created_at) = date('now')
       AND status IN ('proposed', 'pending', 'active', 'done')

--- a/packages/core/src/sentient/propose-tick.ts
+++ b/packages/core/src/sentient/propose-tick.ts
@@ -475,7 +475,7 @@ export async function runProposeTick(options: ProposeTickOptions): Promise<Propo
 
     // DB column is named 'role' (T9067 deferral — CHECK constraint defers rename)
     const insertSql = `
-      INSERT INTO tasks (
+      INSERT INTO tasks_tasks (
         id, title, description, status, priority,
         labels_json, notes_json,
         created_at, updated_at,
@@ -517,7 +517,7 @@ export async function runProposeTick(options: ProposeTickOptions): Promise<Propo
         // labels_json LIKE — see this proposal. INSERT OR IGNORE is idempotent.
         if (tasksNativeDb) {
           const labelStmt = tasksNativeDb.prepare(
-            'INSERT OR IGNORE INTO task_labels (task_id, label) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO tasks_task_labels (task_id, label) VALUES (?, ?)',
           );
           labelStmt.run(taskId, TIER2_LABEL);
           labelStmt.run(taskId, `source:${candidate.source}`);
@@ -715,8 +715,8 @@ export async function runProposalAutoPromoteScan(
               t.labels_json, t.notes_json, t.created_at, t.updated_at,
               t.acceptance_json, t.type, t.kind, t.scope, t.phase,
               t.pipeline_stage, t.blocked_by
-       FROM tasks t
-       INNER JOIN task_labels tl ON tl.task_id = t.id AND tl.label = ?
+       FROM tasks_tasks t
+       INNER JOIN tasks_task_labels tl ON tl.task_id = t.id AND tl.label = ?
        WHERE t.status = 'proposed'
        ORDER BY t.created_at ASC`,
     )
@@ -759,7 +759,7 @@ export async function runProposalAutoPromoteScan(
 
   const now = new Date().toISOString();
   const updateStmt = tasksNativeDb.prepare(
-    `UPDATE tasks SET status = 'pending', updated_at = ? WHERE id = ? AND status = 'proposed'`,
+    `UPDATE tasks_tasks SET status = 'pending', updated_at = ? WHERE id = ? AND status = 'proposed'`,
   );
 
   for (const { row } of toConsider) {

--- a/packages/core/src/sentient/stage-drift-tick.ts
+++ b/packages/core/src/sentient/stage-drift-tick.ts
@@ -174,7 +174,7 @@ export interface StageDriftOutcome {
 function queryActiveEpics(db: DatabaseSync): Array<{ id: string; pipeline_stage: string | null }> {
   const sql = `
     SELECT id, pipeline_stage
-    FROM tasks
+    FROM tasks_tasks
     WHERE type = 'epic'
       AND status IN ('pending', 'active', 'blocked')
     ORDER BY id ASC
@@ -241,7 +241,7 @@ function buildDriftProposalInsert(
 
   // DB column is named 'role' (T9067 deferral — CHECK constraint defers rename)
   const sql = `
-    INSERT INTO tasks (
+    INSERT INTO tasks_tasks (
       id, title, description, status, priority,
       labels_json, notes_json,
       created_at, updated_at,
@@ -446,7 +446,7 @@ export async function runStageDriftScan(options: StageDriftOptions): Promise<Sta
         // filters (now junction joins, not labels_json LIKE) see this proposal.
         if (db) {
           const labelStmt = db.prepare(
-            'INSERT OR IGNORE INTO task_labels (task_id, label) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO tasks_task_labels (task_id, label) VALUES (?, ?)',
           );
           labelStmt.run(taskId, 'sentient-tier2');
           labelStmt.run(taskId, DRIFT_SOURCE_LABEL);

--- a/packages/core/src/sequence/__tests__/allocate.test.ts
+++ b/packages/core/src/sequence/__tests__/allocate.test.ts
@@ -80,10 +80,12 @@ describe('allocateNextTaskId', () => {
     `)
       .run();
 
-    // Insert T006 to cause a collision on next allocation
+    // Insert T006 to cause a collision on next allocation.
+    // T11578 · AC1: the allocator's collision probe + repairSequence read the
+    // PREFIXED consolidated table, so seed the blocking row there.
     nativeDb
       .prepare(
-        `INSERT INTO tasks (id, title, status, priority, created_at) VALUES (?, ?, 'pending', 'medium', datetime('now'))`,
+        `INSERT INTO tasks_tasks (id, title, status, priority, created_at) VALUES (?, ?, 'pending', 'medium', datetime('now'))`,
       )
       .run('T006', 'Blocking task');
 

--- a/packages/core/src/sequence/index.ts
+++ b/packages/core/src/sequence/index.ts
@@ -354,8 +354,12 @@ export async function allocateNextTaskId(cwd?: string, retryCount = 0): Promise<
 
     const newId = `T${String(row.counter).padStart(3, '0')}`;
 
-    // Collision check: verify no existing task with this ID
-    const existing = nativeDb.prepare('SELECT id FROM tasks WHERE id = ?').get(newId) as
+    // Collision check: verify no existing task with this ID.
+    // T11578 · AC1: the runtime task rows now live in the PREFIXED consolidated
+    // table; the collision probe must read `tasks_tasks` (not the dead bare
+    // `tasks`) or it returns a false-negative and allocates an ID that already
+    // exists — overwriting a live row on the next upsert.
+    const existing = nativeDb.prepare('SELECT id FROM tasks_tasks WHERE id = ?').get(newId) as
       | { id: string }
       | undefined;
 

--- a/packages/core/src/sessions/__tests__/drift-watchdog.test.ts
+++ b/packages/core/src/sessions/__tests__/drift-watchdog.test.ts
@@ -80,7 +80,7 @@ describe('drift-watchdog', () => {
       id: 'T9001',
       title: 'In-scope only',
       description: 'Drift test fixture — declared exactly matches modified.',
-      status: 'in_progress',
+      status: 'active', // T11578 AC1: 'in_progress' not a valid TASK_STATUSES member (consolidated CHECK)
       priority: 'medium',
       files: ['src/a.ts', 'src/b.ts'],
     };
@@ -117,7 +117,7 @@ describe('drift-watchdog', () => {
       id: 'T9002',
       title: 'Narrow scope',
       description: 'Drift test fixture — declared scope is intentionally narrow.',
-      status: 'in_progress',
+      status: 'active', // T11578 AC1: 'in_progress' not a valid TASK_STATUSES member (consolidated CHECK)
       priority: 'medium',
       files: ['src/audit.ts'],
     };
@@ -163,7 +163,7 @@ describe('drift-watchdog', () => {
       id: 'T9003',
       title: 'Mostly in-scope',
       description: 'Drift test fixture — only one file outside declared scope.',
-      status: 'in_progress',
+      status: 'active', // T11578 AC1: 'in_progress' not a valid TASK_STATUSES member (consolidated CHECK)
       priority: 'medium',
       files: ['src/a.ts', 'src/b.ts', 'src/c.ts'],
     };

--- a/packages/core/src/stats/index.ts
+++ b/packages/core/src/stats/index.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Task, TaskRecord } from '@cleocode/contracts';
-import { ExitCode } from '@cleocode/contracts';
+import { ARCHIVE_REASON_TOMBSTONE, ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
 import { resolveOrCwd } from '../paths.js';
 import { getProjectInfoSync } from '../project-info.js';
@@ -142,12 +142,20 @@ export async function getProjectStats(
     totalCancelled = statusMap['cancelled'] ?? 0;
     totalArchived = archivedCount;
 
-    // Count archived tasks that were completed (archiveReason = 'completed')
+    // Count archived tasks that were completed without verification.
+    // T11578 · AC1: the canonical archive reason for a completed-but-unverified
+    // task is the tombstone `'completed-unverified'` (T1408 enum). The previous
+    // literal `'completed'` is not a member of the enum — it never matched any
+    // real row and is now also rejected by the consolidated `tasks_tasks`
+    // CHECK constraint.
     const archivedDoneRow = await db
       .select({ c: dbCount() })
       .from(tasksTable)
       .where(
-        dbAnd(dbEq(tasksTable.status, 'archived'), dbEq(tasksTable.archiveReason, 'completed')),
+        dbAnd(
+          dbEq(tasksTable.status, 'archived'),
+          dbEq(tasksTable.archiveReason, ARCHIVE_REASON_TOMBSTONE),
+        ),
       )
       .get();
     archivedCompleted = archivedDoneRow?.c ?? 0;

--- a/packages/core/src/store/__tests__/jsonb-insql-access.test.ts
+++ b/packages/core/src/store/__tests__/jsonb-insql-access.test.ts
@@ -159,14 +159,16 @@ describe('session list append via json_insert($[#]) (T11357 AC4)', () => {
     const schema = await import('../tasks-schema.js');
 
     const nativeDb = openNativeDatabase(join(tempDir, 'tasks.db'));
+    // T11578 · AC1: appendSessionListItem now targets the PREFIXED consolidated
+    // sessions table, so the unit-test fixture creates `tasks_sessions`.
     nativeDb.exec(`
-      CREATE TABLE sessions (
+      CREATE TABLE tasks_sessions (
         id TEXT PRIMARY KEY,
         notes_json TEXT DEFAULT '[]',
         tasks_completed_json TEXT DEFAULT '[]',
         tasks_created_json TEXT DEFAULT '[]'
       );
-      INSERT INTO sessions (id) VALUES ('ses_1');
+      INSERT INTO tasks_sessions (id) VALUES ('ses_1');
     `);
     const db = drizzle({ client: nativeDb, schema });
 
@@ -177,7 +179,7 @@ describe('session list append via json_insert($[#]) (T11357 AC4)', () => {
     // Read whole-value via json(col).
     const row = nativeDb
       .prepare(
-        "SELECT json(tasks_completed_json) AS completed, json(notes_json) AS notes FROM sessions WHERE id = 'ses_1'",
+        "SELECT json(tasks_completed_json) AS completed, json(notes_json) AS notes FROM tasks_sessions WHERE id = 'ses_1'",
       )
       .get() as { completed: string; notes: string };
     expect(JSON.parse(row.completed)).toEqual(['T100', 'T200']);

--- a/packages/core/src/store/__tests__/jsonb-insql-access.test.ts
+++ b/packages/core/src/store/__tests__/jsonb-insql-access.test.ts
@@ -34,12 +34,12 @@ describe('dedupHash exact json_extract (T11357 AC1)', () => {
   function createTasksDb(): DatabaseSync {
     const db = new DatabaseSync(':memory:');
     db.exec(`
-      CREATE TABLE tasks (
+      CREATE TABLE tasks_tasks (
         id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, status TEXT,
         labels_json TEXT DEFAULT '[]', notes_json TEXT DEFAULT '[]',
         created_at TEXT NOT NULL
       );
-      CREATE TABLE task_labels (task_id TEXT, label TEXT, PRIMARY KEY (task_id, label));
+      CREATE TABLE tasks_task_labels (task_id TEXT, label TEXT, PRIMARY KEY (task_id, label));
     `);
     return db;
   }
@@ -47,9 +47,9 @@ describe('dedupHash exact json_extract (T11357 AC1)', () => {
   function insertProposal(db: DatabaseSync, id: string, dedupHash: string): void {
     const meta = JSON.stringify({ kind: 'proposal-meta', dedupHash });
     db.prepare(
-      'INSERT INTO tasks (id, parent_id, title, status, notes_json, created_at) VALUES (?, NULL, ?, ?, ?, ?)',
+      'INSERT INTO tasks_tasks (id, parent_id, title, status, notes_json, created_at) VALUES (?, NULL, ?, ?, ?, ?)',
     ).run(id, `[T2-BRAIN] ${id}`, 'proposed', JSON.stringify([meta]), new Date().toISOString());
-    db.prepare('INSERT INTO task_labels (task_id, label) VALUES (?, ?)').run(
+    db.prepare('INSERT INTO tasks_task_labels (task_id, label) VALUES (?, ?)').run(
       id,
       SENTIENT_TIER2_TAG,
     );

--- a/packages/core/src/store/__tests__/task-labels-junction.test.ts
+++ b/packages/core/src/store/__tests__/task-labels-junction.test.ts
@@ -45,7 +45,8 @@ describe('task_labels junction (T11356)', () => {
     const nativeDb = getNativeTasksDb();
     expect(nativeDb).not.toBeNull();
     const rows = nativeDb!
-      .prepare('SELECT label FROM task_labels WHERE task_id = ? ORDER BY label')
+      // T11578 · AC1: the label junction is now the PREFIXED consolidated table.
+      .prepare('SELECT label FROM tasks_task_labels WHERE task_id = ? ORDER BY label')
       .all('T001') as Array<{ label: string }>;
     expect(rows.map((r) => r.label)).toEqual(['bug', 'frontend']);
   });

--- a/packages/core/src/store/db-helpers.ts
+++ b/packages/core/src/store/db-helpers.ts
@@ -7,7 +7,7 @@
  * @epic T4454
  */
 
-import type { Session, Task } from '@cleocode/contracts';
+import type { ArchiveReasonValue, Session, Task } from '@cleocode/contracts';
 import { eq, inArray, sql } from 'drizzle-orm';
 import type { NodeSQLiteDatabase } from 'drizzle-orm/node-sqlite';
 import { getLogger } from '../logger.js';
@@ -22,7 +22,13 @@ type DrizzleDb = NodeSQLiteDatabase<typeof schema>;
 /** Archive-specific fields for task upsert. */
 export interface ArchiveFields {
   archivedAt?: string;
-  archiveReason?: string;
+  /**
+   * T11578 · AC1: typed to the canonical {@link ArchiveReasonValue} enum so
+   * writes conform to the consolidated `tasks_tasks.archive_reason` CHECK
+   * constraint (the bare legacy `tasks` table had no CHECK, masking
+   * out-of-enum values such as the historical `'completed'` literal).
+   */
+  archiveReason?: ArchiveReasonValue;
   cycleTimeDays?: number | null;
 }
 
@@ -215,7 +221,10 @@ export async function upsertSession(db: DrizzleDb, session: Session): Promise<vo
     // Session stats fields
     statsJson: session.stats ? JSON.stringify(session.stats) : null,
     resumeCount: session.resumeCount ?? null,
-    gradeMode: session.gradeMode ? 1 : null,
+    // T11578 · AC1: the consolidated `tasks_sessions.grade_mode` column is
+    // `integer({ mode: 'boolean' })`, so the writer passes a boolean (drizzle
+    // serializes true→1 / null→NULL) rather than the legacy raw `1`.
+    gradeMode: session.gradeMode ? true : null,
     // T9975 — per-agent session isolation fields
     agentHandle: session.agentHandle ?? null,
     scopeKind: session.scopeKind ?? null,
@@ -275,8 +284,9 @@ export async function appendSessionListItem(
   value: string,
 ): Promise<void> {
   const physicalColumn = APPENDABLE_SESSION_COLUMNS[column];
+  // T11578 · AC1: append into the PREFIXED consolidated sessions table.
   db.run(
-    sql`UPDATE sessions
+    sql`UPDATE tasks_sessions
         SET ${sql.raw(physicalColumn)} = json_insert(
           COALESCE(${sql.raw(physicalColumn)}, '[]'), '$[#]', ${value}
         )

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -556,11 +556,28 @@ const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
       ` END`,
   ],
 
-  // --- tasks_commits.conventional_type (T11548) ----------------------------
-  // 'style' → 'chore' (enum does not include 'style'; chore is the nearest). 33 rows.
+  // --- tasks_commits.conventional_type (T11548 + T11578) -------------------
+  // The consolidated CHECK enum is feat/fix/chore/docs/refactor/test/build/ci/
+  // perf/revert/breaking. Real git history carries non-conventional subjects:
+  //   - 'style'           → 'chore' (pre-T11548 mapping; no 'style' in enum).
+  //   - 'merge'/'release' → 'chore' (T11578): merge + release commits are
+  //     maintenance-class; the precise semantic is preserved by the dedicated
+  //     `is_merge_commit` / `is_release_commit` boolean columns, so collapsing
+  //     `conventional_type` to the maintenance catch-all 'chore' is lossless at
+  //     the row grain. Without this the 'merge'/'release' rows violate the CHECK,
+  //     `INSERT OR IGNORE` drops the WHOLE commits table, and the exodus-on-open
+  //     data-continuity gate aborts the cutover (T11578 CI regression).
+  //   - any OTHER out-of-enum value → 'chore' (defensive: future non-conventional
+  //     subjects must never re-break the zero-deficit gate; the boolean flags and
+  //     raw subject text remain the precise provenance).
   [
     'tasks_commits.conventional_type',
-    (src: string) => `CASE ${src} WHEN 'style' THEN 'chore' ELSE ${src} END`,
+    (src: string) =>
+      `CASE` +
+      ` WHEN ${src} IS NULL THEN NULL` +
+      ` WHEN ${src} IN ('feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'build', 'ci', 'perf', 'revert', 'breaking') THEN ${src}` +
+      ` ELSE 'chore'` +
+      ` END`,
   ],
 
   // --- tasks_task_relations.relation_type (T11548) -------------------------

--- a/packages/core/src/store/migration-sqlite.ts
+++ b/packages/core/src/store/migration-sqlite.ts
@@ -209,8 +209,17 @@ export async function migrateJsonToSqliteAtomic(
     const nativeDb = openNativeDatabase(tempDbPath, { enableWal: true });
     const db = drizzle({ client: nativeDb, schema });
 
-    // Run migrations to create tables
+    // Run migrations to create tables.
+    // T11578 · AC1: the runtime store now reads/writes the PREFIXED consolidated
+    // tables (`tasks_tasks`, …). This standalone temp DB is meant to become the
+    // project runtime DB, so it must carry the CONSOLIDATED schema first (which
+    // creates `tasks_tasks`) — the legacy `drizzle-tasks` bare schema is then
+    // applied for transition-period co-existence (same ordering getDb() uses).
     logger?.info('import', 'create-tables', 'Running drizzle migrations to create tables');
+    const { resolveCorePackageMigrationsFolder } = await import('./resolve-migrations-folder.js');
+    migrateSanitized(db, {
+      migrationsFolder: resolveCorePackageMigrationsFolder('drizzle-cleo-project'),
+    });
     const migrationsFolder = resolveMigrationsFolder();
     migrateSanitized(db, { migrationsFolder });
 

--- a/packages/core/src/store/migration-sqlite.ts
+++ b/packages/core/src/store/migration-sqlite.ts
@@ -12,7 +12,13 @@
 
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import type { Session, Task } from '@cleocode/contracts';
+import {
+  ARCHIVE_REASON_TOMBSTONE,
+  ARCHIVE_REASONS,
+  type ArchiveReasonValue,
+  type Session,
+  type Task,
+} from '@cleocode/contracts';
 import type { NodeSQLiteDatabase } from 'drizzle-orm/node-sqlite';
 import { drizzle } from 'drizzle-orm/node-sqlite';
 import { resolveCleoDir } from '../paths.js';
@@ -20,6 +26,26 @@ import { migrateSanitized } from './migration-manager.js';
 import { dbExists, getDb, openNativeDatabase, resolveMigrationsFolder } from './sqlite.js';
 import type { SessionStatus } from './status-registry.js';
 import * as schema from './tasks-schema.js';
+
+/**
+ * Normalise an imported archive-reason string to a valid {@link ArchiveReasonValue}.
+ *
+ * T11578 · AC1: the consolidated `tasks_tasks.archive_reason` column is
+ * CHECK-backed by the 6-value T1408 enum. Imported migration JSON may carry a
+ * missing reason or a legacy value (e.g. `'completed'`) that the bare legacy
+ * `tasks` table accepted without a CHECK. Any out-of-enum value is mapped
+ * defensively to the canonical tombstone (`'completed-unverified'`) rather than
+ * throwing mid-import.
+ *
+ * @param reason - candidate archive-reason string from the migration source.
+ * @returns a value guaranteed to satisfy the consolidated CHECK constraint.
+ */
+function normalizeImportedArchiveReason(reason: string | undefined): ArchiveReasonValue {
+  if (reason && (ARCHIVE_REASONS as readonly string[]).includes(reason)) {
+    return reason as ArchiveReasonValue;
+  }
+  return ARCHIVE_REASON_TOMBSTONE;
+}
 
 /**
  * Topological sort for tasks: ensures parents and dependency targets are inserted before
@@ -403,7 +429,7 @@ async function runMigrationDataImport(
               updatedAt: task.updatedAt,
               completedAt: task.completedAt,
               archivedAt: task.archivedAt ?? task.completedAt ?? new Date().toISOString(),
-              archiveReason: task.archiveReason ?? 'completed-unverified',
+              archiveReason: normalizeImportedArchiveReason(task.archiveReason),
               cycleTimeDays: task.cycleTimeDays,
             })
             .onConflictDoNothing()
@@ -739,7 +765,7 @@ export async function migrateJsonToSqlite(
               updatedAt: task.updatedAt,
               completedAt: task.completedAt,
               archivedAt: task.archivedAt ?? task.completedAt ?? new Date().toISOString(),
-              archiveReason: task.archiveReason ?? 'completed-unverified',
+              archiveReason: normalizeImportedArchiveReason(task.archiveReason),
               cycleTimeDays: task.cycleTimeDays,
             })
             .onConflictDoNothing()

--- a/packages/core/src/store/sqlite-data-accessor.ts
+++ b/packages/core/src/store/sqlite-data-accessor.ts
@@ -11,7 +11,13 @@
  * @epic T4454
  */
 
-import type { Session, Task, TaskStatus } from '@cleocode/contracts';
+import {
+  ARCHIVE_REASON_TOMBSTONE,
+  type ArchiveReasonValue,
+  type Session,
+  type Task,
+  type TaskStatus,
+} from '@cleocode/contracts';
 import { and, eq, inArray, isNull, like, ne, notInArray, or, sql } from 'drizzle-orm';
 import { archivedTaskToRow, rowToSession, rowToTask, taskToRow } from './converters.js';
 import { cleanupBrainRefsOnSessionDelete } from './cross-db-cleanup.js';
@@ -259,13 +265,17 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
           // Extract archive-specific fields if they exist on the task object
           const taskAny = task as Task & {
             archivedAt?: string;
-            archiveReason?: string;
+            archiveReason?: ArchiveReasonValue;
             cycleTimeDays?: number;
           };
 
           const archiveFields = {
             archivedAt: taskAny.archivedAt ?? row.completedAt ?? new Date().toISOString(),
-            archiveReason: taskAny.archiveReason ?? 'completed',
+            // T11578 · AC1: default to the canonical tombstone enum value
+            // (`'completed-unverified'`) — the legacy `'completed'` literal is
+            // not a member of the T1408 enum and would violate the consolidated
+            // `tasks_tasks.archive_reason` CHECK constraint.
+            archiveReason: taskAny.archiveReason ?? ARCHIVE_REASON_TOMBSTONE,
             cycleTimeDays: taskAny.cycleTimeDays ?? null,
           };
 
@@ -538,7 +548,7 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
           .set({
             status: 'archived',
             archivedAt: fields.archivedAt ?? new Date().toISOString(),
-            archiveReason: fields.archiveReason ?? 'completed',
+            archiveReason: fields.archiveReason ?? ARCHIVE_REASON_TOMBSTONE,
             cycleTimeDays: fields.cycleTimeDays ?? null,
             updatedAt: new Date().toISOString(),
           })
@@ -799,9 +809,9 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       const idRows = nativeDb
         .prepare(
           `WITH RECURSIVE ancestor_ids(id, depth) AS (
-            SELECT parent_id, 0 FROM tasks WHERE id = ? AND parent_id IS NOT NULL
+            SELECT parent_id, 0 FROM tasks_tasks WHERE id = ? AND parent_id IS NOT NULL
             UNION ALL
-            SELECT t.parent_id, a.depth + 1 FROM tasks t
+            SELECT t.parent_id, a.depth + 1 FROM tasks_tasks t
             JOIN ancestor_ids a ON t.id = a.id
             WHERE t.parent_id IS NOT NULL
           )
@@ -839,9 +849,9 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       const idRows = nativeDb
         .prepare(
           `WITH RECURSIVE subtree AS (
-            SELECT id FROM tasks WHERE id = ?
+            SELECT id FROM tasks_tasks WHERE id = ?
             UNION ALL
-            SELECT t.id FROM tasks t
+            SELECT t.id FROM tasks_tasks t
             JOIN subtree s ON t.parent_id = s.id
           )
           SELECT id FROM subtree`,
@@ -897,9 +907,9 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       const rows = nativeDb
         .prepare(
           `WITH RECURSIVE dep_chain(id) AS (
-            SELECT depends_on FROM task_dependencies WHERE task_id = ?
+            SELECT depends_on FROM tasks_task_dependencies WHERE task_id = ?
             UNION
-            SELECT td.depends_on FROM task_dependencies td
+            SELECT td.depends_on FROM tasks_task_dependencies td
             JOIN dep_chain dc ON td.task_id = dc.id
           )
           SELECT id FROM dep_chain`,
@@ -949,12 +959,12 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
         parentId === null
           ? (nativeDb
               .prepare(
-                `SELECT COALESCE(MAX(position), 0) + 1 AS next_pos FROM tasks WHERE parent_id IS NULL AND status != 'archived'`,
+                `SELECT COALESCE(MAX(position), 0) + 1 AS next_pos FROM tasks_tasks WHERE parent_id IS NULL AND status != 'archived'`,
               )
               .get() as { next_pos: number } | undefined)
           : (nativeDb
               .prepare(
-                `SELECT COALESCE(MAX(position), 0) + 1 AS next_pos FROM tasks WHERE parent_id = ? AND status != 'archived'`,
+                `SELECT COALESCE(MAX(position), 0) + 1 AS next_pos FROM tasks_tasks WHERE parent_id = ? AND status != 'archived'`,
               )
               .get(parentId) as { next_pos: number } | undefined);
       return row?.next_pos ?? 1;
@@ -972,13 +982,13 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       if (parentId === null) {
         nativeDb
           .prepare(
-            `UPDATE tasks SET position = position + ?, position_version = position_version + 1, updated_at = ? WHERE parent_id IS NULL AND position >= ? AND status != 'archived'`,
+            `UPDATE tasks_tasks SET position = position + ?, position_version = position_version + 1, updated_at = ? WHERE parent_id IS NULL AND position >= ? AND status != 'archived'`,
           )
           .run(delta, new Date().toISOString(), fromPosition);
       } else {
         nativeDb
           .prepare(
-            `UPDATE tasks SET position = position + ?, position_version = position_version + 1, updated_at = ? WHERE parent_id = ? AND position >= ? AND status != 'archived'`,
+            `UPDATE tasks_tasks SET position = position + ?, position_version = position_version + 1, updated_at = ? WHERE parent_id = ? AND position >= ? AND status != 'archived'`,
           )
           .run(delta, new Date().toISOString(), parentId, fromPosition);
       }
@@ -1074,7 +1084,7 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
               .set({
                 status: 'archived',
                 archivedAt: fields.archivedAt ?? new Date().toISOString(),
-                archiveReason: fields.archiveReason ?? 'completed',
+                archiveReason: fields.archiveReason ?? ARCHIVE_REASON_TOMBSTONE,
                 cycleTimeDays: fields.cycleTimeDays ?? null,
                 updatedAt: new Date().toISOString(),
               })
@@ -1341,9 +1351,9 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       }
 
       // Verify the task exists first
-      const existsRow = nativeDb.prepare('SELECT assignee FROM tasks WHERE id = ?').get(taskId) as
-        | { assignee: string | null }
-        | undefined;
+      const existsRow = nativeDb
+        .prepare('SELECT assignee FROM tasks_tasks WHERE id = ?')
+        .get(taskId) as { assignee: string | null } | undefined;
       if (!existsRow) {
         throw new Error(`Task not found: ${taskId}`);
       }
@@ -1352,14 +1362,14 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       // This prevents race conditions between concurrent agents.
       const result = nativeDb
         .prepare(
-          'UPDATE tasks SET assignee = ?, updated_at = ? WHERE id = ? AND (assignee IS NULL OR assignee = ?)',
+          'UPDATE tasks_tasks SET assignee = ?, updated_at = ? WHERE id = ? AND (assignee IS NULL OR assignee = ?)',
         )
         .run(agentId, new Date().toISOString(), taskId, agentId) as { changes: number };
 
       if (result.changes === 0) {
         // Row was not updated — task is claimed by a different agent
         const currentRow = nativeDb
-          .prepare('SELECT assignee FROM tasks WHERE id = ?')
+          .prepare('SELECT assignee FROM tasks_tasks WHERE id = ?')
           .get(taskId) as { assignee: string | null } | undefined;
         throw new Error(
           `Task ${taskId} is already claimed by agent: ${currentRow?.assignee ?? 'unknown'}`,
@@ -1374,7 +1384,7 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
       }
 
       // Verify the task exists
-      const existsRow = nativeDb.prepare('SELECT id FROM tasks WHERE id = ?').get(taskId) as
+      const existsRow = nativeDb.prepare('SELECT id FROM tasks_tasks WHERE id = ?').get(taskId) as
         | { id: string }
         | undefined;
       if (!existsRow) {
@@ -1383,7 +1393,7 @@ export async function createSqliteDataAccessor(cwd?: string): Promise<DataAccess
 
       // Clear the assignee — no-op if already null
       nativeDb
-        .prepare('UPDATE tasks SET assignee = NULL, updated_at = ? WHERE id = ?')
+        .prepare('UPDATE tasks_tasks SET assignee = NULL, updated_at = ? WHERE id = ?')
         .run(new Date().toISOString(), taskId);
     },
   };

--- a/packages/core/src/store/sqlite.ts
+++ b/packages/core/src/store/sqlite.ts
@@ -146,6 +146,32 @@ const MIN_BACKUP_TASK_COUNT = 10;
  *
  * @task T5188
  */
+/**
+ * Count tasks in a backup snapshot, tolerant of the cutover (T11578 · AC1).
+ *
+ * Post-exodus snapshots of the consolidated `cleo.db` carry the prefixed
+ * `tasks_tasks` table; legacy pre-consolidation `tasks.db` snapshots carry the
+ * bare `tasks` table. Prefer the prefixed table, falling back to the bare one
+ * when the prefixed table is absent, so auto-recovery keeps working across the
+ * substrate transition.
+ *
+ * @param backupDb - Read-only handle to the backup snapshot.
+ * @returns Task row count, or 0 if neither table exists / the read fails.
+ */
+function countBackupTasks(backupDb: DatabaseSync): number {
+  for (const table of ['tasks_tasks', 'tasks']) {
+    try {
+      const row = backupDb.prepare(`SELECT COUNT(*) as cnt FROM "${table}"`).get() as
+        | { cnt: number }
+        | undefined;
+      return row?.cnt ?? 0;
+    } catch {
+      // Table missing in this snapshot — try the next candidate.
+    }
+  }
+  return 0;
+}
+
 async function autoRecoverFromBackup(
   nativeDb: DatabaseSync,
   dbPath: string,
@@ -157,8 +183,11 @@ async function autoRecoverFromBackup(
   const log = getLogger('sqlite');
 
   try {
-    // Count tasks in current database
-    const countResult = nativeDb.prepare('SELECT COUNT(*) as cnt FROM tasks').get() as
+    // Count tasks in current database.
+    // T11578 · AC1: the runtime now reads the PREFIXED consolidated table, so the
+    // emptiness probe targets `tasks_tasks` (the exodus-fill target) rather than
+    // the now-dead bare `tasks` table.
+    const countResult = nativeDb.prepare('SELECT COUNT(*) as cnt FROM tasks_tasks').get() as
       | { cnt: number }
       | undefined;
     const taskCount = countResult?.cnt ?? 0;
@@ -180,10 +209,10 @@ async function autoRecoverFromBackup(
     const backupDb = openNativeDatabase(newestBackup.path, { readonly: true, enableWal: false });
     let backupTaskCount = 0;
     try {
-      const backupCount = backupDb.prepare('SELECT COUNT(*) as cnt FROM tasks').get() as
-        | { cnt: number }
-        | undefined;
-      backupTaskCount = backupCount?.cnt ?? 0;
+      // T11578 · AC1: prefer the PREFIXED consolidated table (post-exodus
+      // snapshots) and fall back to the bare `tasks` table for legacy
+      // pre-consolidation backups so recovery still works across the cutover.
+      backupTaskCount = countBackupTasks(backupDb);
     } finally {
       backupDb.close();
     }

--- a/packages/core/src/store/tasks-schema.ts
+++ b/packages/core/src/store/tasks-schema.ts
@@ -37,7 +37,103 @@ export type {
 } from './schema/chain-schema.js';
 // Re-export WarpChain schema tables so drizzle-kit picks them up for migrations.
 export { warpChainInstances, warpChains } from './schema/chain-schema.js';
+// Row types follow the prefixed tables so `converters.ts` / `db-helpers.ts`
+// and AC/session/link stores operate on the consolidated row shape.
+export type {
+  NewTasksExternalTaskLinkRow as NewExternalTaskLinkRow,
+  NewTasksSessionRow as NewSessionRow,
+  NewTasksTaskAcceptanceCriteriaHistoryRow as NewTaskAcceptanceCriteriaHistoryRow,
+  NewTasksTaskRow as NewTaskRow,
+  TasksExternalTaskLinkRow as ExternalTaskLinkRow,
+  TasksSessionRow as SessionRow,
+  TasksTaskAcceptanceCriteriaHistoryRow as TaskAcceptanceCriteriaHistoryRow,
+  TasksTaskDependencyRow as TaskDependencyRow,
+  TasksTaskRelationRow as TaskRelationRow,
+  TasksTaskRow as TaskRow,
+  TasksTaskWorkHistoryRow as WorkHistoryRow,
+} from './schema/cleo-project/tasks-core.js';
+// ===========================================================================
+// COMPLETE-CUTOVER (T11578 · AC1) — runtime tasks store → prefixed tables
+// ===========================================================================
+//
+// The full tasks-domain table family is repointed from the BARE legacy tables
+// (`tasks`, `task_dependencies`, `task_relations`, `task_labels`, `sessions`,
+// `task_acceptance_criteria`, `acceptance_projection_state`,
+// `acceptance_projection_dirty`, `session_handoff_entries`, `task_work_history`,
+// `task_acceptance_criteria_history`, `external_task_links`,
+// `evidence_ac_bindings`) to the PREFIXED consolidated tables (`tasks_tasks`,
+// `tasks_task_dependencies`, … `tasks_evidence_ac_bindings`) authored for
+// SG-DB-SUBSTRATE-V2 (saga T11242, epic T11245/E2, T11360) and filled by the
+// exodus migration (T11248).
+//
+// ## Why the WHOLE family, not just the 5 named in AC1
+//
+// The satellite tables carry foreign keys onto the task/session rows
+// (`task_acceptance_criteria.task_id → tasks.id`,
+// `evidence_ac_bindings.ac_id → task_acceptance_criteria.id`, etc.). Repointing
+// only `tasks`/`sessions` while leaving the satellites on the bare tables
+// produces a CROSS-TABLE FK split-brain: `cleo add --acceptance` writes the
+// task into `tasks_tasks` but its AC rows into bare `task_acceptance_criteria`,
+// whose FK references the now-empty bare `tasks` → `FOREIGN KEY constraint
+// failed`. The whole family must move together so every intra-domain FK
+// resolves within the consolidated substrate.
+//
+// ## Why an alias-at-the-barrel instead of editing `schema/tasks.ts`
+//
+// The legacy `tasks` / `sessions` table objects are still referenced by OTHER
+// schema files (`audit.ts`, `experiments.ts`, `lifecycle.ts`, `manifest.ts`)
+// for FK `.references(() => tasks.id)` and by the `drizzle-tasks` legacy
+// migration generator — those must keep pointing at the bare definitions. Only
+// the RUNTIME query surface (`import * as schema from './tasks-schema.js'` in
+// `sqlite.ts`) needs the prefixed binding, so the swap lives here.
+//
+// ## Constraint reconciliation
+//
+// Physical column names are identical between legacy and prefixed tables (so
+// `schema.tasks.<field>` access stays byte-identical). The prefixed `tasks_tasks`
+// adds one nullable `idempotency_key` column plus CHECK / GLOB constraints (enum
+// casing + ISO-8601 timestamps + 0/1 booleans). The tasks write path conforms:
+// `converters.ts#taskToRow` emits ISO-8601 `createdAt`; `db-helpers.ts`
+// writes `gradeMode` as a boolean and the canonical `ARCHIVE_REASON_TOMBSTONE`
+// for completed archives (the legacy `'completed'` literal was out-of-enum and
+// only survived because the bare table had no CHECK).
+//
+// The legacy bare tables are now DEAD for runtime reads/writes; they remain
+// physically present (created by `runMigrations` / `drizzle-tasks`) for the
+// exodus source-vs-target equivalence check until E6-L7/L8 removes them.
+export {
+  tasksAcceptanceProjectionDirty as acceptanceProjectionDirty,
+  tasksAcceptanceProjectionState as acceptanceProjectionState,
+  tasksExternalTaskLinks as externalTaskLinks,
+  tasksSessionHandoffEntries as sessionHandoffEntries,
+  tasksSessions as sessions,
+  tasksTaskAcceptanceCriteria as taskAcceptanceCriteria,
+  tasksTaskAcceptanceCriteriaHistory as taskAcceptanceCriteriaHistory,
+  tasksTaskDependencies as taskDependencies,
+  tasksTaskRelations as taskRelations,
+  tasksTasks as tasks,
+  tasksTaskWorkHistory as taskWorkHistory,
+} from './schema/cleo-project/tasks-core.js';
+export type {
+  NewTasksEvidenceAcBindingRow as NewEvidenceAcBindingRow,
+  NewTasksTaskLabelRow as NewTaskLabelRow,
+  TasksEvidenceAcBindingRow as EvidenceAcBindingRow,
+  TasksTaskLabelRow as TaskLabelRow,
+} from './schema/cleo-project/tasks-core-batch2.js';
+export {
+  tasksEvidenceAcBindings as evidenceAcBindings,
+  tasksTaskLabels as taskLabels,
+} from './schema/cleo-project/tasks-core-batch2.js';
 // Re-export all domain tables, constants, and types from the schema subdirectory.
+// NOTE (T11578 · AC1): `./schema/index.js` re-exports the LEGACY bare-name task
+// table objects (`tasks`, `sessions`, `taskDependencies`, `taskRelations`,
+// `taskLabels`). The explicit re-exports in the "COMPLETE-CUTOVER" block at the
+// bottom of this file SHADOW those five names, repointing the runtime drizzle
+// query symbols at the PREFIXED consolidated tables (`tasks_tasks`, …) that the
+// exodus migration fills. Per the ES module spec, a local explicit named
+// re-export takes precedence over a `export *` re-export for the same name, so
+// all 290+ `schema.tasks` / `schema.sessions` call sites keep compiling while
+// now reading and writing the prefixed physical tables.
 export * from './schema/index.js';
 // Re-export status constants and types so existing imports from schema.ts still work.
 export {

--- a/packages/core/src/store/tasks-sqlite.ts
+++ b/packages/core/src/store/tasks-sqlite.ts
@@ -11,6 +11,7 @@
 import {
   ARCHIVE_REASON_TOMBSTONE,
   ArchiveReasonTombstoneError,
+  type ArchiveReasonValue,
   isArchiveTombstoneAllowed,
   type Task,
   type TaskStatus,
@@ -245,9 +246,14 @@ export async function archiveTask(taskId: string, reason?: string, cwd?: string)
   // env flag is set. The fallback when no reason is supplied still maps to
   // the tombstone (since DB CHECK requires one of the 6 enum values), but
   // explicit caller-supplied tombstones from non-migration code are rejected.
-  const normalizedReason = (() => {
+  // T11578 · AC1: the consolidated `tasks_tasks.archive_reason` column is
+  // CHECK-backed by the T1408 enum, so the writer must produce a value typed as
+  // `ArchiveReasonValue` (the prefixed schema narrows the column type). The
+  // normalization already only ever yields canonical enum values; the explicit
+  // return type makes that guarantee visible to the drizzle `.set()` overload.
+  const normalizedReason: ArchiveReasonValue = (() => {
     if (!reason) return ARCHIVE_REASON_TOMBSTONE;
-    const valid = new Set([
+    const valid = new Set<ArchiveReasonValue>([
       'verified',
       'reconciled',
       'superseded',
@@ -258,7 +264,7 @@ export async function archiveTask(taskId: string, reason?: string, cwd?: string)
     if (reason === ARCHIVE_REASON_TOMBSTONE && !isArchiveTombstoneAllowed()) {
       throw new ArchiveReasonTombstoneError(taskId);
     }
-    if (valid.has(reason)) return reason;
+    if (valid.has(reason as ArchiveReasonValue)) return reason as ArchiveReasonValue;
     if (reason === 'deleted') return 'cancelled';
     return ARCHIVE_REASON_TOMBSTONE;
   })();
@@ -405,9 +411,9 @@ export async function getBlockerChain(taskId: string, cwd?: string): Promise<str
   const result = nativeDb
     .prepare(`
     WITH RECURSIVE blocker_chain(id) AS (
-      SELECT depends_on FROM task_dependencies WHERE task_id = ?
+      SELECT depends_on FROM tasks_task_dependencies WHERE task_id = ?
       UNION
-      SELECT td.depends_on FROM task_dependencies td
+      SELECT td.depends_on FROM tasks_task_dependencies td
       JOIN blocker_chain bc ON td.task_id = bc.id
     )
     SELECT id FROM blocker_chain
@@ -436,9 +442,9 @@ export async function getSubtree(rootId: string, cwd?: string): Promise<Task[]> 
   const rows = nativeDb
     .prepare(`
     WITH RECURSIVE subtree AS (
-      SELECT * FROM tasks WHERE id = ?
+      SELECT * FROM tasks_tasks WHERE id = ?
       UNION ALL
-      SELECT t.* FROM tasks t
+      SELECT t.* FROM tasks_tasks t
       JOIN subtree s ON t.parent_id = s.id
     )
     SELECT * FROM subtree

--- a/packages/core/src/tasks/__tests__/ac-wiring.test.ts
+++ b/packages/core/src/tasks/__tests__/ac-wiring.test.ts
@@ -195,7 +195,9 @@ describe('updateTask — AC dual-write update paths (T10508)', () => {
     expect(native).toBeTruthy();
     const historyRows = native!
       .prepare(
-        'SELECT ac_id, previous_text, reason FROM task_acceptance_criteria_history ORDER BY id ASC',
+        // T11578 · AC1: runtime now writes the AC-history rows to the PREFIXED
+        // consolidated table; read it back from there.
+        'SELECT ac_id, previous_text, reason FROM tasks_task_acceptance_criteria_history ORDER BY id ASC',
       )
       .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
     expect(historyRows).toHaveLength(2);
@@ -243,7 +245,9 @@ describe('updateTask — AC dual-write update paths (T10508)', () => {
     const native = getNativeTasksDb();
     const historyRows = native!
       .prepare(
-        'SELECT ac_id, previous_text, reason FROM task_acceptance_criteria_history ORDER BY id ASC',
+        // T11578 · AC1: runtime now writes the AC-history rows to the PREFIXED
+        // consolidated table; read it back from there.
+        'SELECT ac_id, previous_text, reason FROM tasks_task_acceptance_criteria_history ORDER BY id ASC',
       )
       .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
     expect(historyRows).toHaveLength(2);
@@ -294,7 +298,8 @@ describe('updateTask — AC dual-write update paths (T10508)', () => {
     const native = getNativeTasksDb();
     const historyAcIds = (
       native!
-        .prepare('SELECT ac_id FROM task_acceptance_criteria_history ORDER BY id ASC')
+        // T11578 · AC1: read AC-history from the PREFIXED consolidated table.
+        .prepare('SELECT ac_id FROM tasks_task_acceptance_criteria_history ORDER BY id ASC')
         .all() as Array<{ ac_id: string }>
     ).map((h) => h.ac_id);
     expect(historyAcIds.sort()).toEqual([...droppedIds].sort());

--- a/packages/core/src/tasks/__tests__/archive.test.ts
+++ b/packages/core/src/tasks/__tests__/archive.test.ts
@@ -196,7 +196,8 @@ describe('archiveTasks', () => {
     const { getNativeTasksDb } = await import('../../store/sqlite.js');
     const historyRows = getNativeTasksDb()!
       .prepare(
-        'SELECT ac_id, previous_text, reason FROM task_acceptance_criteria_history ORDER BY id ASC',
+        // T11578 · AC1: AC-history rows now land in the PREFIXED consolidated table.
+        'SELECT ac_id, previous_text, reason FROM tasks_task_acceptance_criteria_history ORDER BY id ASC',
       )
       .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
     expect(historyRows).toEqual([

--- a/packages/core/src/tasks/__tests__/delete.test.ts
+++ b/packages/core/src/tasks/__tests__/delete.test.ts
@@ -246,7 +246,8 @@ describe('deleteTask', () => {
     const { getNativeTasksDb } = await import('../../store/sqlite.js');
     const historyRows = getNativeTasksDb()!
       .prepare(
-        'SELECT ac_id, previous_text, reason FROM task_acceptance_criteria_history ORDER BY id ASC',
+        // T11578 · AC1: AC-history rows now land in the PREFIXED consolidated table.
+        'SELECT ac_id, previous_text, reason FROM tasks_task_acceptance_criteria_history ORDER BY id ASC',
       )
       .all() as Array<{ ac_id: string; previous_text: string; reason: string }>;
     expect(historyRows).toEqual([

--- a/packages/core/src/tasks/compute-task-view.ts
+++ b/packages/core/src/tasks/compute-task-view.ts
@@ -76,7 +76,7 @@ function fetchChildAggregates(
       SUM(CASE WHEN status = 'done'    THEN 1 ELSE 0 END)            AS children_done,
       SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END)            AS children_blocked,
       SUM(CASE WHEN status = 'active'  THEN 1 ELSE 0 END)            AS children_active
-    FROM tasks
+    FROM tasks_tasks
     WHERE parent_id IN (${placeholders})
       AND status != 'archived'
     GROUP BY parent_id

--- a/packages/core/src/workgraph/__tests__/relations.test.ts
+++ b/packages/core/src/workgraph/__tests__/relations.test.ts
@@ -62,7 +62,8 @@ class FakeDb {
     return {
       all: (...params: readonly unknown[]) => {
         this.prepared.push({ sql, params: params.map(String) });
-        if (sql.includes('FROM task_dependencies')) return this.rowsByTable.dependencies ?? [];
+        if (sql.includes('FROM tasks_task_dependencies'))
+          return this.rowsByTable.dependencies ?? [];
         return this.rowsByTable.relations ?? [];
       },
     };
@@ -87,7 +88,7 @@ describe('SqliteWorkGraphRelationQueryService', () => {
     const result = service.listRelationEdges({ rootId: 'T1', direction: 'out' });
 
     expect(db.prepared).toHaveLength(1);
-    expect(db.prepared[0]?.sql).toContain('FROM task_relations');
+    expect(db.prepared[0]?.sql).toContain('FROM tasks_task_relations');
     expect(db.prepared[0]?.sql).toContain('WHERE task_id = ?');
     expect(db.prepared[0]?.sql).not.toContain('task_dependencies');
     expect(db.prepared[0]?.params).toEqual(['T1']);
@@ -188,8 +189,8 @@ describe('SqliteWorkGraphRelationQueryService', () => {
     });
 
     expect(db.prepared).toHaveLength(2);
-    expect(db.prepared[0]?.sql).toContain('FROM task_relations');
-    expect(db.prepared[1]?.sql).toContain('FROM task_dependencies');
+    expect(db.prepared[0]?.sql).toContain('FROM tasks_task_relations');
+    expect(db.prepared[1]?.sql).toContain('FROM tasks_task_dependencies');
     expect(db.prepared[1]?.sql).toContain('WHERE (task_id = ? OR depends_on = ?)');
     expect(result.edges).toEqual([
       {

--- a/packages/core/src/workgraph/containment.ts
+++ b/packages/core/src/workgraph/containment.ts
@@ -319,17 +319,17 @@ export class SqliteWorkGraphContainmentQueryService implements WorkGraphContainm
 ancestor_edges(root_id, id, depth) AS (
   SELECT input.root_id, root.parent_id, 1
   FROM input
-  JOIN tasks root ON root.id = input.root_id
+  JOIN tasks_tasks root ON root.id = input.root_id
   WHERE root.parent_id IS NOT NULL
   UNION ALL
   SELECT ancestor_edges.root_id, parent.parent_id, ancestor_edges.depth + 1
   FROM ancestor_edges
-  JOIN tasks parent ON parent.id = ancestor_edges.id
+  JOIN tasks_tasks parent ON parent.id = ancestor_edges.id
   WHERE parent.parent_id IS NOT NULL
 )
 SELECT ancestor_edges.root_id, ancestor_edges.depth, ${TASK_COLUMNS}
 FROM ancestor_edges
-JOIN tasks t ON t.id = ancestor_edges.id
+JOIN tasks_tasks t ON t.id = ancestor_edges.id
 ORDER BY ancestor_edges.root_id ASC, ancestor_edges.depth DESC`;
 
     const rows = this.#db.prepare(sql).all(...ids) as AncestorTaskRow[];
@@ -349,7 +349,7 @@ ORDER BY ancestor_edges.root_id ASC, ancestor_edges.depth DESC`;
 
     const placeholders = ids.map(() => '?').join(', ');
     const sql = `SELECT t.parent_id AS root_id, ${TASK_COLUMNS}
-FROM tasks t
+FROM tasks_tasks t
 WHERE t.parent_id IN (${placeholders})
 ORDER BY t.parent_id ASC, t.position ASC, t.created_at ASC, t.id ASC`;
 
@@ -375,13 +375,13 @@ ORDER BY t.parent_id ASC, t.position ASC, t.created_at ASC, t.id ASC`;
 
     const sql = `WITH RECURSIVE descendants(root_id, id, depth) AS (
   SELECT ? AS root_id, child.id, 1
-  FROM tasks child
+  FROM tasks_tasks child
   WHERE child.parent_id = ?
   UNION ALL
   SELECT descendants.root_id, child.id, descendants.depth + 1
   FROM descendants
-  JOIN tasks parent ON parent.id = descendants.id
-  JOIN tasks child ON child.parent_id = parent.id
+  JOIN tasks_tasks parent ON parent.id = descendants.id
+  JOIN tasks_tasks child ON child.parent_id = parent.id
   WHERE (? IS NULL OR descendants.depth < ?)
 ), ordered AS (
   SELECT descendants.root_id,
@@ -389,7 +389,7 @@ ORDER BY t.parent_id ASC, t.position ASC, t.created_at ASC, t.id ASC`;
          printf('%08d:%s', descendants.depth, t.id) AS sort_cursor,
          ${TASK_COLUMNS}
   FROM descendants
-  JOIN tasks t ON t.id = descendants.id
+  JOIN tasks_tasks t ON t.id = descendants.id
 )
 SELECT *
 FROM ordered
@@ -427,20 +427,20 @@ LIMIT ?`;
   summarizeSubtree(options: WorkGraphSubtreeSummaryOptions): WorkGraphSubtreeSummaryResult {
     const sql = `WITH RECURSIVE summary_descendants(root_id, id, depth) AS (
   SELECT ? AS root_id, child.id, 1
-  FROM tasks child
+  FROM tasks_tasks child
   WHERE child.parent_id = ?
   UNION ALL
   SELECT summary_descendants.root_id, child.id, summary_descendants.depth + 1
   FROM summary_descendants
-  JOIN tasks parent ON parent.id = summary_descendants.id
-  JOIN tasks child ON child.parent_id = parent.id
+  JOIN tasks_tasks parent ON parent.id = summary_descendants.id
+  JOIN tasks_tasks child ON child.parent_id = parent.id
 )
 SELECT summary_descendants.root_id,
        summary_descendants.depth,
        printf('%08d:%s', summary_descendants.depth, t.id) AS sort_cursor,
        ${TASK_COLUMNS}
 FROM summary_descendants
-JOIN tasks t ON t.id = summary_descendants.id
+JOIN tasks_tasks t ON t.id = summary_descendants.id
 ORDER BY sort_cursor ASC`;
 
     const rows = this.#db.prepare(sql).all(options.rootId, options.rootId) as DescendantTaskRow[];
@@ -471,13 +471,13 @@ ORDER BY sort_cursor ASC`;
     const roleFilter = options.role === undefined ? '' : 'AND t.role = ?';
     const sql = `WITH RECURSIVE ready_frontier_scope(root_id, id) AS (
   SELECT ? AS root_id, child.id
-  FROM tasks child
+  FROM tasks_tasks child
   WHERE child.parent_id = ?
   UNION ALL
   SELECT ready_frontier_scope.root_id, child.id
   FROM ready_frontier_scope
-  JOIN tasks parent ON parent.id = ready_frontier_scope.id
-  JOIN tasks child ON child.parent_id = parent.id
+  JOIN tasks_tasks parent ON parent.id = ready_frontier_scope.id
+  JOIN tasks_tasks child ON child.parent_id = parent.id
 )
 SELECT ready_frontier_scope.root_id,
        t.id,
@@ -491,9 +491,9 @@ SELECT ready_frontier_scope.root_id,
        td.depends_on,
        dep.status AS dep_status
 FROM ready_frontier_scope
-JOIN tasks t ON t.id = ready_frontier_scope.id
-LEFT JOIN task_dependencies td ON td.task_id = t.id
-LEFT JOIN tasks dep ON dep.id = td.depends_on
+JOIN tasks_tasks t ON t.id = ready_frontier_scope.id
+LEFT JOIN tasks_task_dependencies td ON td.task_id = t.id
+LEFT JOIN tasks_tasks dep ON dep.id = td.depends_on
 WHERE t.status IN ('pending', 'active', 'blocked', 'proposed')
 ${roleFilter}
 ORDER BY t.priority ASC, t.created_at ASC, t.id ASC, td.depends_on ASC`;

--- a/packages/core/src/workgraph/relations.ts
+++ b/packages/core/src/workgraph/relations.ts
@@ -289,7 +289,7 @@ export class SqliteWorkGraphRelationQueryService implements WorkGraphRelationQue
     const direction = normalizeDirection(options.direction);
     const relationFilter = directionWhere(direction, 'task_id', 'related_to');
     const relationSql = `SELECT task_id, related_to, relation_type, reason
-FROM task_relations
+FROM tasks_task_relations
 WHERE ${relationFilter.clause}
 ORDER BY task_id ASC, related_to ASC, relation_type ASC`;
 
@@ -301,7 +301,7 @@ ORDER BY task_id ASC, related_to ASC, relation_type ASC`;
     if (options.includeDependencies === true) {
       const dependencyFilter = directionWhere(direction, 'task_id', 'depends_on');
       const dependencySql = `SELECT task_id, depends_on
-FROM task_dependencies
+FROM tasks_task_dependencies
 WHERE ${dependencyFilter.clause}
 ORDER BY task_id ASC, depends_on ASC`;
       const dependencyRows = this.#db

--- a/packages/core/src/worktree/list.ts
+++ b/packages/core/src/worktree/list.ts
@@ -486,7 +486,7 @@ export async function loadOwningTaskStatuses(
   if (!db) return out;
 
   const placeholders = taskIds.map(() => '?').join(', ');
-  const sql = `SELECT id, status FROM tasks WHERE id IN (${placeholders})`;
+  const sql = `SELECT id, status FROM tasks_tasks WHERE id IN (${placeholders})`;
   const rows = db.prepare(sql).all(...taskIds) as Array<{ id: string; status: string }>;
   for (const row of rows) {
     out.set(row.id, row.status);


### PR DESCRIPTION
## T11578 AC1 — tasks runtime read/write → prefixed `tasks_*` consolidated tables

Implements **AC1** of the COMPLETE-CUTOVER phase: repoint the tasks-domain runtime store from the BARE legacy tables (`tasks`, `task_dependencies`, `task_relations`, `task_labels`, `sessions` + satellites) to the PREFIXED consolidated tables (`tasks_tasks`, …, `tasks_evidence_ac_bindings`) that the exodus migration (T11248) fills.

**Before:** exodus migrated full-parity data into `tasks_tasks`, but the runtime read `FROM tasks` (bare) → `cleo show/list/find` returned empty (DHQ-046: migration parity ≠ data visibility).
**After:** the runtime reads/writes the prefixed tables → migrated rows are visible.

### Approach (low-blast-radius barrel flip)
- `tasks-schema.ts` barrel aliases the **whole tasks-domain family (13 tables)** to their prefixed equivalents under the legacy export names, shadowing the `export *` legacy bindings. All ~290 `schema.tasks` call sites keep compiling while now hitting the prefixed physical tables. `schema/tasks.ts` is untouched so the legacy FK references (`audit.ts`/`experiments.ts`/`lifecycle.ts`/`manifest.ts`) + the `drizzle-tasks` migration generator stay valid.
- Raw SQL repointed: `sqlite.ts` auto-recover counts, `tasks-sqlite.ts` blocker/subtree CTEs, `sqlite-data-accessor.ts` ancestor/subtree/dep CTEs + position + claim/unclaim, `db-helpers.ts` session-list append, `compute-task-view.ts` child rollup (`cleo show`).

### Write-path constraint reconciliation (the #1 hidden risk)
The prefixed `tasks_tasks` carries CHECK/GLOB constraints the bare table lacked:
- `gradeMode` now written as **boolean** (column is `integer({mode:'boolean'})`).
- `archive_reason` defaults use the canonical `ARCHIVE_REASON_TOMBSTONE` (`'completed-unverified'`) instead of the **out-of-enum `'completed'`** literal the CHECK-less bare table silently tolerated (latent bug fixed). `ArchiveFields.archiveReason` typed to `ArchiveReasonValue`; migration-import normalizes; `stats/index.ts` query fixed to the canonical enum.
- Timestamps already ISO-8601 (`taskToRow` → `new Date().toISOString()`) → GLOB-conforming.

### Why the whole family, not just the 5 named in AC1
Satellite FKs (`task_acceptance_criteria.task_id → tasks.id`, `evidence_ac_bindings.ac_id → task_acceptance_criteria.id`) mean a partial flip causes a cross-table FK split-brain: `cleo add --acceptance` writes the task into `tasks_tasks` but its AC rows into bare `task_acceptance_criteria`, whose FK references the now-empty bare `tasks` → `FOREIGN KEY constraint failed`. Moving the family together keeps every intra-domain FK resolving.

### Mini dry-run (real project `tasks.db`, 4530 tasks)
Sandbox `/tmp/t11578-tasks-dryrun` (no stale `cleo.db`), copied live `tasks.db`, ran `cleo exodus migrate` with the built CLI:

| Table | source (bare) | target (`tasks_*`) |
|---|---|---|
| tasks_tasks | 4530 | **4530** |
| tasks_task_dependencies | 1221 | **1221** |
| tasks_task_relations | 446 | **446** |
| tasks_task_labels | 4587 | **4587** |
| tasks_sessions | 177 | **177** |
| tasks_task_acceptance_criteria | 23808 | **23808** |
| tasks_task_acceptance_criteria_history | 18965 | **18965** |
| tasks_evidence_ac_bindings | 1254 | **1254** |
| tasks_external_task_links | 44 | **44** |
| tasks_session_handoff_entries | 49 | **49** |

**Visibility (was EMPTY before cutover):**
- `cleo list --output count` → **2685**
- `cleo find "exodus"` → **691**
- `cleo show T11242` childRollup → `{total:20, done:5}` (compute-task-view reads `tasks_tasks`)
- `cleo show T11245` relationCounts → `{depends:2, children:7}`

**Write path:** `cleo add --type task --parent T11249 --acceptance "..."` → `T11618` written to `tasks_tasks` (`status=pending`, ISO `created_at`), AC row in `tasks_task_acceptance_criteria` — all CHECK/GLOB conforming. `cleo update --status active` + `cleo relates add` also land in `tasks_*`.

**GO criteria:** zero row deficits across all 11 tasks-domain tables; **0 new FK orphans** (the 2 `tasks_task_relations` orphans are pre-existing source data orphans the migration already flags); show/list/find/add/update non-empty + conforming.

### Constraint surprises hit
1. `archive_reason = 'completed'` was out-of-enum (CHECK-less bare table masked it) — fixed to `'completed-unverified'`.
2. `gradeMode` written as raw `1` — fixed to boolean for the `integer({mode:'boolean'})` column.
3. The satellite cross-table FK split-brain forced extending the flip from 5 → 13 tables (documented above).
4. Out-of-scope: the consolidated `schema_meta.task_id_sequence` is NOT advanced to the migrated max by exodus — a **sequence-reconciliation gap that belongs to the live-cutover (AC7)**, not AC1. (Verified by seeding the sequence in the dry-run, after which all writes succeed.)

### Validation
- `pnpm run typecheck` (tsc -b) — clean
- `node build.mjs` — clean
- Targeted suites green: migration-baseline (29) + sqlite, AC schema (21), tasks-sqlite + db-helpers (48), `@cleocode/runtime` (120).
- `migration-baseline.test.ts` left unchanged: it validates the LEGACY `drizzle-tasks` migration folder which still physically creates the bare `tasks` table (my change only flips the runtime barrel, not the migration folder), so its `EXISTENCE_TABLE.tasks='tasks'` assertion remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
