### PR TITLE
fix(T11648): route nexus graph reads to project scope (T11538/T11539 runtime half) — graph visible post-migrate

### DIFF
--- a/packages/cleo/src/dispatch/domains/nexus.ts
+++ b/packages/cleo/src/dispatch/domains/nexus.ts
@@ -1073,26 +1073,31 @@ function handleTopEntriesFromNexus(
 
   let rows: TopEntryRow[] = [];
   try {
+    // T11545 · ADR-090: the plasticity `weight` was partitioned out of
+    // `nexus_relations` into the sibling `nexus_relation_weights` table — LEFT
+    // JOIN it (absent rows ⇒ weight 0 via COALESCE).
     const sql =
       kind === null
         ? `SELECT r.source_id,
-                  SUM(COALESCE(r.weight, 0)) AS totalWeight,
+                  SUM(COALESCE(w.weight, 0)) AS totalWeight,
                   COUNT(*)                   AS edgeCount,
                   n.label,
                   n.kind,
                   n.file_path
              FROM nexus_relations r
+             LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
              LEFT JOIN nexus_nodes n ON n.id = r.source_id
             GROUP BY r.source_id
             ORDER BY totalWeight DESC, edgeCount DESC
             LIMIT ?`
         : `SELECT r.source_id,
-                  SUM(COALESCE(r.weight, 0)) AS totalWeight,
+                  SUM(COALESCE(w.weight, 0)) AS totalWeight,
                   COUNT(*)                   AS edgeCount,
                   n.label,
                   n.kind,
                   n.file_path
              FROM nexus_relations r
+             LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
              LEFT JOIN nexus_nodes n ON n.id = r.source_id
             WHERE n.kind = ?
             GROUP BY r.source_id
@@ -1193,7 +1198,7 @@ interface ImpactNodeRow {
   kind: string | null;
   file_path: string | null;
   name: string | null;
-  project_id: string;
+  // `project_id` DROPPED (ADR-090 · T11648) — graph is project-scoped.
 }
 
 /**
@@ -1289,14 +1294,15 @@ async function handleImpact(
     // process) never have callers so they are excluded from resolution.
     let allNodes: ImpactNodeRow[] = [];
     try {
+      // ADR-090 · T11648: the project-scope graph DB has one project, so the
+      // former `project_id` column + predicate are dropped.
       const rawRows = db
         .prepare(
-          `SELECT id, label, kind, file_path, name, project_id
+          `SELECT id, label, kind, file_path, name
              FROM nexus_nodes
-            WHERE project_id = ?
-              AND kind NOT IN ('community','process','file','folder')`,
+            WHERE kind NOT IN ('community','process','file','folder')`,
         )
-        .all(projectId);
+        .all();
       allNodes = rawRows.map((raw) => {
         const r = raw as Record<string, unknown>;
         return {
@@ -1305,7 +1311,6 @@ async function handleImpact(
           kind: r['kind'] != null ? String(r['kind']) : null,
           file_path: r['file_path'] != null ? String(r['file_path']) : null,
           name: r['name'] != null ? String(r['name']) : null,
-          project_id: String(r['project_id'] ?? ''),
         };
       });
     } catch {
@@ -1356,14 +1361,17 @@ async function handleImpact(
     // adjacency index: targetId -> list of { source_id, type, weight }.
     let allRelations: ImpactRelationRow[] = [];
     try {
+      // ADR-090 · T11648: project-scoped graph (no `project_id`). T11545: the
+      // plasticity `weight` lives in the sibling `nexus_relation_weights` table —
+      // LEFT JOIN it (NULL when the edge was never strengthened).
       const rawRows = db
         .prepare(
-          `SELECT source_id, target_id, type, weight
-             FROM nexus_relations
-            WHERE project_id = ?
-              AND type IN ('calls','imports','accesses')`,
+          `SELECT r.source_id AS source_id, r.target_id AS target_id, r.type AS type, w.weight AS weight
+             FROM nexus_relations r
+        LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
+            WHERE r.type IN ('calls','imports','accesses')`,
         )
-        .all(projectId);
+        .all();
       allRelations = rawRows.map((raw) => {
         const r = raw as Record<string, unknown>;
         return {

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2487,8 +2487,14 @@ export {
   removeFsHarden,
   resolveAgentWorktreeRoot,
 } from './spawn/branch-lock.js';
-// Nexus DB path (global tier) + native handle for Tier-2 ingesters (T1008)
-export { getNexusDb, getNexusDbPath, getNexusNativeDb } from './store/nexus-sqlite.js';
+// Nexus DB paths — graph (project scope, ADR-090 T11648) + registry (global) —
+// plus native handle for Tier-2 ingesters (T1008).
+export {
+  getNexusDb,
+  getNexusDbPath,
+  getNexusNativeDb,
+  getNexusRegistryDbPath,
+} from './store/nexus-sqlite.js';
 // System — backup (different from store/backup.ts)
 export { createBackup as systemCreateBackup } from './system/backup.js';
 export type { DoctorReport, FixResult } from './system/health.js';

--- a/packages/core/src/memory/__tests__/brain-reasoning-symbol.test.ts
+++ b/packages/core/src/memory/__tests__/brain-reasoning-symbol.test.ts
@@ -115,14 +115,15 @@ describe('brain-reasoning-symbol', () => {
     await getNexusDb();
     const native = getNexusNativeDb();
     if (!native) throw new Error('nexus native db not available');
-    // Use minimal INSERT with only always-present columns to avoid is_external / weight issues
+    // ADR-090 · T11648: the project-scope graph has no `project_id` column.
+    // Use minimal INSERT with only always-present columns.
     native
       .prepare(
         `INSERT OR IGNORE INTO nexus_nodes
-           (id, project_id, kind, label, name, file_path)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+           (id, kind, label, name, file_path)
+         VALUES (?, ?, ?, ?, ?)`,
       )
-      .run(id, 'test-project', kind, label, name, filePath);
+      .run(id, kind, label, name, filePath);
   }
 
   /** Seed a brain decision in brain_decisions table. */

--- a/packages/core/src/nexus/__tests__/living-brain.test.ts
+++ b/packages/core/src/nexus/__tests__/living-brain.test.ts
@@ -41,42 +41,34 @@ async function seedNexusData(nexusNative: ReturnType<typeof getNexusNativeDb>) {
   if (!nexusNative) return;
   const now = new Date().toISOString();
 
+  // ADR-090 · T11648: the project-scope graph tables no longer carry `project_id`.
   // Insert test symbol node
   nexusNative
     .prepare(
       `INSERT OR IGNORE INTO nexus_nodes
-       (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       (id, kind, name, file_path, label, indexed_at, is_exported)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
     )
-    .run(SYMBOL_ID, 'test-project', 'function', SYMBOL_NAME, FILE_PATH, SYMBOL_NAME, now, 1);
+    .run(SYMBOL_ID, 'function', SYMBOL_NAME, FILE_PATH, SYMBOL_NAME, now, 1);
 
   // Insert a caller node
   nexusNative
     .prepare(
       `INSERT OR IGNORE INTO nexus_nodes
-       (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       (id, kind, name, file_path, label, indexed_at, is_exported)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
     )
-    .run(
-      CALLER_ID,
-      'test-project',
-      'function',
-      'callerFunction',
-      'src/caller.ts',
-      'callerFunction',
-      now,
-      1,
-    );
+    .run(CALLER_ID, 'function', 'callerFunction', 'src/caller.ts', 'callerFunction', now, 1);
 
   // Insert a calls relation: callerFunction -> testFunction.
   // T11545: plasticity weight lives in the sibling nexus_relation_weights table.
   nexusNative
     .prepare(
       `INSERT OR IGNORE INTO nexus_relations
-       (id, project_id, source_id, target_id, type, confidence)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+       (id, source_id, target_id, type, confidence)
+       VALUES (?, ?, ?, ?, ?)`,
     )
-    .run('rel-001', 'test-project', CALLER_ID, SYMBOL_ID, 'calls', 0.9);
+    .run('rel-001', CALLER_ID, SYMBOL_ID, 'calls', 0.9);
   nexusNative
     .prepare(
       `INSERT OR IGNORE INTO nexus_relation_weights (relation_id, weight, co_accessed_count)
@@ -163,11 +155,21 @@ async function seedBrainData(brainNative: ReturnType<typeof getBrainNativeDb>) {
 
 describe('living-brain SDK', () => {
   let projectRoot: string;
+  let prevCleoDir: string | undefined;
+  let prevCleoHome: string | undefined;
 
   beforeEach(async () => {
     projectRoot = mkdtempSync(join(tmpdir(), 'living-brain-test-'));
     // Pre-create `.cleo/` so resolveCleoDir resolves the temp dir (T11262).
     mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+
+    // ADR-090 · T11648: getNexusDb() resolves the PROJECT scope from CLEO_DIR/cwd
+    // (the graph home) — pin it to this temp project so the nexus graph lands in
+    // the SAME `.cleo/` as the brain DB and is isolated from the real repo.
+    prevCleoDir = process.env['CLEO_DIR'];
+    prevCleoHome = process.env['CLEO_HOME'];
+    process.env['CLEO_DIR'] = join(projectRoot, '.cleo');
+    process.env['CLEO_HOME'] = join(projectRoot, 'home');
 
     // Initialize databases (creates schema)
     await getBrainDb(projectRoot);
@@ -186,6 +188,10 @@ describe('living-brain SDK', () => {
   afterEach(() => {
     resetBrainDbState();
     resetNexusDbState();
+    if (prevCleoDir === undefined) delete process.env['CLEO_DIR'];
+    else process.env['CLEO_DIR'] = prevCleoDir;
+    if (prevCleoHome === undefined) delete process.env['CLEO_HOME'];
+    else process.env['CLEO_HOME'] = prevCleoHome;
     removeTempDirSync(projectRoot);
   });
 

--- a/packages/core/src/nexus/__tests__/nexus-e2e-graph.test.ts
+++ b/packages/core/src/nexus/__tests__/nexus-e2e-graph.test.ts
@@ -93,6 +93,12 @@ beforeEach(async () => {
   await mkdir(registryDir, { recursive: true });
 
   process.env['CLEO_HOME'] = registryDir;
+  // NOTE (ADR-090 · T11648): CLEO_DIR is intentionally NOT pinned here. These
+  // E2E tests register MULTIPLE synthetic projects (each with its own `.cleo/`)
+  // and assert per-project task/graph counts via each project's path — a global
+  // CLEO_DIR override would funnel every project into one DB. The GLOBAL-registry
+  // ATTACH stays fresh because `ensureGlobalRegistryAttached` self-heals when
+  // CLEO_HOME changes (DETACH + re-ATTACH on path drift).
   process.env['NEXUS_HOME'] = join(registryDir, 'nexus');
   process.env['NEXUS_CACHE_DIR'] = join(registryDir, 'nexus', 'cache');
   process.env['NEXUS_CURRENT_PROJECT'] = 'e2e-project';

--- a/packages/core/src/nexus/__tests__/route-analysis.test.ts
+++ b/packages/core/src/nexus/__tests__/route-analysis.test.ts
@@ -5,16 +5,33 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { eq } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNexusDb, nexusSchema } from '../../store/nexus-sqlite.js';
+import { getNexusDb, nexusSchema, resetNexusDbState } from '../../store/nexus-sqlite.js';
 import { getRouteMap, shapeCheck } from '../route-analysis.js';
 
 describe('route-analysis', () => {
   let projectId: string;
   let db: ReturnType<typeof getNexusDb>;
+  // ADR-090 · T11648: the graph is PROJECT-scoped (no `project_id` filter), so
+  // isolate the project `.cleo/cleo.db` to a tempdir for this suite — otherwise
+  // the route queries would scan the real repo's graph instead of just the
+  // seeded fixtures.
+  let tmpDir: string;
+  let prevCleoDir: string | undefined;
+  let prevCleoHome: string | undefined;
 
   beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'route-analysis-'));
+    prevCleoDir = process.env['CLEO_DIR'];
+    prevCleoHome = process.env['CLEO_HOME'];
+    process.env['CLEO_DIR'] = join(tmpDir, '.cleo');
+    process.env['CLEO_HOME'] = join(tmpDir, 'home');
+    resetNexusDbState();
+
     projectId = `test-project-${randomUUID().slice(0, 8)}`;
     db = await getNexusDb();
 
@@ -162,30 +179,15 @@ describe('route-analysis', () => {
   });
 
   afterAll(async () => {
-    // Clean up: delete test data
-    const cleanDb = await getNexusDb();
-    const testNodes = cleanDb
-      .select()
-      .from(nexusSchema.nexusNodes)
-      .where(eq(nexusSchema.nexusNodes.projectId, projectId))
-      .all();
-
-    for (const node of testNodes) {
-      cleanDb.delete(nexusSchema.nexusNodes).where(eq(nexusSchema.nexusNodes.id, node.id)).run();
-    }
-
-    const testRelations = cleanDb
-      .select()
-      .from(nexusSchema.nexusRelations)
-      .where(eq(nexusSchema.nexusRelations.projectId, projectId))
-      .all();
-
-    for (const rel of testRelations) {
-      cleanDb
-        .delete(nexusSchema.nexusRelations)
-        .where(eq(nexusSchema.nexusRelations.id, rel.id))
-        .run();
-    }
+    // ADR-090 · T11648: the whole suite ran against an isolated tempdir project
+    // DB, so cleanup is just dropping the singleton + removing the tempdir and
+    // restoring env (no per-`project_id` row deletion — that column is gone).
+    resetNexusDbState();
+    if (prevCleoDir === undefined) delete process.env['CLEO_DIR'];
+    else process.env['CLEO_DIR'] = prevCleoDir;
+    if (prevCleoHome === undefined) delete process.env['CLEO_HOME'];
+    else process.env['CLEO_HOME'] = prevCleoHome;
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   describe('getRouteMap', () => {

--- a/packages/core/src/nexus/__tests__/t11024-move-rename.test.ts
+++ b/packages/core/src/nexus/__tests__/t11024-move-rename.test.ts
@@ -67,6 +67,10 @@ beforeEach(async () => {
   pd = join(td, 'tp');
   await mkdir(rd, { recursive: true });
   process.env['CLEO_HOME'] = rd;
+  // ADR-090 · T11648: pin CLEO_DIR per test so the cwd-cached nexus project
+  // handle (and its GLOBAL-registry ATTACH) is re-created against the current
+  // CLEO_HOME each test (avoids a stale ATTACH to a prior test's registry).
+  process.env['CLEO_DIR'] = join(td, '.cleo');
   process.env['NEXUS_HOME'] = join(rd, 'nexus');
   process.env['NEXUS_CACHE_DIR'] = join(rd, 'nexus', 'cache');
   resetNexusDbState();
@@ -74,6 +78,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   delete process.env['CLEO_HOME'];
+  delete process.env['CLEO_DIR'];
   delete process.env['NEXUS_HOME'];
   delete process.env['NEXUS_CACHE_DIR'];
   resetNexusDbState();

--- a/packages/core/src/nexus/__tests__/task-sweeper-wired.test.ts
+++ b/packages/core/src/nexus/__tests__/task-sweeper-wired.test.ts
@@ -162,19 +162,12 @@ describe('task-sweeper post-analyze wiring', { sequential: true }, () => {
     for (let i = 1; i <= 3; i++) {
       nexusNative
         .prepare(
+          // ADR-090 · T11648: project-scope graph has no `project_id` column.
           `INSERT OR REPLACE INTO nexus_nodes
-             (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-             VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)`,
+             (id, kind, name, file_path, label, indexed_at, is_exported)
+             VALUES (?, ?, ?, ?, ?, datetime('now'), ?)`,
         )
-        .run(
-          `src/module${i}.ts::fn${i}`,
-          'test-proj',
-          'function',
-          `fn${i}`,
-          `src/module${i}.ts`,
-          `fn${i}`,
-          1,
-        );
+        .run(`src/module${i}.ts::fn${i}`, 'function', `fn${i}`, `src/module${i}.ts`, `fn${i}`, 1);
     }
 
     // Act: run the sweeper (the post-hook that analyzeCommand triggers)
@@ -222,19 +215,12 @@ describe('task-sweeper post-analyze wiring', { sequential: true }, () => {
     for (let i = 1; i <= 2; i++) {
       nexusNative
         .prepare(
+          // ADR-090 · T11648: project-scope graph has no `project_id` column.
           `INSERT OR REPLACE INTO nexus_nodes
-             (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-             VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)`,
+             (id, kind, name, file_path, label, indexed_at, is_exported)
+             VALUES (?, ?, ?, ?, ?, datetime('now'), ?)`,
         )
-        .run(
-          `src/module${i}.ts::fn${i}`,
-          'test-proj',
-          'function',
-          `fn${i}`,
-          `src/module${i}.ts`,
-          `fn${i}`,
-          1,
-        );
+        .run(`src/module${i}.ts::fn${i}`, 'function', `fn${i}`, `src/module${i}.ts`, `fn${i}`, 1);
     }
 
     // Act: run sweeper twice

--- a/packages/core/src/nexus/__tests__/tasks-bridge.test.ts
+++ b/packages/core/src/nexus/__tests__/tasks-bridge.test.ts
@@ -24,11 +24,22 @@ describe('tasks-bridge', () => {
   let brainDb: DatabaseSync;
   let nexusDb: DatabaseSync;
 
+  let prevCleoDir: string | undefined;
+  let prevCleoHome: string | undefined;
+
   beforeEach(async () => {
     // Create isolated temp directory for this test, with a `.cleo/` so the
     // canonical resolveCleoDir SSoT resolves it as a project root (T11262).
     projectRoot = mkdtempSync(join(tmpdir(), 'tasks-bridge-test-'));
     mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+
+    // ADR-090 · T11648: getNexusDb() resolves the PROJECT graph scope from
+    // CLEO_DIR/cwd — pin it to this temp project so nexus lands in the SAME
+    // `.cleo/` as the brain DB and stays isolated from the real repo.
+    prevCleoDir = process.env['CLEO_DIR'];
+    prevCleoHome = process.env['CLEO_HOME'];
+    process.env['CLEO_DIR'] = join(projectRoot, '.cleo');
+    process.env['CLEO_HOME'] = join(projectRoot, 'home');
 
     // Initialize databases (will create schema)
     await getBrainDb(projectRoot);
@@ -41,40 +52,32 @@ describe('tasks-bridge', () => {
     expect(brainDb).toBeDefined();
     expect(nexusDb).toBeDefined();
 
-    // Insert test symbols into nexus (OR REPLACE to tolerate duplicate IDs across runs)
+    // Insert test symbols into nexus (OR REPLACE to tolerate duplicate IDs across
+    // runs). ADR-090 · T11648: the project-scope graph has no `project_id` column.
     nexusDb
       .prepare(
         `INSERT OR REPLACE INTO nexus_nodes
-         (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-         VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)`,
+         (id, kind, name, file_path, label, indexed_at, is_exported)
+         VALUES (?, ?, ?, ?, ?, datetime('now'), ?)`,
       )
-      .run(
-        'src/file.ts::myFunction',
-        'test-project',
-        'function',
-        'myFunction',
-        'src/file.ts',
-        'myFunction',
-        1,
-      );
+      .run('src/file.ts::myFunction', 'function', 'myFunction', 'src/file.ts', 'myFunction', 1);
 
     nexusDb
       .prepare(
         `INSERT OR REPLACE INTO nexus_nodes
-         (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-         VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)`,
+         (id, kind, name, file_path, label, indexed_at, is_exported)
+         VALUES (?, ?, ?, ?, ?, datetime('now'), ?)`,
       )
-      .run('src/file.ts::MyClass', 'test-project', 'class', 'MyClass', 'src/file.ts', 'MyClass', 1);
+      .run('src/file.ts::MyClass', 'class', 'MyClass', 'src/file.ts', 'MyClass', 1);
 
     nexusDb
       .prepare(
         `INSERT OR REPLACE INTO nexus_nodes
-         (id, project_id, kind, name, file_path, label, indexed_at, is_exported)
-         VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)`,
+         (id, kind, name, file_path, label, indexed_at, is_exported)
+         VALUES (?, ?, ?, ?, ?, datetime('now'), ?)`,
       )
       .run(
         'src/other.ts::helperFunction',
-        'test-project',
         'function',
         'helperFunction',
         'src/other.ts',
@@ -87,6 +90,10 @@ describe('tasks-bridge', () => {
     // Reset DB singletons so the next beforeEach gets fresh DBs with no colliding node IDs
     closeBrainDb();
     closeNexusDb();
+    if (prevCleoDir === undefined) delete process.env['CLEO_DIR'];
+    else process.env['CLEO_DIR'] = prevCleoDir;
+    if (prevCleoHome === undefined) delete process.env['CLEO_HOME'];
+    else process.env['CLEO_HOME'] = prevCleoHome;
     // Clean up temp directory
     rmSync(projectRoot, { recursive: true, force: true });
   });

--- a/packages/core/src/nexus/__tests__/user-profile.test.ts
+++ b/packages/core/src/nexus/__tests__/user-profile.test.ts
@@ -62,18 +62,26 @@ beforeEach(async () => {
   testDir = await mkdtemp(join(tmpdir(), 'nexus-user-profile-test-'));
   await mkdir(join(testDir, '.cleo'), { recursive: true });
 
-  // Point CLEO_HOME to isolated temp directory so nexus.db is isolated.
+  // Point CLEO_HOME to isolated temp directory so the GLOBAL cleo.db
+  // (nexus_user_profile registry home) is isolated.
   process.env['CLEO_HOME'] = testDir;
+  // ADR-090 · T11648: getNexusDb() now opens the PROJECT scope as `main` and
+  // ATTACHes the GLOBAL cleo.db. Pin CLEO_DIR to a fresh path per test so the
+  // project handle (and therefore its global ATTACH) is re-created each test —
+  // otherwise a cwd-cached project handle would keep a stale ATTACH to a prior
+  // test's CLEO_HOME and leak user_profile rows across cases.
+  process.env['CLEO_DIR'] = join(testDir, '.cleo');
 
   // Reset the nexus DB singleton so each test gets a fresh database.
   resetNexusDbState();
 
-  // Initialise the nexus registry (creates nexus.db + applies migrations).
+  // Initialise the nexus registry (creates cleo.db + applies migrations).
   await nexusInit();
 });
 
 afterEach(async () => {
   delete process.env['CLEO_HOME'];
+  delete process.env['CLEO_DIR'];
   resetNexusDbState();
   await rm(testDir, { recursive: true, force: true });
 });

--- a/packages/core/src/nexus/analyze-orchestrator.ts
+++ b/packages/core/src/nexus/analyze-orchestrator.ts
@@ -69,10 +69,9 @@ export async function runNexusAnalysis(params: NexusAnalysisParams): Promise<Nex
   // progress callback that is CLI-only. Extracted here to keep the core
   // runnable without the CLI layer, but the DB/pipeline imports still happen
   // via dynamic imports so the CLI controls when heavy deps are loaded.
-  const [{ getNexusDb, nexusSchema }, { runPipeline }, { eq }] = await Promise.all([
+  const [{ getNexusDb, nexusSchema }, { runPipeline }] = await Promise.all([
     import('@cleocode/core/store/nexus-sqlite' as string),
     import('@cleocode/nexus/pipeline' as string),
-    import('drizzle-orm' as string),
   ]);
 
   const projectId = projectIdOverride ?? Buffer.from(repoPath).toString('base64url').slice(0, 32);
@@ -84,17 +83,16 @@ export async function runNexusAnalysis(params: NexusAnalysisParams): Promise<Nex
   };
 
   if (!incremental) {
+    // ADR-090 · T11648: the graph is project-scoped (one project per `cleo.db`),
+    // so a non-incremental reindex clears the WHOLE graph table — the former
+    // `WHERE project_id = ?` predicate is dropped.
     try {
-      db.delete(nexusSchema.nexusNodes)
-        .where(eq(nexusSchema.nexusNodes.projectId, projectId))
-        .run();
+      db.delete(nexusSchema.nexusNodes).run();
     } catch {
       // table may be empty — ignore
     }
     try {
-      db.delete(nexusSchema.nexusRelations)
-        .where(eq(nexusSchema.nexusRelations.projectId, projectId))
-        .run();
+      db.delete(nexusSchema.nexusRelations).run();
     } catch {
       // table may be empty — ignore
     }

--- a/packages/core/src/nexus/api-extractors/http-extractor.test.ts
+++ b/packages/core/src/nexus/api-extractors/http-extractor.test.ts
@@ -4,6 +4,9 @@
  * @task T1065
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { HttpContract } from '@cleocode/contracts/nexus-contract-ops.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getNexusDb, resetNexusDbState } from '../../store/nexus-sqlite.js';
@@ -11,12 +14,31 @@ import * as nexusSchema from '../../store/schema/nexus-schema.js';
 import { extractHttpContracts } from './http-extractor.js';
 
 describe('HTTP Contract Extractor', () => {
-  beforeEach(async () => {
+  // ADR-090 · T11648: the nexus code-graph is now PROJECT-scoped (one project per
+  // `cleo.db` resolved from `CLEO_DIR`/cwd) instead of a single global DB keyed by
+  // `project_id`. Each test therefore gets its own isolated project `.cleo/` via
+  // `CLEO_DIR` so seeded nodes never leak across cases (the former per-`project_id`
+  // isolation is gone — the project-scope schema has no `project_id` column).
+  let tmpDir: string;
+  let prevCleoDir: string | undefined;
+  let prevCleoHome: string | undefined;
+
+  beforeEach(() => {
     resetNexusDbState();
+    tmpDir = mkdtempSync(join(tmpdir(), 'cleo-http-extractor-'));
+    prevCleoDir = process.env['CLEO_DIR'];
+    prevCleoHome = process.env['CLEO_HOME'];
+    process.env['CLEO_DIR'] = join(tmpDir, '.cleo');
+    process.env['CLEO_HOME'] = join(tmpDir, 'home');
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     resetNexusDbState();
+    if (prevCleoDir === undefined) delete process.env['CLEO_DIR'];
+    else process.env['CLEO_DIR'] = prevCleoDir;
+    if (prevCleoHome === undefined) delete process.env['CLEO_HOME'];
+    else process.env['CLEO_HOME'] = prevCleoHome;
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it('should extract HTTP contracts from route nodes', async () => {

--- a/packages/core/src/nexus/api-extractors/http-extractor.ts
+++ b/packages/core/src/nexus/api-extractors/http-extractor.ts
@@ -29,16 +29,11 @@ export async function extractHttpContracts(
   const db = await getNexusDb();
 
   try {
-    // Query all route nodes for this project
+    // Query all route nodes (project-scoped DB — ADR-090 · T11648: no project_id).
     const routeNodes: NexusNodeRow[] = db
       .select()
       .from(nexusSchema.nexusNodes)
-      .where(
-        and(
-          eq(nexusSchema.nexusNodes.projectId, projectId),
-          eq(nexusSchema.nexusNodes.kind, 'route'),
-        ),
-      )
+      .where(eq(nexusSchema.nexusNodes.kind, 'route'))
       .all();
 
     const contracts: HttpContract[] = [];
@@ -87,7 +82,6 @@ export async function extractHttpContracts(
         .from(nexusSchema.nexusRelations)
         .where(
           and(
-            eq(nexusSchema.nexusRelations.projectId, projectId),
             eq(nexusSchema.nexusRelations.targetId, routeNode.id),
             eq(nexusSchema.nexusRelations.type, 'handles_route'),
           ),

--- a/packages/core/src/nexus/clusters.ts
+++ b/packages/core/src/nexus/clusters.ts
@@ -7,7 +7,7 @@
  * @task T1473
  */
 
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getNexusDb, nexusSchema } from '../store/nexus-sqlite.js';
 
@@ -54,15 +54,11 @@ export async function getProjectClusters(
 
   let communities: Array<Record<string, unknown>> = [];
   try {
+    // ADR-090 · T11648: project-scoped DB — drop the `project_id = ?` predicate.
     communities = db
       .select()
       .from(nexusSchema.nexusNodes)
-      .where(
-        and(
-          eq(nexusSchema.nexusNodes.projectId, projectId),
-          eq(nexusSchema.nexusNodes.kind, 'community'),
-        ),
-      )
+      .where(eq(nexusSchema.nexusNodes.kind, 'community'))
       .all() as Array<Record<string, unknown>>;
   } catch {
     communities = [];

--- a/packages/core/src/nexus/context.ts
+++ b/packages/core/src/nexus/context.ts
@@ -8,7 +8,7 @@
  */
 
 import path from 'node:path';
-import { and, eq, notInArray } from 'drizzle-orm';
+import { notInArray } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getNexusDb, nexusSchema } from '../store/nexus-sqlite.js';
 
@@ -131,19 +131,16 @@ export async function getSymbolContext(
   const { sortMatchingNodes } = await import('./symbol-ranking.js');
   const db = await getNexusDb();
 
-  // Fetch only symbol nodes for this project (exclude community/process structural nodes).
-  // The SQL filter pushes projectId + kind exclusion into the index, avoiding the 89k full scan.
+  // Fetch only symbol nodes (exclude community/process structural nodes).
+  // ADR-090 · T11648: the graph lives in the PROJECT `cleo.db` (one project per
+  // DB), so the former `project_id = ?` predicate is dropped — only the kind
+  // exclusion remains, pushed into the `idx_nexus_nodes_kind` index.
   let projectSymbolNodes: Array<Record<string, unknown>> = [];
   try {
     projectSymbolNodes = db
       .select()
       .from(nexusSchema.nexusNodes)
-      .where(
-        and(
-          eq(nexusSchema.nexusNodes.projectId, projectId),
-          notInArray(nexusSchema.nexusNodes.kind, ['community', 'process']),
-        ),
-      )
+      .where(notInArray(nexusSchema.nexusNodes.kind, ['community', 'process']))
       .all() as Array<Record<string, unknown>>;
   } catch {
     projectSymbolNodes = [];
@@ -161,27 +158,23 @@ export async function getSymbolContext(
     throw err;
   }
 
-  // Fetch all project-scoped relations for callers/callees/process edges in one indexed query.
+  // Fetch all relations for callers/callees/process edges (project-scoped DB).
   let allRelations: Array<Record<string, unknown>> = [];
   try {
-    allRelations = db
-      .select()
-      .from(nexusSchema.nexusRelations)
-      .where(eq(nexusSchema.nexusRelations.projectId, projectId))
-      .all() as Array<Record<string, unknown>>;
+    allRelations = db.select().from(nexusSchema.nexusRelations).all() as Array<
+      Record<string, unknown>
+    >;
   } catch {
     allRelations = [];
   }
 
-  // Fetch ALL project nodes (including community/process) for the nodeById map so community
+  // Fetch ALL nodes (including community/process) for the nodeById map so community
   // labels and process names resolve correctly.
   let allProjectNodes: Array<Record<string, unknown>> = [];
   try {
-    allProjectNodes = db
-      .select()
-      .from(nexusSchema.nexusNodes)
-      .where(eq(nexusSchema.nexusNodes.projectId, projectId))
-      .all() as Array<Record<string, unknown>>;
+    allProjectNodes = db.select().from(nexusSchema.nexusNodes).all() as Array<
+      Record<string, unknown>
+    >;
   } catch {
     allProjectNodes = projectSymbolNodes;
   }

--- a/packages/core/src/nexus/diff.ts
+++ b/packages/core/src/nexus/diff.ts
@@ -134,8 +134,9 @@ export async function diffNexusIndex(
     const allNodesBefore = db.select().from(nexusSchema.nexusNodes).all() as Array<
       Record<string, unknown>
     >;
-    relationsBefore = allRelsBefore.filter((r) => r['projectId'] === projectId).length;
-    nodesBefore = allNodesBefore.filter((n) => n['projectId'] === projectId).length;
+    // ADR-090 · T11648: project-scoped graph DB — count all rows (no project_id).
+    relationsBefore = allRelsBefore.length;
+    nodesBefore = allNodesBefore.length;
   } catch {
     // DB not yet initialized
   }
@@ -162,8 +163,9 @@ export async function diffNexusIndex(
     const allNodesAfter = db.select().from(nexusSchema.nexusNodes).all() as Array<
       Record<string, unknown>
     >;
-    relationsAfter = allRelsAfter.filter((r) => r['projectId'] === projectId).length;
-    nodesAfter = allNodesAfter.filter((n) => n['projectId'] === projectId).length;
+    // ADR-090 · T11648: project-scoped graph DB — count all rows (no project_id).
+    relationsAfter = allRelsAfter.length;
+    nodesAfter = allNodesAfter.length;
   } catch {
     relationsAfter = pipelineResult.relationCount;
     nodesAfter = pipelineResult.nodeCount;

--- a/packages/core/src/nexus/export.ts
+++ b/packages/core/src/nexus/export.ts
@@ -71,10 +71,13 @@ export async function exportNexusGraph(opts: NexusExportOptions = {}): Promise<N
     // DB may be empty
   }
 
-  const nodes = projectFilter ? allNodes.filter((n) => n['projectId'] === projectFilter) : allNodes;
-  const relations = projectFilter
-    ? allRelations.filter((r) => r['projectId'] === projectFilter)
-    : allRelations;
+  // ADR-090 · T11648: the graph is project-scoped (one project per `cleo.db`), so
+  // every row already belongs to the open project — `projectFilter` is a no-op
+  // (the rows no longer carry a `project_id` column to filter on). Retained in the
+  // signature for backward compatibility.
+  void projectFilter;
+  const nodes = allNodes;
+  const relations = allRelations;
 
   let content: string;
 

--- a/packages/core/src/nexus/flows.ts
+++ b/packages/core/src/nexus/flows.ts
@@ -60,7 +60,9 @@ export async function getProjectFlows(
     rows = [];
   }
 
-  const processes = rows.filter((r) => r['kind'] === 'process' && r['projectId'] === projectId);
+  // ADR-090 · T11648: the graph is project-scoped (one project per `cleo.db`),
+  // so the in-memory `projectId` filter is dropped — only the kind filter remains.
+  const processes = rows.filter((r) => r['kind'] === 'process');
 
   return {
     projectId,

--- a/packages/core/src/nexus/impact.ts
+++ b/packages/core/src/nexus/impact.ts
@@ -8,7 +8,7 @@
  * @task T1473
  */
 
-import { and, eq, notInArray } from 'drizzle-orm';
+import { eq, notInArray } from 'drizzle-orm';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { getNexusDb, getNexusNativeDb, nexusSchema } from '../store/nexus-sqlite.js';
 
@@ -105,19 +105,15 @@ export async function getSymbolImpact(
   const { sortMatchingNodes } = await import('./symbol-ranking.js');
   const db = await getNexusDb();
 
-  // Fetch only symbol nodes for this project (exclude community/process structural nodes).
-  // SQL WHERE pushes projectId + kind exclusion into the indexed path, avoiding full-table scan.
+  // Fetch only symbol nodes (exclude community/process structural nodes).
+  // ADR-090 · T11648: project-scoped DB — the former `project_id = ?` predicate
+  // is dropped; only the kind exclusion remains (indexed via idx_nexus_nodes_kind).
   let projectSymbolNodes: Array<Record<string, unknown>> = [];
   try {
     projectSymbolNodes = db
       .select()
       .from(nexusSchema.nexusNodes)
-      .where(
-        and(
-          eq(nexusSchema.nexusNodes.projectId, projectId),
-          notInArray(nexusSchema.nexusNodes.kind, ['community', 'process']),
-        ),
-      )
+      .where(notInArray(nexusSchema.nexusNodes.kind, ['community', 'process']))
       .all() as Array<Record<string, unknown>>;
   } catch {
     projectSymbolNodes = [];
@@ -135,10 +131,10 @@ export async function getSymbolImpact(
     throw err;
   }
 
-  // Fetch project-scoped relations filtered by projectId and BFS-relevant types.
-  // T11545: plasticity `weight` lives in the sibling `nexus_relation_weights`
-  // table — LEFT JOIN it and flatten so downstream reads `r['weight']` (NULL
-  // when the edge has never been strengthened).
+  // Fetch all relations (project-scoped DB — ADR-090 · T11648: no `project_id`
+  // predicate). T11545: plasticity `weight` lives in the sibling
+  // `nexus_relation_weights` table — LEFT JOIN it and flatten so downstream reads
+  // `r['weight']` (NULL when the edge has never been strengthened).
   let allRelations: Array<Record<string, unknown>> = [];
   try {
     const joined = db
@@ -148,7 +144,6 @@ export async function getSymbolImpact(
         nexusSchema.nexusRelationWeights,
         eq(nexusSchema.nexusRelationWeights.relationId, nexusSchema.nexusRelations.id),
       )
-      .where(eq(nexusSchema.nexusRelations.projectId, projectId))
       .all() as Array<{
       nexus_relations: Record<string, unknown>;
       nexus_relation_weights: Record<string, unknown> | null;
@@ -287,7 +282,9 @@ export async function getSymbolImpact(
 // SSoT-EXEMPT:engine-migration-T1569
 export async function nexusImpact(
   symbol: string,
-  projectId?: string,
+  // `projectId` unused since ADR-090 · T11648 (project-scoped graph DB); retained
+  // for the CLI dispatch signature.
+  _projectId?: string,
   why?: boolean,
 ): Promise<
   EngineResult<{
@@ -310,20 +307,20 @@ export async function nexusImpact(
       });
     }
 
+    // ADR-090 · T11648: project-scoped graph DB — drop the `project_id` column +
+    // predicate (one project per DB).
     const allNodes = db
       .prepare(
-        `SELECT id, label, kind, file_path, name, project_id
+        `SELECT id, label, kind, file_path, name
            FROM nexus_nodes
-          WHERE project_id = ?
-            AND kind NOT IN ('community','process','file','folder')`,
+          WHERE kind NOT IN ('community','process','file','folder')`,
       )
-      .all(projectId || '') as Array<{
+      .all() as Array<{
       id: string;
       label: string | null;
       kind: string | null;
       file_path: string | null;
       name: string | null;
-      project_id: string;
     }>;
 
     const lowerSymbol = symbol.toLowerCase();
@@ -358,10 +355,9 @@ export async function nexusImpact(
         `SELECT r.source_id AS source_id, r.target_id AS target_id, r.type AS type, w.weight AS weight
            FROM nexus_relations r
       LEFT JOIN nexus_relation_weights w ON w.relation_id = r.id
-          WHERE r.project_id = ?
-            AND r.type IN ('calls','imports','accesses')`,
+          WHERE r.type IN ('calls','imports','accesses')`,
       )
-      .all(projectId || '') as Array<{
+      .all() as Array<{
       source_id: string;
       target_id: string;
       type: string;

--- a/packages/core/src/nexus/living-brain.ts
+++ b/packages/core/src/nexus/living-brain.ts
@@ -55,7 +55,7 @@ import { getSymbolsForTask, getTasksForSymbol } from './tasks-bridge.js';
 
 interface RawNexusNode {
   id: string;
-  project_id: string;
+  // `project_id` DROPPED (ADR-090 · T11648) — graph is project-scoped.
   kind: string;
   name: string | null;
   file_path: string | null;
@@ -177,10 +177,11 @@ export async function getSymbolFullContext(
     await getNexusDb();
     const nexusNative = getNexusNativeDb();
     if (nexusNative) {
-      // Try exact match on id first; fall back to name lookup
+      // Try exact match on id first; fall back to name lookup.
+      // ADR-090 · T11648: project-scoped graph — `project_id` column dropped.
       let symbolNode = typedGet<RawNexusNode>(
         nexusNative.prepare(
-          `SELECT id, project_id, kind, name, file_path, label, community_id
+          `SELECT id, kind, name, file_path, label, community_id
            FROM nexus_nodes WHERE id = ? LIMIT 1`,
         ),
         symbolId,
@@ -190,7 +191,7 @@ export async function getSymbolFullContext(
         // Fuzzy match on name (case-insensitive)
         symbolNode = typedGet<RawNexusNode>(
           nexusNative.prepare(
-            `SELECT id, project_id, kind, name, file_path, label, community_id
+            `SELECT id, kind, name, file_path, label, community_id
              FROM nexus_nodes
              WHERE LOWER(name) = LOWER(?) AND kind NOT IN ('community', 'process', 'folder')
              LIMIT 1`,
@@ -978,9 +979,11 @@ export async function reasonImpactOfChange(
     await getNexusDb();
     const nexusNative = getNexusNativeDb();
     if (nexusNative) {
+      // ADR-090 · T11648: project-scoped graph — `project_id` column dropped
+      // (the stray `weight` column never existed on nexus_nodes; removed too).
       let nexusNode = typedGet<RawNexusNode>(
         nexusNative.prepare(
-          `SELECT id, project_id, kind, name, file_path, label, community_id, weight
+          `SELECT id, kind, name, file_path, label, community_id
            FROM nexus_nodes WHERE id = ? LIMIT 1`,
         ),
         symbolId,
@@ -988,7 +991,7 @@ export async function reasonImpactOfChange(
       if (!nexusNode) {
         nexusNode = typedGet<RawNexusNode>(
           nexusNative.prepare(
-            `SELECT id, project_id, kind, name, file_path, label, community_id, weight
+            `SELECT id, kind, name, file_path, label, community_id
              FROM nexus_nodes
              WHERE LOWER(name) = LOWER(?) AND kind NOT IN ('community', 'process', 'folder')
              LIMIT 1`,

--- a/packages/core/src/nexus/nexus-bridge.ts
+++ b/packages/core/src/nexus/nexus-bridge.ts
@@ -90,8 +90,14 @@ function typedGet<T>(
 // Query helpers
 // ============================================================================
 
-/** Query total node/relation counts and last indexed timestamp. */
-function queryIndexMeta(db: DatabaseSync, projectId: string): IndexMetaRow {
+/**
+ * Query total node/relation counts and last indexed timestamp.
+ *
+ * ADR-090 · T11648: the graph is project-scoped (one project per `cleo.db`), so
+ * these queries no longer filter by `project_id`. `projectId` is retained in the
+ * signatures for call-site compatibility and display only.
+ */
+function queryIndexMeta(db: DatabaseSync, _projectId: string): IndexMetaRow {
   try {
     const nodeMeta = typedGet<{
       total_nodes: number;
@@ -102,17 +108,13 @@ function queryIndexMeta(db: DatabaseSync, projectId: string): IndexMetaRow {
       `SELECT COUNT(*) as total_nodes,
               COUNT(CASE WHEN kind = 'file' THEN 1 END) as file_count,
               MAX(indexed_at) as last_indexed_at
-       FROM nexus_nodes
-       WHERE project_id = ?`,
-      projectId,
+       FROM nexus_nodes`,
     );
 
     const relMeta = typedGet<{ total_relations: number }>(
       db,
       `SELECT COUNT(*) as total_relations
-       FROM nexus_relations
-       WHERE project_id = ?`,
-      projectId,
+       FROM nexus_relations`,
     );
 
     return {
@@ -131,46 +133,42 @@ function queryIndexMeta(db: DatabaseSync, projectId: string): IndexMetaRow {
   }
 }
 
-/** Query node counts grouped by kind. */
-function queryNodeKindCounts(db: DatabaseSync, projectId: string): NodeKindCountRow[] {
+/** Query node counts grouped by kind (project-scoped DB — no project_id filter). */
+function queryNodeKindCounts(db: DatabaseSync, _projectId: string): NodeKindCountRow[] {
   try {
     return typedAll<NodeKindCountRow>(
       db,
       `SELECT kind, COUNT(*) as count
        FROM nexus_nodes
-       WHERE project_id = ?
-         AND kind NOT IN ('file', 'folder', 'community', 'process')
+       WHERE kind NOT IN ('file', 'folder', 'community', 'process')
        GROUP BY kind
        ORDER BY count DESC
        LIMIT 10`,
-      projectId,
     );
   } catch {
     return [];
   }
 }
 
-/** Query relation counts grouped by type. */
-function queryRelationTypeCounts(db: DatabaseSync, projectId: string): RelationTypeCountRow[] {
+/** Query relation counts grouped by type (project-scoped DB — no project_id filter). */
+function queryRelationTypeCounts(db: DatabaseSync, _projectId: string): RelationTypeCountRow[] {
   try {
     return typedAll<RelationTypeCountRow>(
       db,
       `SELECT type, COUNT(*) as count
        FROM nexus_relations
-       WHERE project_id = ?
-         AND type NOT IN ('member_of', 'step_in_process', 'entry_point_of')
+       WHERE type NOT IN ('member_of', 'step_in_process', 'entry_point_of')
        GROUP BY type
        ORDER BY count DESC
        LIMIT 8`,
-      projectId,
     );
   } catch {
     return [];
   }
 }
 
-/** Query top entry points by outgoing CALLS edge count. */
-function queryTopEntryPoints(db: DatabaseSync, projectId: string, limit = 5): EntryPointRow[] {
+/** Query top entry points by outgoing CALLS edge count (project-scoped DB). */
+function queryTopEntryPoints(db: DatabaseSync, _projectId: string, limit = 5): EntryPointRow[] {
   try {
     return typedAll<EntryPointRow>(
       db,
@@ -178,12 +176,10 @@ function queryTopEntryPoints(db: DatabaseSync, projectId: string, limit = 5): En
        FROM nexus_relations r
        JOIN nexus_nodes n ON r.source_id = n.id
        WHERE r.type = 'calls'
-         AND r.project_id = ?
          AND n.kind IN ('function', 'method', 'constructor')
        GROUP BY r.source_id
        ORDER BY callees DESC
        LIMIT ?`,
-      projectId,
       limit,
     );
   } catch {
@@ -191,18 +187,16 @@ function queryTopEntryPoints(db: DatabaseSync, projectId: string, limit = 5): En
   }
 }
 
-/** Query community nodes ordered by member count. */
-function queryCommunities(db: DatabaseSync, projectId: string, limit = 6): CommunityRow[] {
+/** Query community nodes ordered by member count (project-scoped DB). */
+function queryCommunities(db: DatabaseSync, _projectId: string, limit = 6): CommunityRow[] {
   try {
     return typedAll<CommunityRow>(
       db,
       `SELECT id, label, meta_json, indexed_at
        FROM nexus_nodes
-       WHERE project_id = ?
-         AND kind = 'community'
+       WHERE kind = 'community'
        ORDER BY indexed_at DESC
        LIMIT ?`,
-      projectId,
       limit,
     );
   } catch {
@@ -210,16 +204,14 @@ function queryCommunities(db: DatabaseSync, projectId: string, limit = 6): Commu
   }
 }
 
-/** Query count of execution flow (process) nodes. */
-function queryProcessCount(db: DatabaseSync, projectId: string): number {
+/** Query count of execution flow (process) nodes (project-scoped DB). */
+function queryProcessCount(db: DatabaseSync, _projectId: string): number {
   try {
     const row = typedGet<{ count: number }>(
       db,
       `SELECT COUNT(*) as count
        FROM nexus_nodes
-       WHERE project_id = ?
-         AND kind = 'process'`,
-      projectId,
+       WHERE kind = 'process'`,
     );
     return row?.count ?? 0;
   } catch {

--- a/packages/core/src/nexus/registry.ts
+++ b/packages/core/src/nexus/registry.ts
@@ -201,15 +201,43 @@ async function writeNexusAudit(fields: NexusAuditFields): Promise<void> {
 // ── Registry operations ──────────────────────────────────────────────
 
 /**
+ * Run a registry query against a LIVE nexus handle, retrying ONCE if the shared
+ * project handle was closed mid-flight (ADR-090 · T11648).
+ *
+ * The nexus runtime handle is the PROJECT-scope `cleo.db` (graph home) with the
+ * GLOBAL registry ATTACHed. That handle is SHARED with the tasks/brain domains;
+ * a concurrent cross-project open (`getTaskAccessor(otherProject)`), a
+ * `resetDbState()`, or a sibling exodus-on-open can close it between our
+ * `getNexusDb()` await and the query await — surfacing as `"database is not
+ * open"`. The liveness guard inside `getNexusDb()` re-derives a fresh handle (and
+ * re-attaches the registry), so re-acquiring and retrying once makes registry
+ * reads deterministic under that churn.
+ *
+ * @param fn - Receives a freshly-acquired nexus drizzle handle.
+ * @returns The result of `fn`, or re-throws after one failed retry.
+ */
+async function withLiveNexusDb<T>(
+  fn: (db: Awaited<ReturnType<typeof import('../store/nexus-sqlite.js').getNexusDb>>) => Promise<T>,
+): Promise<T> {
+  const { getNexusDb } = await import('../store/nexus-sqlite.js');
+  try {
+    return await fn(await getNexusDb());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/database is not open|not open/i.test(msg)) throw err;
+    // Re-acquire a live handle (the liveness guard re-opens + re-attaches) and retry once.
+    return await fn(await getNexusDb());
+  }
+}
+
+/**
  * Read all projects from nexus.db and return as a NexusRegistryFile.
  * Compatibility wrapper for consumers that expect the legacy JSON shape.
  * Returns null if nexus.db has not been initialized yet.
  */
 export async function readRegistry(): Promise<NexusRegistryFile | null> {
   try {
-    const { getNexusDb } = await import('../store/nexus-sqlite.js');
-    const db = await getNexusDb();
-    const rows = await db.select().from(projectRegistry);
+    const rows = await withLiveNexusDb((db) => db.select().from(projectRegistry));
     const projects: Record<string, NexusProject> = {};
     let latestUpdate = '';
     for (const row of rows) {
@@ -538,9 +566,7 @@ export async function nexusList(
   _params: NexusListParams = {},
 ): Promise<NexusProject[]> {
   try {
-    const { getNexusDb } = await import('../store/nexus-sqlite.js');
-    const db = await getNexusDb();
-    const rows = await db.select().from(projectRegistry);
+    const rows = await withLiveNexusDb((db) => db.select().from(projectRegistry));
     return rows.map(rowToProject);
   } catch {
     return [];
@@ -564,39 +590,43 @@ export async function nexusGetProject(
   const nameOrHash =
     paramsOrUndefined !== undefined ? paramsOrUndefined.name : projectRootOrNameOrHash;
   try {
-    const { getNexusDb } = await import('../store/nexus-sqlite.js');
     const { eq, or } = await import('drizzle-orm');
-    const db = await getNexusDb();
-
-    // Try hash match first, then name
-    let rows = await db
-      .select()
-      .from(projectRegistry)
-      .where(or(eq(projectRegistry.projectHash, nameOrHash), eq(projectRegistry.name, nameOrHash)));
-
-    if (rows.length === 0) {
-      // Try direct projectId match
-      rows = await db
+    // ADR-090 · T11648: run on a LIVE handle with retry — the registry lives in
+    // the GLOBAL ATTACH of the shared project handle, which a concurrent
+    // cross-project open can close mid-query.
+    const row = await withLiveNexusDb(async (db) => {
+      // Try hash match first, then name
+      let rows = await db
         .select()
         .from(projectRegistry)
-        .where(eq(projectRegistry.projectId, nameOrHash));
-    }
-    if (rows.length === 0) {
-      // Try alias resolution: legacyId → canonicalId lookup (T11025)
-      const aliasRows = await db
-        .select()
-        .from(projectIdAliases)
-        .where(eq(projectIdAliases.legacyId, nameOrHash))
-        .limit(1);
-      if (aliasRows.length > 0) {
+        .where(
+          or(eq(projectRegistry.projectHash, nameOrHash), eq(projectRegistry.name, nameOrHash)),
+        );
+
+      if (rows.length === 0) {
+        // Try direct projectId match
         rows = await db
           .select()
           .from(projectRegistry)
-          .where(eq(projectRegistry.projectId, aliasRows[0].canonicalId));
+          .where(eq(projectRegistry.projectId, nameOrHash));
       }
-    }
+      if (rows.length === 0) {
+        // Try alias resolution: legacyId → canonicalId lookup (T11025)
+        const aliasRows = await db
+          .select()
+          .from(projectIdAliases)
+          .where(eq(projectIdAliases.legacyId, nameOrHash))
+          .limit(1);
+        if (aliasRows.length > 0) {
+          rows = await db
+            .select()
+            .from(projectRegistry)
+            .where(eq(projectRegistry.projectId, aliasRows[0].canonicalId));
+        }
+      }
+      return rows[0] ?? null;
+    });
 
-    const row = rows[0];
     if (!row) return null;
     return rowToProject(row);
   } catch {
@@ -668,11 +698,18 @@ export async function nexusSyncAll(): Promise<{ synced: number; failed: number }
   let failed = 0;
   const { getNexusDb } = await import('../store/nexus-sqlite.js');
   const { eq } = await import('drizzle-orm');
-  const db = await getNexusDb();
 
   for (const project of projects) {
     try {
+      // readProjectMeta opens the TARGET project's own `cleo.db` (a different
+      // project than the open nexus handle). Under the ADR-090 · T11648 residency
+      // split the nexus runtime handle is the PROJECT-scope `cleo.db` (graph home)
+      // with the GLOBAL registry ATTACHed; opening another project's `cleo.db`
+      // can churn the shared dual-scope project cache and close our nexus handle.
+      // Re-acquire `getNexusDb()` AFTER readProjectMeta so the registry UPDATE
+      // always runs against a live handle (the liveness guard re-opens + re-attaches).
       const meta = await readProjectMeta(project.path);
+      const db = await getNexusDb();
       const now = new Date().toISOString();
       await db
         .update(projectRegistry)

--- a/packages/core/src/nexus/route-analysis.ts
+++ b/packages/core/src/nexus/route-analysis.ts
@@ -39,16 +39,11 @@ export async function getRouteMap(
   const db = await getNexusDb();
 
   try {
-    // Query all route nodes for this project
+    // Query all route nodes (project-scoped DB — ADR-090 · T11648: no project_id).
     const routeNodes: NexusNodeRow[] = db
       .select()
       .from(nexusSchema.nexusNodes)
-      .where(
-        and(
-          eq(nexusSchema.nexusNodes.projectId, projectId),
-          eq(nexusSchema.nexusNodes.kind, 'route'),
-        ),
-      )
+      .where(eq(nexusSchema.nexusNodes.kind, 'route'))
       .all();
 
     const routes: RouteMapEntry[] = [];
@@ -61,7 +56,6 @@ export async function getRouteMap(
         .from(nexusSchema.nexusRelations)
         .where(
           and(
-            eq(nexusSchema.nexusRelations.projectId, projectId),
             eq(nexusSchema.nexusRelations.targetId, routeNode.id),
             eq(nexusSchema.nexusRelations.type, 'handles_route'),
           ),
@@ -85,7 +79,6 @@ export async function getRouteMap(
           .from(nexusSchema.nexusRelations)
           .where(
             and(
-              eq(nexusSchema.nexusRelations.projectId, projectId),
               eq(nexusSchema.nexusRelations.sourceId, handlerNode.id),
               eq(nexusSchema.nexusRelations.type, 'fetches'),
             ),
@@ -107,7 +100,6 @@ export async function getRouteMap(
           .from(nexusSchema.nexusRelations)
           .where(
             and(
-              eq(nexusSchema.nexusRelations.projectId, projectId),
               eq(nexusSchema.nexusRelations.targetId, handlerNode.id),
               eq(nexusSchema.nexusRelations.type, 'calls'),
             ),
@@ -163,13 +155,14 @@ export async function getRouteMap(
  * from call sites, which is deferred to T1534 (AST-based shape inference).
  *
  * @param routeSymbol - Route symbol ID (format: `<filePath>::<routeName>`)
- * @param projectId - Project identifier from registry
+ * @param _projectId - Unused since ADR-090 · T11648 (project-scoped graph DB);
+ *   kept for the dispatch signature.
  * @param _projectRoot - Root directory of the project (unused, kept for signature)
  * @returns Promise resolving to shape check result
  */
 export async function shapeCheck(
   routeSymbol: string,
-  projectId: string,
+  _projectId: string,
   _projectRoot: string,
 ): Promise<ShapeCheckResult> {
   const { getNexusDb, nexusSchema } = await import('../store/nexus-sqlite.js');
@@ -180,12 +173,7 @@ export async function shapeCheck(
     const routeNode: NexusNodeRow | undefined = db
       .select()
       .from(nexusSchema.nexusNodes)
-      .where(
-        and(
-          eq(nexusSchema.nexusNodes.projectId, projectId),
-          eq(nexusSchema.nexusNodes.id, routeSymbol),
-        ),
-      )
+      .where(eq(nexusSchema.nexusNodes.id, routeSymbol))
       .get();
 
     if (!routeNode || routeNode.kind !== 'route') {
@@ -211,7 +199,6 @@ export async function shapeCheck(
       .from(nexusSchema.nexusRelations)
       .where(
         and(
-          eq(nexusSchema.nexusRelations.projectId, projectId),
           eq(nexusSchema.nexusRelations.targetId, routeSymbol),
           eq(nexusSchema.nexusRelations.type, 'handles_route'),
         ),
@@ -240,7 +227,6 @@ export async function shapeCheck(
       .from(nexusSchema.nexusRelations)
       .where(
         and(
-          eq(nexusSchema.nexusRelations.projectId, projectId),
           eq(nexusSchema.nexusRelations.targetId, handlerNode.id),
           eq(nexusSchema.nexusRelations.type, 'calls'),
         ),

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -2239,14 +2239,15 @@ export interface ProjectRegistryEntry {
 /** Look up a project by canonical or legacy projectId (AC1, AC4). */
 export async function resolveProjectById(projectId: string): Promise<ProjectRegistryEntry | null> {
   try {
-    // E6-L4 (T11524): the nexus domain now lives in the GLOBAL consolidated
-    // `cleo.db` (getNexusDbPath() → <cleoHome>/cleo.db). Gate on that file's
-    // existence — NOT the legacy standalone `nexus.db` — so the lookup keeps
-    // working post-cutover when only `cleo.db` is present. We avoid creating the
-    // DB here: if the consolidated file does not exist yet there is nothing to
-    // resolve, so return null rather than letting getNexusDb() bootstrap it.
-    const { getNexusDb, getNexusDbPath } = await import('./store/nexus-sqlite.js');
-    if (!existsSync(getNexusDbPath())) return null;
+    // ADR-090 · T11648: the nexus REGISTRY (project_registry / aliases) lives in
+    // the GLOBAL consolidated `cleo.db` (getNexusRegistryDbPath() →
+    // <cleoHome>/cleo.db) — NOT the project graph DB. Gate on the REGISTRY file's
+    // existence so the lookup keeps working when only the global cleo.db is
+    // present. We avoid creating the DB here: if the registry file does not exist
+    // yet there is nothing to resolve, so return null rather than letting
+    // getNexusDb() bootstrap it.
+    const { getNexusDb, getNexusRegistryDbPath } = await import('./store/nexus-sqlite.js');
+    if (!existsSync(getNexusRegistryDbPath())) return null;
     const { eq } = await import('drizzle-orm');
     const { projectRegistry, projectIdAliases } = await import('./store/schema/nexus-schema.js');
     const db = await getNexusDb();

--- a/packages/core/src/store/__tests__/migration-fresh-no-repair.nexus.test.ts
+++ b/packages/core/src/store/__tests__/migration-fresh-no-repair.nexus.test.ts
@@ -67,17 +67,21 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
     mkdirSync(cleoHome, { recursive: true });
 
     // ------------------------------------------------------------------
-    // 2. Mock paths.js so the consolidated GLOBAL cleo.db is written to our
-    //    isolated tmpdir. E6-L4 (T11524): nexus opens via openDualScopeDb('global'),
-    //    which resolves getCleoHome()+'cleo.db'. resolveCleoDir is included for
-    //    the project-scope resolver path (dual-scope-db.ts imports it), though the
-    //    global scope only consults getCleoHome().
+    // 2. Mock paths.js so BOTH consolidated cleo.db files land in our isolated
+    //    tmpdir. ADR-090 · T11648: nexus now opens the PROJECT scope as `main`
+    //    (the graph home) via openDualScopeDb('project', process.cwd()) and
+    //    ATTACHes the GLOBAL cleo.db (registry home) — so we must pin BOTH:
+    //      - getCleoHome()  → cleoHome      (GLOBAL cleo.db = registry/identity)
+    //      - resolveCleoDir → tempDir/.cleo (PROJECT cleo.db = code-graph)
+    //    `resolveCleoDir` IGNORES the passed cwd here so `getNexusDb()`'s
+    //    `process.cwd()` (the real repo) cannot leak the project DB outside the
+    //    sandbox.
     // ------------------------------------------------------------------
     vi.doMock('../../paths.js', () => ({
       getCleoHome: () => cleoHome,
-      getCleoDirAbsolute: (cwd?: string) => (cwd ? join(cwd, '.cleo') : join(tempDir, '.cleo')),
+      getCleoDirAbsolute: () => join(tempDir, '.cleo'),
       getProjectRoot: () => tempDir,
-      resolveCleoDir: (cwd?: string) => (cwd ? join(cwd, '.cleo') : join(tempDir, '.cleo')),
+      resolveCleoDir: () => join(tempDir, '.cleo'),
     }));
 
     // ------------------------------------------------------------------
@@ -134,9 +138,15 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
 
       // ------------------------------------------------------------------
       // 7. SECONDARY: verify required columns exist via PRAGMA table_info.
-      //    E6-L4 (T11524): the nexus tables now live in the GLOBAL `cleo.db`.
+      //    ADR-090 · T11648: the four code-graph tables (`nexus_nodes`,
+      //    `nexus_relations`, …) + the `nexus_relation_weights` sibling now live
+      //    in the PROJECT `cleo.db` (`<projectRoot>/.cleo/cleo.db`). `getNexusDb()`
+      //    opens the PROJECT scope as `main`, so the graph-table assertions run
+      //    against the project DB — NOT the GLOBAL one (which only holds the
+      //    registry/identity tables for the runtime + empty frozen-migration
+      //    graph leftovers).
       // ------------------------------------------------------------------
-      const dbPath = join(cleoHome, 'cleo.db');
+      const dbPath = join(tempDir, '.cleo', 'cleo.db');
       const nativeDb = new DatabaseSync(dbPath, { readonly: true });
 
       try {
@@ -146,6 +156,9 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
         }>;
         const nodesColNames = nodesCols.map((c) => c.name);
         expect(nodesColNames).toContain('is_external');
+        // ADR-090 · T11648: the redundant per-row `project_id` column is dropped
+        // (scope is implicit in the owning project DB).
+        expect(nodesColNames).not.toContain('project_id');
 
         // T11545 (ADR-090 §5.3): the three plasticity columns are partitioned
         // OUT of nexus_relations into the sibling nexus_relation_weights table.
@@ -156,6 +169,7 @@ describe('nexus.db fresh init — zero "Adding missing column" warnings', () => 
         expect(relColNames).not.toContain('weight');
         expect(relColNames).not.toContain('last_accessed_at');
         expect(relColNames).not.toContain('co_accessed_count');
+        expect(relColNames).not.toContain('project_id');
 
         // The sibling weights table exists and carries the partitioned columns.
         const weightCols = nativeDb

--- a/packages/core/src/store/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/store/__tests__/migration-smoke.test.ts
@@ -139,40 +139,57 @@ describe('Test 1: fresh init — all 5 DBs migrate clean', () => {
     }
   });
 
-  it('nexus.db (drizzle-nexus) — fresh init succeeds, nexus_project_registry table exists', async () => {
+  it('nexus (drizzle-nexus) — fresh init succeeds; graph table in PROJECT scope, registry in GLOBAL scope', async () => {
     vi.resetModules();
     const cleoHome = join(tempDir, 'nexus-home');
+    const projectCleoDir = join(tempDir, 'nexus-proj', '.cleo');
     mkdirSync(cleoHome, { recursive: true });
+    mkdirSync(projectCleoDir, { recursive: true });
 
+    // ADR-090 · T11648: getNexusDb() opens the PROJECT scope as `main` (the graph
+    // home, resolved via resolveCleoDir) and ATTACHes the GLOBAL cleo.db (registry
+    // home, resolved via getCleoHome). Mock BOTH resolvers to isolated tmpdirs.
     vi.doMock('../../paths.js', () => ({
       getCleoHome: () => cleoHome,
-      getCleoDirAbsolute: (cwd?: string) => (cwd ? join(cwd, '.cleo') : join(tempDir, '.cleo')),
-      getProjectRoot: () => tempDir,
+      getCleoDirAbsolute: () => projectCleoDir,
+      getProjectRoot: () => join(tempDir, 'nexus-proj'),
+      resolveCleoDir: () => projectCleoDir,
     }));
 
-    const { getNexusDb, getNexusDbPath, resetNexusDbState } = await import('../nexus-sqlite.js');
+    const { getNexusDb, getNexusDbPath, getNexusRegistryDbPath, resetNexusDbState } = await import(
+      '../nexus-sqlite.js'
+    );
     resetNexusDbState();
 
     try {
       const db = await getNexusDb();
       expect(db).toBeTruthy();
 
-      // E6-L4 (T11524): the nexus domain consolidated into the GLOBAL `cleo.db`
-      // under getCleoHome(); getNexusDbPath() resolves to `<cleoHome>/cleo.db`.
-      const dbPath = getNexusDbPath();
-      expect(dbPath).toBe(join(cleoHome, 'cleo.db'));
-      expect(existsSync(dbPath)).toBe(true);
+      // ADR-090 · T11648: getNexusDbPath() = PROJECT graph home; registry path = GLOBAL.
+      const graphPath = getNexusDbPath();
+      const registryPath = getNexusRegistryDbPath();
+      expect(graphPath).toBe(join(projectCleoDir, 'cleo.db'));
+      expect(registryPath).toBe(join(cleoHome, 'cleo.db'));
+      expect(existsSync(graphPath)).toBe(true);
+      expect(existsSync(registryPath)).toBe(true);
 
-      // T11578 · AC3: the consolidated cleo-global migration creates the PREFIXED
-      // `nexus_project_registry` (the bare `project_registry` runtime shape is retired).
-      const nativeDb = new DatabaseSync(dbPath, { readonly: true });
-      const row = nativeDb
+      // The four code-graph tables live in the PROJECT `cleo.db` (graph home).
+      const graphDb = new DatabaseSync(graphPath, { readonly: true });
+      const nodesRow = graphDb
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='nexus_nodes'")
+        .get() as { name: string } | undefined;
+      graphDb.close();
+      expect(nodesRow?.name).toBe('nexus_nodes');
+
+      // The registry/identity tables live in the GLOBAL `cleo.db` (registry home).
+      const regDb = new DatabaseSync(registryPath, { readonly: true });
+      const regRow = regDb
         .prepare(
           "SELECT name FROM sqlite_master WHERE type='table' AND name='nexus_project_registry'",
         )
         .get() as { name: string } | undefined;
-      nativeDb.close();
-      expect(row?.name).toBe('nexus_project_registry');
+      regDb.close();
+      expect(regRow?.name).toBe('nexus_project_registry');
     } finally {
       resetNexusDbState();
       vi.restoreAllMocks();

--- a/packages/core/src/store/nexus-sqlite.ts
+++ b/packages/core/src/store/nexus-sqlite.ts
@@ -96,6 +96,14 @@ export const NEXUS_SCHEMA_VERSION = '1.0.0';
 let _nexusDb: NodeSQLiteDatabase<typeof nexusSchema> | null = null;
 let _nexusNativeDb: DatabaseSync | null = null;
 let _nexusDbPath: string | null = null;
+/**
+ * The GLOBAL registry path the current singleton's ATTACH targets (ADR-090 ·
+ * T11648). When `getCleoHome()` changes (e.g. tests mutating `CLEO_HOME`), the
+ * attached global differs AND must be migrated via `openDualScopeDb('global')` —
+ * which only runs on the init path. So a registry-path change forces a full
+ * singleton reset rather than a cheap re-attach to an unmigrated file.
+ */
+let _nexusRegistryPath: string | null = null;
 /** Guard against concurrent initialization (async migration). */
 let _nexusInitPromise: Promise<NodeSQLiteDatabase<typeof nexusSchema>> | null = null;
 
@@ -707,10 +715,19 @@ function runNexusMigrations(
  */
 export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchema>> {
   const requestedPath = getNexusDbPath();
+  const requestedRegistryPath = getNexusRegistryDbPath();
 
-  // If singleton exists but points to a different path (e.g. CLEO_HOME changed
-  // between tests), reset it.
+  // If singleton exists but points to a different PROJECT graph path (e.g.
+  // CLEO_DIR changed between tests), reset it.
   if (_nexusDb && _nexusDbPath !== requestedPath) {
+    resetNexusDbState();
+  }
+
+  // If the GLOBAL registry path changed (e.g. CLEO_HOME changed), reset fully so
+  // the init path runs `openDualScopeDb('global')` to MIGRATE the new registry
+  // file before the ATTACH — a cheap re-attach alone would bind an unmigrated
+  // global (→ "no such table: nexus_project_registry"). (ADR-090 · T11648)
+  if (_nexusDb && _nexusRegistryPath !== requestedRegistryPath) {
     resetNexusDbState();
   }
 
@@ -749,6 +766,7 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
   _nexusInitPromise = (async () => {
     const dbPath = requestedPath;
     _nexusDbPath = dbPath;
+    _nexusRegistryPath = requestedRegistryPath;
 
     // ADR-086 / T10321 — warn (one-shot, non-blocking) if the install still
     // carries the nested-nexus migration debris. Does not alter the open.
@@ -841,6 +859,7 @@ export function closeNexusDb(): void {
   _nexusNativeDb = null;
   _nexusDb = null;
   _nexusDbPath = null;
+  _nexusRegistryPath = null;
   _nexusInitPromise = null;
 }
 
@@ -859,6 +878,7 @@ export function resetNexusDbState(): void {
   _nexusNativeDb = null;
   _nexusDb = null;
   _nexusDbPath = null;
+  _nexusRegistryPath = null;
   _nexusInitPromise = null;
 }
 

--- a/packages/core/src/store/nexus-sqlite.ts
+++ b/packages/core/src/store/nexus-sqlite.ts
@@ -764,11 +764,15 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
     await openDualScopeDb('global');
 
     // ── Graph home: open PROJECT scope as `main` (T11648 · ADR-090 §2.1/§2.4) ─
-    // openDualScopeDb('project', cwd) applies the pragma SSoT, creates the
-    // directory, runs the consolidated cleo-project migrations (which OWN the
-    // five PREFIXED graph tables), and manages the singleton cache. We extract
-    // its native handle and re-wrap it with the `nexusSchema` drizzle instance.
-    const dualHandle = await openDualScopeDb('project', process.cwd());
+    // openDualScopeDb('project') applies the pragma SSoT, creates the directory,
+    // runs the consolidated cleo-project migrations (which OWN the five PREFIXED
+    // graph tables), and manages the singleton cache. We pass NO cwd: the
+    // dual-scope resolver resolves the canonical project root via the
+    // `resolveCleoDir()` SSoT (CWD-walk / CLEO_DIR / worktree scope) — never a
+    // bare `process.cwd()` (T9584). Omitting the cwd also keeps the exodus-on-open
+    // hook un-armed, which is correct for the runtime READ path (exodus is a
+    // separate explicit step).
+    const dualHandle = await openDualScopeDb('project');
 
     // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
     const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;

--- a/packages/core/src/store/nexus-sqlite.ts
+++ b/packages/core/src/store/nexus-sqlite.ts
@@ -1,59 +1,71 @@
 /**
- * SQLite store for the global-scope NEXUS domain via drizzle-orm/node-sqlite +
- * node:sqlite (DatabaseSync).
+ * SQLite store for the NEXUS domain via drizzle-orm/node-sqlite + node:sqlite
+ * (DatabaseSync).
  *
- * ## E6-L4 — thin-facade migration (T11524)
+ * ## Dual-scope residency split (ADR-090 · T11648 — runtime read half)
  *
- * `getNexusDb()` is now a thin facade that delegates the database open to
- * {@link openDualScopeDb}('global') — the canonical dual-scope chokepoint
- * introduced by E3/E4 (T11512/T11517) and already adopted by the tasks domain
- * (E6-L1, T11521), the brain domain (E6-L2, T11522), and the conduit domain
- * (E6-L3, T11523). This is the GLOBAL-scope variant: nexus is a cross-project
- * registry and stays GLOBAL — its tables live inside the consolidated GLOBAL
- * `cleo.db` under {@link getCleoHome}, NOT a per-project `.cleo/` file.
+ * The nexus domain is now SPLIT across the two consolidated `cleo.db` files:
  *
- * This ensures:
+ * - **GRAPH (project scope):** the four code-graph tables (`nexus_nodes`,
+ *   `nexus_relations`, `nexus_contracts`, `nexus_code_index`) + the
+ *   `nexus_relation_weights` plasticity sibling live in
+ *   `<projectRoot>/.cleo/cleo.db` — the portable per-project living brain.
+ *   This is where exodus WRITES them (`resolveTableTargetScope` in
+ *   `store/exodus/table-name-map.ts`), so the runtime READS them from there too.
+ * - **REGISTRY/identity (global scope):** the six cross-project tables
+ *   (`nexus_project_registry`, `nexus_project_id_aliases`, `nexus_user_profile`,
+ *   `nexus_sigils`, `nexus_audit_log`, `nexus_schema_meta`) stay in the GLOBAL
+ *   `cleo.db` under {@link getCleoHome} (ADR-090 §2.2).
  *
+ * `getNexusDb()` opens the PROJECT scope as `main` (via {@link openDualScopeDb}
+ * ('project')) and ATTACHes the GLOBAL `cleo.db` under
+ * {@link NEXUS_GLOBAL_ATTACH_ALIAS}. SQLite's bare-name resolution then routes
+ * each query to the correct file with ZERO accessor changes: graph tables exist
+ * in `main` (project) and resolve there; registry/identity tables are absent
+ * from `main` and fall through to the attached GLOBAL db. The GLOBAL db also
+ * carries empty graph tables (frozen T11363 migration leftovers), correctly
+ * SHADOWED by `main`.
+ *
+ * ### Why this fix (T11648)
+ *
+ * T11538/T11539 moved the graph schema to PROJECT scope and routed exodus there,
+ * but the runtime READ accessors still opened the GLOBAL handle — so after a
+ * `cleo exodus migrate` the project held 24k+ `nexus_nodes` while the runtime
+ * read 0 from global (`cleo nexus search-code` / `context` returned empty). This
+ * module is the deferred runtime half: it reads the graph from the SAME scope
+ * exodus writes it.
+ *
+ * This preserves the prior guarantees:
  * - Every nexus-domain open flows through the single pragma SSoT (ADR-068/069).
- * - The nexus tables now live inside the consolidated GLOBAL `cleo.db` — NOT a
- *   separate `nexus.db` file — co-existing with `signaldock_*` / `skills_*` /
- *   global `brain_*`.
  * - DB Open Guard Gate 3 (`scripts/lint-no-direct-db-open.mjs`) stays green: the
- *   only native open is inside `dual-scope-db.ts`. The remaining raw opens in
- *   `nexus/**` migration scripts are the allowlisted migration paths.
+ *   only native open is inside `dual-scope-db.ts` (the ATTACH below is a SQL
+ *   statement on an already-chokepointed handle, not a `new DatabaseSync(`).
  *
  * ## COMPLETE-CUTOVER to prefixed `nexus_*` tables (T11578 · AC3)
  *
- * The nexus runtime READ + WRITE path now targets the PREFIXED consolidated
- * `nexus_*` tables that the consolidated cleo-global migration
- * (`drizzle-cleo-global/…t11363-consolidation-cleo-global`) creates and OWNS —
- * the single SSoT for the 10 base tables (`nexus_project_registry`,
- * `nexus_project_id_aliases`, `nexus_user_profile`, `nexus_sigils`, `nexus_nodes`,
- * `nexus_relations`, `nexus_contracts`, `nexus_code_index`, `nexus_audit_log`,
- * `nexus_schema_meta`). The former legacy drop/rebuild (`establishLegacyNexusSchema`)
- * and the BARE registry tables (`project_registry`, `user_profile`, `sigils`,
- * `project_id_aliases`) are GONE. The runtime schema barrel `schema/nexus-schema.ts`
- * now maps those four export symbols (`projectRegistry`, `userProfile`, `sigils`,
- * `projectIdAliases`) to the prefixed physical tables — accessors need ZERO change.
+ * The nexus runtime READ + WRITE path targets PREFIXED consolidated tables. The
+ * five PROJECT graph tables are owned by the consolidated cleo-project migration;
+ * the six GLOBAL registry/identity tables by the consolidated cleo-global
+ * migration. The former legacy drop/rebuild (`establishLegacyNexusSchema`) and
+ * BARE registry tables (`project_registry`, …) are GONE. The runtime schema
+ * barrel `schema/nexus-schema.ts` maps every export symbol to its prefixed
+ * physical name — accessors need ZERO change.
  *
  * The `drizzle-nexus` migration set carries ONLY the delta the consolidated
  * migration cannot model: the `nexus_symbols_fts` FTS5 virtual table + its three
  * `nexus_nodes` triggers, the `nexus_relation_weights` plasticity-partition
  * sibling (T11545), and the `_nexus_meta` health-probe table (the reconcile
- * sentinel). The destructive half of the plasticity partition (DROP the inline
- * `weight`/`last_accessed_at`/`co_accessed_count` columns the T11363
- * `nexus_relations` still carries) is applied idempotently at open by
- * `ensureNexusRelationWeights` — never as a non-idempotent journaled ALTER.
+ * sentinel). The destructive half of the plasticity partition is applied
+ * idempotently at open by `ensureNexusRelationWeights` (a no-op for the
+ * already-narrow project-scope `nexus_relations`).
  *
- * The four nexus code-graph tables keep their `project_id` column (the runtime
- * keeps a SINGLE global handle; the graph accessors filter by `project_id`). The
- * ADR-090 residency MOVE to PROJECT scope (drop `project_id`, open per-project
- * handles) is a SEPARATE later task (T11538/T11539) — out of scope for AC3.
- *
- * @adr ADR-036 — nexus.db (now the global `cleo.db`) is global-only.
+ * @adr ADR-036 — registry/identity is global-only (relaxed for the 4 graph
+ *   tables by ADR-090 §2.4).
+ * @adr ADR-090 — nexus code-graph residency global→project scope split.
  * @task T5365
- * @task T11524 - E6-L4: route getNexusDb through openDualScopeDb('global') (SG-DB-SUBSTRATE-V2)
- * @task T11578 - AC3: COMPLETE-CUTOVER nexus runtime → prefixed nexus_* consolidated tables
+ * @task T11524 - E6-L4: route getNexusDb through the dual-scope chokepoint
+ * @task T11578 - AC3: COMPLETE-CUTOVER nexus runtime → prefixed nexus_* tables
+ * @task T11648 - ADR-090 runtime read half: route graph reads to project scope
  */
 
 import { copyFileSync, existsSync } from 'node:fs';
@@ -88,43 +100,138 @@ let _nexusDbPath: string | null = null;
 let _nexusInitPromise: Promise<NodeSQLiteDatabase<typeof nexusSchema>> | null = null;
 
 /**
- * Returns the global-tier nexus DB path — the consolidated GLOBAL `cleo.db`.
+ * SQLite ATTACH alias under which the GLOBAL consolidated `cleo.db` is mounted
+ * into the PROJECT-scope nexus handle so the cross-project registry/identity
+ * tables (`nexus_project_registry`, `nexus_user_profile`, `nexus_sigils`,
+ * `nexus_project_id_aliases`, `nexus_audit_log`, `nexus_schema_meta`) stay
+ * reachable by their BARE names (ADR-090 · T11648).
  *
- * E6-L4 (T11524): delegates to {@link resolveDualScopeDbPath}('global'), which
- * resolves `getCleoHome()` + `cleo.db`. nexus is a cross-project registry and
- * must live in the global CLEO home directory (`~/.local/share/cleo/` on Linux
- * via XDG). It is NEVER written to a per-project `.cleo/` directory.
+ * SQLite resolves a bare table name against `main` first, then attached
+ * databases in attach order. The PROJECT `cleo.db` (`main`) physically carries
+ * ONLY the five graph tables (`nexus_nodes`, `nexus_relations`,
+ * `nexus_contracts`, `nexus_code_index`, `nexus_relation_weights`), so those
+ * bare names resolve to the populated project graph; the registry/identity
+ * tables — absent from `main` — fall through to this attached GLOBAL db. The
+ * GLOBAL db ALSO carries empty graph tables (frozen T11363 migration leftovers),
+ * but those are correctly SHADOWED by `main` and never read or written.
+ */
+const NEXUS_GLOBAL_ATTACH_ALIAS = 'nexus_global';
+
+/**
+ * Returns the nexus GRAPH DB path — the consolidated PROJECT `cleo.db`
+ * (`<projectRoot>/.cleo/cleo.db`), where the four code-graph tables
+ * (`nexus_nodes`, `nexus_relations`, `nexus_contracts`, `nexus_code_index`) and
+ * the `nexus_relation_weights` plasticity sibling physically reside post the
+ * ADR-090 residency split (T11538/T11539).
  *
+ * ## ADR-090 residency move — runtime read half (T11648)
+ *
+ * Exodus WRITES the graph tables to PROJECT scope (per `resolveTableTargetScope`
+ * in `store/exodus/table-name-map.ts`); this resolver routes the runtime READ
+ * path to the SAME scope so the migrated graph is visible. Previously this
+ * returned the GLOBAL `cleo.db` (`resolveDualScopeDbPath('global')`), which left
+ * `cleo nexus search-code` / `context` reading the empty global graph tables —
+ * the T11538/T11539 runtime-half gap this fix closes. The cross-project
+ * registry/identity tables stay GLOBAL and are reached via the
+ * {@link NEXUS_GLOBAL_ATTACH_ALIAS} attach (see {@link getNexusRegistryDbPath}).
+ *
+ * @param cwd - Optional working directory used to resolve the owning project
+ *   root (forwarded to {@link resolveDualScopeDbPath}('project', cwd)).
  * @task T307
  * @epic T299
- * @why ADR-036 §Decision/Global-Tier: nexus is global-only. This guard
- *   throws immediately if path resolution ever drifts outside getCleoHome(),
- *   preventing silent creation of project-tier stray DB files. The dual-scope
- *   global resolver builds the path from getCleoHome() so the invariant holds;
- *   the assertion is retained as defence-in-depth against future regressions.
- * @throws {Error} If the resolved path is not under `getCleoHome()` — this
- *   indicates a code path that bypasses canonical path resolution and is a
- *   bug that must be fixed rather than silently tolerated.
+ * @task T11648 (ADR-090 runtime read half — route graph reads to project scope)
+ * @why ADR-090 §2.1/§2.4 supersedes ADR-036's global-only assertion FOR THE
+ *   GRAPH TABLES ONLY. The graph is per-project and must live in the portable
+ *   `.cleo/cleo.db`; the registry/identity tables remain global-asserted in
+ *   {@link getNexusRegistryDbPath}.
  */
-export function getNexusDbPath(): string {
-  const cleoHome = getCleoHome();
-  const nexusPath = resolveDualScopeDbPath('global');
+export function getNexusDbPath(cwd?: string): string {
+  return resolveDualScopeDbPath('project', cwd);
+}
 
-  // Guard: the resolved path MUST be under the global tier (ADR-036). The
-  // dual-scope global resolver joins getCleoHome() with 'cleo.db', so the
-  // invariant is always satisfied under normal operation. The assertion catches
-  // hypothetical future regressions where getCleoHome() is monkey-patched or the
-  // resolver drifts.
-  if (!nexusPath.startsWith(cleoHome)) {
+/**
+ * Returns the cross-project nexus REGISTRY/identity DB path — the consolidated
+ * GLOBAL `cleo.db` under `getCleoHome()`.
+ *
+ * The registry/identity tables (`nexus_project_registry`,
+ * `nexus_project_id_aliases`, `nexus_user_profile`, `nexus_sigils`,
+ * `nexus_audit_log`, `nexus_schema_meta`) are genuinely global (ADR-090 §2.2)
+ * and MUST stay under `getCleoHome()`. The ADR-036 global-only assertion is
+ * retained here as defence-in-depth (it was relaxed only for the four graph
+ * tables, now homed in PROJECT scope via {@link getNexusDbPath}).
+ *
+ * @task T11648 (ADR-090 — registry stays global-asserted)
+ * @adr ADR-036 — registry/identity is global-only.
+ * @throws {Error} If the resolved path is not under `getCleoHome()`.
+ */
+export function getNexusRegistryDbPath(): string {
+  const cleoHome = getCleoHome();
+  const registryPath = resolveDualScopeDbPath('global');
+
+  // Guard: the registry/identity home MUST be under the global tier (ADR-036).
+  if (!registryPath.startsWith(cleoHome)) {
     throw new Error(
-      `BUG: getNexusDbPath() resolved to "${nexusPath}" which is NOT under ` +
-        `getCleoHome() ("${cleoHome}"). nexus is global-only per ADR-036. ` +
-        `This indicates a code path that bypasses canonical path resolution — ` +
-        `fix the caller, do not suppress this error.`,
+      `BUG: getNexusRegistryDbPath() resolved to "${registryPath}" which is NOT ` +
+        `under getCleoHome() ("${cleoHome}"). The nexus registry/identity tables ` +
+        `are global-only per ADR-036/ADR-090 §2.2. This indicates a code path that ` +
+        `bypasses canonical path resolution — fix the caller, do not suppress this error.`,
     );
   }
 
-  return nexusPath;
+  return registryPath;
+}
+
+/**
+ * Idempotently ATTACH the GLOBAL consolidated `cleo.db` into a PROJECT-scope
+ * nexus handle under {@link NEXUS_GLOBAL_ATTACH_ALIAS}, so the cross-project
+ * registry/identity tables resolve by their bare names (ADR-090 · T11648).
+ *
+ * Safe to call repeatedly: if the alias is already attached (a sibling domain
+ * opened the same shared project handle first, or a prior nexus open ran this),
+ * the duplicate `ATTACH` throws and is swallowed. The global `cleo.db` is the
+ * canonical registry home; we ensure its directory exists via the global open
+ * resolver before attaching.
+ *
+ * @param nativeDb - The open PROJECT-scope `DatabaseSync` handle.
+ * @task T11648
+ */
+function ensureGlobalRegistryAttached(nativeDb: DatabaseSync): void {
+  const globalPath = getNexusRegistryDbPath();
+  const escaped = globalPath.replace(/'/g, "''");
+
+  // Inspect the current attach (if any). `PRAGMA database_list` reports the alias
+  // + the file each schema is bound to. The registry home is resolved fresh from
+  // `getNexusRegistryDbPath()` (which reads `getCleoHome()`), so it can change
+  // between opens — e.g. tests that mutate `CLEO_HOME` while sharing the cwd-keyed
+  // project handle, or a sibling domain that re-opened the shared project DB. A
+  // stale ATTACH would silently read a prior registry. To stay deterministic we
+  // DETACH any existing `nexus_global` (unless it is provably the same file) and
+  // re-ATTACH the current registry path.
+  const existing = (
+    nativeDb.prepare('PRAGMA database_list').all() as Array<{ name?: string; file?: string }>
+  ).find((row) => row.name === NEXUS_GLOBAL_ATTACH_ALIAS);
+
+  if (existing) {
+    // Fast path: the alias is already bound to exactly the current registry file.
+    if (existing.file === globalPath) return;
+    // Otherwise re-bind. DETACH is best-effort; the subsequent ATTACH surfaces a
+    // clear error rather than silently leaving a stale binding.
+    try {
+      nativeDb.exec(`DETACH DATABASE ${NEXUS_GLOBAL_ATTACH_ALIAS}`);
+    } catch {
+      // Alias still bound (e.g. an open statement) — the ATTACH below would throw
+      // "database nexus_global is already in use"; treat the existing binding as
+      // authoritative only when its file matches, which we already returned for.
+      return;
+    }
+  }
+
+  // The global cleo.db is created/migrated by the global dual-scope open path
+  // (sibling domains: skills/agent-registry/global-brain). ATTACH only needs the
+  // file to exist; SQLite creates it if absent, but it will then lack the
+  // consolidated registry schema. Registry readers tolerate a missing table
+  // (try/catch), so a bare ATTACH is sufficient and non-fatal here.
+  nativeDb.exec(`ATTACH DATABASE '${escaped}' AS ${NEXUS_GLOBAL_ATTACH_ALIAS}`);
 }
 
 /**
@@ -468,31 +575,34 @@ function ensureNexusRelationWeights(nativeDb: DatabaseSync): void {
 
 /**
  * Apply the nexus-domain DELTA migration + idempotent safety nets on top of the
- * PREFIXED consolidated `nexus_*` tables the dual-scope chokepoint already
- * created (T11578 · AC3).
+ * PREFIXED consolidated graph tables the PROJECT dual-scope chokepoint already
+ * created (T11578 · AC3 · ADR-090 T11648).
  *
- * ## COMPLETE-CUTOVER (T11578 · AC3)
+ * ## COMPLETE-CUTOVER (T11578 · AC3) + residency move (ADR-090 · T11648)
  *
- * The consolidated cleo-global migration (T11363) OWNS the 10 prefixed nexus base
- * tables (`nexus_project_registry`, `nexus_user_profile`, `nexus_sigils`,
- * `nexus_project_id_aliases`, `nexus_nodes`, `nexus_relations`, `nexus_contracts`,
- * `nexus_code_index`, `nexus_audit_log`, `nexus_schema_meta`). The runtime no
- * longer drops/rebuilds a legacy shape (former `establishLegacyNexusSchema`) and
- * no longer creates the BARE registry tables. The `drizzle-nexus` set carries
- * ONLY the delta the consolidated migration cannot model:
+ * The consolidated cleo-project migration OWNS the five PREFIXED graph tables
+ * in the PROJECT `cleo.db` `main` (`nexus_nodes`, `nexus_relations`,
+ * `nexus_contracts`, `nexus_code_index`, `nexus_relation_weights`); the
+ * cross-project registry/identity tables are owned by the cleo-global migration
+ * and reached through the {@link NEXUS_GLOBAL_ATTACH_ALIAS} attach. The runtime
+ * no longer drops/rebuilds a legacy shape (former `establishLegacyNexusSchema`).
+ * The `drizzle-nexus` set carries ONLY the delta the consolidated migration
+ * cannot model:
  *   - the `nexus_relation_weights` sibling (plasticity partition, T11545),
- *   - the `nexus_symbols_fts` FTS5 virtual table + its three triggers, and
+ *   - the `nexus_symbols_fts` FTS5 virtual table + its three triggers (over the
+ *     project-scope `nexus_nodes`), and
  *   - the `_nexus_meta` health-probe table (also the reconcile sentinel).
  *
  * The reconcile sentinel is `_nexus_meta` (a table the nexus migration ITSELF
  * creates, NOT a consolidated-owned table). This keeps `reconcileJournal`
  * Scenario 2 (orphan deletion) dormant until the nexus migration set is journaled
- * — otherwise the consolidated migration's journal entries (written FIRST by
- * `openDualScopeDb`) would look like orphans and be deleted, corrupting the shared
- * journal (mirrors the conduit `_conduit_meta` sentinel, AC4).
+ * — otherwise the consolidated PROJECT migration's journal entries (written FIRST
+ * by `openDualScopeDb`) would look like orphans and be deleted, corrupting the
+ * shared journal (mirrors the conduit `_conduit_meta` sentinel, AC4).
  *
  * @task T5365
  * @task T11578
+ * @task T11648
  */
 function runNexusMigrations(
   nativeDb: DatabaseSync,
@@ -500,9 +610,11 @@ function runNexusMigrations(
 ): void {
   const migrationsFolder = resolveNexusMigrationsFolder();
 
-  // If existing DB with pending migrations, create safety backup (cleo compat).
-  // Sentinel is the prefixed consolidated registry table (T11578 · AC3).
-  if (tableExists(nativeDb, 'nexus_project_registry') && _nexusDbPath) {
+  // If existing DB with populated graph, create a safety backup (cleo compat).
+  // Sentinel is `nexus_nodes` — the canonical project-scope graph table in
+  // `main` (ADR-090 · T11648); the former `nexus_project_registry` sentinel now
+  // lives in the attached GLOBAL db, not this project handle.
+  if (tableExists(nativeDb, 'nexus_nodes') && _nexusDbPath) {
     const backupPath = _nexusDbPath.replace(/\.db$/, '-pre-cleo.db.bak');
     if (!existsSync(backupPath)) {
       try {
@@ -565,18 +677,33 @@ function runNexusMigrations(
 }
 
 /**
- * Initialize the consolidated GLOBAL `cleo.db` and the nexus DELTA schema within
- * it (lazy, singleton).
+ * Initialize the consolidated PROJECT `cleo.db` (the nexus GRAPH home) with the
+ * GLOBAL `cleo.db` ATTACHed for registry/identity reads, plus the nexus DELTA
+ * schema within it (lazy, singleton).
  *
- * T11578 · AC3: delegates the physical open to {@link openDualScopeDb}('global')
- * — the canonical dual-scope chokepoint, which runs the consolidated cleo-global
- * migrations that OWN the prefixed `nexus_*` base tables — and re-wraps its native
- * handle with the `nexusSchema` drizzle instance (now mapping the PREFIXED
- * physical tables). Returns the drizzle ORM instance (async via the dual-scope
- * migration step).
+ * ## ADR-090 residency move — runtime read half (T11648)
  *
- * Uses a promise guard so concurrent callers wait for the same
- * initialization to complete (migrations are async).
+ * The four code-graph tables (`nexus_nodes`, `nexus_relations`, `nexus_contracts`,
+ * `nexus_code_index`) + the `nexus_relation_weights` plasticity sibling now live
+ * in PROJECT scope (`<projectRoot>/.cleo/cleo.db`) — that is where exodus WRITES
+ * them. The runtime READ path therefore opens the PROJECT scope as `main` so the
+ * graph is visible (previously it opened GLOBAL and read empty graph tables —
+ * the T11538/T11539 gap). The cross-project registry/identity tables stay GLOBAL;
+ * we open GLOBAL first (so its consolidated migration creates them) then ATTACH
+ * it under {@link NEXUS_GLOBAL_ATTACH_ALIAS} so the registry/identity accessors —
+ * which reference bare names (`nexus_project_registry`, `nexus_user_profile`,
+ * `nexus_sigils`, `nexus_project_id_aliases`, `nexus_audit_log`,
+ * `nexus_schema_meta`) — resolve via SQLite's bare-name fall-through to the
+ * attached GLOBAL db. ADR-036's global-only assertion is relaxed for the four
+ * graph tables ONLY (registry stays global-asserted in {@link getNexusRegistryDbPath}).
+ *
+ * Uses a promise guard so concurrent callers wait for the same initialization to
+ * complete (migrations are async).
+ *
+ * @task T307
+ * @task T11524 (E6-L4 — dual-scope chokepoint delegation)
+ * @task T11578 (AC3 — prefixed `nexus_*` tables)
+ * @task T11648 (ADR-090 runtime read half — project-scope graph + global attach)
  */
 export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchema>> {
   const requestedPath = getNexusDbPath();
@@ -587,8 +714,8 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
     resetNexusDbState();
   }
 
-  // Liveness guard (T11524): nexus shares the consolidated GLOBAL `cleo.db`
-  // handle with the other global-tier domains (signaldock/skills, E6-L5). Another
+  // Liveness guard (T11524): nexus shares the consolidated PROJECT `cleo.db`
+  // handle with the other project-tier domains (tasks/brain/conduit). Another
   // domain may have closed + re-opened the shared `DatabaseSync` while our nexus
   // singleton still references the now-closed handle. Detect a stale (closed)
   // handle and drop the singleton so we re-derive from the live openDualScopeDb
@@ -597,7 +724,24 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
     resetNexusDbState();
   }
 
-  if (_nexusDb) return _nexusDb;
+  if (_nexusDb) {
+    // Re-validate the GLOBAL registry ATTACH on every singleton hit (ADR-090 ·
+    // T11648). The registry home (`getCleoHome()`) can change between calls —
+    // tests that mutate `CLEO_HOME` while the cwd-keyed project handle stays
+    // cached, or a sibling domain that re-opened the shared project handle and
+    // dropped the attach. `ensureGlobalRegistryAttached` early-returns when the
+    // current attach already points at the right file, so this is cheap.
+    if (_nexusNativeDb) {
+      try {
+        ensureGlobalRegistryAttached(_nexusNativeDb);
+      } catch {
+        // A failed re-attach means the shared handle is unusable — drop the
+        // singleton so the next call re-derives a fresh handle + attach.
+        resetNexusDbState();
+      }
+    }
+    if (_nexusDb) return _nexusDb;
+  }
 
   // If already initializing, wait for the in-flight init
   if (_nexusInitPromise) return _nexusInitPromise;
@@ -610,26 +754,39 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
     // carries the nested-nexus migration debris. Does not alter the open.
     detectAndWarnOnNestedNexus();
 
-    // ── Dual-scope chokepoint delegation (T11524 · E6-L4 · T11578 · AC3) ───
-    // openDualScopeDb('global') applies the pragma SSoT, creates the directory,
-    // runs the consolidated cleo-global migrations (which OWN the PREFIXED
-    // `nexus_*` base tables), and manages the singleton cache. We extract its
-    // native handle and re-wrap it with the `nexusSchema` drizzle instance (now
-    // mapping the prefixed physical tables) so existing accessors run unchanged.
-    const dualHandle = await openDualScopeDb('global');
+    // ── Registry home: open GLOBAL first (T11648) ──────────────────────────
+    // The registry/identity tables are global (ADR-090 §2.2). Opening the GLOBAL
+    // scope through the dual-scope chokepoint runs its consolidated migration,
+    // guaranteeing those tables (and their schema) physically exist before we
+    // ATTACH the global file into the project handle below. This is the same
+    // shared handle the global-tier siblings (skills/agent-registry) hold; we do
+    // NOT keep a reference to it — we only need its schema materialised on disk.
+    await openDualScopeDb('global');
+
+    // ── Graph home: open PROJECT scope as `main` (T11648 · ADR-090 §2.1/§2.4) ─
+    // openDualScopeDb('project', cwd) applies the pragma SSoT, creates the
+    // directory, runs the consolidated cleo-project migrations (which OWN the
+    // five PREFIXED graph tables), and manages the singleton cache. We extract
+    // its native handle and re-wrap it with the `nexusSchema` drizzle instance.
+    const dualHandle = await openDualScopeDb('project', process.cwd());
 
     // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
     const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;
     if (!nativeDb) {
       throw new Error(
-        'T11578 · AC3: openDualScopeDb returned a handle without $client — ' +
+        'T11648: openDualScopeDb returned a handle without $client — ' +
           'cannot extract DatabaseSync for the nexus-schema drizzle wrapping.',
       );
     }
     _nexusNativeDb = nativeDb;
 
+    // ATTACH the GLOBAL `cleo.db` so the registry/identity tables resolve by
+    // their bare names via SQLite's fall-through (ADR-090 · T11648). Idempotent.
+    ensureGlobalRegistryAttached(nativeDb);
+
     // Wrap the native handle with the `nexusSchema` drizzle instance so existing
-    // accessors (nexusSchema.* queries) run against the PREFIXED tables unchanged.
+    // accessors (nexusSchema.* queries) run unchanged: graph tables resolve to
+    // the project `main`; registry/identity tables fall through to the attach.
     const db = drizzle({ client: nativeDb, schema: nexusSchema });
 
     // Apply the nexus DELTA migration + idempotent safety nets on top of the
@@ -662,20 +819,21 @@ export async function getNexusDb(): Promise<NodeSQLiteDatabase<typeof nexusSchem
 /**
  * Close the nexus-domain database connection and release resources.
  *
- * ## E6-L4 (T11524)
+ * ## E6-L4 (T11524) · ADR-090 runtime read half (T11648)
  *
- * The nexus domain now SHARES the consolidated GLOBAL `cleo.db` handle with the
- * other global-tier domains (signaldock/skills, E6-L5 — all open it via
- * {@link openDualScopeDb}('global'), same cache key). This function therefore must
- * NOT close the underlying `DatabaseSync` nor evict the dual-scope cache — doing
- * so would break in-flight queries from those siblings with "database is not
- * open". It only drops the nexus-domain singleton references; the shared handle's
- * lifecycle is owned by `openDualScopeDb` and torn down by a coordinated reset
- * (`closeAllDatabases` → `_resetDualScopeDbCache`).
+ * The nexus GRAPH domain now SHARES the consolidated PROJECT `cleo.db` handle
+ * with the other project-tier domains (tasks/brain/conduit — all open it via
+ * {@link openDualScopeDb}('project'), same cache key), with the GLOBAL `cleo.db`
+ * ATTACHed for registry/identity reads. This function therefore must NOT close
+ * the underlying `DatabaseSync` nor evict the dual-scope cache — doing so would
+ * break in-flight queries from those siblings with "database is not open". It
+ * only drops the nexus-domain singleton references; the shared handle's lifecycle
+ * (and the global ATTACH) is owned by `openDualScopeDb` and torn down by a
+ * coordinated reset (`closeAllDatabases` → `_resetDualScopeDbCache`).
  */
 export function closeNexusDb(): void {
   // Drop only the nexus singleton references. Do NOT close `_nexusNativeDb` — it
-  // is the shared dual-scope handle, possibly still in use by global siblings.
+  // is the shared dual-scope project handle, possibly still in use by siblings.
   _nexusNativeDb = null;
   _nexusDb = null;
   _nexusDbPath = null;
@@ -687,11 +845,11 @@ export function closeNexusDb(): void {
  * Used during tests or when the database file is recreated.
  * Safe to call multiple times.
  *
- * ## E6-L4 (T11524)
+ * ## E6-L4 (T11524) · ADR-090 runtime read half (T11648)
  *
  * Drops only the nexus-domain singleton references — does NOT close the shared
- * dual-scope GLOBAL `cleo.db` handle nor evict the dual-scope cache (that handle
- * is shared with the other global-tier domains). Mirrors {@link closeNexusDb}.
+ * dual-scope PROJECT `cleo.db` handle nor evict the dual-scope cache (that handle
+ * is shared with the other project-tier domains). Mirrors {@link closeNexusDb}.
  */
 export function resetNexusDbState(): void {
   _nexusNativeDb = null;

--- a/packages/core/src/store/schema/nexus-schema.ts
+++ b/packages/core/src/store/schema/nexus-schema.ts
@@ -41,17 +41,25 @@
  *     `nexus_relations` (which still carries them in the T11363 shape) and
  *     ensures the sibling table.
  *
- * The four nexus code-graph tables retain their `project_id` column here (the
- * runtime keeps a SINGLE global handle and the graph accessors filter by
- * `project_id`). The ADR-090 residency move to PROJECT scope (drop `project_id`,
- * open per-project handles) is a SEPARATE later task (T11538/T11539) — out of
- * scope for AC3.
+ * ## ADR-090 residency split — graph tables PROJECT-scoped (T11648)
+ *
+ * The four code-graph tables (`nexus_nodes`, `nexus_relations`,
+ * `nexus_contracts`, `nexus_code_index`) + the `nexus_relation_weights`
+ * plasticity sibling no longer carry `project_id` (ADR-090 §2.1): they live in
+ * the PROJECT `cleo.db` and `nexus-sqlite.ts` opens the project scope as `main`,
+ * so scope is implicit. The graph accessors therefore DROP the former
+ * `WHERE project_id = ?` predicate (single project per DB). The
+ * registry/identity tables (`nexus_project_registry`, `nexus_user_profile`,
+ * `nexus_sigils`, `nexus_project_id_aliases`, `nexus_audit_log`,
+ * `nexus_schema_meta`) stay GLOBAL and are reached through the
+ * `nexus_global` ATTACH (see `nexus-sqlite.ts`); their mappings are unchanged.
  *
  * @task T5365
  * @task T529
  * @task T1077
  * @task T1148
  * @task T11578
+ * @task T11648
  */
 
 import { sql } from 'drizzle-orm';
@@ -263,8 +271,11 @@ export const nexusNodes = sqliteTable(
      *  `process:<slug>` for execution flow nodes. */
     id: text('id').primaryKey(),
 
-    /** Foreign key to project_registry.project_id. Scopes the node. */
-    projectId: text('project_id').notNull(),
+    // `project_id` DROPPED (ADR-090 §2.1 · T11648): the graph now lives in the
+    // PROJECT `cleo.db` (`nexus-sqlite.ts` opens the project scope as `main`), so
+    // scope is implicit in the owning project DB — a redundant per-row scope
+    // column is no longer carried. Matches the project-scope physical shape
+    // (`schema/cleo-project/nexus-graph.ts`) that exodus writes.
 
     /** Node kind from GraphNodeKind union. */
     kind: text('kind', { enum: NEXUS_NODE_KINDS }).notNull(),
@@ -326,12 +337,12 @@ export const nexusNodes = sqliteTable(
     indexedAt: text('indexed_at').notNull().default(sql`(datetime('now'))`),
   },
   (table) => [
-    index('idx_nexus_nodes_project').on(table.projectId),
+    // `idx_nexus_nodes_project` + the two `project_id`-leading composite indexes
+    // are DROPPED (ADR-090 §2.1 · T11648) — they collapse to the non-leading
+    // siblings (kind / file) since scope is implicit per project DB.
     index('idx_nexus_nodes_kind').on(table.kind),
     index('idx_nexus_nodes_file').on(table.filePath),
     index('idx_nexus_nodes_name').on(table.name),
-    index('idx_nexus_nodes_project_kind').on(table.projectId, table.kind),
-    index('idx_nexus_nodes_project_file').on(table.projectId, table.filePath),
     index('idx_nexus_nodes_community').on(table.communityId),
     index('idx_nexus_nodes_parent').on(table.parentId),
     index('idx_nexus_nodes_exported').on(table.isExported),
@@ -404,8 +415,8 @@ export const nexusRelations = sqliteTable(
     /** UUID v4 row identifier. */
     id: text('id').primaryKey(),
 
-    /** Foreign key to project_registry.project_id. */
-    projectId: text('project_id').notNull(),
+    // `project_id` DROPPED (ADR-090 §2.1 · T11648) — scope is implicit in the
+    // owning project `cleo.db`. Matches `schema/cleo-project/nexus-graph.ts`.
 
     /** Source node ID (nexus_nodes.id). */
     sourceId: text('source_id').notNull(),
@@ -436,11 +447,11 @@ export const nexusRelations = sqliteTable(
     // and isolate the write-heavy Hebbian hot path. See {@link nexusRelationWeights}.
   },
   (table) => [
-    index('idx_nexus_relations_project').on(table.projectId),
+    // `idx_nexus_relations_project` + `idx_nexus_relations_project_type` DROPPED
+    // (ADR-090 §2.1 · T11648) — collapse to the non-leading type sibling.
     index('idx_nexus_relations_source').on(table.sourceId),
     index('idx_nexus_relations_target').on(table.targetId),
     index('idx_nexus_relations_type').on(table.type),
-    index('idx_nexus_relations_project_type').on(table.projectId, table.type),
     index('idx_nexus_relations_source_type').on(table.sourceId, table.type),
     index('idx_nexus_relations_target_type').on(table.targetId, table.type),
     index('idx_nexus_relations_confidence').on(table.confidence),
@@ -515,8 +526,8 @@ export const nexusContracts = sqliteTable(
     /** Unique contract ID (format: `<type>:<projectId>::<path>::<method>` or similar). */
     contractId: text('contract_id').primaryKey(),
 
-    /** Foreign key to project_registry.project_id. */
-    projectId: text('project_id').notNull(),
+    // `project_id` DROPPED (ADR-090 §2.1 · T11648) — scope is implicit in the
+    // owning project `cleo.db`. Matches `schema/cleo-project/nexus-graph.ts`.
 
     /** Contract type: 'http', 'grpc', 'topic'. */
     type: text('type', { enum: NEXUS_CONTRACT_TYPES }).notNull(),
@@ -552,11 +563,11 @@ export const nexusContracts = sqliteTable(
     updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
   },
   (table) => [
-    index('idx_nexus_contracts_project').on(table.projectId),
+    // `idx_nexus_contracts_project` + `idx_nexus_contracts_project_type` DROPPED
+    // (ADR-090 §2.1 · T11648) — collapse to the non-leading type sibling.
     index('idx_nexus_contracts_type').on(table.type),
     index('idx_nexus_contracts_path').on(table.path),
     index('idx_nexus_contracts_method').on(table.method),
-    index('idx_nexus_contracts_project_type').on(table.projectId, table.type),
     index('idx_nexus_contracts_source_symbol').on(table.sourceSymbolId),
     index('idx_nexus_contracts_created').on(table.createdAt),
   ],

--- a/packages/nexus/src/pipeline/index.ts
+++ b/packages/nexus/src/pipeline/index.ts
@@ -150,7 +150,7 @@ export type { WorkerPool } from './workers/worker-pool.js';
 export { createWorkerPool } from './workers/worker-pool.js';
 
 import fs from 'node:fs/promises';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { resolveCalls } from './call-processor.js';
 import { detectCommunities } from './community-processor.js';
 import type { ScannedFile } from './filesystem-walker.js';
@@ -237,8 +237,13 @@ export interface IndexStats {
  * Extends the insert-only NexusDbInsert with select capabilities.
  */
 export interface NexusDbReadInsert extends NexusDbInsert {
+  // `from(table)` is itself awaitable (the Drizzle query builder is a thenable
+  // resolving to the rows) AND chainable with `.where()` / `.orderBy()`. The
+  // awaitable shape is required since ADR-090 · T11648 dropped the per-query
+  // `WHERE project_id = ?` filter — project-scoped graph reads now await the
+  // unfiltered `select().from(table)` directly.
   select: (fields?: Record<string, unknown>) => {
-    from: (table: unknown) => {
+    from: (table: unknown) => Promise<Record<string, unknown>[]> & {
       where: (condition: unknown) => Promise<Record<string, unknown>[]>;
       orderBy?: (...args: unknown[]) => Promise<Record<string, unknown>[]>;
     };
@@ -303,13 +308,14 @@ export interface PipelineResult {
  * Safe to call even if the project has never been indexed — returns
  * `{ indexed: false, ... }` in that case.
  *
- * @param projectId - Project registry ID (same value passed to `runPipeline`)
+ * @param _projectId - Unused since ADR-090 · T11648 (project-scoped graph DB);
+ *   retained for call-site compatibility with `runPipeline`.
  * @param repoPath - Absolute path to the repository root (used for mtime checks)
  * @param db - Drizzle database instance
  * @param tables - Drizzle table references
  */
 export async function getIndexStats(
-  projectId: string,
+  _projectId: string,
   repoPath: string,
   db: NexusDbReadInsert,
   tables: NexusTables,
@@ -321,6 +327,8 @@ export async function getIndexStats(
   const nodesTable = tables.nexusNodes;
   const relationsTable = tables.nexusRelations;
 
+  // ADR-090 · T11648: the graph tables are PROJECT-scoped (one project per
+  // `cleo.db`), so these queries no longer filter by `project_id`.
   let rows: NodeRow[] = [];
   try {
     const raw = await db
@@ -328,8 +336,7 @@ export async function getIndexStats(
         filePath: nodesTable['filePath'],
         indexedAt: nodesTable['indexedAt'],
       })
-      .from(tables.nexusNodes)
-      .where(eq(nodesTable['projectId'], projectId));
+      .from(tables.nexusNodes);
     rows = raw as NodeRow[];
   } catch {
     // Table may not exist yet
@@ -369,10 +376,7 @@ export async function getIndexStats(
   // Count relations
   let relationCount = 0;
   try {
-    const relRows = await db
-      .select({ id: relationsTable['id'] })
-      .from(tables.nexusRelations)
-      .where(eq(relationsTable['projectId'], projectId));
+    const relRows = await db.select({ id: relationsTable['id'] }).from(tables.nexusRelations);
     relationCount = (relRows as unknown[]).length;
   } catch {
     // ignore
@@ -413,20 +417,20 @@ export async function getIndexStats(
 
 /** Internal: get existing indexed file paths and their indexedAt timestamps. */
 async function getIndexedFileMtimes(
-  projectId: string,
+  _projectId: string,
   db: NexusDbReadInsert,
   tables: NexusTables,
 ): Promise<Map<string, string>> {
   type Row = { filePath: string | null; indexedAt: string };
   const nodesTable = tables.nexusNodes;
   try {
+    // ADR-090 · T11648: project-scoped graph DB — no `project_id` predicate.
     const rows = await db
       .select({
         filePath: nodesTable['filePath'],
         indexedAt: nodesTable['indexedAt'],
       })
-      .from(tables.nexusNodes)
-      .where(eq(nodesTable['projectId'], projectId));
+      .from(tables.nexusNodes);
     const map = new Map<string, string>();
     for (const row of rows as Row[]) {
       if (row.filePath) map.set(row.filePath, row.indexedAt);
@@ -442,7 +446,7 @@ async function getIndexedFileMtimes(
  * or deleted file, wrapped in a transaction for atomicity.
  */
 async function deleteStaleEntries(
-  projectId: string,
+  _projectId: string,
   stalePaths: string[],
   db: NexusDbReadInsert,
   tables: NexusTables,
@@ -456,12 +460,13 @@ async function deleteStaleEntries(
   const CHUNK = 200;
   for (let i = 0; i < stalePaths.length; i += CHUNK) {
     const chunk = stalePaths.slice(i, i + CHUNK);
-    // Delete nodes for these file paths
+    // Delete nodes for these file paths (project-scoped DB — ADR-090 · T11648:
+    // no `project_id` predicate).
     for (const filePath of chunk) {
       try {
         await (db as NexusDbReadInsert)
           .delete(tables.nexusNodes)
-          .where(and(eq(nodesTable['projectId'], projectId), eq(nodesTable['filePath'], filePath)));
+          .where(eq(nodesTable['filePath'], filePath));
       } catch {
         // ignore — node may not exist for this file
       }
@@ -472,12 +477,7 @@ async function deleteStaleEntries(
       try {
         await (db as NexusDbReadInsert)
           .delete(tables.nexusRelations)
-          .where(
-            and(
-              eq(relationsTable['projectId'], projectId),
-              eq(relationsTable['sourceId'], filePath),
-            ),
-          );
+          .where(eq(relationsTable['sourceId'], filePath));
       } catch {
         // ignore
       }
@@ -589,17 +589,10 @@ export async function runPipeline(
         let existingNodeCount = 0;
         let existingRelationCount = 0;
         try {
-          const nodesT = tables.nexusNodes;
-          const relationsT = tables.nexusRelations;
-          const nr = await readableDb
-            .select()
-            .from(tables.nexusNodes)
-            .where(eq(nodesT['projectId'], projectId));
+          // ADR-090 · T11648: project-scoped graph DB — no `project_id` predicate.
+          const nr = await readableDb.select().from(tables.nexusNodes);
           existingNodeCount = (nr as unknown[]).length;
-          const rr = await readableDb
-            .select()
-            .from(tables.nexusRelations)
-            .where(eq(relationsT['projectId'], projectId));
+          const rr = await readableDb.select().from(tables.nexusRelations);
           existingRelationCount = (rr as unknown[]).length;
         } catch {
           /* ignore */

--- a/packages/nexus/src/pipeline/knowledge-graph.ts
+++ b/packages/nexus/src/pipeline/knowledge-graph.ts
@@ -71,10 +71,13 @@ export interface NexusTables {
 // Row types (matches nexus-schema.ts NewNexusNodeRow / NewNexusRelationRow)
 // ---------------------------------------------------------------------------
 
+// ADR-090 · T11648: the graph tables are PROJECT-scoped (one project per
+// `cleo.db`), so `project_id` was dropped from `nexus_nodes` / `nexus_relations`.
+// The insert rows below therefore no longer carry `projectId`.
+
 /** Insert row shape for nexus_nodes. */
 interface NexusNodeInsertRow {
   id: string;
-  projectId: string;
   kind: string;
   label: string;
   name: string | null;
@@ -95,7 +98,6 @@ interface NexusNodeInsertRow {
 /** Insert row shape for nexus_relations. */
 interface NexusRelationInsertRow {
   id: string;
-  projectId: string;
   sourceId: string;
   targetId: string;
   type: string;
@@ -165,15 +167,14 @@ export function createKnowledgeGraph(): KnowledgeGraph {
     }
   }
 
-  async function flush(projectId: string, db: NexusDbInsert, tables: NexusTables): Promise<void> {
+  async function flush(_projectId: string, db: NexusDbInsert, tables: NexusTables): Promise<void> {
     const now = new Date().toISOString();
 
-    // Build node insert rows
+    // Build node insert rows (ADR-090 · T11648 — no `projectId`).
     const nodeRows: NexusNodeInsertRow[] = [];
     for (const node of nodes.values()) {
       nodeRows.push({
         id: node.id,
-        projectId,
         kind: node.kind,
         label: node.name || node.id,
         name: node.name || null,
@@ -192,12 +193,11 @@ export function createKnowledgeGraph(): KnowledgeGraph {
       });
     }
 
-    // Build relation insert rows
+    // Build relation insert rows (ADR-090 · T11648 — no `projectId`).
     const relationRows: NexusRelationInsertRow[] = [];
     for (const rel of relations) {
       relationRows.push({
         id: randomUUID(),
-        projectId,
         sourceId: rel.source,
         targetId: rel.target,
         type: rel.type,


### PR DESCRIPTION
## Root cause — scope mismatch (cutover GO-blocker)

Exodus WRITES the 4 nexus code-graph tables — `nexus_nodes` (24482), `nexus_relations` (39163), `nexus_contracts`, `nexus_code_index` — plus `nexus_relation_weights` to **PROJECT** scope (project `cleo.db`) per the ADR-090 residency split (`resolveTableTargetScope` in `store/exodus/table-name-map.ts`). But the runtime graph readers resolved **GLOBAL**: `getNexusDbPath()` = `resolveDualScopeDbPath('global')`, hard-guarded by the ADR-036 global-only assertion; `getNexusDb()`/`getNexusNativeDb()`/`nexus/augment.ts` all read GLOBAL.

Result: PROJECT `nexus_nodes`=24482 but GLOBAL `nexus_nodes`=0 → `cleo nexus search-code` → 0 matches, `cleo nexus context` → empty, despite 24482 nodes migrated. This is the deferred **T11538/T11539 runtime half** of the residency move.

## The read-routing change

The nexus runtime handle now opens the **PROJECT** `cleo.db` as `main` (graph home) via `openDualScopeDb('project', cwd)` and **ATTACHes** the GLOBAL `cleo.db` as `nexus_global`. SQLite bare-name resolution routes:
- graph tables (`nexus_nodes`/`relations`/`contracts`/`code_index`/`relation_weights`) → project `main` (populated) ✓
- registry/identity tables (`nexus_project_registry`/`project_id_aliases`/`user_profile`/`sigils`/`audit_log`/`schema_meta`) → absent from `main` → fall through to the attached GLOBAL db ✓ (the empty global graph leftovers from the frozen T11363 migration are correctly shadowed by `main`)

Zero accessor churn for the bare-name case. Additionally, the graph tables' `project_id` column was dropped from the runtime schema + every graph reader/writer (`context`/`impact`/`clusters`/`route-analysis`/`nexus-bridge`/`living-brain`/`flows`/`diff`/`export`/`analyze-orchestrator` + `@cleocode/nexus` pipeline + `cleo` dispatch), matching the project-scope physical shape exodus writes; `top-entries`/`impact` weight reads now `LEFT JOIN nexus_relation_weights` (T11545 partition). A `withLiveNexusDb` retry guards the registry reads against the shared project handle being closed mid-query by a concurrent cross-project task open.

## ADR-036 relaxation scope

ADR-036's global-only assertion is **relaxed for the 4 graph tables ONLY** (now homed in PROJECT scope, ADR-090 §2.4). The registry/identity tables stay **global-asserted** via the new `getNexusRegistryDbPath()` (retains the `getCleoHome()` guard).

## Mini dry-run — before/after (sandbox, NOT /mnt/projects/cleocode)

Copied the live legacy global `~/.local/share/cleo/nexus.db` (24482 nodes / 39163 relations) into a sandbox global home, no stale `cleo.db`, then `cleo exodus migrate`:

| | PROJECT cleo.db | GLOBAL cleo.db |
|---|---|---|
| `nexus_nodes` | **24482** | 0 |
| `nexus_relations` | **39163** | 0 |
| `nexus_project_registry` | (absent) | **75** |

- **BEFORE (old runtime read GLOBAL):** `nexus_nodes`=0 → `search-code`/`context` empty.
- **AFTER (this fix):** `cleo nexus search-code "session"` → **10 results**; `cleo nexus context "load"` → **matchCount 193** with populated callers/callees. Bare `nexus_nodes` resolves to PROJECT (24482); bare `nexus_project_registry` resolves via attach to GLOBAL (75).

Graph tables confirmed read from PROJECT scope; registry stays GLOBAL.

## Studio fan-out note

Studio reads the **legacy** `<cleoHome>/nexus.db` via its own `studio/src/lib/server/db/connections.ts` + `cleo-home.ts`, fully independent of `@cleocode/core`'s `nexus-sqlite.ts`. **This PR does not touch Studio** — its reads are unaffected. Studio's post-cutover migration to the project-scope graph (with `project_registry` fan-out for `scope=all`) is a separate, ADR-090 §9-flagged follow-up.

## Validation

- `pnpm run typecheck` clean, `pnpm biome check .` clean, `node build.mjs` clean.
- `@cleocode/core` nexus suite (29 files / 372 tests) green twice; `@cleocode/runtime` (120) + `@cleocode/nexus` (166) green. Must-pass nexus migration + graph + DDL-snapshot + parity tests green.
- DB Open Guard Gate 3 (`--strict`) green (the ATTACH is a SQL `exec` on the chokepointed handle, not a raw open).
- Residual cross-suite file-parallelism flakiness in multi-project E2E is **pre-existing on `main`** (confirmed: base `store`+`nexus` combo flakes identically across runs) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)