### PR TITLE
fix(T11649): widen consolidated enums to preserve real values (transport mcp) — no silent exodus coercion

### DIFF
--- a/packages/cleo/src/cli/commands/token.ts
+++ b/packages/cleo/src/cli/commands/token.ts
@@ -197,7 +197,7 @@ const estimateCommand = defineCommand({
       responsePayload,
       provider: args.provider as string | undefined,
       model: args.model as string | undefined,
-      transport: args.transport as 'cli' | 'api' | 'agent' | 'unknown' | undefined,
+      transport: args.transport as 'cli' | 'api' | 'agent' | 'mcp' | 'unknown' | undefined,
       gateway: args.gateway as string | undefined,
       domain: args.domain as string | undefined,
       operation: args.operation as string | undefined,

--- a/packages/contracts/src/operations/admin.ts
+++ b/packages/contracts/src/operations/admin.ts
@@ -30,9 +30,11 @@
 
 /**
  * Known transport categories for token recording.
- * Mirrors `TokenTransport` from `@cleocode/core`.
+ * Mirrors `TokenTransport` from `@cleocode/core`. `'mcp'` is a first-class
+ * origin (MCP-gateway requests); it is preserved verbatim, never coerced to
+ * `'agent'` (T11649).
  */
-export type AdminTokenTransport = 'cli' | 'api' | 'agent' | 'unknown';
+export type AdminTokenTransport = 'cli' | 'api' | 'agent' | 'mcp' | 'unknown';
 
 /**
  * Token measurement method classification.

--- a/packages/core/migrations/drizzle-cleo-project/20260602000002_t11649-token-usage-transport-mcp/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260602000002_t11649-token-usage-transport-mcp/migration.sql
@@ -1,0 +1,146 @@
+-- T11649 — Widen `tasks_token_usage.transport` CHECK to preserve 'mcp'.
+--
+-- Background:
+--   The consolidation migration (20260531000001_t11363) created
+--   `tasks_token_usage` with `CHECK ("transport" IN ('cli','api','agent','unknown'))`.
+--   `'mcp'` was NOT in the enum, so the exodus migrate layer coerced
+--   `transport = 'mcp'` → `'agent'` (T11548) to satisfy the CHECK. The full
+--   cutover dry-run flagged this as a SILENT SEMANTIC ALTERATION: ~194 real
+--   telemetry rows had their true origin (MCP-gateway, `source: "mcp"`) rewritten
+--   to `'agent'`, with no preserving column capturing the lost value. Count was
+--   preserved; integrity was not.
+--
+-- Owner directive (T11649): 100% data integrity. `'mcp'` is a first-class
+--   transport origin, distinct from `'agent'`, and MUST be stored verbatim.
+--
+-- Change:
+--   Old CHECK: transport IN ('cli','api','agent','unknown')
+--   New CHECK: transport IN ('cli','api','agent','mcp','unknown')
+--
+--   The widened enum is the canonical `TOKEN_USAGE_TRANSPORTS` SSoT in
+--   packages/core/src/store/schema/audit.ts. The exodus `tasks_token_usage.transport`
+--   normalization rule is removed in the same change so `'mcp'` lands unmodified.
+--
+-- SQLite cannot ALTER a CHECK constraint in place, so this migration follows the
+-- canonical "table rebuild" recipe (same pattern as drizzle-tasks T9073 / T1408):
+--
+--   1. Create `__new_tasks_token_usage` with the widened CHECK (every other
+--      column / default / CHECK preserved verbatim from the T11363 DDL).
+--   2. INSERT … SELECT every row (no data transformation — existing values are
+--      all valid under the wider constraint).
+--   3. DROP `tasks_token_usage`; RENAME `__new_tasks_token_usage` TO it.
+--   4. Recreate all nine indexes.
+--
+-- This migration is purely additive at the schema level (the enum only GROWS),
+-- runs AFTER the consolidation CREATE, and leaves every other table untouched.
+--
+-- @task T11649
+-- @epic T11245
+-- @saga T11242
+
+PRAGMA foreign_keys = OFF;
+--> statement-breakpoint
+
+-- --------------------------------------------------------------------------
+-- Step 1 — Drop the nine indexes attached to `tasks_token_usage`
+--          (they are recreated against the rebuilt table in Step 4).
+-- --------------------------------------------------------------------------
+DROP INDEX IF EXISTS `idx_tasks_token_usage_created_at`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_request_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_session_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_task_id`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_provider`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_transport`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_domain_operation`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_method`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_tasks_token_usage_gateway`;
+--> statement-breakpoint
+
+-- --------------------------------------------------------------------------
+-- Step 2 — Create `__new_tasks_token_usage` with the widened transport CHECK.
+--          All other columns / constraints / defaults are byte-identical to the
+--          T11363 consolidation DDL — the only change is the transport enum.
+-- --------------------------------------------------------------------------
+CREATE TABLE `__new_tasks_token_usage` (
+	`id` text PRIMARY KEY,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`provider` text DEFAULT 'unknown' NOT NULL,
+	`model` text,
+	`transport` text DEFAULT 'unknown' NOT NULL,
+	`gateway` text,
+	`domain` text,
+	`operation` text,
+	`session_id` text,
+	`task_id` text,
+	`request_id` text,
+	`input_chars` integer DEFAULT 0 NOT NULL,
+	`output_chars` integer DEFAULT 0 NOT NULL,
+	`input_tokens` integer DEFAULT 0 NOT NULL,
+	`output_tokens` integer DEFAULT 0 NOT NULL,
+	`total_tokens` integer DEFAULT 0 NOT NULL,
+	`method` text DEFAULT 'heuristic' NOT NULL,
+	`confidence` text DEFAULT 'coarse' NOT NULL,
+	`request_hash` text,
+	`response_hash` text,
+	`metadata_json` text DEFAULT '{}' NOT NULL,
+	-- consolidation CHECK constraints (T11363) — transport widened to include 'mcp' (T11649)
+	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+	CHECK ("transport" IN ('cli', 'api', 'agent', 'mcp', 'unknown')),
+	CHECK ("method" IN ('otel', 'provider_api', 'tokenizer', 'heuristic')),
+	CHECK ("confidence" IN ('real', 'high', 'estimated', 'coarse'))
+);
+--> statement-breakpoint
+
+-- --------------------------------------------------------------------------
+-- Step 3 — Copy every row (no transformation; every value is valid under the
+--          wider constraint) then swap tables.
+-- --------------------------------------------------------------------------
+INSERT INTO `__new_tasks_token_usage` (
+	`id`, `created_at`, `provider`, `model`, `transport`, `gateway`, `domain`,
+	`operation`, `session_id`, `task_id`, `request_id`, `input_chars`,
+	`output_chars`, `input_tokens`, `output_tokens`, `total_tokens`, `method`,
+	`confidence`, `request_hash`, `response_hash`, `metadata_json`
+)
+SELECT
+	`id`, `created_at`, `provider`, `model`, `transport`, `gateway`, `domain`,
+	`operation`, `session_id`, `task_id`, `request_id`, `input_chars`,
+	`output_chars`, `input_tokens`, `output_tokens`, `total_tokens`, `method`,
+	`confidence`, `request_hash`, `response_hash`, `metadata_json`
+FROM `tasks_token_usage`;
+--> statement-breakpoint
+DROP TABLE `tasks_token_usage`;
+--> statement-breakpoint
+ALTER TABLE `__new_tasks_token_usage` RENAME TO `tasks_token_usage`;
+--> statement-breakpoint
+
+-- --------------------------------------------------------------------------
+-- Step 4 — Recreate all nine indexes (verbatim from the T11363 DDL).
+-- --------------------------------------------------------------------------
+CREATE INDEX `idx_tasks_token_usage_created_at` ON `tasks_token_usage` (`created_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_request_id` ON `tasks_token_usage` (`request_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_session_id` ON `tasks_token_usage` (`session_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_task_id` ON `tasks_token_usage` (`task_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_provider` ON `tasks_token_usage` (`provider`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_transport` ON `tasks_token_usage` (`transport`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_domain_operation` ON `tasks_token_usage` (`domain`,`operation`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_method` ON `tasks_token_usage` (`method`);
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_token_usage_gateway` ON `tasks_token_usage` (`gateway`);
+--> statement-breakpoint
+
+PRAGMA foreign_keys = ON;

--- a/packages/core/src/metrics/token-service.ts
+++ b/packages/core/src/metrics/token-service.ts
@@ -15,13 +15,24 @@ import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getCleoHome } from '../paths.js';
-import { type NewTokenUsageRow, type TokenUsageRow, tokenUsage } from '../store/tasks-schema.js';
+import {
+  type NewTokenUsageRow,
+  type TOKEN_USAGE_TRANSPORTS,
+  type TokenUsageRow,
+  tokenUsage,
+} from '../store/tasks-schema.js';
 import { resolveProviderFromModelRegistry } from './model-provider-registry.js';
 import { detectRuntimeProviderContext } from './provider-detection.js';
 
 export type TokenMethod = 'otel' | 'provider_api' | 'tokenizer' | 'heuristic';
 export type TokenConfidence = 'real' | 'high' | 'estimated' | 'coarse';
-export type TokenTransport = 'cli' | 'api' | 'agent' | 'unknown';
+/**
+ * Transport origin of a token exchange. Derived from the canonical
+ * {@link TOKEN_USAGE_TRANSPORTS} enum SSoT (`cli | api | agent | mcp | unknown`)
+ * so the type, the schema CHECK, and the exodus normalization stay in lockstep
+ * (T11649 — `'mcp'` is a first-class origin, no longer coerced to `'agent'`).
+ */
+export type TokenTransport = (typeof TOKEN_USAGE_TRANSPORTS)[number];
 
 export interface TokenExchangeInput {
   requestPayload?: unknown;

--- a/packages/core/src/store/__tests__/exodus.test.ts
+++ b/packages/core/src/store/__tests__/exodus.test.ts
@@ -1977,8 +1977,9 @@ describe('T11547 regression — enum normalization in migrate layer', () => {
 // ---------------------------------------------------------------------------
 // T11548 REGRESSION — final enum coverage (285 rows, zero genuine loss)
 //
-// Verifies the 8 new ENUM_NORMALIZATIONS entries added in T11548:
-//   - tasks_token_usage.transport: 'mcp' → 'agent'
+// Verifies the ENUM_NORMALIZATIONS entries added in T11548:
+//   - tasks_token_usage.transport: 'mcp' PRESERVED (T11649 — coercion removed,
+//     CHECK enum widened to include 'mcp'; no longer rewritten to 'agent')
 //   - brain_decisions.decision_category: 'architecture' → 'architectural'
 //   - brain_decisions.confidence: out-of-vocab → 'medium'
 //   - tasks_commits.conventional_type: 'style' → 'chore'
@@ -2069,7 +2070,12 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
     return targetPath;
   }
 
-  it('normalizes tasks_token_usage.transport: mcp → agent', async () => {
+  // T11649 — INTEGRITY: 'mcp' is a first-class transport origin (MCP-gateway,
+  // `source: "mcp"`), NOT coerced to 'agent'. The consolidated CHECK enum was
+  // widened to include 'mcp', so exodus stores the true value verbatim. The
+  // earlier T11548 'mcp' → 'agent' mapping was a silent semantic alteration of
+  // ~194 rows (count-preserving, NOT integrity-preserving).
+  it('preserves tasks_token_usage.transport: mcp stays mcp (T11649 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -2085,9 +2091,11 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Widened CHECK enum (T11649) — the consolidated schema + forward migration
+      // `20260602000002_t11649-token-usage-transport-mcp` now accept 'mcp'.
       tgtDb.exec(
         `CREATE TABLE tasks_token_usage (id INTEGER PRIMARY KEY, ` +
-          `transport TEXT NOT NULL CHECK (transport IN ('cli','api','agent','unknown')) DEFAULT 'unknown', ` +
+          `transport TEXT NOT NULL CHECK (transport IN ('cli','api','agent','mcp','unknown')) DEFAULT 'unknown', ` +
           `tokens INTEGER)`,
       );
     } finally {
@@ -2103,10 +2111,16 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
         .prepare('SELECT id, transport FROM tasks_token_usage ORDER BY id')
         .all() as Array<{ id: number; transport: string }>;
       expect(rows).toHaveLength(4);
-      expect(rows.find((r) => r.id === 1)?.transport, 'mcp → agent').toBe('agent');
+      // The crux of T11649: 'mcp' is PRESERVED, never rewritten to 'agent'.
+      expect(rows.find((r) => r.id === 1)?.transport, 'mcp preserved (not coerced)').toBe('mcp');
       expect(rows.find((r) => r.id === 2)?.transport, 'cli passthrough').toBe('cli');
       expect(rows.find((r) => r.id === 3)?.transport, 'agent passthrough').toBe('agent');
-      expect(rows.find((r) => r.id === 4)?.transport, 'mcp → agent').toBe('agent');
+      expect(rows.find((r) => r.id === 4)?.transport, 'mcp preserved (not coerced)').toBe('mcp');
+      // No row was silently rewritten to 'agent' from an 'mcp' source.
+      expect(
+        rows.filter((r) => r.transport === 'agent').length,
+        'only the genuinely-agent row is agent',
+      ).toBe(1);
     } finally {
       tgt.close();
     }

--- a/packages/core/src/store/exodus/__fixtures__/representative-fixture.ts
+++ b/packages/core/src/store/exodus/__fixtures__/representative-fixture.ts
@@ -17,8 +17,10 @@
  *     `tasks_architecture_decisions`).
  *   - **Epoch-INTEGER timestamps** (seconds AND milliseconds) destined for a
  *     target `text` column with an ISO-8601 GLOB CHECK constraint.
- *   - **Legacy enum aliases** (`'Accepted'`, `'mcp'`, `'observation'`) that fail
- *     the target CHECK unless the migration normalises them.
+ *   - **Legacy enum aliases** (`'Accepted'`, `'observation'`) that fail the
+ *     target CHECK unless the migration normalises them, AND the real value
+ *     `'mcp'` (transport) which the consolidated CHECK now ACCEPTS verbatim —
+ *     proving exodus preserves it without coercion (T11649).
  *   - **A self-referential FK** (`tasks.parent_id → tasks.id`) copied
  *     child-before-parent to exercise the FK-defer path.
  *
@@ -267,11 +269,13 @@ function buildTargetSchema(
         decided_at TEXT CHECK ("decided_at" IS NULL OR "decided_at" GLOB ${ISO_GLOB})
       )`,
     );
-    // tasks_token_usage: transport CHECK enum (no 'mcp').
+    // tasks_token_usage: transport CHECK enum — WIDENED to include 'mcp' (T11649).
+    // 'mcp' is a first-class transport origin; the consolidated CHECK accepts it
+    // so exodus stores the real value verbatim (no coercion to 'agent').
     db.exec(
       `CREATE TABLE "tasks_token_usage" (
         id INTEGER PRIMARY KEY,
-        transport TEXT CHECK ("transport" IN ('cli', 'api', 'agent', 'unknown'))
+        transport TEXT CHECK ("transport" IN ('cli', 'api', 'agent', 'mcp', 'unknown'))
       )`,
     );
     // brain_observations: type CHECK enum + created_at ISO GLOB.

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -397,10 +397,16 @@ function typeDefaultLiteral(colType: string): string {
  *
  * ## Additional entries (T11548 — final 285 rows)
  *
- * - `tasks_token_usage.transport`
- *   → `'mcp'` → `'agent'` (CHECK enum: cli/api/agent/unknown). Legacy writers
- *   emitted 'mcp' before the transport taxonomy was consolidated; 'agent' is
- *   the nearest canonical for MCP-originated requests. [194 rows]
+ * - `tasks_token_usage.transport` (T11649 — coercion REMOVED, value PRESERVED)
+ *   → `'mcp'` is NOT coerced. It is a first-class transport origin (MCP-gateway
+ *   requests, `source: "mcp"`), semantically distinct from `'agent'`. The earlier
+ *   T11548 mapping (`'mcp'` → `'agent'`) was count-preserving but NOT
+ *   integrity-preserving — it silently altered the true origin of ~194 telemetry
+ *   rows with no column capturing the lost value. T11649 instead WIDENS the
+ *   consolidated CHECK enum to `cli/api/agent/mcp/unknown` (canonical SSoT
+ *   `TOKEN_USAGE_TRANSPORTS` in `schema/audit.ts` + forward migration
+ *   `20260602000002_t11649-token-usage-transport-mcp`) so exodus stores `'mcp'`
+ *   verbatim — zero semantic loss.
  *
  * - `brain_decisions.decision_category`
  *   → `'architecture'` → `'architectural'` (enum: architectural/agent_dispatch/other).
@@ -519,13 +525,13 @@ const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
       ` END`,
   ],
 
-  // --- tasks_token_usage.transport (T11548) --------------------------------
-  // 'mcp' → 'agent' (CHECK enum: cli/api/agent/unknown). 194 rows.
-  // Legacy writers emitted 'mcp' before transport taxonomy was consolidated.
-  [
-    'tasks_token_usage.transport',
-    (src: string) => `CASE ${src} WHEN 'mcp' THEN 'agent' ELSE ${src} END`,
-  ],
+  // --- tasks_token_usage.transport (T11548 → REMOVED T11649) ---------------
+  // NO normalization. 'mcp' is a first-class transport origin (MCP-gateway
+  // requests) and is preserved verbatim. The consolidated CHECK enum was WIDENED
+  // to include 'mcp' (canonical TOKEN_USAGE_TRANSPORTS SSoT + forward migration
+  // 20260602000002_t11649-token-usage-transport-mcp), so the value lands without
+  // coercion. The earlier 'mcp' → 'agent' mapping was a silent semantic alteration
+  // of ~194 rows (count-preserving, NOT integrity-preserving) — see T11649.
 
   // --- brain_decisions.decision_category (T11548 + T11549) -----------------
   // 'architecture' → 'architectural' (enum: architectural/agent_dispatch/other). 31 rows.

--- a/packages/core/src/store/schema/audit.ts
+++ b/packages/core/src/store/schema/audit.ts
@@ -24,8 +24,18 @@ export const TOKEN_USAGE_METHODS = ['otel', 'provider_api', 'tokenizer', 'heuris
 /** Confidence levels for token measurements. */
 export const TOKEN_USAGE_CONFIDENCE = ['real', 'high', 'estimated', 'coarse'] as const;
 
-/** Transport types for token telemetry. */
-export const TOKEN_USAGE_TRANSPORTS = ['cli', 'api', 'agent', 'unknown'] as const;
+/**
+ * Transport types for token telemetry.
+ *
+ * `'mcp'` is a first-class transport (MCP-originated requests through the unified
+ * gateway — see `packages/runtime/src/gateway/mcp`, `source: "mcp"`). It is a
+ * distinct origin from `'agent'` and MUST be preserved verbatim: the exodus
+ * migration previously coerced `'mcp'` → `'agent'`, silently altering ~194 rows
+ * of real telemetry. Widening the canonical enum (T11649) lets the consolidated
+ * `tasks_token_usage.transport` CHECK accept `'mcp'`, so the exodus copy stores
+ * the true origin with zero semantic loss.
+ */
+export const TOKEN_USAGE_TRANSPORTS = ['cli', 'api', 'agent', 'mcp', 'unknown'] as const;
 
 // === SCHEMA METADATA ===
 


### PR DESCRIPTION
## Summary

The full cutover dry-run flagged `transport='mcp'` (~194 rows) being silently coerced to `'agent'` by the exodus enum-normalization layer. Row **count** was preserved, but the **value** was genuinely lost — no column captures `'mcp'`, so the true origin (MCP-gateway requests, `source: "mcp"`) was permanently altered. Count-preserving ≠ integrity-preserving. The owner's bar is 100% data integrity, so this is a cutover NO-GO (T11649).

`'mcp'` is a first-class transport origin, semantically distinct from `'agent'`. The fix **widens the canonical enum** so exodus stores the real value verbatim — zero coercion.

## Enums widened / values preserved

| Table.column | Old CHECK enum | New CHECK enum | Value preserved |
|---|---|---|---|
| `tasks_token_usage.transport` | `cli, api, agent, unknown` | `cli, api, agent, **mcp**, unknown` | `'mcp'` (was → `'agent'`) |

Canonical SSoT: `TOKEN_USAGE_TRANSPORTS` in `packages/core/src/store/schema/audit.ts` (the consolidated-schema CHECK and the AC2 parity gate both derive from it).

## Changes

- **`store/schema/audit.ts`** — `TOKEN_USAGE_TRANSPORTS` gains `'mcp'`.
- **`metrics/token-service.ts`** — `TokenTransport` now **derived** from the canonical enum const (DRY) instead of a hardcoded literal union.
- **`contracts/operations/admin.ts`** — `AdminTokenTransport` gains `'mcp'`.
- **`cleo/cli/commands/token.ts`** — widen the inline `transport` cast.
- **`migrations/drizzle-cleo-project/20260602000002_t11649-token-usage-transport-mcp/migration.sql`** — forward **table-rebuild** migration (SQLite cannot `ALTER` a CHECK) widening `tasks_token_usage.transport` to `cli/api/agent/mcp/unknown`, all 9 indexes recreated. The frozen consolidation migration is **untouched**; the AC2 parity gate re-derives the widened CHECK from the schema and confirms the applied DDL matches (same pattern as the T9073 severity-widening rebuild).
- **`store/exodus/migrate.ts`** — **REMOVE** the `tasks_token_usage.transport` `'mcp'→'agent'` normalization rule so the real value lands without coercion.
- **`exodus/__fixtures__/representative-fixture.ts`** + **`store/__tests__/exodus.test.ts`** — target CHECK widened; the regression test now asserts `'mcp'` is **PRESERVED** (not rewritten to `'agent'`), and that no `mcp`-source row is silently turned into `agent`.

## Test

`store/__tests__/exodus.test.ts` → "preserves tasks_token_usage.transport: mcp stays mcp (T11649 — no coercion)" — seeds `mcp/cli/agent/mcp`, runs the real exodus migrate against a widened-CHECK target, asserts the two `mcp` rows stay `mcp` and exactly one row is `agent`. Plus end-to-end: cumulative migration application produces `CHECK ("transport" IN ('cli','api','agent','mcp','unknown'))`, accepts `'mcp'`, still rejects out-of-enum.

## Other non-brain coercions audited (for the re-dry-run picture)

Audited every entry in `ENUM_NORMALIZATIONS` (brain entries are owned by T11647 and untouched here):

- **`tasks_commits.conventional_type`** (`'merge'`/`'release'`→`'chore'`) — **left as-is, lossless by design (T11578).** Live data confirms the precise semantic is faithfully captured in dedicated boolean columns `is_merge_commit` / `is_release_commit` + raw `subject` text; `merge`/`release` are not conventional-commit-spec types. Documented, recoverable, not a silent loss.
- **Case/format normalizations** (`architecture_decisions.status`, `brain_decisions.confirmation_state`) — `'Accepted'`/`'ACCEPTED'`/`'Accepted (date)'`→`'accepted'`: same semantic value, different casing. Correct as-is.
- **Pure renames** (`task_commits.link_source` `'commit-message'`→`'commit-subject'`; `task_relations.relation_type` `'grouped-by'`→`'groups'`) and the lifecycle/gate/binding rules: **zero live-data drift** (probed `.cleo/tasks.db` + `~/.local/share/cleo/tasks.db` — all 0 distinct out-of-enum values), so they never fire on real data.

**Net for the re-dry-run:** the only genuine non-brain integrity violation was `transport='mcp'`, now fixed. The remaining brain coercions (`source_type`/`type`/etc.) are owned by T11647.

## Validation

- `pnpm biome check`, `pnpm run typecheck`, `node build.mjs` — all green.
- `cleo check arch` — 5/5 gates pass.
- Changed-domain store tests: **171/171** (exodus, exodus-on-open, verify-migration, consolidated-schema-parity-fk **AC2**, commits-schema-parity, migration-smoke, migration-baseline).
- `@cleocode/runtime` **120/120**, `@cleocode/contracts` **739/739**.
- Full `@cleocode/core` suite: remaining failures are pre-existing **local environmental flakes** (stale worktree-napi binary `integrateWorktree is not a function`; perf-test timeouts under 8-worker parallel load; cross-file `resetDbState` isolation) — non-deterministic across runs and each file **passes in isolation**. None touch the changed surface. Trust CI per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
