### PR TITLE
feat(T11578): conduit runtime read/write → prefixed conduit_* + FTS5 rewrite + DDL snapshot test (AC4)

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/agent-install.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/agent-install.test.ts
@@ -436,7 +436,7 @@ describe('T889 cleo agent install — real sqlite + real fs', () => {
     const conduitDb = openDb(conduitPath);
     try {
       const refRow = conduitDb
-        .prepare('SELECT agent_id, enabled FROM project_agent_refs WHERE agent_id = ?')
+        .prepare('SELECT agent_id, enabled FROM conduit_project_agent_refs WHERE agent_id = ?')
         .get('cleo-historian') as { agent_id: string; enabled: number } | undefined;
       expect(refRow?.agent_id).toBe('cleo-historian');
       expect(refRow?.enabled).toBe(1);

--- a/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/doctor-db-substrate.test.ts
@@ -1146,12 +1146,13 @@ describe('doctor db-substrate (T10307)', () => {
   }
 
   /**
-   * Seed a conduit.db with a `dead_letters` table carrying job_id rows.
+   * Seed a conduit.db with a `conduit_dead_letters` table carrying job_id rows
+   * (T11578 · AC4 — prefixed table the I5 invariant check now reads).
    */
   function seedConduitDbForCrossDb(dbPath: string, jobIds: string[]): void {
     const writer = new DatabaseSyncCtor(dbPath);
     writer.exec(
-      `CREATE TABLE dead_letters (
+      `CREATE TABLE conduit_dead_letters (
          id         TEXT PRIMARY KEY,
          message_id TEXT NOT NULL,
          job_id     TEXT NOT NULL,
@@ -1161,7 +1162,7 @@ describe('doctor db-substrate (T10307)', () => {
        );`,
     );
     const insert = writer.prepare(
-      'INSERT INTO dead_letters (id, message_id, job_id, reason, attempts, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT INTO conduit_dead_letters (id, message_id, job_id, reason, attempts, created_at) VALUES (?, ?, ?, ?, ?, ?)',
     );
     let i = 0;
     for (const jobId of jobIds) {

--- a/packages/cleo/src/dispatch/domains/conduit.ts
+++ b/packages/cleo/src/dispatch/domains/conduit.ts
@@ -616,11 +616,12 @@ async function listenTopicImpl(
     apiBaseUrl: credential.apiBaseUrl,
   });
   try {
-    // Convert ISO since to unix timestamp for pollTopic
-    const sinceUnix = since ? Math.floor(new Date(since).getTime() / 1000) : 0;
+    // T11578 (AC4): pollTopic now compares ISO-8601 `created_at` directly — pass
+    // the ISO `since` through unchanged (the prior epoch-seconds conversion is
+    // gone). An empty floor returns all topic messages.
     const messages = await transport.pollTopic(topicName, {
       limit: limit ?? 50,
-      since: sinceUnix,
+      since: since ?? '',
     });
     return {
       success: true,

--- a/packages/core/migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql
+++ b/packages/core/migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema/migration.sql
@@ -1,336 +1,74 @@
--- T11523 (E6-L3): Forward Drizzle migration carrying the conduit-domain schema
--- that previously lived ONLY as an inline `CREATE TABLE IF NOT EXISTS` blob
--- (`CONDUIT_SCHEMA_SQL`) applied by `applyConduitSchema()` in conduit-sqlite.ts.
+-- T11523 (E6-L3) → T11578 (AC4 · COMPLETE-CUTOVER): conduit FTS5 quartet over the
+-- consolidated `conduit_*` tables.
 --
--- E6-L3 routes `ensureConduitDb()` through `openDualScopeDb('project')` (the
--- consolidated `cleo.db` chokepoint, ADR-068/069). The inline DDL is removed and
--- replaced by this migration (T11523 AC: inline DDL → forward Drizzle migration),
--- matching the T1407 baseline marker + the L1/L2 precedent.
+-- ## History
 --
--- The conduit legacy physical table names are BARE (`conversations`, `messages`,
--- `delivery_jobs`, …) while the consolidated schema (`cleo-project/conduit.ts`)
--- carries the `conduit_` domain prefix (`conduit_conversations`, …). They are
--- therefore DISJOINT physical names — the legacy runtime-shape tables co-exist
--- harmlessly alongside the consolidated `conduit_*` tables in the same `cleo.db`,
--- exactly like the tasks domain (legacy `tasks` ≠ consolidated `tasks_tasks`).
--- No DROP/rebuild is needed (unlike the brain domain, E6-L2).
+-- E6-L3 (T11523) routed `ensureConduitDb()` through `openDualScopeDb('project')`
+-- (the consolidated `cleo.db` chokepoint, ADR-068/069) and reproduced the legacy
+-- BARE-table conduit shape (`conversations`, `messages`, `delivery_jobs`, …) here
+-- as a forward migration so the runtime writers kept working unchanged. The bare
+-- tables co-existed (disjoint names) with the consolidated `conduit_*` tables the
+-- exodus migration (T11248 / T11553) renames into.
 --
--- All DDL is reproduced VERBATIM from `CONDUIT_SCHEMA_SQL` (legacy runtime shape):
--- 16 tables + indexes + FTS5 virtual table + 3 FTS5 triggers. Every statement is
--- `IF NOT EXISTS`, so re-running on a DB that already has the tables is idempotent.
--- The exodus migration (T11248 / T11553) later renames these to `conduit_*`.
+-- ## AC4 cutover (T11578)
+--
+-- The conduit runtime READ + WRITE path now targets the PREFIXED consolidated
+-- tables (`conduit_conversations`, `conduit_messages`, `conduit_topics`, …) that
+-- the consolidated cleo-project migration
+-- (`drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project`)
+-- creates. Those 14 prefixed tables are therefore NO LONGER created here — the
+-- consolidated migration owns them (single SSoT; CHECK constraints + ISO-8601
+-- TEXT timestamp affinity are injected by T11363). This migration's sole
+-- remaining responsibility is the FTS5 full-text index over `conduit_messages`,
+-- which drizzle-orm sqlite-core cannot model (FTS5 virtual tables) and which the
+-- consolidated migration therefore omits.
+--
+-- ## FTS5 rename: `messages_fts` → `conduit_messages_fts` (T11578 decision)
+--
+-- The full-text index and its three sync triggers are renamed with the `conduit_`
+-- domain prefix for clarity and to stay disjoint inside the shared `cleo.db`
+-- (which also holds `brain_*_fts` indexes). The index content table is
+-- `conduit_messages` and `content_rowid='rowid'` is preserved. The exodus
+-- migration skips `*_fts` tables (rebuilt post-migration from their content
+-- table — see exodus/table-name-map.ts `isDerivedFtsTable`), so the
+-- `INSERT INTO conduit_messages_fts(conduit_messages_fts) VALUES('rebuild')` seed
+-- below reindexes whatever rows the consolidated migration + exodus already
+-- placed in `conduit_messages`. Every statement is `IF NOT EXISTS`, so re-running
+-- on a DB that already has the FTS index is idempotent.
 
 -- -------------------------------------------------------------------------
--- Project-scoped conversations (LocalTransport DM threads).
+-- FTS5 virtual table for full-text search on conduit_messages content.
+-- The INSERT … VALUES('rebuild') is idempotent — safe to run on every open;
+-- it (re)indexes the existing conduit_messages rows.
 -- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS conversations (
-    id TEXT PRIMARY KEY,
-    participants TEXT NOT NULL,
-    visibility TEXT NOT NULL DEFAULT 'private',
-    message_count INTEGER NOT NULL DEFAULT 0,
-    last_message_at INTEGER,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-);
+CREATE VIRTUAL TABLE IF NOT EXISTS conduit_messages_fts
+    USING fts5(content, from_agent_id, content='conduit_messages', content_rowid='rowid');
 --> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Project-scoped agent-to-agent messages (LocalTransport content).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS messages (
-    id TEXT PRIMARY KEY,
-    conversation_id TEXT NOT NULL REFERENCES conversations(id),
-    from_agent_id TEXT NOT NULL,
-    to_agent_id TEXT NOT NULL,
-    content TEXT NOT NULL,
-    content_type TEXT NOT NULL DEFAULT 'text',
-    status TEXT NOT NULL DEFAULT 'pending',
-    attachments TEXT NOT NULL DEFAULT '[]',
-    group_id TEXT,
-    metadata TEXT DEFAULT '{}',
-    reply_to TEXT,
-    created_at INTEGER NOT NULL,
-    delivered_at INTEGER,
-    read_at INTEGER
-);
+INSERT INTO conduit_messages_fts(conduit_messages_fts) VALUES('rebuild');
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS messages_conversation_idx ON messages(conversation_id);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS messages_from_agent_idx ON messages(from_agent_id);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS messages_to_agent_idx ON messages(to_agent_id);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS messages_created_at_idx ON messages(created_at);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_messages_group_id ON messages(group_id) WHERE group_id IS NOT NULL;
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_messages_reply_to ON messages(reply_to) WHERE reply_to IS NOT NULL;
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- FTS5 virtual table for full-text search on message content.
--- NOTE: Must be migrated using VACUUM INTO, not DDL-only copy, to preserve
--- triggers. The INSERT INTO messages_fts(messages_fts) VALUES('rebuild')
--- is idempotent — safe to run on every open.
--- -------------------------------------------------------------------------
-CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
-    USING fts5(content, from_agent_id, content='messages', content_rowid='rowid');
---> statement-breakpoint
-INSERT INTO messages_fts(messages_fts) VALUES('rebuild');
---> statement-breakpoint
-CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-    INSERT INTO messages_fts(rowid, content, from_agent_id)
+CREATE TRIGGER IF NOT EXISTS conduit_messages_ai AFTER INSERT ON conduit_messages BEGIN
+    INSERT INTO conduit_messages_fts(rowid, content, from_agent_id)
         VALUES (new.rowid, new.content, new.from_agent_id);
 END;
 --> statement-breakpoint
-CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content, from_agent_id)
+CREATE TRIGGER IF NOT EXISTS conduit_messages_ad AFTER DELETE ON conduit_messages BEGIN
+    INSERT INTO conduit_messages_fts(conduit_messages_fts, rowid, content, from_agent_id)
         VALUES('delete', old.rowid, old.content, old.from_agent_id);
 END;
 --> statement-breakpoint
-CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content, from_agent_id)
+CREATE TRIGGER IF NOT EXISTS conduit_messages_au AFTER UPDATE ON conduit_messages BEGIN
+    INSERT INTO conduit_messages_fts(conduit_messages_fts, rowid, content, from_agent_id)
         VALUES('delete', old.rowid, old.content, old.from_agent_id);
-    INSERT INTO messages_fts(rowid, content, from_agent_id)
+    INSERT INTO conduit_messages_fts(rowid, content, from_agent_id)
         VALUES (new.rowid, new.content, new.from_agent_id);
 END;
 --> statement-breakpoint
 
 -- -------------------------------------------------------------------------
--- Async delivery queue for deferred message dispatch.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS delivery_jobs (
-    id TEXT PRIMARY KEY,
-    message_id TEXT NOT NULL,
-    payload TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    attempts INTEGER NOT NULL DEFAULT 0,
-    max_attempts INTEGER NOT NULL DEFAULT 6,
-    next_attempt_at INTEGER NOT NULL,
-    last_error TEXT,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_delivery_jobs_status ON delivery_jobs(status, next_attempt_at);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Dead-letter queue for messages that exceeded max delivery attempts.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS dead_letters (
-    id TEXT PRIMARY KEY,
-    message_id TEXT NOT NULL,
-    job_id TEXT NOT NULL,
-    reason TEXT NOT NULL,
-    attempts INTEGER NOT NULL,
-    created_at INTEGER NOT NULL
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_dead_letters_message ON dead_letters(message_id);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Pinned messages within a conversation.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS message_pins (
-    id TEXT PRIMARY KEY,
-    message_id TEXT NOT NULL,
-    conversation_id TEXT NOT NULL,
-    pinned_by TEXT NOT NULL,
-    note TEXT,
-    created_at INTEGER NOT NULL,
-    UNIQUE(message_id, pinned_by)
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_pins_conversation ON message_pins(conversation_id);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_pins_agent ON message_pins(pinned_by);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- File/blob attachments associated with messages.
---
--- T11563: the conduit attachment-family tables carry the `conduit_` prefix so
--- they are PHYSICALLY DISJOINT from the docs-domain bare `attachments` table
--- (store/schema/attachments.ts) that ALSO lives in the consolidated `cleo.db`.
--- Before E6-L3 (#900) the conduit domain had its own `conduit.db` file, so the
--- bare names `attachments` / `attachment_versions` / `attachment_approvals` /
--- `attachment_contributors` did not collide. Routing conduit into `cleo.db`
--- (#900) put them in the same physical DB as the docs `attachments` table; the
--- bare `CREATE TABLE IF NOT EXISTS attachments` then silently no-opped against
--- the docs table and the `conversation_id` index crashed (no such column). The
--- `conduit_`-prefixed names match the consolidated schema (cleo-project/conduit.ts)
--- and the exodus rename map target (table-name-map.ts: `attachments` →
--- `conduit_attachments`), restoring the intended "disjoint physical names".
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS conduit_attachments (
-    slug TEXT PRIMARY KEY,
-    conversation_id TEXT NOT NULL,
-    from_agent_id TEXT NOT NULL,
-    content BLOB NOT NULL,
-    original_size INTEGER NOT NULL,
-    compressed_size INTEGER NOT NULL,
-    content_hash TEXT NOT NULL,
-    format TEXT NOT NULL DEFAULT 'text',
-    title TEXT,
-    tokens INTEGER NOT NULL DEFAULT 0,
-    expires_at INTEGER NOT NULL DEFAULT 0,
-    storage_key TEXT,
-    mode TEXT NOT NULL DEFAULT 'draft',
-    version_count INTEGER NOT NULL DEFAULT 1,
-    current_version INTEGER NOT NULL DEFAULT 1,
-    created_at INTEGER NOT NULL
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS conduit_attachments_conversation_idx ON conduit_attachments(conversation_id);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS conduit_attachments_agent_idx ON conduit_attachments(from_agent_id);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Version history for attachments (collaborative editing).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS conduit_attachment_versions (
-    id TEXT PRIMARY KEY,
-    slug TEXT NOT NULL REFERENCES conduit_attachments(slug) ON DELETE CASCADE,
-    version_number INTEGER NOT NULL,
-    author_agent_id TEXT NOT NULL,
-    change_type TEXT NOT NULL DEFAULT 'patch',
-    patch_text TEXT,
-    storage_key TEXT NOT NULL,
-    content_hash TEXT NOT NULL,
-    original_size INTEGER NOT NULL,
-    compressed_size INTEGER NOT NULL,
-    tokens INTEGER NOT NULL,
-    change_summary TEXT,
-    sections_modified TEXT NOT NULL DEFAULT '[]',
-    tokens_added INTEGER NOT NULL DEFAULT 0,
-    tokens_removed INTEGER NOT NULL DEFAULT 0,
-    created_at INTEGER NOT NULL,
-    UNIQUE(slug, version_number)
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_conduit_attachment_versions_slug ON conduit_attachment_versions(slug);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_conduit_attachment_versions_author ON conduit_attachment_versions(author_agent_id);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Approval records for attachment content review.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS conduit_attachment_approvals (
-    id TEXT PRIMARY KEY,
-    slug TEXT NOT NULL REFERENCES conduit_attachments(slug) ON DELETE CASCADE,
-    reviewer_agent_id TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    comment TEXT,
-    version_reviewed INTEGER NOT NULL,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL,
-    UNIQUE(slug, reviewer_agent_id)
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_conduit_attachment_approvals_slug ON conduit_attachment_approvals(slug);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Contributor statistics per attachment (who edited, how much).
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS conduit_attachment_contributors (
-    slug TEXT NOT NULL REFERENCES conduit_attachments(slug) ON DELETE CASCADE,
-    agent_id TEXT NOT NULL,
-    version_count INTEGER NOT NULL DEFAULT 0,
-    total_tokens_added INTEGER NOT NULL DEFAULT 0,
-    total_tokens_removed INTEGER NOT NULL DEFAULT 0,
-    first_contribution_at INTEGER NOT NULL,
-    last_contribution_at INTEGER NOT NULL,
-    PRIMARY KEY (slug, agent_id)
-);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- NEW: Per-project agent reference overrides (ADR-037 §3, Q6=A).
--- agent_id is a SOFT FK to global signaldock.db:agents.agent_id.
--- Cross-DB FK enforcement is not possible in SQLite; the accessor layer
--- (T355) validates on every cross-DB join.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS project_agent_refs (
-    agent_id TEXT PRIMARY KEY,
-    attached_at TEXT NOT NULL,
-    role TEXT,
-    capabilities_override TEXT,
-    last_used_at TEXT,
-    enabled INTEGER NOT NULL DEFAULT 1
-);
---> statement-breakpoint
--- Partial index: covers the dominant query path (list enabled agents).
-CREATE INDEX IF NOT EXISTS idx_project_agent_refs_enabled
-    ON project_agent_refs(enabled) WHERE enabled = 1;
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- A2A Topics (T1252 — Wave 9 Agent-to-Agent coordination pub-sub).
--- Topics are named channels that agents can publish to / subscribe from.
--- Topic names follow "<epicId>.<waveId>" or "<epicId>.coordination".
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topics (
-    id TEXT PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE,
-    epic_id TEXT NOT NULL,
-    wave_id INTEGER,
-    created_by TEXT NOT NULL,
-    created_at INTEGER NOT NULL
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_topics_epic ON topics(epic_id);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- A2A Topic subscriptions — links an agent_id to a topic_id.
--- Created by subscribeTopic(); removed by unsubscribeTopic().
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topic_subscriptions (
-    topic_id TEXT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
-    agent_id TEXT NOT NULL,
-    subscribed_at INTEGER NOT NULL,
-    PRIMARY KEY (topic_id, agent_id)
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_topic_subscriptions_agent ON topic_subscriptions(agent_id);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- A2A Topic messages — broadcast messages published to a topic.
--- payload is stored as JSON text.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topic_messages (
-    id TEXT PRIMARY KEY,
-    topic_id TEXT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
-    from_agent_id TEXT NOT NULL,
-    kind TEXT NOT NULL DEFAULT 'message',
-    content TEXT NOT NULL,
-    payload TEXT,
-    created_at INTEGER NOT NULL
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS idx_topic_messages_topic_created ON topic_messages(topic_id, created_at);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- A2A Topic message ACKs — per-subscriber delivery tracking.
--- -------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS topic_message_acks (
-    message_id TEXT NOT NULL REFERENCES topic_messages(id) ON DELETE CASCADE,
-    subscriber_agent_id TEXT NOT NULL,
-    delivered_at INTEGER,
-    read_at INTEGER,
-    PRIMARY KEY (message_id, subscriber_agent_id)
-);
---> statement-breakpoint
-
--- -------------------------------------------------------------------------
--- Schema tracking tables (mirrors _signaldock_meta / _signaldock_migrations).
+-- Legacy meta tracking tables — retained for backwards-compatible health
+-- probes (`checkConduitDbHealth` reads `_conduit_meta.schema_version`).
+-- `__drizzle_migrations` is the canonical migration journal; these are kept
+-- only for the pre-T1407 health-check consumers.
 -- -------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS _conduit_meta (
     key TEXT PRIMARY KEY,

--- a/packages/core/src/conduit/__tests__/a2a-topic.test.ts
+++ b/packages/core/src/conduit/__tests__/a2a-topic.test.ts
@@ -207,8 +207,11 @@ describe('LocalTransport — A2A Topic Operations (T1252)', () => {
       await transport.connect(testConfig('lead-1'));
       await transport.subscribeTopic('epic-T1149.wave-2');
 
-      // Record a point-in-time before any messages are published
-      const beforeAny = Math.floor(Date.now() / 1000) - 1;
+      // T11578 (AC4): `since` is now a TEXT ISO-8601 watermark (conduit_topic_
+      // messages.created_at is canonical ISO), not the prior epoch-seconds number.
+      // ISO-8601 is lexicographically sortable, so `created_at > since` compares
+      // string-wise. Record an ISO instant before any messages are published.
+      const beforeAny = new Date(Date.now() - 1000).toISOString();
 
       // Publish two messages
       await transport.publishToTopic('epic-T1149.wave-2', 'msg-1', { kind: 'notify' });
@@ -218,8 +221,8 @@ describe('LocalTransport — A2A Topic Operations (T1252)', () => {
       const all = await transport.pollTopic('epic-T1149.wave-2');
       expect(all.length).toBeGreaterThanOrEqual(2);
 
-      // With since = a future time: returns nothing
-      const afterAll = Math.floor(Date.now() / 1000) + 9999;
+      // With since = a future ISO time: returns nothing
+      const afterAll = new Date(Date.now() + 9_999_000).toISOString();
       const none = await transport.pollTopic('epic-T1149.wave-2', { since: afterAll });
       expect(none).toHaveLength(0);
 

--- a/packages/core/src/conduit/local-transport.ts
+++ b/packages/core/src/conduit/local-transport.ts
@@ -68,8 +68,13 @@ interface LocalTransportState {
   pollTimer: ReturnType<typeof setInterval> | null;
   /** Poll timer for cross-process topic message delivery. */
   topicPollTimer: ReturnType<typeof setInterval> | null;
-  /** Tracks the highest `created_at` unix timestamp seen per topic for incremental polling. */
-  topicLastSeen: Map<string, number>;
+  /**
+   * Tracks the highest `created_at` watermark seen per topic for incremental
+   * polling. T11578 (AC4): `conduit_topic_messages.created_at` is canonical TEXT
+   * ISO-8601, so the watermark is an ISO string (lexicographically comparable),
+   * not the prior unix-seconds number.
+   */
+  topicLastSeen: Map<string, string>;
 }
 
 /** In-process SQLite transport for fully offline agent messaging. */
@@ -102,15 +107,15 @@ export class LocalTransport implements Transport {
     // Open fresh (non-singleton) conduit connection with pragmas applied (T9189)
     const db = openFreshConduitDb(process.cwd()); // CWD-OK: LocalTransport pre-init contract
 
-    // Verify the messages table exists
+    // Verify the conduit_messages table exists (T11578 · AC4: prefixed table).
     const hasMessages = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'")
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='conduit_messages'")
       .get() as { name: string } | undefined;
 
     if (!hasMessages) {
       db.close();
       throw new Error(
-        'LocalTransport: conduit.db exists but messages table missing — run cleo init or allow auto-migration (T358)',
+        'LocalTransport: conduit.db exists but conduit_messages table missing — run cleo init or allow auto-migration (T358)',
       );
     }
 
@@ -158,20 +163,22 @@ export class LocalTransport implements Transport {
     this.ensureConnected();
     const { db, agentId } = this.state!;
     const messageId = randomUUID();
-    const nowUnix = Math.floor(Date.now() / 1000);
+    // T11578 (AC4): the consolidated `conduit_messages.created_at` is canonical
+    // TEXT ISO-8601 (CHECK enforces the ISO GLOB) — write ISO, not epoch.
+    const nowIso = new Date().toISOString();
 
     if (options?.conversationId) {
       db.prepare(
-        `INSERT INTO messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at)
+        `INSERT INTO conduit_messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at)
          VALUES (?, ?, ?, ?, ?, 'text', 'pending', ?)`,
-      ).run(messageId, options.conversationId, agentId, to, content, nowUnix);
+      ).run(messageId, options.conversationId, agentId, to, content, nowIso);
     } else {
       // Direct message — create or reuse a DM conversation
       const convId = this.ensureDmConversation(agentId, to);
       db.prepare(
-        `INSERT INTO messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at)
+        `INSERT INTO conduit_messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at)
          VALUES (?, ?, ?, ?, ?, 'text', 'pending', ?)`,
-      ).run(messageId, convId, agentId, to, content, nowUnix);
+      ).run(messageId, convId, agentId, to, content, nowIso);
     }
 
     // Notify local subscribers
@@ -180,7 +187,7 @@ export class LocalTransport implements Transport {
       from: agentId,
       content,
       threadId: options?.conversationId,
-      timestamp: new Date(nowUnix * 1000).toISOString(),
+      timestamp: nowIso,
     });
 
     return { messageId };
@@ -200,16 +207,20 @@ export class LocalTransport implements Transport {
     let query: string;
     let params: (string | number)[];
 
+    // T11578 (AC4): `created_at` is now canonical TEXT ISO-8601. ISO-8601 is
+    // lexicographically sortable, so `created_at > ?` and `ORDER BY created_at`
+    // remain correct against the prefixed `conduit_messages` table; `since` is an
+    // ISO string supplied by the caller (the prior epoch-number contract is gone).
     if (options?.since) {
       query = `SELECT id, from_agent_id, content, conversation_id, created_at
-               FROM messages
+               FROM conduit_messages
                WHERE to_agent_id = ? AND status = 'pending' AND created_at > ?
                ORDER BY created_at ASC
                LIMIT ?`;
       params = [agentId, options.since, limit];
     } else {
       query = `SELECT id, from_agent_id, content, conversation_id, created_at
-               FROM messages
+               FROM conduit_messages
                WHERE to_agent_id = ? AND status = 'pending'
                ORDER BY created_at ASC
                LIMIT ?`;
@@ -221,7 +232,7 @@ export class LocalTransport implements Transport {
       from_agent_id: string;
       content: string;
       conversation_id: string | null;
-      created_at: number;
+      created_at: string;
     }>;
 
     return rows.map((r) => ({
@@ -229,7 +240,7 @@ export class LocalTransport implements Transport {
       from: r.from_agent_id,
       content: r.content,
       threadId: r.conversation_id ?? undefined,
-      timestamp: new Date(r.created_at * 1000).toISOString(),
+      timestamp: r.created_at,
     }));
   }
 
@@ -243,12 +254,14 @@ export class LocalTransport implements Transport {
     if (messageIds.length === 0) return;
 
     const { db } = this.state!;
-    const nowUnix = Math.floor(Date.now() / 1000);
+    // T11578 (AC4): `conduit_messages.delivered_at` is canonical TEXT ISO-8601
+    // (CHECK enforces the ISO GLOB) — write ISO, not epoch.
+    const nowIso = new Date().toISOString();
 
     const placeholders = messageIds.map(() => '?').join(', ');
     db.prepare(
-      `UPDATE messages SET status = 'delivered', delivered_at = ? WHERE id IN (${placeholders})`,
-    ).run(nowUnix, ...messageIds);
+      `UPDATE conduit_messages SET status = 'delivered', delivered_at = ? WHERE id IN (${placeholders})`,
+    ).run(nowIso, ...messageIds);
   }
 
   /**
@@ -297,7 +310,9 @@ export class LocalTransport implements Transport {
   async subscribeTopic(topicName: string, _options?: ConduitTopicSubscribeOptions): Promise<void> {
     this.ensureConnected();
     const { db, agentId } = this.state!;
-    const nowUnix = Math.floor(Date.now() / 1000);
+    // T11578 (AC4): `conduit_topics.created_at` + `conduit_topic_subscriptions.
+    // subscribed_at` are canonical TEXT ISO-8601 (CHECK enforces the ISO GLOB).
+    const nowIso = new Date().toISOString();
 
     // Derive epic_id / wave_id from the topic name (e.g. "epic-T1149.wave-2" or "epic-T1149.coordination")
     const { epicId, waveId } = parseTopicName(topicName);
@@ -305,22 +320,22 @@ export class LocalTransport implements Transport {
 
     // Create topic if absent
     db.prepare(
-      `INSERT INTO topics (id, name, epic_id, wave_id, created_by, created_at)
+      `INSERT INTO conduit_topics (id, name, epic_id, wave_id, created_by, created_at)
        VALUES (?, ?, ?, ?, ?, ?)
        ON CONFLICT(name) DO NOTHING`,
-    ).run(topicId, topicName, epicId, waveId ?? null, agentId, nowUnix);
+    ).run(topicId, topicName, epicId, waveId ?? null, agentId, nowIso);
 
     // Resolve the actual topic id (might have been inserted above or pre-existing)
-    const topic = db.prepare('SELECT id FROM topics WHERE name = ?').get(topicName) as
+    const topic = db.prepare('SELECT id FROM conduit_topics WHERE name = ?').get(topicName) as
       | { id: string }
       | undefined;
     if (!topic) return; // Should not happen; inserted above
 
     db.prepare(
-      `INSERT INTO topic_subscriptions (topic_id, agent_id, subscribed_at)
+      `INSERT INTO conduit_topic_subscriptions (topic_id, agent_id, subscribed_at)
        VALUES (?, ?, ?)
        ON CONFLICT(topic_id, agent_id) DO NOTHING`,
-    ).run(topic.id, agentId, nowUnix);
+    ).run(topic.id, agentId, nowIso);
   }
 
   /**
@@ -346,7 +361,9 @@ export class LocalTransport implements Transport {
   ): Promise<{ messageId: string }> {
     this.ensureConnected();
     const { db, agentId } = this.state!;
-    const nowUnix = Math.floor(Date.now() / 1000);
+    // T11578 (AC4): `conduit_topics.created_at` + `conduit_topic_messages.
+    // created_at` are canonical TEXT ISO-8601 (CHECK enforces the ISO GLOB).
+    const nowIso = new Date().toISOString();
     const messageId = randomUUID();
     const kind = options?.kind ?? 'message';
 
@@ -354,12 +371,12 @@ export class LocalTransport implements Transport {
     const { epicId, waveId } = parseTopicName(topicName);
     const topicInsertId = randomUUID();
     db.prepare(
-      `INSERT INTO topics (id, name, epic_id, wave_id, created_by, created_at)
+      `INSERT INTO conduit_topics (id, name, epic_id, wave_id, created_by, created_at)
        VALUES (?, ?, ?, ?, ?, ?)
        ON CONFLICT(name) DO NOTHING`,
-    ).run(topicInsertId, topicName, epicId, waveId ?? null, agentId, nowUnix);
+    ).run(topicInsertId, topicName, epicId, waveId ?? null, agentId, nowIso);
 
-    const topic = db.prepare('SELECT id FROM topics WHERE name = ?').get(topicName) as
+    const topic = db.prepare('SELECT id FROM conduit_topics WHERE name = ?').get(topicName) as
       | { id: string }
       | undefined;
     if (!topic) {
@@ -367,7 +384,7 @@ export class LocalTransport implements Transport {
     }
 
     db.prepare(
-      `INSERT INTO topic_messages (id, topic_id, from_agent_id, kind, content, payload, created_at)
+      `INSERT INTO conduit_topic_messages (id, topic_id, from_agent_id, kind, content, payload, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       messageId,
@@ -376,7 +393,7 @@ export class LocalTransport implements Transport {
       kind,
       content,
       options?.payload != null ? JSON.stringify(options.payload) : null,
-      nowUnix,
+      nowIso,
     );
 
     // Notify in-process topic handlers immediately
@@ -389,7 +406,7 @@ export class LocalTransport implements Transport {
       kind,
       threadId: topicName,
       payload: options?.payload,
-      timestamp: new Date(nowUnix * 1000).toISOString(),
+      timestamp: nowIso,
     });
 
     return { messageId };
@@ -455,12 +472,12 @@ export class LocalTransport implements Transport {
     this.ensureConnected();
     const { db, agentId } = this.state!;
 
-    const topic = db.prepare('SELECT id FROM topics WHERE name = ?').get(topicName) as
+    const topic = db.prepare('SELECT id FROM conduit_topics WHERE name = ?').get(topicName) as
       | { id: string }
       | undefined;
     if (!topic) return; // Topic doesn't exist — nothing to do
 
-    db.prepare('DELETE FROM topic_subscriptions WHERE topic_id = ? AND agent_id = ?').run(
+    db.prepare('DELETE FROM conduit_topic_subscriptions WHERE topic_id = ? AND agent_id = ?').run(
       topic.id,
       agentId,
     );
@@ -477,14 +494,16 @@ export class LocalTransport implements Transport {
    */
   async pollTopic(
     topicName: string,
-    options?: { limit?: number; since?: number },
+    options?: { limit?: number; since?: string },
   ): Promise<ConduitMessage[]> {
     this.ensureConnected();
     const { db } = this.state!;
     const limit = options?.limit ?? 50;
-    const since = options?.since ?? 0;
+    // T11578 (AC4): `since` is now an ISO-8601 watermark. The empty-string floor
+    // sorts before any real ISO timestamp, so `created_at > ''` returns all rows.
+    const since = options?.since ?? '';
 
-    const topic = db.prepare('SELECT id FROM topics WHERE name = ?').get(topicName) as
+    const topic = db.prepare('SELECT id FROM conduit_topics WHERE name = ?').get(topicName) as
       | { id: string }
       | undefined;
     if (!topic) return [];
@@ -492,7 +511,7 @@ export class LocalTransport implements Transport {
     const rows = db
       .prepare(
         `SELECT id, from_agent_id, kind, content, payload, created_at
-         FROM topic_messages
+         FROM conduit_topic_messages
          WHERE topic_id = ? AND created_at > ?
          ORDER BY created_at ASC
          LIMIT ?`,
@@ -503,7 +522,7 @@ export class LocalTransport implements Transport {
       kind: string;
       content: string;
       payload: string | null;
-      created_at: number;
+      created_at: string;
     }>;
 
     return rows.map((r) => ({
@@ -515,7 +534,7 @@ export class LocalTransport implements Transport {
       kind: r.kind as ConduitMessage['kind'],
       threadId: topicName,
       payload: r.payload != null ? (JSON.parse(r.payload) as Record<string, unknown>) : undefined,
-      timestamp: new Date(r.created_at * 1000).toISOString(),
+      timestamp: r.created_at,
     }));
   }
 
@@ -561,16 +580,14 @@ export class LocalTransport implements Transport {
     if (!this.state || this.state.topicHandlers.size === 0) return;
 
     for (const [topicName] of this.state.topicHandlers) {
-      const since = this.state.topicLastSeen.get(topicName) ?? 0;
+      // T11578 (AC4): watermark is an ISO-8601 string ('' floor matches all rows).
+      const since = this.state.topicLastSeen.get(topicName) ?? '';
       const messages = await this.pollTopic(topicName, { limit: 50, since });
       if (messages.length > 0) {
-        // Advance the watermark
+        // Advance the watermark to the last message's ISO timestamp.
         const lastTs = messages[messages.length - 1];
-        if (lastTs) {
-          this.state.topicLastSeen.set(
-            topicName,
-            Math.floor(new Date(lastTs.timestamp).getTime() / 1000),
-          );
+        if (lastTs?.timestamp) {
+          this.state.topicLastSeen.set(topicName, lastTs.timestamp);
         }
         for (const msg of messages) {
           this.notifyTopicHandlers(topicName, msg);
@@ -622,7 +639,7 @@ export class LocalTransport implements Transport {
     // Check for existing DM conversation with these exact participants
     const existing = db
       .prepare(
-        `SELECT id FROM conversations
+        `SELECT id FROM conduit_conversations
          WHERE visibility = 'private' AND participants = ?
          LIMIT 1`,
       )
@@ -630,14 +647,15 @@ export class LocalTransport implements Transport {
 
     if (existing) return existing.id;
 
-    // Create new DM conversation
+    // Create new DM conversation. T11578 (AC4): `conduit_conversations.created_at`
+    // / `updated_at` are canonical TEXT ISO-8601 (CHECK enforces the ISO GLOB).
     const convId = randomUUID();
-    const nowUnix = Math.floor(Date.now() / 1000);
+    const nowIso = new Date().toISOString();
 
     db.prepare(
-      `INSERT INTO conversations (id, participants, visibility, message_count, created_at, updated_at)
+      `INSERT INTO conduit_conversations (id, participants, visibility, message_count, created_at, updated_at)
        VALUES (?, ?, 'private', 0, ?, ?)`,
-    ).run(convId, sortedParticipants, nowUnix, nowUnix);
+    ).run(convId, sortedParticipants, nowIso, nowIso);
 
     return convId;
   }

--- a/packages/core/src/doctor/db-substrate.ts
+++ b/packages/core/src/doctor/db-substrate.ts
@@ -1225,13 +1225,18 @@ export function checkInvariantI5(
   conduitSnap: ReturnType<typeof openCleoDbSnapshot> | null,
 ): DbCrossDbOrphanReport {
   const description =
-    'conduit.db dead_letters.job_id must reference an existing tasks.id row OR a brain anchor (brain_page_nodes.id / brain_observations.id)';
+    'conduit.db conduit_dead_letters.job_id must reference an existing tasks.id row OR a brain anchor (brain_page_nodes.id / brain_observations.id)';
 
   if (conduitSnap === null) {
     return buildSkippedReport('I5', description, I5_FIX, 'conduit.db missing or unreadable');
   }
-  if (!snapshotHasTable(conduitSnap, 'dead_letters')) {
-    return buildSkippedReport('I5', description, I5_FIX, 'conduit.db has no dead_letters table');
+  if (!snapshotHasTable(conduitSnap, 'conduit_dead_letters')) {
+    return buildSkippedReport(
+      'I5',
+      description,
+      I5_FIX,
+      'conduit.db has no conduit_dead_letters table',
+    );
   }
   // Both targets missing → cannot resolve; skip.
   if (tasksSnap === null && brainSnap === null) {
@@ -1248,7 +1253,7 @@ export function checkInvariantI5(
   try {
     const rows = conduitSnap.db
       .prepare(
-        `SELECT DISTINCT job_id FROM dead_letters WHERE job_id IS NOT NULL LIMIT ${CROSS_DB_QUERY_LIMIT}`,
+        `SELECT DISTINCT job_id FROM conduit_dead_letters WHERE job_id IS NOT NULL LIMIT ${CROSS_DB_QUERY_LIMIT}`,
       )
       .all() as JobRow[];
     candidates = rows.map((r) => r.job_id);

--- a/packages/core/src/events/__tests__/event-bus.test.ts
+++ b/packages/core/src/events/__tests__/event-bus.test.ts
@@ -29,7 +29,18 @@ function mockConduitAvailable(value: boolean) {
   _mockConduitAvailable = value;
 }
 
-vi.mock('../conduit/local-transport.js', () => ({
+// NOTE: the mock specifier MUST match the module id that `event-bus.ts` imports.
+// `event-bus.ts` lives in `src/events/` and dynamically imports
+// `'../conduit/local-transport.js'` → resolves to `src/conduit/local-transport.js`.
+// This test file lives in `src/events/__tests__/`, so the vitest mock path
+// (resolved relative to the test file) must be `'../../conduit/local-transport.js'`
+// to target the SAME module. The previous `'../conduit/…'` pointed at the
+// nonexistent `src/events/conduit/…`, so the mock never intercepted and the test
+// silently exercised the REAL LocalTransport — passing only when no conduit DB was
+// resolvable from cwd (T11578: after the conduit namespace cutover the real
+// publish path succeeds against the prefixed `conduit_*` tables, so the accidental
+// fallback no longer fired and the test flaked by shard cwd).
+vi.mock('../../conduit/local-transport.js', () => ({
   LocalTransport: {
     isAvailable: () => _mockConduitAvailable,
   },

--- a/packages/core/src/memory/__tests__/graph-memory-bridge-integration.test.ts
+++ b/packages/core/src/memory/__tests__/graph-memory-bridge-integration.test.ts
@@ -422,18 +422,20 @@ describe('graph-memory-bridge', () => {
       await ensureConduitDb(tempDir);
       const conduitDb = getConduitNativeDb();
 
+      // T11578 (AC4): prefixed conduit_* tables + TEXT ISO-8601 timestamps.
+      const nowIso = new Date().toISOString();
       const convId = 'conv-001';
       conduitDb
         ?.prepare(
-          `INSERT INTO conversations (id, participants, visibility, message_count, created_at, updated_at)
+          `INSERT INTO conduit_conversations (id, participants, visibility, message_count, created_at, updated_at)
            VALUES (?, ?, 'private', 0, ?, ?)`,
         )
-        .run(convId, JSON.stringify(['agent-a', 'agent-b']), Date.now(), Date.now());
+        .run(convId, JSON.stringify(['agent-a', 'agent-b']), nowIso, nowIso);
 
       const msgId = 'msg-001';
       conduitDb
         ?.prepare(
-          `INSERT INTO messages (id, conversation_id, from_agent_id, to_agent_id, content, attachments, created_at)
+          `INSERT INTO conduit_messages (id, conversation_id, from_agent_id, to_agent_id, content, attachments, created_at)
            VALUES (?, ?, ?, ?, ?, '[]', ?)`,
         )
         .run(
@@ -442,7 +444,7 @@ describe('graph-memory-bridge', () => {
           'agent-a',
           'agent-b',
           'We should refactor the initApp function to improve startup performance',
-          Date.now(),
+          nowIso,
         );
 
       // Seed a nexus symbol with the same name
@@ -481,18 +483,20 @@ describe('graph-memory-bridge', () => {
       await ensureConduitDb(tempDir);
       const conduitDb = getConduitNativeDb();
 
+      // T11578 (AC4): prefixed conduit_* tables + TEXT ISO-8601 timestamps.
+      const nowIso = new Date().toISOString();
       const convId = 'conv-002';
       conduitDb
         ?.prepare(
-          `INSERT INTO conversations (id, participants, visibility, message_count, created_at, updated_at)
+          `INSERT INTO conduit_conversations (id, participants, visibility, message_count, created_at, updated_at)
            VALUES (?, ?, 'private', 0, ?, ?)`,
         )
-        .run(convId, JSON.stringify(['agent-c', 'agent-d']), Date.now(), Date.now());
+        .run(convId, JSON.stringify(['agent-c', 'agent-d']), nowIso, nowIso);
 
       const msgId = 'msg-002';
       conduitDb
         ?.prepare(
-          `INSERT INTO messages (id, conversation_id, from_agent_id, to_agent_id, content, attachments, created_at)
+          `INSERT INTO conduit_messages (id, conversation_id, from_agent_id, to_agent_id, content, attachments, created_at)
            VALUES (?, ?, ?, ?, ?, '[]', ?)`,
         )
         .run(
@@ -501,7 +505,7 @@ describe('graph-memory-bridge', () => {
           'agent-c',
           'agent-d',
           'The validateConfig function needs to handle edge cases',
-          Date.now(),
+          nowIso,
         );
 
       await seedNexusNode(

--- a/packages/core/src/memory/graph-memory-bridge.ts
+++ b/packages/core/src/memory/graph-memory-bridge.ts
@@ -1385,12 +1385,15 @@ export async function linkConduitMessagesToSymbols(
         attachments: string;
       }
 
+      // T11578 (AC4): conduit runtime read path repointed to the prefixed
+      // consolidated tables — `conduit_messages` + the `conduit_messages_fts`
+      // FTS5 index over it.
       const messages = typedAll<RawConduitMessage>(
         conduitDb.prepare(`
           SELECT id, content, attachments
-          FROM messages
+          FROM conduit_messages
           WHERE attachments != '[]'
-             OR rowid IN (SELECT rowid FROM messages_fts WHERE content MATCH ?)
+             OR rowid IN (SELECT rowid FROM conduit_messages_fts WHERE content MATCH ?)
           LIMIT 10000
         `),
         ftsQuery,

--- a/packages/core/src/store/__tests__/__snapshots__/conduit-ddl-snapshot.test.ts.snap
+++ b/packages/core/src/store/__tests__/__snapshots__/conduit-ddl-snapshot.test.ts.snap
@@ -1,0 +1,116 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`T11578 AC4 — conduit DDL snapshot (post-cutover prefixed shape + FTS5) > conduit_* + *_fts* sqlite_master shape matches the committed baseline 1`] = `
+[
+  {
+    "name": "conduit_attachment_approvals",
+    "sql": "CREATE TABLE \`conduit_attachment_approvals\` ( \`id\` text PRIMARY KEY, \`slug\` text NOT NULL, \`reviewer_agent_id\` text NOT NULL, \`status\` text DEFAULT 'pending' NOT NULL, \`comment\` text, \`version_reviewed\` integer NOT NULL, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, \`updated_at\` text DEFAULT (datetime('now')) NOT NULL, CONSTRAINT \`fk_conduit_attachment_approvals_slug_conduit_attachments_slug_fk\` FOREIGN KEY (\`slug\`) REFERENCES \`conduit_attachments\`(\`slug\`) ON DELETE CASCADE, CONSTRAINT \`uq_conduit_attachment_approvals_slug_reviewer\` UNIQUE(\`slug\`,\`reviewer_agent_id\`), -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_attachment_contributors",
+    "sql": "CREATE TABLE \`conduit_attachment_contributors\` ( \`slug\` text NOT NULL, \`agent_id\` text NOT NULL, \`version_count\` integer DEFAULT 0 NOT NULL, \`total_tokens_added\` integer DEFAULT 0 NOT NULL, \`total_tokens_removed\` integer DEFAULT 0 NOT NULL, \`first_contribution_at\` text NOT NULL, \`last_contribution_at\` text NOT NULL, CONSTRAINT \`conduit_attachment_contributors_pk\` PRIMARY KEY(\`slug\`, \`agent_id\`), CONSTRAINT \`fk_conduit_attachment_contributors_slug_conduit_attachments_slug_fk\` FOREIGN KEY (\`slug\`) REFERENCES \`conduit_attachments\`(\`slug\`) ON DELETE CASCADE, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("first_contribution_at" IS NULL OR "first_contribution_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("last_contribution_at" IS NULL OR "last_contribution_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_attachment_versions",
+    "sql": "CREATE TABLE \`conduit_attachment_versions\` ( \`id\` text PRIMARY KEY, \`slug\` text NOT NULL, \`version_number\` integer NOT NULL, \`author_agent_id\` text NOT NULL, \`change_type\` text DEFAULT 'patch' NOT NULL, \`patch_text\` text, \`storage_key\` text NOT NULL, \`content_hash\` text NOT NULL, \`original_size\` integer NOT NULL, \`compressed_size\` integer NOT NULL, \`tokens\` integer NOT NULL, \`change_summary\` text, \`sections_modified\` text DEFAULT '[]' NOT NULL, \`tokens_added\` integer DEFAULT 0 NOT NULL, \`tokens_removed\` integer DEFAULT 0 NOT NULL, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, CONSTRAINT \`fk_conduit_attachment_versions_slug_conduit_attachments_slug_fk\` FOREIGN KEY (\`slug\`) REFERENCES \`conduit_attachments\`(\`slug\`) ON DELETE CASCADE, CONSTRAINT \`uq_conduit_attachment_versions_slug_version\` UNIQUE(\`slug\`,\`version_number\`), -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_attachments",
+    "sql": "CREATE TABLE \`conduit_attachments\` ( \`slug\` text PRIMARY KEY, \`conversation_id\` text NOT NULL, \`from_agent_id\` text NOT NULL, \`content\` blob NOT NULL, \`original_size\` integer NOT NULL, \`compressed_size\` integer NOT NULL, \`content_hash\` text NOT NULL, \`format\` text DEFAULT 'text' NOT NULL, \`title\` text, \`tokens\` integer DEFAULT 0 NOT NULL, \`expires_at\` text, \`storage_key\` text, \`mode\` text DEFAULT 'draft' NOT NULL, \`version_count\` integer DEFAULT 1 NOT NULL, \`current_version\` integer DEFAULT 1 NOT NULL, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("expires_at" IS NULL OR "expires_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_conversations",
+    "sql": "CREATE TABLE \`conduit_conversations\` ( \`id\` text PRIMARY KEY, \`participants\` text NOT NULL, \`visibility\` text DEFAULT 'private' NOT NULL, \`message_count\` integer DEFAULT 0 NOT NULL, \`last_message_at\` text, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, \`updated_at\` text DEFAULT (datetime('now')) NOT NULL, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("last_message_at" IS NULL OR "last_message_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_dead_letters",
+    "sql": "CREATE TABLE \`conduit_dead_letters\` ( \`id\` text PRIMARY KEY, \`message_id\` text NOT NULL, \`job_id\` text NOT NULL, \`reason\` text NOT NULL, \`attempts\` integer NOT NULL, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_delivery_jobs",
+    "sql": "CREATE TABLE \`conduit_delivery_jobs\` ( \`id\` text PRIMARY KEY, \`message_id\` text NOT NULL, \`payload\` text NOT NULL, \`status\` text DEFAULT 'pending' NOT NULL, \`attempts\` integer DEFAULT 0 NOT NULL, \`max_attempts\` integer DEFAULT 6 NOT NULL, \`next_attempt_at\` text NOT NULL, \`last_error\` text, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, \`updated_at\` text DEFAULT (datetime('now')) NOT NULL, \`idempotency_key\` text CONSTRAINT \`uq_conduit_delivery_jobs_idempotency_key\` UNIQUE, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("next_attempt_at" IS NULL OR "next_attempt_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_message_pins",
+    "sql": "CREATE TABLE \`conduit_message_pins\` ( \`id\` text PRIMARY KEY, \`message_id\` text NOT NULL, \`conversation_id\` text NOT NULL, \`pinned_by\` text NOT NULL, \`note\` text, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, CONSTRAINT \`uq_conduit_message_pins_message_pinned_by\` UNIQUE(\`message_id\`,\`pinned_by\`), -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages",
+    "sql": "CREATE TABLE \`conduit_messages\` ( \`id\` text PRIMARY KEY, \`conversation_id\` text NOT NULL, \`from_agent_id\` text NOT NULL, \`to_agent_id\` text NOT NULL, \`content\` text NOT NULL, \`content_type\` text DEFAULT 'text' NOT NULL, \`status\` text DEFAULT 'pending' NOT NULL, \`attachments\` text DEFAULT '[]' NOT NULL, \`group_id\` text, \`metadata\` text DEFAULT '{}', \`reply_to\` text, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, \`delivered_at\` text, \`read_at\` text, \`idempotency_key\` text CONSTRAINT \`uq_conduit_messages_idempotency_key\` UNIQUE, CONSTRAINT \`fk_conduit_messages_conversation_id_conduit_conversations_id_fk\` FOREIGN KEY (\`conversation_id\`) REFERENCES \`conduit_conversations\`(\`id\`), -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("delivered_at" IS NULL OR "delivered_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("read_at" IS NULL OR "read_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages_fts",
+    "sql": "CREATE VIRTUAL TABLE conduit_messages_fts USING fts5(content, from_agent_id, content='conduit_messages', content_rowid='rowid')",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages_fts_config",
+    "sql": "CREATE TABLE 'conduit_messages_fts_config'(k PRIMARY KEY, v) WITHOUT ROWID",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages_fts_data",
+    "sql": "CREATE TABLE 'conduit_messages_fts_data'(id INTEGER PRIMARY KEY, block BLOB)",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages_fts_docsize",
+    "sql": "CREATE TABLE 'conduit_messages_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB)",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages_fts_idx",
+    "sql": "CREATE TABLE 'conduit_messages_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID",
+    "type": "table",
+  },
+  {
+    "name": "conduit_project_agent_refs",
+    "sql": "CREATE TABLE \`conduit_project_agent_refs\` ( \`agent_id\` text PRIMARY KEY, \`attached_at\` text NOT NULL, \`role\` text, \`capabilities_override\` text, \`last_used_at\` text, \`enabled\` integer DEFAULT true NOT NULL, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("attached_at" IS NULL OR "attached_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("last_used_at" IS NULL OR "last_used_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("enabled" IN (0, 1)) )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_topic_message_acks",
+    "sql": "CREATE TABLE \`conduit_topic_message_acks\` ( \`message_id\` text NOT NULL, \`subscriber_agent_id\` text NOT NULL, \`delivered_at\` text, \`read_at\` text, CONSTRAINT \`conduit_topic_message_acks_pk\` PRIMARY KEY(\`message_id\`, \`subscriber_agent_id\`), CONSTRAINT \`fk_conduit_topic_message_acks_message_id_conduit_topic_messages_id_fk\` FOREIGN KEY (\`message_id\`) REFERENCES \`conduit_topic_messages\`(\`id\`) ON DELETE CASCADE, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("delivered_at" IS NULL OR "delivered_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'), CHECK ("read_at" IS NULL OR "read_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_topic_messages",
+    "sql": "CREATE TABLE \`conduit_topic_messages\` ( \`id\` text PRIMARY KEY, \`topic_id\` text NOT NULL, \`from_agent_id\` text NOT NULL, \`kind\` text DEFAULT 'message' NOT NULL, \`content\` text NOT NULL, \`payload\` text, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, \`idempotency_key\` text CONSTRAINT \`uq_conduit_topic_messages_idempotency_key\` UNIQUE, CONSTRAINT \`fk_conduit_topic_messages_topic_id_conduit_topics_id_fk\` FOREIGN KEY (\`topic_id\`) REFERENCES \`conduit_topics\`(\`id\`) ON DELETE CASCADE, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_topic_subscriptions",
+    "sql": "CREATE TABLE \`conduit_topic_subscriptions\` ( \`topic_id\` text NOT NULL, \`agent_id\` text NOT NULL, \`subscribed_at\` text NOT NULL, CONSTRAINT \`conduit_topic_subscriptions_pk\` PRIMARY KEY(\`topic_id\`, \`agent_id\`), CONSTRAINT \`fk_conduit_topic_subscriptions_topic_id_conduit_topics_id_fk\` FOREIGN KEY (\`topic_id\`) REFERENCES \`conduit_topics\`(\`id\`) ON DELETE CASCADE, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("subscribed_at" IS NULL OR "subscribed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_topics",
+    "sql": "CREATE TABLE \`conduit_topics\` ( \`id\` text PRIMARY KEY, \`name\` text NOT NULL UNIQUE, \`epic_id\` text NOT NULL, \`wave_id\` integer, \`created_by\` text NOT NULL, \`created_at\` text DEFAULT (datetime('now')) NOT NULL, -- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*') )",
+    "type": "table",
+  },
+  {
+    "name": "conduit_messages_ad",
+    "sql": "CREATE TRIGGER conduit_messages_ad AFTER DELETE ON conduit_messages BEGIN INSERT INTO conduit_messages_fts(conduit_messages_fts, rowid, content, from_agent_id) VALUES('delete', old.rowid, old.content, old.from_agent_id); END",
+    "type": "trigger",
+  },
+  {
+    "name": "conduit_messages_ai",
+    "sql": "CREATE TRIGGER conduit_messages_ai AFTER INSERT ON conduit_messages BEGIN INSERT INTO conduit_messages_fts(rowid, content, from_agent_id) VALUES (new.rowid, new.content, new.from_agent_id); END",
+    "type": "trigger",
+  },
+  {
+    "name": "conduit_messages_au",
+    "sql": "CREATE TRIGGER conduit_messages_au AFTER UPDATE ON conduit_messages BEGIN INSERT INTO conduit_messages_fts(conduit_messages_fts, rowid, content, from_agent_id) VALUES('delete', old.rowid, old.content, old.from_agent_id); INSERT INTO conduit_messages_fts(rowid, content, from_agent_id) VALUES (new.rowid, new.content, new.from_agent_id); END",
+    "type": "trigger",
+  },
+]
+`;

--- a/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
+++ b/packages/core/src/store/__tests__/agent-registry-accessor.test.ts
@@ -243,7 +243,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // Manually set enabled=0 in conduit.db
     const conduitDb = env.openConduit();
     conduitDb
-      .prepare('UPDATE project_agent_refs SET enabled = 0 WHERE agent_id = ?')
+      .prepare('UPDATE conduit_project_agent_refs SET enabled = 0 WHERE agent_id = ?')
       .run(BASE_SPEC.agentId);
     conduitDb.close();
 
@@ -448,7 +448,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // Verify conduit.db project_agent_refs was written
     const conduitDb = env.openConduit();
     const refRow = conduitDb
-      .prepare('SELECT agent_id, enabled FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id, enabled FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(BASE_SPEC.agentId) as { agent_id: string; enabled: number } | undefined;
     conduitDb.close();
     expect(refRow).toBeDefined();
@@ -487,7 +487,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // project_agent_refs row should be disabled (enabled=0), not deleted
     const conduitDb = env.openConduit();
     const refRow = conduitDb
-      .prepare('SELECT agent_id, enabled FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id, enabled FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(BASE_SPEC.agentId) as { agent_id: string; enabled: number } | undefined;
     conduitDb.close();
     expect(refRow).toBeDefined();
@@ -590,7 +590,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // Check conduit.db project_agent_refs last_used_at was updated (stored as ISO string)
     const conduitDb = env.openConduit();
     const refRow = conduitDb
-      .prepare('SELECT last_used_at FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT last_used_at FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(BASE_SPEC.agentId) as { last_used_at: string | null } | undefined;
     conduitDb.close();
     expect(refRow?.last_used_at).toBeTruthy();
@@ -626,7 +626,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     const conduitDb = env.openConduit();
     conduitDb
       .prepare(
-        `INSERT INTO project_agent_refs (agent_id, attached_at, enabled)
+        `INSERT INTO conduit_project_agent_refs (agent_id, attached_at, enabled)
          VALUES (?, ?, 1)`,
       )
       .run('dangling-agent', new Date().toISOString());
@@ -684,7 +684,7 @@ describe('agent-registry-accessor (cross-DB T355)', () => {
     // Verify no duplicate rows in conduit.db
     const conduitDb = env.openConduit();
     const rows = conduitDb
-      .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id FROM conduit_project_agent_refs WHERE agent_id = ?')
       .all(BASE_SPEC.agentId) as Array<{ agent_id: string }>;
     conduitDb.close();
     expect(rows).toHaveLength(1);

--- a/packages/core/src/store/__tests__/conduit-ddl-snapshot.test.ts
+++ b/packages/core/src/store/__tests__/conduit-ddl-snapshot.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Conduit DDL snapshot + functional FTS5 gate — the AC4 deliverable for the
+ * COMPLETE-CUTOVER of the conduit runtime onto the prefixed `conduit_*` tables.
+ *
+ * SG-DB-SUBSTRATE-V2 · saga T11242 · task T11578 (AC4).
+ *
+ * ## What this suite proves
+ *
+ * After the AC4 cutover, the conduit domain's physical shape inside the
+ * consolidated project `cleo.db` is the union of:
+ *
+ *   1. the 14 PREFIXED `conduit_*` tables created by the consolidated cleo-project
+ *      migration (`drizzle-cleo-project/…t11363-consolidation-cleo-project`), and
+ *   2. the `conduit_messages_fts` FTS5 virtual table + its three sync triggers
+ *      (`conduit_messages_ai/ad/au`) created by the `drizzle-conduit` forward
+ *      migration — the FTS5 quartet the consolidated migration cannot model.
+ *
+ * The suite applies BOTH migration layers (in the same order `ensureConduitDb`
+ * does — consolidated first, conduit FTS second) to a fresh in-memory
+ * `DatabaseSync` via the canonical `migrateSanitized` statement-splitting
+ * pipeline, then:
+ *
+ *   - **DDL snapshot.** Captures `type,name,sql` for every `conduit_*` / `*_fts*`
+ *     object from `sqlite_master`, normalizes whitespace, and `toMatchSnapshot()`.
+ *     The committed `.snap` baseline locks the post-cutover shape so a future
+ *     drift (a bare table sneaking back, a trigger pointed at `messages`, a lost
+ *     `content=` option) fails loudly.
+ *   - **Functional FTS5 round-trip.** Inserts a row into `conduit_messages`,
+ *     asserts the AFTER-INSERT trigger populated `conduit_messages_fts`, then runs
+ *     `MATCH 'hello'` and asserts the row is returned — proving the renamed FTS
+ *     index's `content='conduit_messages'` option + triggers point at the right
+ *     content table.
+ *
+ * Test isolation: every DB is `:memory:`. FK enforcement is ON so the
+ * conduit_messages → conduit_conversations FK is honoured (a parent conversation
+ * is seeded first). The real user's project root is never touched.
+ *
+ * @task T11578
+ * @epic T11245
+ * @saga T11242
+ * @see ./consolidated-schema-parity-fk.test.ts (migration-apply pattern this mirrors)
+ * @see ../conduit-sqlite.ts (runtime — sentinel = `conduit_messages`)
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getDbSyncConstructor } from '../sqlite-native.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Resolve a `drizzle-<name>` migrations dir relative to this test file. */
+function migrationsDir(name: string): string {
+  // Test:       packages/core/src/store/__tests__/
+  // Migrations: packages/core/migrations/<name>/
+  return join(__dirname, '..', '..', '..', 'migrations', name);
+}
+
+/**
+ * Read every `<dir>/<timestamp_name>/migration.sql` body in ascending
+ * folder-name (timestamp) order — the same chronological order the runtime
+ * applies them.
+ *
+ * @param dir - A `drizzle-<name>` migrations directory.
+ * @returns Migration SQL bodies in ascending folder order.
+ */
+function readMigrationBodies(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+    .map((folder) => readFileSync(join(dir, folder, 'migration.sql'), 'utf8'));
+}
+
+/**
+ * Apply a drizzle-kit migration body to an open handle: split on the canonical
+ * `--> statement-breakpoint` delimiter, drop comment-only / whitespace-only
+ * chunks (the `migrateSanitized` contract), and execute each remaining statement.
+ *
+ * @param db - The open `node:sqlite` handle.
+ * @param body - The full `migration.sql` body.
+ */
+function applyMigrationBody(db: DatabaseSync, body: string): void {
+  const statements = body
+    .split('--> statement-breakpoint')
+    .map((s) => s.trim())
+    .filter((s) => {
+      if (s === '') return false;
+      // Drop comment-only statements (baseline markers) — mirrors
+      // migration-manager.sanitizeMigrationStatements.isExecutableStatement.
+      const stripped = s
+        .replace(/--[^\n]*/g, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .trim();
+      return stripped !== '';
+    });
+  for (const statement of statements) db.exec(statement);
+}
+
+/**
+ * Build a fresh in-memory `cleo.db` with the post-cutover conduit shape: the
+ * consolidated cleo-project migration (creates the 14 prefixed `conduit_*`
+ * tables) followed by the conduit FTS migration (adds `conduit_messages_fts` +
+ * triggers) — the exact two-layer order `ensureConduitDb` applies.
+ *
+ * @returns An open FK-enforcing in-memory handle.
+ */
+function buildPostCutoverConduitDb(): DatabaseSync {
+  const Ctor = getDbSyncConstructor();
+  const db = new Ctor(':memory:', { enableForeignKeyConstraints: true });
+  db.exec('PRAGMA foreign_keys = ON;');
+  for (const body of readMigrationBodies(migrationsDir('drizzle-cleo-project'))) {
+    applyMigrationBody(db, body);
+  }
+  for (const body of readMigrationBodies(migrationsDir('drizzle-conduit'))) {
+    applyMigrationBody(db, body);
+  }
+  return db;
+}
+
+/** Collapse runs of whitespace so the snapshot is robust to formatting drift. */
+function normalizeSql(sql: string | null): string | null {
+  if (sql === null) return null;
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+describe('T11578 AC4 — conduit DDL snapshot (post-cutover prefixed shape + FTS5)', () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = buildPostCutoverConduitDb();
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  it('conduit_* + *_fts* sqlite_master shape matches the committed baseline', () => {
+    const rows = db
+      .prepare(
+        `SELECT type, name, sql FROM sqlite_master
+         WHERE (name LIKE 'conduit_%' OR name LIKE '%_fts%')
+           AND name NOT LIKE 'sqlite_%'
+         ORDER BY type, name`,
+      )
+      .all() as Array<{ type: string; name: string; sql: string | null }>;
+
+    const normalized = rows.map((r) => ({
+      type: r.type,
+      name: r.name,
+      sql: normalizeSql(r.sql),
+    }));
+
+    expect(normalized).toMatchSnapshot();
+  });
+
+  it('the FTS5 index is renamed conduit_messages_fts and its content table is conduit_messages', () => {
+    const fts = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='conduit_messages_fts'")
+      .get() as { sql: string } | undefined;
+    expect(fts).toBeDefined();
+    expect(fts?.sql).toContain("content='conduit_messages'");
+    expect(fts?.sql).toContain("content_rowid='rowid'");
+
+    // No legacy bare FTS index / triggers should survive the cutover.
+    const bare = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE name IN ('messages_fts','messages_ai','messages_ad','messages_au')",
+      )
+      .all() as Array<{ name: string }>;
+    expect(bare).toHaveLength(0);
+  });
+
+  it('AFTER-INSERT trigger populates conduit_messages_fts and MATCH returns the row', () => {
+    // Seed a parent conversation first (FK conduit_messages → conduit_conversations).
+    // Timestamps are canonical TEXT ISO-8601 (the CHECK enforces the ISO GLOB).
+    db.exec(`INSERT INTO conduit_conversations (id, participants, created_at, updated_at)
+             VALUES ('conv-fts', '["a","b"]', '2026-06-02T00:00:00.000Z', '2026-06-02T00:00:00.000Z')`);
+    db.exec(`INSERT INTO conduit_messages
+             (id, conversation_id, from_agent_id, to_agent_id, content, created_at)
+             VALUES ('msg-fts', 'conv-fts', 'agent-a', 'agent-b', 'hello world', '2026-06-02T00:00:00.000Z')`);
+
+    // The conduit_messages_ai trigger should have indexed the row into the FTS table.
+    const ftsCount = db.prepare('SELECT COUNT(*) AS n FROM conduit_messages_fts').get() as {
+      n: number;
+    };
+    expect(ftsCount.n).toBeGreaterThan(0);
+
+    // MATCH against the FTS index returns the seeded message.
+    const hit = db
+      .prepare(
+        `SELECT m.id AS id FROM conduit_messages m
+         WHERE m.rowid IN (SELECT rowid FROM conduit_messages_fts WHERE conduit_messages_fts MATCH 'hello')`,
+      )
+      .get() as { id: string } | undefined;
+    expect(hit?.id).toBe('msg-fts');
+  });
+});

--- a/packages/core/src/store/__tests__/conduit-idempotency.test.ts
+++ b/packages/core/src/store/__tests__/conduit-idempotency.test.ts
@@ -82,16 +82,16 @@ describe('conduit.db idempotency contract (T10314)', () => {
 
     const attachedAt = '2026-05-23T00:00:00.000Z';
     const insertSql = `
-      INSERT INTO project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
+      INSERT INTO conduit_project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
       VALUES ('idem-agent', '${attachedAt}', NULL, NULL, NULL, 1)
       ON CONFLICT(agent_id) DO UPDATE SET
         enabled = 1,
-        attached_at = project_agent_refs.attached_at
+        attached_at = conduit_project_agent_refs.attached_at
     `;
     dbFirst!.exec(insertSql);
 
     const countFirst = dbFirst!
-      .prepare('SELECT count(*) AS n FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT count(*) AS n FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get('idem-agent') as { n: number };
     expect(countFirst.n).toBe(1);
 
@@ -107,14 +107,14 @@ describe('conduit.db idempotency contract (T10314)', () => {
     dbSecond!.exec(insertSql);
 
     const countSecond = dbSecond!
-      .prepare('SELECT count(*) AS n FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT count(*) AS n FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get('idem-agent') as { n: number };
     expect(countSecond.n).toBe(1);
 
     // Original attached_at must be preserved by the ON CONFLICT clause —
     // the second open's upsert intentionally keeps the historical value.
     const row = dbSecond!
-      .prepare('SELECT attached_at, enabled FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT attached_at, enabled FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get('idem-agent') as { attached_at: string; enabled: number };
     expect(row.attached_at).toBe(attachedAt);
     expect(row.enabled).toBe(1);

--- a/packages/core/src/store/__tests__/conduit-sqlite.test.ts
+++ b/packages/core/src/store/__tests__/conduit-sqlite.test.ts
@@ -1,21 +1,23 @@
 /**
  * Tests for conduit-sqlite.ts — project-tier CONDUIT domain module.
  *
- * ## E6-L3 (T11523)
+ * ## E6-L3 (T11523) → AC4 cutover (T11578)
  *
- * `ensureConduitDb()` now routes through `openDualScopeDb('project')` — the
- * conduit domain lives inside the consolidated project `cleo.db`, not a standalone
- * `conduit.db`. The 16-table inline DDL blob was converted to the forward Drizzle
- * migration `drizzle-conduit/20260601000003_t11523-conduit-inline-schema`. The
- * BARE legacy tables (`conversations`, `messages`, …) co-exist with the
- * consolidated `conduit_*` tables (disjoint names — no drop/rebuild).
+ * `ensureConduitDb()` routes through `openDualScopeDb('project')` — the conduit
+ * domain lives inside the consolidated project `cleo.db`, not a standalone
+ * `conduit.db`. After the AC4 cutover (T11578) the conduit runtime READ + WRITE
+ * path targets the PREFIXED consolidated tables (`conduit_conversations`,
+ * `conduit_messages`, `conduit_topics`, …) created by the consolidated
+ * cleo-project migration; the `drizzle-conduit` forward migration carries ONLY
+ * the `conduit_messages_fts` FTS5 quartet (the consolidated migration cannot model
+ * FTS5) + the two legacy `_conduit_*` health-probe tables.
  *
  * These tests therefore:
  * - await the now-async `ensureConduitDb`,
  * - assert the consolidated `cleo.db` path,
- * - assert the legacy BARE tables are PRESENT (via arrayContaining) rather than
- *   the only tables (the shared cleo.db also holds `tasks_*` / `brain_*` /
- *   `conduit_*` / etc.),
+ * - assert the PREFIXED conduit tables are PRESENT (via arrayContaining) rather
+ *   than the only tables (the shared cleo.db also holds `tasks_*` / `brain_*` /
+ *   etc.),
  * - reset the shared dual-scope cache between cases for deterministic
  *   created/exists semantics.
  *
@@ -25,6 +27,7 @@
  *
  * @task T344
  * @task T11523
+ * @task T11578
  * @epic T310
  * @epic T11249
  */
@@ -32,7 +35,6 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   applyConduitSchema,
@@ -55,36 +57,31 @@ import { _resetDualScopeDbCache, resolveDualScopeDbPath } from '../dual-scope-db
 // ---------------------------------------------------------------------------
 
 /**
- * The legacy conduit tables the forward migration creates. These now live INSIDE
- * the consolidated `cleo.db` alongside the prefixed `conduit_*` tables and the
+ * The PREFIXED conduit tables present after `ensureConduitDb`. After the AC4
+ * cutover (T11578) the 14 `conduit_*` tables are created by the consolidated
+ * cleo-project migration; the `drizzle-conduit` forward migration adds the
+ * `conduit_messages_fts` FTS5 index + the two legacy `_conduit_*` health-probe
+ * tables. They all live INSIDE the consolidated `cleo.db` alongside the
  * `tasks_*` / `brain_*` domains, so we assert PRESENCE (arrayContaining) rather
- * than equality. `_conduit_meta` / `_conduit_migrations` are the two legacy meta
- * tables.
- *
- * T11563: the attachment-family tables carry the `conduit_` prefix
- * (`conduit_attachments`, `conduit_attachment_versions`,
- * `conduit_attachment_approvals`, `conduit_attachment_contributors`) so they are
- * PHYSICALLY DISJOINT from the docs-domain bare `attachments` table that also
- * lives in the consolidated `cleo.db` — the bare names collided once conduit was
- * routed into `cleo.db` (#900), crashing the `conversation_id` index.
+ * than equality.
  */
-const EXPECTED_LEGACY_TABLES = [
+const EXPECTED_PREFIXED_TABLES = [
   '_conduit_meta',
   '_conduit_migrations',
   'conduit_attachment_approvals',
   'conduit_attachment_contributors',
   'conduit_attachment_versions',
   'conduit_attachments',
-  'conversations',
-  'dead_letters',
-  'delivery_jobs',
-  'message_pins',
-  'messages',
-  'project_agent_refs',
-  'topic_message_acks',
-  'topic_messages',
-  'topic_subscriptions',
-  'topics',
+  'conduit_conversations',
+  'conduit_dead_letters',
+  'conduit_delivery_jobs',
+  'conduit_message_pins',
+  'conduit_messages',
+  'conduit_project_agent_refs',
+  'conduit_topic_message_acks',
+  'conduit_topic_messages',
+  'conduit_topic_subscriptions',
+  'conduit_topics',
 ];
 
 // ---------------------------------------------------------------------------
@@ -145,25 +142,25 @@ describe('conduit-sqlite', () => {
       .all() as Array<{ name: string }>;
 
     const tableNames = rows.map((r) => r.name);
-    // The consolidated cleo.db holds tasks_*/brain_*/conduit_* too, so assert the
-    // legacy BARE conduit tables are PRESENT rather than the only tables.
-    expect(tableNames).toEqual(expect.arrayContaining(EXPECTED_LEGACY_TABLES));
+    // The consolidated cleo.db holds tasks_*/brain_* too, so assert the PREFIXED
+    // conduit tables are PRESENT rather than the only tables.
+    expect(tableNames).toEqual(expect.arrayContaining(EXPECTED_PREFIXED_TABLES));
   });
 
-  // TC-011 — messages_fts virtual table created
-  it('ensureConduitDb creates messages_fts virtual table', async () => {
+  // TC-011 — conduit_messages_fts virtual table created (T11578 · AC4)
+  it('ensureConduitDb creates conduit_messages_fts virtual table', async () => {
     await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb();
     expect(db).not.toBeNull();
 
     const row = db!
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'")
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='conduit_messages_fts'")
       .get() as { name: string } | undefined;
-    expect(row?.name).toBe('messages_fts');
+    expect(row?.name).toBe('conduit_messages_fts');
   });
 
-  // TC-012 — FTS5 triggers created and functional
-  it('messages_fts triggers are created and FTS search works after insert', async () => {
+  // TC-012 — FTS5 triggers created and functional (T11578 · AC4)
+  it('conduit_messages_fts triggers are created and FTS search works after insert', async () => {
     await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb();
     expect(db).not.toBeNull();
@@ -173,22 +170,23 @@ describe('conduit-sqlite', () => {
       .prepare("SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name")
       .all() as Array<{ name: string }>;
     const triggerNames = triggers.map((t) => t.name);
-    expect(triggerNames).toContain('messages_ai');
-    expect(triggerNames).toContain('messages_ad');
-    expect(triggerNames).toContain('messages_au');
+    expect(triggerNames).toContain('conduit_messages_ai');
+    expect(triggerNames).toContain('conduit_messages_ad');
+    expect(triggerNames).toContain('conduit_messages_au');
 
     // FK is enabled under the dual-scope pragma SSoT — insert a conversation
-    // first to satisfy the messages → conversations FK.
-    db!.exec(`INSERT INTO conversations (id, participants, created_at, updated_at)
-              VALUES ('conv-1', '["a","b"]', 1000, 1000)`);
+    // first to satisfy the conduit_messages → conduit_conversations FK.
+    // Timestamps are canonical TEXT ISO-8601 (CHECK enforces the ISO GLOB).
+    db!.exec(`INSERT INTO conduit_conversations (id, participants, created_at, updated_at)
+              VALUES ('conv-1', '["a","b"]', '2026-06-02T00:00:00.000Z', '2026-06-02T00:00:00.000Z')`);
 
-    // Insert a message — messages_ai trigger should populate messages_fts.
-    db!.exec(`INSERT INTO messages
+    // Insert a message — conduit_messages_ai trigger populates conduit_messages_fts.
+    db!.exec(`INSERT INTO conduit_messages
               (id, conversation_id, from_agent_id, to_agent_id, content, created_at)
-              VALUES ('msg-1', 'conv-1', 'agent-a', 'agent-b', 'hello world', 1000)`);
+              VALUES ('msg-1', 'conv-1', 'agent-a', 'agent-b', 'hello world', '2026-06-02T00:00:00.000Z')`);
 
     const ftsRow = db!
-      .prepare("SELECT * FROM messages_fts WHERE messages_fts MATCH 'hello'")
+      .prepare("SELECT * FROM conduit_messages_fts WHERE conduit_messages_fts MATCH 'hello'")
       .get() as Record<string, unknown> | undefined;
     expect(ftsRow).toBeDefined();
   });
@@ -211,7 +209,7 @@ describe('conduit-sqlite', () => {
   it('ensureConduitDb is idempotent: data survives across two opens', async () => {
     await ensureConduitDb(tmpRoot);
     const db1 = getConduitNativeDb()!;
-    db1.exec(`INSERT INTO project_agent_refs (agent_id, attached_at)
+    db1.exec(`INSERT INTO conduit_project_agent_refs (agent_id, attached_at)
               VALUES ('test-agent', '2026-04-12T00:00:00Z')`);
     closeConduitDb();
     _resetDualScopeDbCache();
@@ -219,7 +217,7 @@ describe('conduit-sqlite', () => {
     await ensureConduitDb(tmpRoot);
     const db2 = getConduitNativeDb()!;
     const row = db2
-      .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get('test-agent') as { agent_id: string } | undefined;
     expect(row?.agent_id).toBe('test-agent');
   });
@@ -252,12 +250,12 @@ describe('conduit-sqlite', () => {
     expect(result.integrity_check).toBe('ok');
   });
 
-  // project_agent_refs schema
-  it('project_agent_refs has expected columns with correct constraints', async () => {
+  // conduit_project_agent_refs schema (T11578 · AC4 — prefixed, consolidated)
+  it('conduit_project_agent_refs has expected columns with correct constraints', async () => {
     await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
 
-    const cols = db.prepare('PRAGMA table_info(project_agent_refs)').all() as Array<{
+    const cols = db.prepare('PRAGMA table_info(conduit_project_agent_refs)').all() as Array<{
       cid: number;
       name: string;
       type: string;
@@ -279,36 +277,22 @@ describe('conduit-sqlite', () => {
     const agentIdCol = cols.find((c) => c.name === 'agent_id');
     expect(agentIdCol?.pk).toBe(1);
 
+    // E10 §3b: `enabled` is a typed boolean → `integer DEFAULT true` with a
+    // `CHECK (enabled IN (0,1))` (the consolidated schema; the builder writes 0/1).
     const enabledCol = cols.find((c) => c.name === 'enabled');
     expect(enabledCol?.notnull).toBe(1);
-    expect(enabledCol?.dflt_value).toBe('1');
+    expect(enabledCol?.dflt_value).toBe('true');
   });
 
-  // partial index on project_agent_refs
-  it('idx_project_agent_refs_enabled partial index exists on project_agent_refs', async () => {
+  // applyConduitSchema — idempotent on a conduit-initialized db (T11578 · AC4).
+  // The FTS5 `content='conduit_messages'` index references the consolidated
+  // `conduit_messages` table, so the schema must be applied to a `cleo.db` that
+  // the consolidated migration has already populated — not a bare manual file.
+  it('applyConduitSchema is idempotent when called twice on the conduit db', async () => {
     await ensureConduitDb(tmpRoot);
     const db = getConduitNativeDb()!;
-
-    const indices = db.prepare('PRAGMA index_list(project_agent_refs)').all() as Array<{
-      seq: number;
-      name: string;
-      unique: number;
-      origin: string;
-      partial: number;
-    }>;
-    const enabledIdx = indices.find((i) => i.name === 'idx_project_agent_refs_enabled');
-    expect(enabledIdx).toBeDefined();
-    expect(enabledIdx?.partial).toBe(1);
-  });
-
-  // applyConduitSchema — idempotent on a caller-owned db
-  it('applyConduitSchema is idempotent when called twice on the same db', () => {
-    const dbPath = join(tmpRoot, 'manual.db');
-    mkdirSync(tmpRoot, { recursive: true });
-    const db = new DatabaseSync(dbPath);
     expect(() => applyConduitSchema(db)).not.toThrow();
     expect(() => applyConduitSchema(db)).not.toThrow();
-    db.close();
   });
 
   // schema version recorded in _conduit_meta
@@ -380,8 +364,8 @@ describe('conduit-sqlite', () => {
     expect(health.walMode).toBe(true);
     expect(health.schemaVersion).toBe(CONDUIT_SCHEMA_VERSION);
     expect(health.foreignKeysEnabled).toBe(true);
-    // At minimum all legacy conduit tables (the consolidated cleo.db has more).
-    expect(health.tableCount).toBeGreaterThanOrEqual(EXPECTED_LEGACY_TABLES.length);
+    // At minimum all prefixed conduit tables (the consolidated cleo.db has more).
+    expect(health.tableCount).toBeGreaterThanOrEqual(EXPECTED_PREFIXED_TABLES.length);
   });
 
   // ensureConduitDb with pre-existing .cleo/ dir
@@ -422,7 +406,7 @@ describe('conduit-sqlite', () => {
       expect(reattached?.role).toBe('reviewer');
       const count = (
         db
-          .prepare('SELECT COUNT(*) AS c FROM project_agent_refs WHERE agent_id = ?')
+          .prepare('SELECT COUNT(*) AS c FROM conduit_project_agent_refs WHERE agent_id = ?')
           .get('agent-1') as {
           c: number;
         }

--- a/packages/core/src/store/__tests__/migrate-signaldock-to-conduit.test.ts
+++ b/packages/core/src/store/__tests__/migrate-signaldock-to-conduit.test.ts
@@ -447,14 +447,16 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(result.agentsCopied).toBe(3);
     expect(result.errors).toHaveLength(0);
 
-    // Verify project_agent_refs in conduit.db
+    // Verify conduit_project_agent_refs in conduit.db (T11578 · AC4 — prefixed)
     const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
     const refs = conduitDb
-      .prepare('SELECT agent_id FROM project_agent_refs ORDER BY agent_id')
+      .prepare('SELECT agent_id FROM conduit_project_agent_refs ORDER BY agent_id')
       .all() as Array<{ agent_id: string }>;
     expect(refs.map((r) => r.agent_id)).toEqual(['agent-alpha', 'agent-beta', 'agent-gamma']);
 
-    const allEnabled = conduitDb.prepare('SELECT enabled FROM project_agent_refs').all() as Array<{
+    const allEnabled = conduitDb
+      .prepare('SELECT enabled FROM conduit_project_agent_refs')
+      .all() as Array<{
       enabled: number;
     }>;
     for (const row of allEnabled) {
@@ -510,10 +512,10 @@ describe('migrate-signaldock-to-conduit', () => {
     expect(agents[0]?.name).toBe('Agent X Original');
     globalDb.close();
 
-    // conduit.db should have a project_agent_refs row for agent-x
+    // conduit.db should have a conduit_project_agent_refs row for agent-x (AC4)
     const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
     const refs = conduitDb
-      .prepare("SELECT agent_id FROM project_agent_refs WHERE agent_id = 'agent-x'")
+      .prepare("SELECT agent_id FROM conduit_project_agent_refs WHERE agent_id = 'agent-x'")
       .all() as Array<{ agent_id: string }>;
     expect(refs).toHaveLength(1);
     conduitDb.close();
@@ -581,12 +583,16 @@ describe('migrate-signaldock-to-conduit', () => {
 
     const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
 
-    const convRows = conduitDb.prepare('SELECT id FROM conversations ORDER BY id').all() as Array<{
+    const convRows = conduitDb
+      .prepare('SELECT id FROM conduit_conversations ORDER BY id')
+      .all() as Array<{
       id: string;
     }>;
     expect(convRows.map((r) => r.id)).toEqual(['conv-1', 'conv-2']);
 
-    const msgRows = conduitDb.prepare('SELECT id FROM messages ORDER BY id').all() as Array<{
+    const msgRows = conduitDb
+      .prepare('SELECT id FROM conduit_messages ORDER BY id')
+      .all() as Array<{
       id: string;
     }>;
     expect(msgRows.map((r) => r.id)).toEqual(['msg-1', 'msg-2', 'msg-3', 'msg-4', 'msg-5']);
@@ -597,7 +603,7 @@ describe('migrate-signaldock-to-conduit', () => {
   // -------------------------------------------------------------------------
   // TC-072: FTS search after migration
   // -------------------------------------------------------------------------
-  it('TC-072: messages_fts search returns results after migration', async () => {
+  it('TC-072: conduit_messages_fts search returns results after migration', async () => {
     const now = Math.floor(Date.now() / 1000);
     createLegacySignaldockDb(
       dirs.projectRoot,
@@ -621,7 +627,9 @@ describe('migrate-signaldock-to-conduit', () => {
 
     const conduitDb = new DatabaseSync(join(dirs.projectRoot, '.cleo', 'cleo.db'));
     const ftsResults = conduitDb
-      .prepare("SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'migration'")
+      .prepare(
+        "SELECT rowid FROM conduit_messages_fts WHERE conduit_messages_fts MATCH 'migration'",
+      )
       .all() as Array<{ rowid: number }>;
     expect(ftsResults.length).toBeGreaterThan(0);
     conduitDb.close();

--- a/packages/core/src/store/agent-registry-accessor.ts
+++ b/packages/core/src/store/agent-registry-accessor.ts
@@ -3,15 +3,15 @@
  *
  * Post-T310 (ADR-037), agent identity lives in the GLOBAL `agents` table;
  * per-project visibility and overrides live in the PROJECT
- * `project_agent_refs` table.
+ * `conduit_project_agent_refs` table (T11578 · AC4 — conduit namespace cutover).
  *
  * Post-E6-L5 (T11525) / E6-L6 (T11526), both tables are hosted inside the
  * CONSOLIDATED dual-scope `cleo.db` files (global `$XDG_DATA_HOME/cleo/cleo.db`
  * and project `.cleo/cleo.db`) — the standalone `signaldock.db` / `conduit.db`
- * files are gone. The bare `agents` / `project_agent_refs` runtime tables are
- * materialized into `cleo.db` by `ensureGlobalSignaldockDb()` /
- * `ensureConduitDb()` (legacy drizzle migrations), which co-exist with the
- * prefixed `signaldock_*` / `conduit_*` consolidated tables. The read path MUST
+ * files are gone. The global `agents` table is materialized by
+ * `ensureGlobalSignaldockDb()`; the prefixed conduit `conduit_project_agent_refs`
+ * table is created by the consolidated cleo-project migration (T11578 · AC4) and
+ * `ensureConduitDb()` ensures the project `cleo.db` is open. The read path MUST
  * therefore go through those `ensure*` calls so it shares the same handle as the
  * write path (T11562 — agents read/write path divergence regression).
  *
@@ -21,7 +21,7 @@
  *
  * Architecture:
  *   global  cleo.db — canonical identity `agents` (openGlobalDb → ensureGlobalSignaldockDb)
- *   project cleo.db — `project_agent_refs`        (openConduitDb)
+ *   project cleo.db — `conduit_project_agent_refs` (openConduitDb)
  *   Join performed in Node (SQLite cannot cross-file-handle JOIN).
  *
  * @see .cleo/rcasd/T310/specification/T310-specification.md §3.5
@@ -481,9 +481,9 @@ export async function lookupAgent(
 ): Promise<AgentWithProjectOverride | null> {
   const includeGlobal = opts?.includeGlobal ?? false;
 
-  // Ensure the consolidated project cleo.db has the bare `project_agent_refs`
-  // table before the raw-open read below (mirrors the global side, which is
-  // ensured inside openGlobalDb).
+  // Ensure the consolidated project cleo.db has the prefixed
+  // `conduit_project_agent_refs` table (T11578 · AC4) before the raw-open read
+  // below (mirrors the global side, which is ensured inside openGlobalDb).
   await ensureConduitDb(projectRoot);
 
   // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
@@ -496,7 +496,7 @@ export async function lookupAgent(
       | undefined;
 
     const refRow = conduitDb
-      .prepare('SELECT * FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT * FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(agentId) as ProjectAgentRefRow | undefined;
 
     // Dangling soft-FK: ref exists in conduit but not in global
@@ -561,9 +561,9 @@ export async function listAgentsForProject(
   const includeGlobal = opts?.includeGlobal ?? false;
   const includeDisabled = opts?.includeDisabled ?? false;
 
-  // Ensure the consolidated project cleo.db has the bare `project_agent_refs`
-  // table before the raw-open read below (mirrors the global side, which is
-  // ensured inside openGlobalDb).
+  // Ensure the consolidated project cleo.db has the prefixed
+  // `conduit_project_agent_refs` table (T11578 · AC4) before the raw-open read
+  // below (mirrors the global side, which is ensured inside openGlobalDb).
   await ensureConduitDb(projectRoot);
 
   // SHARED global cleo.db handle — do NOT close (lifecycle owned by openDualScopeDb).
@@ -576,7 +576,7 @@ export async function listAgentsForProject(
       .all() as unknown as AgentDbRow[];
 
     const allRefs = conduitDb
-      .prepare('SELECT * FROM project_agent_refs')
+      .prepare('SELECT * FROM conduit_project_agent_refs')
       .all() as unknown as ProjectAgentRefRow[];
 
     // Build a map from agentId → ref row for O(1) lookup during join
@@ -719,20 +719,22 @@ export async function createProjectAgent(
   const conduitDb = openConduitDb(projectRoot);
   try {
     const existingRef = conduitDb
-      .prepare('SELECT agent_id, enabled FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id, enabled FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(spec.agentId) as { agent_id: string; enabled: number } | undefined;
 
     if (!existingRef) {
       conduitDb
         .prepare(
-          `INSERT INTO project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
+          `INSERT INTO conduit_project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
            VALUES (?, ?, NULL, NULL, NULL, 1)`,
         )
         .run(spec.agentId, nowIso);
     } else if (existingRef.enabled === 0) {
       // Re-enable a previously detached agent
       conduitDb
-        .prepare(`UPDATE project_agent_refs SET enabled = 1, attached_at = ? WHERE agent_id = ?`)
+        .prepare(
+          `UPDATE conduit_project_agent_refs SET enabled = 1, attached_at = ? WHERE agent_id = ?`,
+        )
         .run(nowIso, spec.agentId);
     }
     // If enabled=1 already, leave the existing ref intact
@@ -779,20 +781,20 @@ export function attachAgentToProject(
   const nowIso = new Date().toISOString();
   try {
     const existingRef = conduitDb
-      .prepare('SELECT agent_id, enabled FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id, enabled FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(agentId) as { agent_id: string; enabled: number } | undefined;
 
     if (!existingRef) {
       conduitDb
         .prepare(
-          `INSERT INTO project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
+          `INSERT INTO conduit_project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
            VALUES (?, ?, ?, ?, NULL, 1)`,
         )
         .run(agentId, nowIso, opts?.role ?? null, opts?.capabilitiesOverride ?? null);
     } else if (existingRef.enabled === 0) {
       conduitDb
         .prepare(
-          `UPDATE project_agent_refs SET enabled = 1, attached_at = ?, role = ?, capabilities_override = ? WHERE agent_id = ?`,
+          `UPDATE conduit_project_agent_refs SET enabled = 1, attached_at = ?, role = ?, capabilities_override = ? WHERE agent_id = ?`,
         )
         .run(nowIso, opts?.role ?? null, opts?.capabilitiesOverride ?? null, agentId);
     }
@@ -822,12 +824,14 @@ export function detachAgentFromProject(projectRoot: string, agentId: string): bo
   const conduitDb = openConduitDb(projectRoot);
   try {
     const ref = conduitDb
-      .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT agent_id FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(agentId) as { agent_id: string } | undefined;
 
     if (!ref) return false;
 
-    conduitDb.prepare('UPDATE project_agent_refs SET enabled = 0 WHERE agent_id = ?').run(agentId);
+    conduitDb
+      .prepare('UPDATE conduit_project_agent_refs SET enabled = 0 WHERE agent_id = ?')
+      .run(agentId);
     return true;
   } finally {
     conduitDb.close();
@@ -850,7 +854,7 @@ export function getProjectAgentRef(projectRoot: string, agentId: string): Projec
   const conduitDb = openConduitDb(projectRoot);
   try {
     const row = conduitDb
-      .prepare('SELECT * FROM project_agent_refs WHERE agent_id = ?')
+      .prepare('SELECT * FROM conduit_project_agent_refs WHERE agent_id = ?')
       .get(agentId) as ProjectAgentRefRow | undefined;
     if (!row) return null;
     return rowToProjectRef(row);
@@ -1078,13 +1082,13 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
     const conduitDb = openConduitDb(this.projectPath);
     try {
       const ref = conduitDb
-        .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ?')
+        .prepare('SELECT agent_id FROM conduit_project_agent_refs WHERE agent_id = ?')
         .get(agentId) as { agent_id: string } | undefined;
       if (!ref) {
         throw new Error(`Agent not found in current project: ${agentId}`);
       }
       conduitDb
-        .prepare('UPDATE project_agent_refs SET enabled = 0 WHERE agent_id = ?')
+        .prepare('UPDATE conduit_project_agent_refs SET enabled = 0 WHERE agent_id = ?')
         .run(agentId);
     } finally {
       conduitDb.close();
@@ -1116,7 +1120,9 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
       const conduitDb = openConduitDb(this.projectPath);
       try {
         const ref = conduitDb
-          .prepare('SELECT agent_id FROM project_agent_refs WHERE agent_id = ? AND enabled = 1')
+          .prepare(
+            'SELECT agent_id FROM conduit_project_agent_refs WHERE agent_id = ? AND enabled = 1',
+          )
           .get(agentId) as { agent_id: string } | undefined;
         if (ref) {
           throw new Error(
@@ -1198,7 +1204,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
       // Get all project-attached, enabled agent IDs ordered by project last_used_at
       const enabledRefs = conduitDb
         .prepare(
-          'SELECT agent_id, last_used_at FROM project_agent_refs WHERE enabled = 1 ORDER BY last_used_at DESC',
+          'SELECT agent_id, last_used_at FROM conduit_project_agent_refs WHERE enabled = 1 ORDER BY last_used_at DESC',
         )
         .all() as unknown as Array<{ agent_id: string; last_used_at: string | null }>;
 
@@ -1246,7 +1252,7 @@ export class AgentRegistryAccessor implements AgentRegistryAPI {
     const conduitDb = openConduitDb(this.projectPath);
     try {
       conduitDb
-        .prepare('UPDATE project_agent_refs SET last_used_at = ? WHERE agent_id = ?')
+        .prepare('UPDATE conduit_project_agent_refs SET last_used_at = ? WHERE agent_id = ?')
         .run(nowIso, agentId);
     } finally {
       conduitDb.close();

--- a/packages/core/src/store/conduit-sqlite.ts
+++ b/packages/core/src/store/conduit-sqlite.ts
@@ -15,28 +15,38 @@
  * - DB Open Guard Gate 3 (`scripts/lint-no-direct-db-open.mjs`) stays green: the
  *   only native open is inside `dual-scope-db.ts`.
  *
- * ## Inline DDL → forward migration (T11523 acceptance criteria)
+ * ## COMPLETE-CUTOVER to prefixed `conduit_*` tables (T11578 · AC4)
  *
- * The 16-table inline `CONDUIT_SCHEMA_SQL` blob (formerly applied by
- * `applyConduitSchema()`) has been removed and converted to a forward Drizzle
- * migration under
- * `migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema`,
- * matching the T1407 baseline marker and the L1/L2 precedent. The migration is
- * reproduced VERBATIM (legacy runtime shape) — 16 tables + indexes + the
- * `messages_fts` FTS5 virtual table + its 3 triggers — so the LocalTransport and
- * accessor writers keep working unchanged.
+ * The conduit runtime READ + WRITE path now targets the PREFIXED consolidated
+ * tables (`conduit_conversations`, `conduit_messages`, `conduit_topics`, …) that
+ * the consolidated cleo-project migration creates — NOT the legacy BARE tables
+ * (`conversations`, `messages`, …). The schema barrel imported below is therefore
+ * `schema/cleo-project/conduit.ts` (the prefixed target shape, TEXT ISO-8601
+ * timestamps + CHECK constraints), replacing the legacy `schema/conduit-schema.ts`
+ * bare shape. The drizzle journal `runConduitMigrations` reconciles now only needs
+ * the FTS5 quartet that the consolidated migration omits (drizzle-orm sqlite-core
+ * does not model FTS5 virtual tables).
  *
- * ## Disjoint physical names (no DROP/rebuild)
+ * ## Inline DDL → forward migration (T11523 → T11578)
  *
- * The conduit legacy physical tables are BARE (`conversations`, `messages`,
- * `delivery_jobs`, …) while the consolidated schema (`cleo-project/conduit.ts`)
- * carries the `conduit_` domain prefix (`conduit_conversations`, …). They are
- * therefore DISJOINT names — the legacy runtime-shape tables co-exist harmlessly
- * with the consolidated `conduit_*` tables in the same `cleo.db`, exactly like the
- * tasks domain (legacy `tasks` ≠ consolidated `tasks_tasks`). Unlike the brain
- * domain (E6-L2, same prefixed names → drop + rebuild), the conduit facade needs
- * no teardown. The exodus migration (T11248 / T11553) renames the legacy tables to
- * `conduit_*`.
+ * The legacy 16-table inline `CONDUIT_SCHEMA_SQL` blob was first converted to a
+ * forward Drizzle migration under
+ * `migrations/drizzle-conduit/20260601000003_t11523-conduit-inline-schema`
+ * (T11523, bare runtime shape). The AC4 cutover (T11578) rewrote that migration to
+ * carry ONLY the `conduit_messages_fts` FTS5 virtual table + its 3 sync triggers
+ * (`conduit_messages_ai/ad/au`) + the two legacy `_conduit_meta` /
+ * `_conduit_migrations` health-probe tables. The 14 prefixed `conduit_*` tables
+ * are owned by the consolidated cleo-project migration (single SSoT) — this
+ * migration no longer creates them.
+ *
+ * ## Single physical shape (consolidated owns the tables)
+ *
+ * After AC4 the runtime writes the SAME prefixed `conduit_*` tables the
+ * consolidated schema (`cleo-project/conduit.ts`) declares — there is no longer a
+ * disjoint bare runtime shape. The exodus migration (T11248 / T11553) still
+ * renames any LEGACY bare data (`messages` → `conduit_messages`) from a
+ * pre-cutover DB into those same prefixed tables; the FTS index is rebuilt
+ * post-migration from `conduit_messages` (exodus skips `*_fts` tables).
  *
  * Architecture (ADR-037):
  *   conduit (this module) — project-scoped — messaging, delivery, attachments,
@@ -78,7 +88,7 @@ import type { drizzle as drizzleFn } from 'drizzle-orm/node-sqlite';
 import { openDualScopeDb, resolveDualScopeDbPath } from './dual-scope-db.js';
 import { migrateSanitized, reconcileJournal } from './migration-manager.js';
 import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
-import * as conduitSchema from './schema/conduit-schema.js';
+import * as conduitSchema from './schema/cleo-project/conduit.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
 
 const _require = createRequire(import.meta.url);
@@ -218,11 +228,23 @@ export function applyConduitSchema(db: DatabaseSync): void {
  * the same `cleo.db` as the consolidated cleo-project journal; the hashes are
  * disjoint, so the conduit migrations reconcile/apply independently.
  *
- * The existence sentinel is `conversations` — the first table created by the
- * conduit schema migration (always present on any conduit-initialized DB).
+ * The existence sentinel is `_conduit_meta` (T11578 · AC4) — a table the conduit
+ * forward migration ITSELF creates, NOT one the consolidated migration owns. This
+ * is critical: `reconcileJournal` Scenario 2 (orphan deletion) is gated on the
+ * sentinel already existing. The consolidated cleo-project migration runs FIRST
+ * (via `openDualScopeDb`) and writes its OWN entries into the SHARED
+ * `__drizzle_migrations` journal; if the sentinel were a consolidated-owned table
+ * (e.g. `conduit_messages`) it would already exist on the first conduit open, so
+ * Scenario 2 would fire, see the consolidated entries as "orphans" (absent from
+ * the conduit folder), and DELETE them — corrupting the consolidated journal and
+ * forcing a destructive re-run on the next open (`table … already exists`).
+ * Pinning the sentinel to a conduit-migration-created table keeps Scenario 2
+ * dormant until the conduit set is journaled, exactly as the pre-cutover bare
+ * `conversations` sentinel did.
  *
  * @task T1407
  * @task T11523
+ * @task T11578
  * @epic T310
  */
 function runConduitMigrations(nativeDb: DatabaseSync): void {
@@ -230,8 +252,10 @@ function runConduitMigrations(nativeDb: DatabaseSync): void {
 
   // Reconcile the Drizzle journal first so existing DBs don't try to re-run the
   // comment-only baseline marker (Scenario 3 marks it applied immediately when
-  // the schema already matches).
-  reconcileJournal(nativeDb, migrationsFolder, 'conversations', 'conduit');
+  // the schema already matches). Sentinel = `_conduit_meta` (created by the
+  // conduit migration itself — see the doc note above on why it must NOT be a
+  // consolidated-owned table).
+  reconcileJournal(nativeDb, migrationsFolder, '_conduit_meta', 'conduit');
 
   const db = _getDrizzle()({ client: nativeDb, schema: conduitSchema });
   migrateSanitized(db, { migrationsFolder });
@@ -245,12 +269,12 @@ function runConduitMigrations(nativeDb: DatabaseSync): void {
  * Delegates the physical DB open to {@link openDualScopeDb}('project', cwd) — the
  * canonical dual-scope chokepoint. openDualScopeDb applies the pragma SSoT,
  * creates the directory, runs the consolidated cleo-project migrations (which
- * create the `conduit_*` tables), and manages the singleton cache. We extract its
- * native handle (`$client`) and run the legacy `drizzle-conduit` migrations on it
- * to (idempotently) create the BARE legacy runtime-shape tables (`conversations`,
- * `messages`, FTS5, …) that the LocalTransport + accessor writers query. The
- * legacy and consolidated `conduit_*` tables co-exist (disjoint names) — the
- * exodus migration (T11248 / T11553) renames the legacy ones.
+ * create the prefixed `conduit_*` tables), and manages the singleton cache. We
+ * extract its native handle (`$client`) and run the `drizzle-conduit` migration on
+ * it to (idempotently) create the `conduit_messages_fts` FTS5 quartet that the
+ * consolidated migration omits. After the AC4 cutover (T11578) the LocalTransport +
+ * accessor writers query the SAME prefixed `conduit_*` tables — the exodus
+ * migration (T11248 / T11553) renames any pre-cutover BARE data into them.
  *
  * On subsequent calls the existing singleton is returned immediately if the
  * resolved path matches AND the shared handle is still live (liveness guard);
@@ -308,12 +332,12 @@ export async function ensureConduitDb(
       );
     }
 
-    // Establish the LEGACY conduit-domain schema inside the consolidated cleo.db.
-    // The consolidated migrations created the prefixed `conduit_*` tables; the
-    // runtime writers query the BARE legacy tables (`conversations`, `messages`,
-    // FTS5, …). Running the `drizzle-conduit` set creates those bare tables. They
-    // are disjoint from the consolidated names, so no drop is needed (unlike the
-    // brain domain, E6-L2). Idempotent: a no-op once the tables already exist.
+    // Establish the FTS5 index over the consolidated `conduit_messages` table.
+    // The consolidated migrations already created the prefixed `conduit_*` tables;
+    // running the `drizzle-conduit` set adds the `conduit_messages_fts` virtual
+    // table + its 3 sync triggers (drizzle-orm cannot model FTS5, so the
+    // consolidated migration omits them). Idempotent: a no-op once the FTS index
+    // already exists (T11578 · AC4).
     runConduitMigrations(nativeDb);
 
     // Record schema version in the legacy `_conduit_meta` table for backwards-
@@ -419,11 +443,11 @@ export function attachAgentToProject(
 ): void {
   const now = new Date().toISOString();
   db.prepare(
-    `INSERT INTO project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
+    `INSERT INTO conduit_project_agent_refs (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
      VALUES (?, ?, ?, ?, NULL, 1)
      ON CONFLICT(agent_id) DO UPDATE SET
        enabled = 1,
-       attached_at = CASE WHEN project_agent_refs.enabled = 0 THEN excluded.attached_at ELSE project_agent_refs.attached_at END,
+       attached_at = CASE WHEN conduit_project_agent_refs.enabled = 0 THEN excluded.attached_at ELSE conduit_project_agent_refs.attached_at END,
        role = excluded.role,
        capabilities_override = excluded.capabilities_override`,
   ).run(agentId, now, opts?.role ?? null, opts?.capabilitiesOverride ?? null);
@@ -439,7 +463,7 @@ export function attachAgentToProject(
  * @epic T310
  */
 export function detachAgentFromProject(db: DatabaseSync, agentId: string): void {
-  db.prepare(`UPDATE project_agent_refs SET enabled = 0 WHERE agent_id = ?`).run(agentId);
+  db.prepare(`UPDATE conduit_project_agent_refs SET enabled = 0 WHERE agent_id = ?`).run(agentId);
 }
 
 /**
@@ -459,10 +483,10 @@ export function listProjectAgentRefs(
   const enabledOnly = opts?.enabledOnly ?? true;
   const sql = enabledOnly
     ? `SELECT agent_id, attached_at, role, capabilities_override, last_used_at, enabled
-       FROM project_agent_refs WHERE enabled = 1
+       FROM conduit_project_agent_refs WHERE enabled = 1
        ORDER BY attached_at DESC`
     : `SELECT agent_id, attached_at, role, capabilities_override, last_used_at, enabled
-       FROM project_agent_refs
+       FROM conduit_project_agent_refs
        ORDER BY attached_at DESC`;
   const rows = db.prepare(sql).all() as Array<{
     agent_id: string;
@@ -495,7 +519,7 @@ export function getProjectAgentRef(db: DatabaseSync, agentId: string): ProjectAg
   const row = db
     .prepare(
       `SELECT agent_id, attached_at, role, capabilities_override, last_used_at, enabled
-       FROM project_agent_refs WHERE agent_id = ?`,
+       FROM conduit_project_agent_refs WHERE agent_id = ?`,
     )
     .get(agentId) as
     | {
@@ -528,7 +552,7 @@ export function getProjectAgentRef(db: DatabaseSync, agentId: string): ProjectAg
  * @epic T310
  */
 export function updateProjectAgentLastUsed(db: DatabaseSync, agentId: string): void {
-  db.prepare(`UPDATE project_agent_refs SET last_used_at = ? WHERE agent_id = ?`).run(
+  db.prepare(`UPDATE conduit_project_agent_refs SET last_used_at = ? WHERE agent_id = ?`).run(
     new Date().toISOString(),
     agentId,
   );

--- a/packages/core/src/store/migrate-signaldock-to-conduit.ts
+++ b/packages/core/src/store/migrate-signaldock-to-conduit.ts
@@ -81,12 +81,16 @@ export interface MigrationResult {
  * source name to the prefixed destination name, otherwise rows would be inserted
  * into the unrelated docs `attachments` table.
  */
+// T11578 (AC4): destinations are the PREFIXED consolidated `conduit_*` tables —
+// the conduit runtime no longer materializes the BARE legacy tables. Copying
+// from the legacy bare source into these prefixed targets is epoch-→-ISO coerced
+// by copyTableRows for any target column carrying an ISO-8601 GLOB CHECK.
 const PROJECT_TIER_TABLES = [
-  { src: 'messages', dest: 'messages' },
-  { src: 'conversations', dest: 'conversations' },
-  { src: 'delivery_jobs', dest: 'delivery_jobs' },
-  { src: 'dead_letters', dest: 'dead_letters' },
-  { src: 'message_pins', dest: 'message_pins' },
+  { src: 'messages', dest: 'conduit_messages' },
+  { src: 'conversations', dest: 'conduit_conversations' },
+  { src: 'delivery_jobs', dest: 'conduit_delivery_jobs' },
+  { src: 'dead_letters', dest: 'conduit_dead_letters' },
+  { src: 'message_pins', dest: 'conduit_message_pins' },
   { src: 'attachments', dest: 'conduit_attachments' },
   { src: 'attachment_versions', dest: 'conduit_attachment_versions' },
   { src: 'attachment_approvals', dest: 'conduit_attachment_approvals' },
@@ -206,6 +210,12 @@ function copyTableRows(
   const cols = srcCols.filter((c) => destCols.includes(c));
   if (cols.length === 0) return 0;
 
+  // T11578 (AC4): the prefixed `conduit_*` targets carry ISO-8601 TEXT timestamp
+  // columns with an ISO GLOB CHECK, while the legacy bare source stored epoch
+  // SECONDS integers. Coerce those columns to ISO so the verbatim row copy does
+  // not fail (or, under INSERT OR IGNORE, silently drop) on the GLOB CHECK.
+  const isoGlobCols = detectIsoGlobColumns(destDb, destTableName);
+
   const colList = cols.map((c) => `"${c}"`).join(', ');
   const placeholders = cols.map(() => '?').join(', ');
   const conflictClause = ignoreConflicts ? 'OR IGNORE' : '';
@@ -222,10 +232,67 @@ function copyTableRows(
     // Values originate from another SQLite row via prepare().all(), so at runtime
     // they are already SQLInputValue-compatible (string | number | bigint | Uint8Array | null).
     // The surrounding `Record<string, unknown>` type erases this, hence the narrow cast.
-    const values = cols.map((c) => (row[c] ?? null) as SQLInputValue);
+    const values = cols.map((c) => {
+      const raw = row[c] ?? null;
+      if (isoGlobCols.has(c) && typeof raw === 'number') {
+        return epochSecondsToIso(raw);
+      }
+      return (raw ?? null) as SQLInputValue;
+    });
     stmt.run(...values);
   }
   return rows.length;
+}
+
+/**
+ * Regex matching the T11363-generated ISO-8601 GLOB CHECK constraint, e.g.
+ * `CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-...')`.
+ *
+ * The constrained column name appears twice; we capture the first occurrence.
+ *
+ * @task T11578
+ */
+const ISO_GLOB_CHECK_REGEX = /CHECK\s*\(\s*"([^"]+)"\s+IS\s+NULL\s+OR\s+"[^"]+"\s+GLOB\s+'\[0-9/gi;
+
+/**
+ * Read a target table's DDL from `sqlite_master` and return the set of column
+ * names that carry an ISO-8601 GLOB CHECK constraint (the consolidated
+ * `conduit_*` timestamp columns introduced by T11363).
+ *
+ * @param db        - The destination DB handle (consolidated `cleo.db`).
+ * @param tableName - Physical destination table name (e.g. `conduit_messages`).
+ * @returns Set of column names requiring ISO-8601 TEXT values.
+ * @task T11578
+ */
+function detectIsoGlobColumns(db: DatabaseSync, tableName: string): Set<string> {
+  const escaped = tableName.replace(/'/g, "''");
+  const row = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='${escaped}'`)
+    .get() as { sql: string | null } | undefined;
+  const out = new Set<string>();
+  if (!row?.sql) return out;
+  ISO_GLOB_CHECK_REGEX.lastIndex = 0; // global regex is stateful — reset before reuse
+  for (const match of row.sql.matchAll(ISO_GLOB_CHECK_REGEX)) {
+    const col = match[1];
+    if (col) out.add(col);
+  }
+  return out;
+}
+
+/**
+ * Convert a legacy epoch-SECONDS integer to a canonical ISO-8601 UTC string.
+ *
+ * The legacy conduit writers stored timestamps as `Math.floor(Date.now() / 1000)`
+ * (§8.1 — seconds, never milliseconds), so this multiplies by 1000 before
+ * constructing the `Date`. Used by {@link copyTableRows} to satisfy the ISO GLOB
+ * CHECK on the prefixed `conduit_*` targets (T11578 · AC4).
+ *
+ * @param epochSeconds - Epoch seconds value from a legacy bare conduit row.
+ * @returns ISO-8601 UTC timestamp string.
+ * @task T11578
+ */
+function epochSecondsToIso(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toISOString();
 }
 
 /**
@@ -413,10 +480,10 @@ export async function migrateSignaldockToConduit(projectRoot: string): Promise<M
       }
     }
 
-    // Rebuild FTS after message copy
-    if (tableExistsInDb(conduit, 'messages_fts')) {
+    // Rebuild FTS after message copy (T11578 · AC4: prefixed FTS index).
+    if (tableExistsInDb(conduit, 'conduit_messages_fts')) {
       try {
-        conduit.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+        conduit.exec("INSERT INTO conduit_messages_fts(conduit_messages_fts) VALUES('rebuild')");
       } catch {
         // FTS rebuild failure is non-fatal — the triggers will populate it over time
       }
@@ -452,7 +519,7 @@ export async function migrateSignaldockToConduit(projectRoot: string): Promise<M
 
         conduit
           .prepare(
-            `INSERT OR IGNORE INTO project_agent_refs
+            `INSERT OR IGNORE INTO conduit_project_agent_refs
                (agent_id, attached_at, role, capabilities_override, last_used_at, enabled)
              VALUES (?, ?, ?, NULL, ?, 1)`,
           )

--- a/packages/core/src/store/role-accessors-impl.ts
+++ b/packages/core/src/store/role-accessors-impl.ts
@@ -41,12 +41,15 @@ export function createConduitAccessor(projectRoot?: string): ConduitAccessor {
       const db = getConduitNativeDb();
       if (!db) throw new Error('ConduitAccessor: conduit.db not initialized');
 
-      // Insert into a generic topic_messages table if available, or conduit messages.
-      // This is a best-effort publish — conduit schema evolves independently.
+      // Best-effort publish into the prefixed conduit_messages table (T11578 ·
+      // AC4). `created_at` is canonical TEXT ISO-8601 (CHECK enforces the ISO
+      // GLOB), so write ISO not epoch. The conversation_id is a synthetic
+      // `topic-*` value with no parent row; under FK enforcement the insert may
+      // throw — the surrounding try/catch keeps publish a graceful no-op.
       try {
         const payload_str = JSON.stringify(payload);
         db.prepare(
-          `INSERT OR IGNORE INTO messages (id, from_agent_id, to_agent_id, conversation_id, content, content_type, status, created_at)
+          `INSERT OR IGNORE INTO conduit_messages (id, from_agent_id, to_agent_id, conversation_id, content, content_type, status, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         ).run(
           `conduit-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -56,11 +59,11 @@ export function createConduitAccessor(projectRoot?: string): ConduitAccessor {
           payload_str,
           'application/json',
           'pending',
-          Date.now(),
+          new Date().toISOString(),
         );
       } catch {
-        // Messages table may not exist yet (conduit not initialized).
-        // Graceful no-op — publish is best-effort.
+        // conduit_messages may not exist yet (conduit not initialized) or the
+        // synthetic conversation_id may violate the FK — graceful no-op.
       }
     },
 

--- a/packages/runtime/src/__tests__/lifecycle-e2e.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-e2e.test.ts
@@ -88,17 +88,18 @@ describe('Agent Lifecycle E2E', () => {
     const db = new DatabaseSync(dbPath);
 
     try {
+      // T11578 (AC4): prefixed conduit_project_agent_refs; attached_at is TEXT ISO.
       const now = new Date().toISOString();
       db.prepare(
-        'INSERT INTO project_agent_refs (agent_id, attached_at, role, enabled) VALUES (?, ?, ?, 1)',
+        'INSERT INTO conduit_project_agent_refs (agent_id, attached_at, role, enabled) VALUES (?, ?, ?, 1)',
       ).run('agent-alpha', now, 'worker');
       db.prepare(
-        'INSERT INTO project_agent_refs (agent_id, attached_at, role, enabled) VALUES (?, ?, ?, 1)',
+        'INSERT INTO conduit_project_agent_refs (agent_id, attached_at, role, enabled) VALUES (?, ?, ?, 1)',
       ).run('agent-beta', now, 'worker');
 
       const refs = db
         .prepare(
-          'SELECT agent_id, role FROM project_agent_refs WHERE enabled = 1 ORDER BY agent_id',
+          'SELECT agent_id, role FROM conduit_project_agent_refs WHERE enabled = 1 ORDER BY agent_id',
         )
         .all() as Array<{ agent_id: string; role: string }>;
       expect(refs).toHaveLength(2);
@@ -120,22 +121,24 @@ describe('Agent Lifecycle E2E', () => {
     const db = new DatabaseSync(dbPath);
 
     try {
-      const now = Math.floor(Date.now() / 1000);
+      // T11578 (AC4): prefixed conduit_* tables; timestamps are canonical TEXT
+      // ISO-8601 (the consolidated GLOB CHECK rejects epoch integers).
+      const now = new Date().toISOString();
 
       // Create conversation. Messaging tables reference agent ids as plain
       // TEXT — they are not FK-bound to a project-tier agents table.
       db.exec(`
-        INSERT INTO conversations (id, participants, visibility, message_count, created_at, updated_at)
-        VALUES ('conv-1', '["agent-alpha","agent-beta"]', 'private', 0, ${now}, ${now});
+        INSERT INTO conduit_conversations (id, participants, visibility, message_count, created_at, updated_at)
+        VALUES ('conv-1', '["agent-alpha","agent-beta"]', 'private', 0, '${now}', '${now}');
       `);
 
       // Agent Alpha sends a message to Agent Beta.
       db.exec(`
-        INSERT INTO messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at)
-        VALUES ('msg-1', 'conv-1', 'agent-alpha', 'agent-beta', '/action @agent-beta Hello from Alpha!', 'text', 'pending', ${now});
+        INSERT INTO conduit_messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at)
+        VALUES ('msg-1', 'conv-1', 'agent-alpha', 'agent-beta', '/action @agent-beta Hello from Alpha!', 'text', 'pending', '${now}');
       `);
 
-      const msg = db.prepare('SELECT * FROM messages WHERE id = ?').get('msg-1') as {
+      const msg = db.prepare('SELECT * FROM conduit_messages WHERE id = ?').get('msg-1') as {
         from_agent_id: string;
         to_agent_id: string;
         content: string;
@@ -147,15 +150,21 @@ describe('Agent Lifecycle E2E', () => {
       expect(msg.status).toBe('pending');
 
       // Mark delivered.
-      db.exec(`UPDATE messages SET status = 'delivered', delivered_at = ${now} WHERE id = 'msg-1'`);
-      const delivered = db.prepare('SELECT status FROM messages WHERE id = ?').get('msg-1') as {
+      db.exec(
+        `UPDATE conduit_messages SET status = 'delivered', delivered_at = '${now}' WHERE id = 'msg-1'`,
+      );
+      const delivered = db
+        .prepare('SELECT status FROM conduit_messages WHERE id = ?')
+        .get('msg-1') as {
         status: string;
       };
       expect(delivered.status).toBe('delivered');
 
       // FTS index should pick up the word "Alpha".
       const ftsResults = db
-        .prepare("SELECT content FROM messages_fts WHERE messages_fts MATCH 'Alpha'")
+        .prepare(
+          "SELECT content FROM conduit_messages_fts WHERE conduit_messages_fts MATCH 'Alpha'",
+        )
         .all() as Array<{ content: string }>;
       expect(ftsResults.length).toBeGreaterThanOrEqual(1);
     } finally {
@@ -185,29 +194,30 @@ describe('Agent Lifecycle E2E', () => {
     const _require = createRequire(import.meta.url);
     const { DatabaseSync } = _require('node:sqlite') as typeof import('node:sqlite');
     const db = new DatabaseSync(path);
-    const now = Math.floor(Date.now() / 1000);
+    // T11578 (AC4): prefixed conduit_* tables; timestamps are TEXT ISO-8601.
+    const now = new Date().toISOString();
 
     try {
       db.exec(
-        `INSERT INTO conversations (id, participants, visibility, message_count, created_at, updated_at) VALUES ('c1', '["alice","bob"]', 'private', 0, ${now}, ${now})`,
+        `INSERT INTO conduit_conversations (id, participants, visibility, message_count, created_at, updated_at) VALUES ('c1', '["alice","bob"]', 'private', 0, '${now}', '${now}')`,
       );
       db.exec(
-        `INSERT INTO messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at) VALUES ('m1', 'c1', 'alice', 'bob', 'Hello Bob!', 'text', 'pending', ${now})`,
+        `INSERT INTO conduit_messages (id, conversation_id, from_agent_id, to_agent_id, content, content_type, status, created_at) VALUES ('m1', 'c1', 'alice', 'bob', 'Hello Bob!', 'text', 'pending', '${now}')`,
       );
 
       // 4. Verify roundtrip.
       const received = db
-        .prepare("SELECT * FROM messages WHERE to_agent_id = 'bob'")
+        .prepare("SELECT * FROM conduit_messages WHERE to_agent_id = 'bob'")
         .all() as Array<{ content: string }>;
       expect(received).toHaveLength(1);
       expect(received[0]?.content).toBe('Hello Bob!');
 
       // 5. Mark delivered.
-      db.exec("UPDATE messages SET status = 'delivered' WHERE id = 'm1'");
+      db.exec("UPDATE conduit_messages SET status = 'delivered' WHERE id = 'm1'");
 
       // 6. Verify delivery state persisted.
       const delivered = db
-        .prepare("SELECT COUNT(*) as c FROM messages WHERE status = 'delivered'")
+        .prepare("SELECT COUNT(*) as c FROM conduit_messages WHERE status = 'delivered'")
         .get() as { c: number };
       expect(delivered.c).toBe(1);
     } finally {

--- a/packages/studio/src/routes/api/brain/stream/+server.ts
+++ b/packages/studio/src/routes/api/brain/stream/+server.ts
@@ -77,7 +77,8 @@ interface MsgRow {
   content: string;
   from_agent_id: string | null;
   to_agent_id: string | null;
-  created_at: number;
+  /** Canonical TEXT ISO-8601 (T11578 · AC4 — `conduit_messages.created_at`). */
+  created_at: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -183,7 +184,7 @@ function initWatermarks(ctx: ProjectContext): WatermarkState {
     const conduitDb = getConduitDb(ctx);
     if (conduitDb) {
       const msgMax = conduitDb
-        .prepare('SELECT COALESCE(MAX(rowid), 0) AS max_rowid FROM messages')
+        .prepare('SELECT COALESCE(MAX(rowid), 0) AS max_rowid FROM conduit_messages')
         .get() as { max_rowid: number } | undefined;
       state.lastMsgRowid = msgMax?.max_rowid ?? 0;
     }
@@ -370,7 +371,7 @@ function detectNewMessages(state: WatermarkState, ctx: ProjectContext): BrainStr
     const rows = db
       .prepare(
         `SELECT rowid, id, content, from_agent_id, to_agent_id, created_at
-         FROM messages
+         FROM conduit_messages
          WHERE rowid > ?
          ORDER BY rowid ASC`,
       )

--- a/packages/studio/src/routes/api/brain/stream/__tests__/stream.test.ts
+++ b/packages/studio/src/routes/api/brain/stream/__tests__/stream.test.ts
@@ -458,7 +458,7 @@ describe('GET /api/brain/stream', () => {
         if (sql.includes('MAX(rowid)')) {
           return makeStmt({ max_rowid: 0 });
         }
-        if (sql.includes('FROM messages')) {
+        if (sql.includes('FROM conduit_messages')) {
           return {
             get: () => undefined,
             all() {


### PR DESCRIPTION
## T11578 AC4 — COMPLETE-CUTOVER of the conduit domain (HIGH-RISK)

Repoints the **conduit** runtime store's READ **and WRITE** path off the BARE legacy tables (`messages`, `conversations`, `topics`, `delivery_jobs`, `dead_letters`, `message_pins`, `topic_*`, `project_agent_refs`) + the `messages_fts` FTS5 quartet, onto the PREFIXED consolidated tables (`conduit_conversations`, `conduit_messages`, …) that the consolidated cleo-project migration creates and exodus fills. Before this PR, exodus migrated data into `conduit_messages` but the runtime read bare `messages` → conduit reads were empty (DHQ-046).

### FTS-rename decision
Renamed `messages_fts` → **`conduit_messages_fts`** (and triggers `messages_ai/ad/au` → `conduit_messages_ai/ad/au`) for domain clarity and disjointness inside the shared `cleo.db` (which also holds `brain_*_fts`). `content='messages'` → `content='conduit_messages'`; `content_rowid='rowid'` preserved; the `INSERT INTO conduit_messages_fts(conduit_messages_fts) VALUES('rebuild')` seed reindexes whatever rows the consolidated migration + exodus placed in `conduit_messages`. All references (graph-memory-bridge, migrate-signaldock, lifecycle-e2e) updated.

### Architecture: consolidated migration owns the tables
The 14 prefixed `conduit_*` tables are created by `drizzle-cleo-project/…t11363` (single SSoT). The `drizzle-conduit` forward migration was rewritten to carry ONLY the FTS5 quartet (which drizzle-orm sqlite-core cannot model) + the two legacy `_conduit_*` health-probe tables. The runtime opens consolidated first (`openDualScopeDb`), then layers the conduit FTS migration.

**Reconcile sentinel fix:** changed from `conversations` (gone) to `_conduit_meta` — a conduit-migration-owned table. Critical: `reconcileJournal` Scenario 2 (orphan deletion) is gated on the sentinel already existing. A consolidated-owned sentinel (e.g. `conduit_messages`) exists on first conduit open → Scenario 2 fires, sees the consolidated journal entries as "orphans", and DELETES them, corrupting the shared journal (`table … already exists` on next open). Pinning the sentinel to a conduit-created table keeps Scenario 2 dormant until the conduit set is journaled — exactly as the pre-cutover bare `conversations` sentinel did. Verified: journal preserves all 6 entries (4 consolidated + 2 conduit) across reopen.

### Constraint-normalization summary (WRITE path)
The prefixed `conduit_*` tables carry canonical **TEXT ISO-8601** timestamps (`datetime('now')` defaults + ISO GLOB `CHECK` on every `_at` column) and `conduit_project_agent_refs.enabled` is a typed boolean (`integer DEFAULT true` + `CHECK IN (0,1)`). The legacy writers wrote epoch-seconds. Normalized every conduit WRITE to ISO so inserts/updates conform (else they throw / silently drop under `INSERT OR IGNORE`):
- `local-transport.ts`: `push`/`ack`/`subscribeTopic`/`publishToTopic`/`ensureDmConversation` now write `new Date().toISOString()`; topic-poll watermark switched `number` → ISO string (lexicographically sortable, so `created_at > ?` + `ORDER BY` stay correct); `connect()` existence check → `conduit_messages`.
- `agent-registry-accessor.ts`: `project_agent_refs` → `conduit_project_agent_refs` (writes already ISO/0-1).
- `role-accessors-impl.ts`: best-effort publish → `conduit_messages` + ISO.
- `migrate-signaldock-to-conduit.ts`: `PROJECT_TIER_TABLES` dest → prefixed; `copyTableRows` gains an epoch-seconds→ISO coercion for ISO-GLOB-constrained target columns; FTS rebuild + `project_agent_refs` repointed.
- `cleo dispatch conduit.ts`: passes ISO `since` to `pollTopic`.
- `graph-memory-bridge.ts`, `doctor/db-substrate.ts` (I5 `conduit_dead_letters`), studio brain stream: conduit reads repointed.

### Pair-review checklist (all verified)
- [x] Every `ON messages` → `ON conduit_messages` (3 triggers)
- [x] `content='messages'` → `content='conduit_messages'` (FTS5 virtual table)
- [x] `INSERT … VALUES('rebuild')` seed present (now `conduit_messages_fts`)
- [x] FK `topic_message_acks → topic_messages(id)` repointed to `conduit_topic_message_acks → conduit_topic_messages(id)` (owned by consolidated migration)
- [x] Every `_at` write emits ISO-8601 (passes GLOB CHECK); `enabled` writes 0/1 (passes boolean CHECK)
- [x] Index names / partial-index WHERE predicates preserved (owned by consolidated migration)

### AC4 DELIVERABLE — DDL snapshot test
`packages/core/src/store/__tests__/conduit-ddl-snapshot.test.ts`: applies consolidated + conduit FTS migrations to a fresh in-memory `DatabaseSync`, snapshots `SELECT type,name,sql FROM sqlite_master WHERE name LIKE 'conduit_%' OR name LIKE '%_fts%'` (whitespace-normalized, committed `.snap`), PLUS functional FTS assertions: insert a `conduit_messages` row → AFTER-INSERT trigger populates the FTS index → `MATCH 'hello'` returns the row (proves `content=` + triggers point at the renamed table). Snapshot confirms 14 `conduit_*` tables, `conduit_messages_fts` (`content='conduit_messages'`), 3 triggers `ON conduit_messages`, zero bare tables.

### MINI DRY-RUN (sandbox, on real data)
Copied the live `conduit.db` (1900 messages / 15 conversations) into an isolated sandbox (sandboxed `XDG_DATA_HOME`, no stale `cleo.db`), ran `cleo exodus migrate` then a runtime conduit read.

| Surface | Before (source conduit.db) | After (consolidated cleo.db, runtime read target) |
|---|---|---|
| messages | `messages`=1900 | `conduit_messages`=**1900** |
| conversations | `conversations`=15 | `conduit_conversations`=**15** |
| topic_messages | 130 | `conduit_topic_messages`=**130** |
| topics | 3 | `conduit_topics`=**3** |
| project_agent_refs | 2 | `conduit_project_agent_refs`=**2** |
| FTS | `messages_fts` | `conduit_messages_fts` rebuilt = **1900 indexed**; `MATCH 'agent'` → 5 hits |
| `created_at` affinity | epoch seconds | ISO-8601 (`2026-03-31T02:51:16.000Z`) |

`exodus migrate` copied 2051 rows (FTS tables skipped — rebuilt post-migration). `cleo exodus verify` reports row counts EQUAL across all conduit tables (15/15, 1900/1900, 130/130, 1/1, 3/3) with `hashMatch=false` — expected, because exodus value-transforms epoch→ISO (T11546/T11549) so the digest legitimately differs (pre-existing exodus behavior, not introduced here). **Runtime read proven NON-EMPTY** post-cutover (the DHQ-046 fix).

### Validation
- `pnpm biome check` clean (20 files); `pnpm run typecheck` (tsc -b) clean; `node build.mjs` clean.
- Conduit-domain suites GREEN: conduit-sqlite, conduit-idempotency, conduit-ddl-snapshot, migrate-signaldock-to-conduit, exodus*, consolidated-schema-parity-fk, all conduit transport (local-transport/a2a-topic/messaging-e2e/…), agent-registry-accessor, graph-memory-bridge-integration, doctor-db-substrate, studio stream, and the canonical runtime **lifecycle-e2e.test.ts** gate.
- Full `@cleocode/core` suite: 40 failures across 24 files — **all pre-existing baseline failures in unrelated domains** (tasks/sagas/lifecycle/orchestrate/spawn/audit/events/memory-attention/worktree/init-e2e); confirmed by running a representative subset on the `main` baseline (identical failures). ZERO of my changed/added files are in the failing set. **Zero NEW failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)