### PR TITLE
fix(T11647): brain cutover — exodus brain target = runtime shape (no DROP, zero brain-data loss + no enum coercion)

### DIFF
--- a/packages/core/migrations/drizzle-cleo-global/20260531000001_t11363-consolidation-cleo-global/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260531000001_t11363-consolidation-cleo-global/migration.sql
@@ -6,15 +6,10 @@ CREATE TABLE `brain_attention` (
 	`scope_kind` text NOT NULL,
 	`scope_id` text NOT NULL,
 	`tags` blob DEFAULT (jsonb('[]')),
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`expires_at` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`expires_at` integer,
 	`decay_score` real,
-	`status` text DEFAULT 'open' NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("scope_kind" IN ('agent', 'task', 'epic', 'saga', 'session', 'global')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("expires_at" IS NULL OR "expires_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("status" IN ('open', 'consolidated', 'discarded'))
+	`status` text DEFAULT 'open' NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_backfill_runs` (
@@ -27,12 +22,7 @@ CREATE TABLE `brain_backfill_runs` (
 	`rollback_snapshot_json` text,
 	`source` text DEFAULT 'unknown' NOT NULL,
 	`target_table` text DEFAULT 'brain_observations' NOT NULL,
-	`approved_by` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("kind" IN ('observation-promotion', 'transcript-ingest', 'graph-backfill', 'noise-sweep-2440', 'custom')),
-	CHECK ("status" IN ('staged', 'approved', 'rolled-back')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("approved_at" IS NULL OR "approved_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`approved_by` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_consolidation_events` (
@@ -42,10 +32,7 @@ CREATE TABLE `brain_consolidation_events` (
 	`step_results_json` text NOT NULL,
 	`duration_ms` integer,
 	`succeeded` integer DEFAULT true NOT NULL,
-	`started_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("succeeded" IN (0, 1)),
-	CHECK ("started_at" IS NULL OR "started_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`started_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_decisions` (
@@ -81,27 +68,10 @@ CREATE TABLE `brain_decisions` (
 	`superseded_by` text,
 	`confirmation_state` text DEFAULT 'proposed' NOT NULL,
 	`decided_by` text DEFAULT 'agent' NOT NULL,
-	`validator_run_at` text,
+	`validator_run_at` integer,
 	`decision_category` text DEFAULT 'architectural' NOT NULL,
 	CONSTRAINT `fk_brain_decisions_supersedes_brain_decisions_id_fk` FOREIGN KEY (`supersedes`) REFERENCES `brain_decisions`(`id`),
-	CONSTRAINT `fk_brain_decisions_superseded_by_brain_decisions_id_fk` FOREIGN KEY (`superseded_by`) REFERENCES `brain_decisions`(`id`),
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("type" IN ('architecture', 'technical', 'process', 'strategic', 'tactical')),
-	CHECK ("confidence" IN ('low', 'medium', 'high')),
-	CHECK ("outcome" IN ('success', 'failure', 'mixed', 'pending')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("confirmation_state" IN ('proposed', 'accepted', 'superseded')),
-	CHECK ("decided_by" IN ('owner', 'council', 'agent')),
-	CHECK ("validator_run_at" IS NULL OR "validator_run_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("decision_category" IN ('architectural', 'agent_dispatch', 'other'))
+	CONSTRAINT `fk_brain_decisions_superseded_by_brain_decisions_id_fk` FOREIGN KEY (`superseded_by`) REFERENCES `brain_decisions`(`id`)
 );
 --> statement-breakpoint
 CREATE TABLE `brain_deriver_queue` (
@@ -115,13 +85,7 @@ CREATE TABLE `brain_deriver_queue` (
 	`error_msg` text,
 	`retry_count` integer DEFAULT 0 NOT NULL,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`completed_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("item_type" IN ('observation', 'session', 'narrative', 'embedding')),
-	CHECK ("status" IN ('pending', 'in_progress', 'done', 'failed')),
-	CHECK ("claimed_at" IS NULL OR "claimed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("completed_at" IS NULL OR "completed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`completed_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_learnings` (
@@ -147,18 +111,7 @@ CREATE TABLE `brain_learnings` (
 	`content_hash` text,
 	`provenance_class` text DEFAULT 'swept-clean',
 	`peer_id` text DEFAULT 'global' NOT NULL,
-	`peer_scope` text DEFAULT 'project' NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("actionable" IN (0, 1)),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`peer_scope` text DEFAULT 'project' NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_memory_links` (
@@ -167,11 +120,7 @@ CREATE TABLE `brain_memory_links` (
 	`task_id` text NOT NULL,
 	`link_type` text NOT NULL,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	CONSTRAINT `brain_memory_links_pk` PRIMARY KEY(`memory_type`, `memory_id`, `task_id`, `link_type`),
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("memory_type" IN ('decision', 'pattern', 'learning', 'observation')),
-	CHECK ("link_type" IN ('produced_by', 'applies_to', 'informed_by', 'contradicts')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	CONSTRAINT `brain_memory_links_pk` PRIMARY KEY(`memory_type`, `memory_id`, `task_id`, `link_type`)
 );
 --> statement-breakpoint
 CREATE TABLE `brain_memory_trees` (
@@ -181,10 +130,7 @@ CREATE TABLE `brain_memory_trees` (
 	`centroid` text,
 	`parent_id` integer,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`updated_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`updated_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_modulators` (
@@ -195,9 +141,7 @@ CREATE TABLE `brain_modulators` (
 	`source_event_id` text,
 	`session_id` text,
 	`description` text,
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_observations` (
@@ -240,20 +184,7 @@ CREATE TABLE `brain_observations` (
 	`origin` text,
 	`validated_at` text,
 	`provenance_chain` text,
-	`idempotency_key` text CONSTRAINT `uq_brain_observations_idempotency_key` UNIQUE,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("type" IN ('discovery', 'change', 'feature', 'bugfix', 'decision', 'refactor', 'diary', 'session-summary')),
-	CHECK ("source_type" IN ('agent', 'session-debrief', 'claude-mem', 'manual')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("validated_at" IS NULL OR "validated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`idempotency_key` text CONSTRAINT `uq_brain_observations_idempotency_key` UNIQUE
 );
 --> statement-breakpoint
 CREATE TABLE `brain_observations_staging` (
@@ -266,12 +197,7 @@ CREATE TABLE `brain_observations_staging` (
 	`new_invalid_at` text,
 	`new_provenance_class` text,
 	`validation_status` text DEFAULT 'pending' NOT NULL,
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("action" IN ('purge', 'keep', 'reclassify', 'promote')),
-	CHECK ("new_invalid_at" IS NULL OR "new_invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("validation_status" IN ('pending', 'applied', 'skipped')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_page_edges` (
@@ -287,13 +213,7 @@ CREATE TABLE `brain_page_edges` (
 	`last_depressed_at` text,
 	`depression_count` integer DEFAULT 0 NOT NULL,
 	`stability_score` real,
-	CONSTRAINT `brain_page_edges_pk` PRIMARY KEY(`from_id`, `to_id`, `edge_type`),
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("edge_type" IN ('derived_from', 'produced_by', 'informed_by', 'supports', 'contradicts', 'supersedes', 'applies_to', 'documents', 'summarizes', 'part_of', 'references', 'modified_by', 'code_reference', 'affects', 'mentions', 'conduit_mentions_symbol', 'co_retrieved', 'blocks', 'discusses', 'cites', 'embeds', 'touches_code', 'task_touches_symbol')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("last_reinforced_at" IS NULL OR "last_reinforced_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("plasticity_class" IN ('static', 'hebbian', 'stdp')),
-	CHECK ("last_depressed_at" IS NULL OR "last_depressed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	CONSTRAINT `brain_page_edges_pk` PRIMARY KEY(`from_id`, `to_id`, `edge_type`)
 );
 --> statement-breakpoint
 CREATE TABLE `brain_page_nodes` (
@@ -305,12 +225,7 @@ CREATE TABLE `brain_page_nodes` (
 	`last_activity_at` text DEFAULT (datetime('now')) NOT NULL,
 	`metadata_json` text,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`updated_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("node_type" IN ('decision', 'pattern', 'learning', 'observation', 'sticky', 'task', 'session', 'epic', 'file', 'symbol', 'concept', 'summary', 'msg', 'llmtxt', 'commit')),
-	CHECK ("last_activity_at" IS NULL OR "last_activity_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`updated_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_patterns` (
@@ -341,20 +256,7 @@ CREATE TABLE `brain_patterns` (
 	`peer_id` text DEFAULT 'global' NOT NULL,
 	`peer_scope` text DEFAULT 'project' NOT NULL,
 	`occurrence_count` integer DEFAULT 1 NOT NULL,
-	`last_seen_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("type" IN ('workflow', 'blocker', 'success', 'failure', 'optimization')),
-	CHECK ("impact" IN ('low', 'medium', 'high')),
-	CHECK ("extracted_at" IS NULL OR "extracted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("last_seen_at" IS NULL OR "last_seen_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`last_seen_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_plasticity_events` (
@@ -369,9 +271,7 @@ CREATE TABLE `brain_plasticity_events` (
 	`weight_after` real,
 	`retrieval_log_id` integer,
 	`reward_signal` real,
-	`delta_t_ms` integer,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("kind" IN ('ltp', 'ltd'))
+	`delta_t_ms` integer
 );
 --> statement-breakpoint
 CREATE TABLE `brain_promotion_log` (
@@ -382,9 +282,7 @@ CREATE TABLE `brain_promotion_log` (
 	`score` real NOT NULL,
 	`decided_at` text DEFAULT (datetime('now')) NOT NULL,
 	`decided_by` text DEFAULT 'composite-scorer' NOT NULL,
-	`rationale_json` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("decided_at" IS NULL OR "decided_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`rationale_json` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_retrieval_log` (
@@ -398,9 +296,7 @@ CREATE TABLE `brain_retrieval_log` (
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
 	`retrieval_order` integer,
 	`delta_ms` integer,
-	`reward_signal` real,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`reward_signal` real
 );
 --> statement-breakpoint
 CREATE TABLE `brain_schema_meta` (
@@ -412,10 +308,8 @@ CREATE TABLE `brain_session_narrative` (
 	`session_id` text PRIMARY KEY,
 	`narrative` text DEFAULT '' NOT NULL,
 	`turn_count` integer DEFAULT 0 NOT NULL,
-	`last_updated_at` text,
-	`pivot_count` integer DEFAULT 0 NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("last_updated_at" IS NULL OR "last_updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`last_updated_at` integer DEFAULT 0 NOT NULL,
+	`pivot_count` integer DEFAULT 0 NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_sticky_notes` (
@@ -428,13 +322,7 @@ CREATE TABLE `brain_sticky_notes` (
 	`converted_to_json` text,
 	`color` text,
 	`priority` text,
-	`source_type` text DEFAULT 'sticky-note',
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("status" IN ('active', 'converted', 'archived')),
-	CHECK ("color" IN ('yellow', 'blue', 'green', 'red', 'purple')),
-	CHECK ("priority" IN ('low', 'medium', 'high'))
+	`source_type` text DEFAULT 'sticky-note'
 );
 --> statement-breakpoint
 CREATE TABLE `brain_sticky_tags` (
@@ -453,11 +341,7 @@ CREATE TABLE `brain_transcript_events` (
 	`content` text NOT NULL,
 	`tokens` integer,
 	`redacted_at` text,
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("role" IN ('user', 'assistant', 'system')),
-	CHECK ("redacted_at" IS NULL OR "redacted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_weight_history` (
@@ -472,9 +356,7 @@ CREATE TABLE `brain_weight_history` (
 	`source_plasticity_event_id` integer,
 	`retrieval_log_id` integer,
 	`reward_signal` real,
-	`changed_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("changed_at" IS NULL OR "changed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`changed_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `nexus_audit_log` (

--- a/packages/core/migrations/drizzle-cleo-global/20260531000001_t11363-consolidation-cleo-global/snapshot.json
+++ b/packages/core/migrations/drizzle-cleo-global/20260531000001_t11363-consolidation-cleo-global/snapshot.json
@@ -277,17 +277,17 @@
       "table": "brain_attention"
     },
     {
-      "type": "text",
+      "type": "integer",
       "notNull": true,
       "autoincrement": false,
-      "default": "(datetime('now'))",
+      "default": "(unixepoch() * 1000)",
       "generated": null,
       "name": "created_at",
       "entityType": "columns",
       "table": "brain_attention"
     },
     {
-      "type": "text",
+      "type": "integer",
       "notNull": false,
       "autoincrement": false,
       "default": null,
@@ -807,7 +807,7 @@
       "table": "brain_decisions"
     },
     {
-      "type": "text",
+      "type": "integer",
       "notNull": false,
       "autoincrement": false,
       "default": null,
@@ -2717,10 +2717,10 @@
       "table": "brain_session_narrative"
     },
     {
-      "type": "text",
-      "notNull": false,
+      "type": "integer",
+      "notNull": true,
       "autoincrement": false,
-      "default": null,
+      "default": 0,
       "generated": null,
       "name": "last_updated_at",
       "entityType": "columns",

--- a/packages/core/migrations/drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project/migration.sql
@@ -6,15 +6,10 @@ CREATE TABLE `brain_attention` (
 	`scope_kind` text NOT NULL,
 	`scope_id` text NOT NULL,
 	`tags` blob DEFAULT (jsonb('[]')),
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`expires_at` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`expires_at` integer,
 	`decay_score` real,
-	`status` text DEFAULT 'open' NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("scope_kind" IN ('agent', 'task', 'epic', 'saga', 'session', 'global')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("expires_at" IS NULL OR "expires_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("status" IN ('open', 'consolidated', 'discarded'))
+	`status` text DEFAULT 'open' NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_backfill_runs` (
@@ -27,12 +22,7 @@ CREATE TABLE `brain_backfill_runs` (
 	`rollback_snapshot_json` text,
 	`source` text DEFAULT 'unknown' NOT NULL,
 	`target_table` text DEFAULT 'brain_observations' NOT NULL,
-	`approved_by` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("kind" IN ('observation-promotion', 'transcript-ingest', 'graph-backfill', 'noise-sweep-2440', 'custom')),
-	CHECK ("status" IN ('staged', 'approved', 'rolled-back')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("approved_at" IS NULL OR "approved_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`approved_by` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_consolidation_events` (
@@ -42,10 +32,7 @@ CREATE TABLE `brain_consolidation_events` (
 	`step_results_json` text NOT NULL,
 	`duration_ms` integer,
 	`succeeded` integer DEFAULT true NOT NULL,
-	`started_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("succeeded" IN (0, 1)),
-	CHECK ("started_at" IS NULL OR "started_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`started_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_decisions` (
@@ -81,27 +68,10 @@ CREATE TABLE `brain_decisions` (
 	`superseded_by` text,
 	`confirmation_state` text DEFAULT 'proposed' NOT NULL,
 	`decided_by` text DEFAULT 'agent' NOT NULL,
-	`validator_run_at` text,
+	`validator_run_at` integer,
 	`decision_category` text DEFAULT 'architectural' NOT NULL,
 	CONSTRAINT `fk_brain_decisions_supersedes_brain_decisions_id_fk` FOREIGN KEY (`supersedes`) REFERENCES `brain_decisions`(`id`),
-	CONSTRAINT `fk_brain_decisions_superseded_by_brain_decisions_id_fk` FOREIGN KEY (`superseded_by`) REFERENCES `brain_decisions`(`id`),
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("type" IN ('architecture', 'technical', 'process', 'strategic', 'tactical')),
-	CHECK ("confidence" IN ('low', 'medium', 'high')),
-	CHECK ("outcome" IN ('success', 'failure', 'mixed', 'pending')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("confirmation_state" IN ('proposed', 'accepted', 'superseded')),
-	CHECK ("decided_by" IN ('owner', 'council', 'agent')),
-	CHECK ("validator_run_at" IS NULL OR "validator_run_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("decision_category" IN ('architectural', 'agent_dispatch', 'other'))
+	CONSTRAINT `fk_brain_decisions_superseded_by_brain_decisions_id_fk` FOREIGN KEY (`superseded_by`) REFERENCES `brain_decisions`(`id`)
 );
 --> statement-breakpoint
 CREATE TABLE `brain_deriver_queue` (
@@ -115,13 +85,7 @@ CREATE TABLE `brain_deriver_queue` (
 	`error_msg` text,
 	`retry_count` integer DEFAULT 0 NOT NULL,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`completed_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("item_type" IN ('observation', 'session', 'narrative', 'embedding')),
-	CHECK ("status" IN ('pending', 'in_progress', 'done', 'failed')),
-	CHECK ("claimed_at" IS NULL OR "claimed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("completed_at" IS NULL OR "completed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`completed_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_learnings` (
@@ -147,18 +111,7 @@ CREATE TABLE `brain_learnings` (
 	`content_hash` text,
 	`provenance_class` text DEFAULT 'swept-clean',
 	`peer_id` text DEFAULT 'global' NOT NULL,
-	`peer_scope` text DEFAULT 'project' NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("actionable" IN (0, 1)),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`peer_scope` text DEFAULT 'project' NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_memory_links` (
@@ -167,11 +120,7 @@ CREATE TABLE `brain_memory_links` (
 	`task_id` text NOT NULL,
 	`link_type` text NOT NULL,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	CONSTRAINT `brain_memory_links_pk` PRIMARY KEY(`memory_type`, `memory_id`, `task_id`, `link_type`),
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("memory_type" IN ('decision', 'pattern', 'learning', 'observation')),
-	CHECK ("link_type" IN ('produced_by', 'applies_to', 'informed_by', 'contradicts')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	CONSTRAINT `brain_memory_links_pk` PRIMARY KEY(`memory_type`, `memory_id`, `task_id`, `link_type`)
 );
 --> statement-breakpoint
 CREATE TABLE `brain_memory_trees` (
@@ -181,10 +130,7 @@ CREATE TABLE `brain_memory_trees` (
 	`centroid` text,
 	`parent_id` integer,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`updated_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`updated_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_modulators` (
@@ -195,9 +141,7 @@ CREATE TABLE `brain_modulators` (
 	`source_event_id` text,
 	`session_id` text,
 	`description` text,
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_observations` (
@@ -240,20 +184,7 @@ CREATE TABLE `brain_observations` (
 	`origin` text,
 	`validated_at` text,
 	`provenance_chain` text,
-	`idempotency_key` text CONSTRAINT `uq_brain_observations_idempotency_key` UNIQUE,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("type" IN ('discovery', 'change', 'feature', 'bugfix', 'decision', 'refactor', 'diary', 'session-summary')),
-	CHECK ("source_type" IN ('agent', 'session-debrief', 'claude-mem', 'manual')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("validated_at" IS NULL OR "validated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`idempotency_key` text CONSTRAINT `uq_brain_observations_idempotency_key` UNIQUE
 );
 --> statement-breakpoint
 CREATE TABLE `brain_observations_staging` (
@@ -266,12 +197,7 @@ CREATE TABLE `brain_observations_staging` (
 	`new_invalid_at` text,
 	`new_provenance_class` text,
 	`validation_status` text DEFAULT 'pending' NOT NULL,
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("action" IN ('purge', 'keep', 'reclassify', 'promote')),
-	CHECK ("new_invalid_at" IS NULL OR "new_invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("validation_status" IN ('pending', 'applied', 'skipped')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_page_edges` (
@@ -287,13 +213,7 @@ CREATE TABLE `brain_page_edges` (
 	`last_depressed_at` text,
 	`depression_count` integer DEFAULT 0 NOT NULL,
 	`stability_score` real,
-	CONSTRAINT `brain_page_edges_pk` PRIMARY KEY(`from_id`, `to_id`, `edge_type`),
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("edge_type" IN ('derived_from', 'produced_by', 'informed_by', 'supports', 'contradicts', 'supersedes', 'applies_to', 'documents', 'summarizes', 'part_of', 'references', 'modified_by', 'code_reference', 'affects', 'mentions', 'conduit_mentions_symbol', 'co_retrieved', 'blocks', 'discusses', 'cites', 'embeds', 'touches_code', 'task_touches_symbol')),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("last_reinforced_at" IS NULL OR "last_reinforced_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("plasticity_class" IN ('static', 'hebbian', 'stdp')),
-	CHECK ("last_depressed_at" IS NULL OR "last_depressed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	CONSTRAINT `brain_page_edges_pk` PRIMARY KEY(`from_id`, `to_id`, `edge_type`)
 );
 --> statement-breakpoint
 CREATE TABLE `brain_page_nodes` (
@@ -305,12 +225,7 @@ CREATE TABLE `brain_page_nodes` (
 	`last_activity_at` text DEFAULT (datetime('now')) NOT NULL,
 	`metadata_json` text,
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	`updated_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("node_type" IN ('decision', 'pattern', 'learning', 'observation', 'sticky', 'task', 'session', 'epic', 'file', 'symbol', 'concept', 'summary', 'msg', 'llmtxt', 'commit')),
-	CHECK ("last_activity_at" IS NULL OR "last_activity_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`updated_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_patterns` (
@@ -341,20 +256,7 @@ CREATE TABLE `brain_patterns` (
 	`peer_id` text DEFAULT 'global' NOT NULL,
 	`peer_scope` text DEFAULT 'project' NOT NULL,
 	`occurrence_count` integer DEFAULT 1 NOT NULL,
-	`last_seen_at` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("type" IN ('workflow', 'blocker', 'success', 'failure', 'optimization')),
-	CHECK ("impact" IN ('low', 'medium', 'high')),
-	CHECK ("extracted_at" IS NULL OR "extracted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("memory_tier" IN ('short', 'medium', 'long')),
-	CHECK ("memory_type" IN ('semantic', 'episodic', 'procedural')),
-	CHECK ("verified" IN (0, 1)),
-	CHECK ("valid_at" IS NULL OR "valid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("invalid_at" IS NULL OR "invalid_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("source_confidence" IN ('owner', 'task-outcome', 'agent', 'speculative')),
-	CHECK ("tier_promoted_at" IS NULL OR "tier_promoted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("last_seen_at" IS NULL OR "last_seen_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`last_seen_at` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_plasticity_events` (
@@ -369,9 +271,7 @@ CREATE TABLE `brain_plasticity_events` (
 	`weight_after` real,
 	`retrieval_log_id` integer,
 	`reward_signal` real,
-	`delta_t_ms` integer,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("kind" IN ('ltp', 'ltd'))
+	`delta_t_ms` integer
 );
 --> statement-breakpoint
 CREATE TABLE `brain_promotion_log` (
@@ -382,9 +282,7 @@ CREATE TABLE `brain_promotion_log` (
 	`score` real NOT NULL,
 	`decided_at` text DEFAULT (datetime('now')) NOT NULL,
 	`decided_by` text DEFAULT 'composite-scorer' NOT NULL,
-	`rationale_json` text,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("decided_at" IS NULL OR "decided_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`rationale_json` text
 );
 --> statement-breakpoint
 CREATE TABLE `brain_retrieval_log` (
@@ -398,9 +296,7 @@ CREATE TABLE `brain_retrieval_log` (
 	`created_at` text DEFAULT (datetime('now')) NOT NULL,
 	`retrieval_order` integer,
 	`delta_ms` integer,
-	`reward_signal` real,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`reward_signal` real
 );
 --> statement-breakpoint
 CREATE TABLE `brain_schema_meta` (
@@ -412,10 +308,8 @@ CREATE TABLE `brain_session_narrative` (
 	`session_id` text PRIMARY KEY,
 	`narrative` text DEFAULT '' NOT NULL,
 	`turn_count` integer DEFAULT 0 NOT NULL,
-	`last_updated_at` text,
-	`pivot_count` integer DEFAULT 0 NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("last_updated_at" IS NULL OR "last_updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`last_updated_at` integer DEFAULT 0 NOT NULL,
+	`pivot_count` integer DEFAULT 0 NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_sticky_notes` (
@@ -428,13 +322,7 @@ CREATE TABLE `brain_sticky_notes` (
 	`converted_to_json` text,
 	`color` text,
 	`priority` text,
-	`source_type` text DEFAULT 'sticky-note',
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("status" IN ('active', 'converted', 'archived')),
-	CHECK ("color" IN ('yellow', 'blue', 'green', 'red', 'purple')),
-	CHECK ("priority" IN ('low', 'medium', 'high'))
+	`source_type` text DEFAULT 'sticky-note'
 );
 --> statement-breakpoint
 CREATE TABLE `brain_sticky_tags` (
@@ -453,11 +341,7 @@ CREATE TABLE `brain_transcript_events` (
 	`content` text NOT NULL,
 	`tokens` integer,
 	`redacted_at` text,
-	`created_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("role" IN ('user', 'assistant', 'system')),
-	CHECK ("redacted_at" IS NULL OR "redacted_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
-	CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `brain_weight_history` (
@@ -472,9 +356,7 @@ CREATE TABLE `brain_weight_history` (
 	`source_plasticity_event_id` integer,
 	`retrieval_log_id` integer,
 	`reward_signal` real,
-	`changed_at` text DEFAULT (datetime('now')) NOT NULL,
-	-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed
-	CHECK ("changed_at" IS NULL OR "changed_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+	`changed_at` text DEFAULT (datetime('now')) NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE `tasks_adr_relations` (

--- a/packages/core/migrations/drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project/snapshot.json
+++ b/packages/core/migrations/drizzle-cleo-project/20260531000001_t11363-consolidation-cleo-project/snapshot.json
@@ -425,17 +425,17 @@
       "table": "brain_attention"
     },
     {
-      "type": "text",
+      "type": "integer",
       "notNull": true,
       "autoincrement": false,
-      "default": "(datetime('now'))",
+      "default": "(unixepoch() * 1000)",
       "generated": null,
       "name": "created_at",
       "entityType": "columns",
       "table": "brain_attention"
     },
     {
-      "type": "text",
+      "type": "integer",
       "notNull": false,
       "autoincrement": false,
       "default": null,
@@ -955,7 +955,7 @@
       "table": "brain_decisions"
     },
     {
-      "type": "text",
+      "type": "integer",
       "notNull": false,
       "autoincrement": false,
       "default": null,
@@ -2865,10 +2865,10 @@
       "table": "brain_session_narrative"
     },
     {
-      "type": "text",
-      "notNull": false,
+      "type": "integer",
+      "notNull": true,
       "autoincrement": false,
-      "default": null,
+      "default": 0,
       "generated": null,
       "name": "last_updated_at",
       "entityType": "columns",

--- a/packages/core/src/store/__tests__/consolidated-schema-parity-fk.test.ts
+++ b/packages/core/src/store/__tests__/consolidated-schema-parity-fk.test.ts
@@ -366,6 +366,15 @@ describe('T11364 AC2 — consolidated migration parity (declared == written)', (
 
         let totalChecks = 0;
         for (const { config } of iterateTables(descriptor.schema)) {
+          // brain_* tables intentionally carry NO SQL CHECK constraints (T11647):
+          // the consolidated brain target matches the LEGACY RUNTIME shape, whose
+          // `drizzle-brain` tables have zero CHECKs (enum unions enforced at the
+          // app layer only). `scripts/inject-consolidation-checks.mjs` skips them
+          // via `isCheckExemptTable`, so the migration carries none — assert the
+          // same exemption here rather than expecting CHECKs that must not exist.
+          if (config.name.startsWith('brain_')) {
+            continue;
+          }
           for (const check of deriveChecks(config)) {
             totalChecks++;
             expect(
@@ -375,8 +384,12 @@ describe('T11364 AC2 — consolidated migration parity (declared == written)', (
           }
         }
         // Guard against a vacuous pass: the consolidated schema is enum/boolean
-        // heavy, so each scope MUST contribute many CHECKs.
-        expect(totalChecks).toBeGreaterThan(50);
+        // heavy, so each scope MUST still contribute many CHECKs. The floor is
+        // 40 (was 50) because the brain_* family — a large CHECK contributor,
+        // especially in the global scope where brain is one of few domains — is
+        // now intentionally CHECK-exempt (T11647: brain target = runtime shape,
+        // no SQL CHECKs). Project still emits 200+; global emits ~50.
+        expect(totalChecks).toBeGreaterThanOrEqual(40);
       });
     });
   }

--- a/packages/core/src/store/__tests__/exodus.test.ts
+++ b/packages/core/src/store/__tests__/exodus.test.ts
@@ -1877,7 +1877,11 @@ describe('T11547 regression — enum normalization in migrate layer', () => {
     }
   });
 
-  it('normalizes brain_observations.source_type legacy values → agent', async () => {
+  // T11647: brain enum coercion REMOVED — the consolidated brain target now
+  // matches the legacy RUNTIME shape (no SQL CHECK), so every legacy value must
+  // survive VERBATIM (zero semantic alteration). Target tables here carry NO
+  // CHECK, mirroring the real consolidated `brain_*` DDL.
+  it('preserves brain_observations.source_type legacy values verbatim (T11647 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -1897,10 +1901,10 @@ describe('T11547 regression — enum normalization in migrate layer', () => {
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on source_type (T11647).
       tgtDb.exec(
         `CREATE TABLE brain_observations (id TEXT PRIMARY KEY, type TEXT NOT NULL, ` +
-          `source_type TEXT CHECK (source_type IS NULL OR source_type IN ('agent','session-debrief','claude-mem','manual')), ` +
-          `narrative TEXT NOT NULL)`,
+          `source_type TEXT, narrative TEXT NOT NULL)`,
       );
     } finally {
       tgtDb.close();
@@ -1916,20 +1920,22 @@ describe('T11547 regression — enum normalization in migrate layer', () => {
         .prepare('SELECT id, source_type FROM brain_observations ORDER BY id')
         .all() as Array<{ id: string; source_type: string }>;
       expect(rows).toHaveLength(4);
-      expect(rows.find((r) => r.id === 'O-1')?.source_type, 'observer-compressed → agent').toBe(
-        'agent',
-      );
-      expect(rows.find((r) => r.id === 'O-2')?.source_type, 'sleep-consolidation → agent').toBe(
-        'agent',
-      );
-      expect(rows.find((r) => r.id === 'O-3')?.source_type, 'agent passthrough').toBe('agent');
-      expect(rows.find((r) => r.id === 'O-4')?.source_type, 'manual passthrough').toBe('manual');
+      expect(
+        rows.find((r) => r.id === 'O-1')?.source_type,
+        'observer-compressed preserved verbatim',
+      ).toBe('observer-compressed');
+      expect(
+        rows.find((r) => r.id === 'O-2')?.source_type,
+        'sleep-consolidation preserved verbatim',
+      ).toBe('sleep-consolidation');
+      expect(rows.find((r) => r.id === 'O-3')?.source_type, 'agent preserved').toBe('agent');
+      expect(rows.find((r) => r.id === 'O-4')?.source_type, 'manual preserved').toBe('manual');
     } finally {
       tgt.close();
     }
   });
 
-  it('normalizes brain_observations.type legacy values to canonical types', async () => {
+  it('preserves brain_observations.type legacy values verbatim (T11647 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -1945,10 +1951,9 @@ describe('T11547 regression — enum normalization in migrate layer', () => {
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on type (T11647).
       tgtDb.exec(
-        `CREATE TABLE brain_observations (id TEXT PRIMARY KEY, ` +
-          `type TEXT NOT NULL CHECK (type IN ('discovery','change','feature','bugfix','decision','refactor','diary','session-summary')), ` +
-          `narrative TEXT NOT NULL)`,
+        `CREATE TABLE brain_observations (id TEXT PRIMARY KEY, type TEXT NOT NULL, narrative TEXT NOT NULL)`,
       );
     } finally {
       tgtDb.close();
@@ -1964,10 +1969,14 @@ describe('T11547 regression — enum normalization in migrate layer', () => {
         .prepare('SELECT id, type FROM brain_observations ORDER BY id')
         .all() as Array<{ id: string; type: string }>;
       expect(rows).toHaveLength(4);
-      expect(rows.find((r) => r.id === 'O-1')?.type, 'observation → discovery').toBe('discovery');
-      expect(rows.find((r) => r.id === 'O-2')?.type, 'proposal → decision').toBe('decision');
-      expect(rows.find((r) => r.id === 'O-3')?.type, 'pattern → refactor').toBe('refactor');
-      expect(rows.find((r) => r.id === 'O-4')?.type, 'discovery passthrough').toBe('discovery');
+      expect(rows.find((r) => r.id === 'O-1')?.type, 'observation preserved verbatim').toBe(
+        'observation',
+      );
+      expect(rows.find((r) => r.id === 'O-2')?.type, 'proposal preserved verbatim').toBe(
+        'proposal',
+      );
+      expect(rows.find((r) => r.id === 'O-3')?.type, 'pattern preserved verbatim').toBe('pattern');
+      expect(rows.find((r) => r.id === 'O-4')?.type, 'discovery preserved').toBe('discovery');
     } finally {
       tgt.close();
     }
@@ -2112,7 +2121,7 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
     }
   });
 
-  it('normalizes brain_decisions.decision_category: architecture → architectural', async () => {
+  it('preserves brain_decisions.decision_category verbatim (T11647 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -2127,9 +2136,9 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on decision_category (T11647).
       tgtDb.exec(
-        `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, ` +
-          `decision_category TEXT CHECK (decision_category IS NULL OR decision_category IN ('architectural','agent_dispatch','other')))`,
+        `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, decision_category TEXT)`,
       );
     } finally {
       tgtDb.close();
@@ -2146,20 +2155,18 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
       expect(rows).toHaveLength(3);
       expect(
         rows.find((r) => r.id === 'D-1')?.decision_category,
-        'architecture → architectural',
-      ).toBe('architectural');
-      expect(rows.find((r) => r.id === 'D-2')?.decision_category, 'architectural passthrough').toBe(
+        'architecture preserved verbatim',
+      ).toBe('architecture');
+      expect(rows.find((r) => r.id === 'D-2')?.decision_category, 'architectural preserved').toBe(
         'architectural',
       );
-      expect(rows.find((r) => r.id === 'D-3')?.decision_category, 'other passthrough').toBe(
-        'other',
-      );
+      expect(rows.find((r) => r.id === 'D-3')?.decision_category, 'other preserved').toBe('other');
     } finally {
       tgt.close();
     }
   });
 
-  it('normalizes brain_decisions.confidence: out-of-vocab → medium', async () => {
+  it('preserves brain_decisions.confidence verbatim (T11647 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -2176,9 +2183,9 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on confidence (T11647).
       tgtDb.exec(
-        `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, ` +
-          `confidence TEXT CHECK (confidence IS NULL OR confidence IN ('low','medium','high')))`,
+        `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, confidence TEXT)`,
       );
     } finally {
       tgtDb.close();
@@ -2193,11 +2200,15 @@ describe('T11548 regression — final enum coverage: transport/conventional_type
         .prepare('SELECT id, confidence FROM brain_decisions ORDER BY id')
         .all() as Array<{ id: string; confidence: string }>;
       expect(rows).toHaveLength(5);
-      expect(rows.find((r) => r.id === 'D-1')?.confidence, 'high passthrough').toBe('high');
-      expect(rows.find((r) => r.id === 'D-2')?.confidence, 'medium passthrough').toBe('medium');
-      expect(rows.find((r) => r.id === 'D-3')?.confidence, 'low passthrough').toBe('low');
-      expect(rows.find((r) => r.id === 'D-4')?.confidence, 'very-high → medium').toBe('medium');
-      expect(rows.find((r) => r.id === 'D-5')?.confidence, 'uncertain → medium').toBe('medium');
+      expect(rows.find((r) => r.id === 'D-1')?.confidence, 'high preserved').toBe('high');
+      expect(rows.find((r) => r.id === 'D-2')?.confidence, 'medium preserved').toBe('medium');
+      expect(rows.find((r) => r.id === 'D-3')?.confidence, 'low preserved').toBe('low');
+      expect(rows.find((r) => r.id === 'D-4')?.confidence, 'very-high preserved verbatim').toBe(
+        'very-high',
+      );
+      expect(rows.find((r) => r.id === 'D-5')?.confidence, 'uncertain preserved verbatim').toBe(
+        'uncertain',
+      );
     } finally {
       tgt.close();
     }
@@ -2551,7 +2562,7 @@ describe('T11549 regression — zero-loss final mile: confidence/decision_catego
     return targetPath;
   }
 
-  it('normalizes brain_decisions.confidence: confirmed → high (not medium)', async () => {
+  it('preserves brain_decisions.confidence verbatim incl. confirmed/unknown (T11647 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -2579,11 +2590,10 @@ describe('T11549 regression — zero-loss final mile: confidence/decision_catego
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on confidence (T11647).
       tgtDb.exec(
         `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, decision TEXT NOT NULL, ` +
-          `rationale TEXT NOT NULL, ` +
-          `confidence TEXT NOT NULL CHECK (confidence IN ('low','medium','high')), ` +
-          `type TEXT NOT NULL DEFAULT 'architecture')`,
+          `rationale TEXT NOT NULL, confidence TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'architecture')`,
       );
     } finally {
       tgtDb.close();
@@ -2598,19 +2608,21 @@ describe('T11549 regression — zero-loss final mile: confidence/decision_catego
         .prepare('SELECT id, confidence FROM brain_decisions ORDER BY id')
         .all() as Array<{ id: string; confidence: string }>;
       expect(rows).toHaveLength(5);
-      expect(rows.find((r) => r.id === 'D-1')?.confidence, 'confirmed → high').toBe('high');
-      expect(rows.find((r) => r.id === 'D-2')?.confidence, 'high passthrough').toBe('high');
-      expect(rows.find((r) => r.id === 'D-3')?.confidence, 'medium passthrough').toBe('medium');
-      expect(rows.find((r) => r.id === 'D-4')?.confidence, 'low passthrough').toBe('low');
-      expect(rows.find((r) => r.id === 'D-5')?.confidence, 'unknown-val → medium fallback').toBe(
-        'medium',
+      expect(rows.find((r) => r.id === 'D-1')?.confidence, 'confirmed preserved verbatim').toBe(
+        'confirmed',
+      );
+      expect(rows.find((r) => r.id === 'D-2')?.confidence, 'high preserved').toBe('high');
+      expect(rows.find((r) => r.id === 'D-3')?.confidence, 'medium preserved').toBe('medium');
+      expect(rows.find((r) => r.id === 'D-4')?.confidence, 'low preserved').toBe('low');
+      expect(rows.find((r) => r.id === 'D-5')?.confidence, 'unknown-val preserved verbatim').toBe(
+        'unknown-val',
       );
     } finally {
       tgt.close();
     }
   });
 
-  it('normalizes brain_decisions.decision_category: process/technical → other', async () => {
+  it('preserves brain_decisions.decision_category verbatim incl. process/technical (T11647 — no coercion)', async () => {
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -2638,13 +2650,12 @@ describe('T11549 regression — zero-loss final mile: confidence/decision_catego
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on confidence/decision_category (T11647).
       tgtDb.exec(
         `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, decision TEXT NOT NULL, ` +
-          `rationale TEXT NOT NULL, ` +
-          `confidence TEXT NOT NULL CHECK (confidence IN ('low','medium','high')) DEFAULT 'medium', ` +
+          `rationale TEXT NOT NULL, confidence TEXT NOT NULL DEFAULT 'medium', ` +
           `type TEXT NOT NULL DEFAULT 'architecture', ` +
-          `decision_category TEXT NOT NULL ` +
-          `CHECK (decision_category IN ('architectural','agent_dispatch','other')) DEFAULT 'architectural')`,
+          `decision_category TEXT NOT NULL DEFAULT 'architectural')`,
       );
     } finally {
       tgtDb.close();
@@ -2659,24 +2670,25 @@ describe('T11549 regression — zero-loss final mile: confidence/decision_catego
         .prepare('SELECT id, decision_category FROM brain_decisions ORDER BY id')
         .all() as Array<{ id: string; decision_category: string }>;
       expect(rows).toHaveLength(6);
-      expect(rows.find((r) => r.id === 'D-1')?.decision_category, 'process → other').toBe('other');
-      expect(rows.find((r) => r.id === 'D-2')?.decision_category, 'technical → other').toBe(
-        'other',
-      );
+      expect(
+        rows.find((r) => r.id === 'D-1')?.decision_category,
+        'process preserved verbatim',
+      ).toBe('process');
+      expect(
+        rows.find((r) => r.id === 'D-2')?.decision_category,
+        'technical preserved verbatim',
+      ).toBe('technical');
       expect(
         rows.find((r) => r.id === 'D-3')?.decision_category,
-        'architecture → architectural',
-      ).toBe('architectural');
-      expect(rows.find((r) => r.id === 'D-4')?.decision_category, 'architectural passthrough').toBe(
+        'architecture preserved verbatim',
+      ).toBe('architecture');
+      expect(rows.find((r) => r.id === 'D-4')?.decision_category, 'architectural preserved').toBe(
         'architectural',
       );
-      expect(
-        rows.find((r) => r.id === 'D-5')?.decision_category,
-        'agent_dispatch passthrough',
-      ).toBe('agent_dispatch');
-      expect(rows.find((r) => r.id === 'D-6')?.decision_category, 'other passthrough').toBe(
-        'other',
+      expect(rows.find((r) => r.id === 'D-5')?.decision_category, 'agent_dispatch preserved').toBe(
+        'agent_dispatch',
       );
+      expect(rows.find((r) => r.id === 'D-6')?.decision_category, 'other preserved').toBe('other');
     } finally {
       tgt.close();
     }
@@ -2978,9 +2990,9 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
     }
   });
 
-  it('normalizes brain_decisions.outcome: accepted → success (1 row, P0 enum fix)', async () => {
-    // Legacy 'accepted' not in consolidated CHECK enum (success|failure|mixed|pending).
-    // Maps to 'success' (decision was accepted = successfully ratified).
+  it('preserves brain_decisions.outcome verbatim incl. accepted (T11647 — no coercion)', async () => {
+    // T11647: brain target carries no CHECK, so legacy 'accepted' survives
+    // VERBATIM (previously coerced to 'success'). Zero semantic alteration.
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -2996,9 +3008,9 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on outcome (T11647).
       tgtDb.exec(
-        `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, ` +
-          `outcome TEXT CHECK (outcome IS NULL OR outcome IN ('success','failure','mixed','pending')))`,
+        `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, outcome TEXT)`,
       );
     } finally {
       tgtDb.close();
@@ -3013,18 +3025,20 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
         .prepare('SELECT id, outcome FROM brain_decisions ORDER BY id')
         .all() as Array<{ id: string; outcome: string | null }>;
       expect(rows, 'all 4 rows must migrate (none dropped)').toHaveLength(4);
-      expect(rows.find((r) => r.id === 'D11132')?.outcome, 'accepted → success').toBe('success');
-      expect(rows.find((r) => r.id === 'D-ok1')?.outcome, 'success passthrough').toBe('success');
-      expect(rows.find((r) => r.id === 'D-ok2')?.outcome, 'pending passthrough').toBe('pending');
+      expect(rows.find((r) => r.id === 'D11132')?.outcome, 'accepted preserved verbatim').toBe(
+        'accepted',
+      );
+      expect(rows.find((r) => r.id === 'D-ok1')?.outcome, 'success preserved').toBe('success');
+      expect(rows.find((r) => r.id === 'D-ok2')?.outcome, 'pending preserved').toBe('pending');
       expect(rows.find((r) => r.id === 'D-ok3')?.outcome, 'null preserved').toBeNull();
     } finally {
       tgt.close();
     }
   });
 
-  it('normalizes brain_decisions.decided_by: prime → agent (3 rows, P0 enum fix)', async () => {
-    // Legacy 'prime' not in consolidated CHECK enum (owner|council|agent).
-    // Maps to 'agent' (CLEO Prime is a system agent persona).
+  it('preserves brain_decisions.decided_by verbatim incl. prime (T11647 — no coercion)', async () => {
+    // T11647: brain target carries no CHECK, so legacy 'prime' survives VERBATIM
+    // (previously coerced to 'agent'). Zero semantic alteration.
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -3048,9 +3062,10 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on decided_by (T11647).
       tgtDb.exec(
         `CREATE TABLE brain_decisions (id TEXT PRIMARY KEY, title TEXT NOT NULL, ` +
-          `decided_by TEXT NOT NULL DEFAULT 'agent' CHECK (decided_by IN ('owner','council','agent')))`,
+          `decided_by TEXT NOT NULL DEFAULT 'agent')`,
       );
     } finally {
       tgtDb.close();
@@ -3064,33 +3079,35 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
       const rows = tgt
         .prepare('SELECT id, decided_by FROM brain_decisions ORDER BY id')
         .all() as Array<{ id: string; decided_by: string }>;
-      expect(rows, 'all 6 rows must migrate (none dropped by CHECK)').toHaveLength(6);
+      expect(rows, 'all 6 rows must migrate (none dropped)').toHaveLength(6);
       expect(
         rows.find((r) => r.id === 'T11025-alias-registration')?.decided_by,
-        'prime → agent',
-      ).toBe('agent');
+        'prime preserved verbatim',
+      ).toBe('prime');
       expect(
         rows.find((r) => r.id === 'T11027-envelope-compliance')?.decided_by,
-        'prime → agent',
-      ).toBe('agent');
+        'prime preserved verbatim',
+      ).toBe('prime');
       expect(
         rows.find((r) => r.id === 'T11030-integration-test')?.decided_by,
-        'prime → agent',
-      ).toBe('agent');
-      expect(rows.find((r) => r.id === 'D-owner')?.decided_by, 'owner passthrough').toBe('owner');
-      expect(rows.find((r) => r.id === 'D-council')?.decided_by, 'council passthrough').toBe(
+        'prime preserved verbatim',
+      ).toBe('prime');
+      expect(rows.find((r) => r.id === 'D-owner')?.decided_by, 'owner preserved').toBe('owner');
+      expect(rows.find((r) => r.id === 'D-council')?.decided_by, 'council preserved').toBe(
         'council',
       );
-      expect(rows.find((r) => r.id === 'D-agent')?.decided_by, 'agent passthrough').toBe('agent');
+      expect(rows.find((r) => r.id === 'D-agent')?.decided_by, 'agent preserved').toBe('agent');
     } finally {
       tgt.close();
     }
   });
 
-  it('brain_decisions 118→118: all 4 real-project rows survive with combined outcome+decided_by normalization', async () => {
-    // Simulate the exact 4 rows from the real-project brain.db that were dropping.
-    // D11132: outcome='accepted' (→ success), decided_by='agent' (ok), confidence='confirmed' (→ high via T11549 rule), decision_category='process' (→ other via T11549 rule)
-    // T11025/T11027/T11030: outcome=null (ok), decided_by='prime' (→ agent), confidence='confirmed' (→ high), decision_category='technical' (→ other)
+  it('brain_decisions 118→118: all 4 real-project rows survive with values preserved VERBATIM (T11647)', async () => {
+    // The exact 4 rows from the real-project brain.db that were dropping under
+    // the old CHECK-enforced target. T11647: brain target = runtime shape (no
+    // CHECK) → every legacy value survives UNCHANGED, zero coercion.
+    // D11132: outcome='accepted', decided_by='agent', confidence='confirmed', decision_category='process'
+    // T11025/T11027/T11030: outcome=null, decided_by='prime', confidence='confirmed', decision_category='technical'
     const srcDb = new DatabaseSync(sourcePath);
     try {
       srcDb.exec(
@@ -3102,11 +3119,9 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
           `confidence TEXT NOT NULL DEFAULT 'medium', ` +
           `decision_category TEXT NOT NULL DEFAULT 'architectural')`,
       );
-      // D11132: outcome='accepted', decided_by='agent' (already canonical)
       srcDb.exec(
         `INSERT INTO brain_decisions VALUES ('D11132', 'D11132', 'accepted', 'agent', 'confirmed', 'process')`,
       );
-      // Three 'prime' rows with null outcome
       srcDb.exec(
         `INSERT INTO brain_decisions VALUES ('T11025-alias-registration', 'T11025', null, 'prime', 'confirmed', 'technical')`,
       );
@@ -3122,14 +3137,15 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
 
     const tgtDb = new DatabaseSync(targetProjectPath);
     try {
+      // Runtime shape: NO CHECK on any brain_decisions enum column (T11647).
       tgtDb.exec(
         `CREATE TABLE brain_decisions (` +
           `id TEXT PRIMARY KEY, ` +
           `title TEXT NOT NULL, ` +
-          `outcome TEXT CHECK (outcome IS NULL OR outcome IN ('success','failure','mixed','pending')), ` +
-          `decided_by TEXT NOT NULL DEFAULT 'agent' CHECK (decided_by IN ('owner','council','agent')), ` +
-          `confidence TEXT NOT NULL DEFAULT 'medium' CHECK (confidence IN ('low','medium','high')), ` +
-          `decision_category TEXT NOT NULL DEFAULT 'architectural' CHECK (decision_category IN ('architectural','agent_dispatch','other')))`,
+          `outcome TEXT, ` +
+          `decided_by TEXT NOT NULL DEFAULT 'agent', ` +
+          `confidence TEXT NOT NULL DEFAULT 'medium', ` +
+          `decision_category TEXT NOT NULL DEFAULT 'architectural')`,
       );
     } finally {
       tgtDb.close();
@@ -3154,18 +3170,26 @@ describe('T11550 regression — agent_credentials/brain_release_links from tasks
       expect(rows, 'all 4 rows must survive — brain_decisions 118→118').toHaveLength(4);
 
       const d11132 = rows.find((r) => r.id === 'D11132');
-      expect(d11132?.outcome, 'D11132 outcome: accepted → success').toBe('success');
-      expect(d11132?.decided_by, 'D11132 decided_by: agent passthrough').toBe('agent');
-      expect(d11132?.confidence, 'D11132 confidence: confirmed → high').toBe('high');
-      expect(d11132?.decision_category, 'D11132 decision_category: process → other').toBe('other');
+      expect(d11132?.outcome, 'D11132 outcome: accepted preserved verbatim').toBe('accepted');
+      expect(d11132?.decided_by, 'D11132 decided_by: agent preserved').toBe('agent');
+      expect(d11132?.confidence, 'D11132 confidence: confirmed preserved verbatim').toBe(
+        'confirmed',
+      );
+      expect(
+        d11132?.decision_category,
+        'D11132 decision_category: process preserved verbatim',
+      ).toBe('process');
 
       const t11025 = rows.find((r) => r.id === 'T11025-alias-registration');
       expect(t11025?.outcome, 'T11025 outcome: null preserved').toBeNull();
-      expect(t11025?.decided_by, 'T11025 decided_by: prime → agent').toBe('agent');
-      expect(t11025?.confidence, 'T11025 confidence: confirmed → high').toBe('high');
-      expect(t11025?.decision_category, 'T11025 decision_category: technical → other').toBe(
-        'other',
+      expect(t11025?.decided_by, 'T11025 decided_by: prime preserved verbatim').toBe('prime');
+      expect(t11025?.confidence, 'T11025 confidence: confirmed preserved verbatim').toBe(
+        'confirmed',
       );
+      expect(
+        t11025?.decision_category,
+        'T11025 decision_category: technical preserved verbatim',
+      ).toBe('technical');
     } finally {
       tgt.close();
     }

--- a/packages/core/src/store/exodus/__fixtures__/representative-fixture.ts
+++ b/packages/core/src/store/exodus/__fixtures__/representative-fixture.ts
@@ -16,16 +16,24 @@
  *     (`tasks` → `tasks_tasks`, `architecture_decisions` →
  *     `tasks_architecture_decisions`).
  *   - **Epoch-INTEGER timestamps** (seconds AND milliseconds) destined for a
- *     target `text` column with an ISO-8601 GLOB CHECK constraint.
- *   - **Legacy enum aliases** (`'Accepted'`, `'mcp'`, `'observation'`) that fail
- *     the target CHECK unless the migration normalises them.
+ *     TASKS-domain target `text` column with an ISO-8601 GLOB CHECK constraint.
+ *   - **Legacy enum aliases** (`'Accepted'`, `'mcp'`) that fail the TASKS-domain
+ *     target CHECK unless the migration normalises them.
  *   - **A self-referential FK** (`tasks.parent_id → tasks.id`) copied
  *     child-before-parent to exercise the FK-defer path.
  *
- * The matching consolidated target schemas are built with the REAL CHECK and
- * GLOB constraints the production schema declares, so a regression in the
- * coercion/normalisation layer surfaces as a row deficit caught by
+ * The matching consolidated TASKS-domain target schemas are built with the REAL
+ * CHECK and GLOB constraints the production schema declares, so a regression in
+ * the coercion/normalisation layer surfaces as a row deficit caught by
  * {@link verifyMigration}.
+ *
+ * **Brain domain (T11647):** the consolidated `brain_*` target now matches the
+ * LEGACY RUNTIME shape — INTEGER epoch-ms timestamps and NO SQL CHECK
+ * constraints. So the fixture's `brain_observations` target carries no `type`
+ * CHECK and an INTEGER `created_at`: every legacy `type` value (`'observation'`,
+ * `'proposal'`, `'pattern'`) and the raw epoch-ms timestamp copy through VERBATIM
+ * — zero coercion, zero deficit. This is what proves the brain data-loss /
+ * corruption fix end-to-end against representative data.
  *
  * @task T11551 (DHQ-045 — exodus zero-loss durable guard · AC3)
  * @epic T10878
@@ -274,12 +282,15 @@ function buildTargetSchema(
         transport TEXT CHECK ("transport" IN ('cli', 'api', 'agent', 'unknown'))
       )`,
     );
-    // brain_observations: type CHECK enum + created_at ISO GLOB.
+    // brain_observations: LEGACY RUNTIME shape (T11647) — NO CHECK on `type`,
+    // INTEGER epoch-ms `created_at`. The consolidated brain target equals the
+    // runtime shape (no SQL CHECKs), so every legacy `type` value and the raw
+    // epoch-ms timestamp copy through VERBATIM (zero coercion, zero deficit).
     db.exec(
       `CREATE TABLE "brain_observations" (
         id INTEGER PRIMARY KEY,
-        type TEXT CHECK ("type" IN ('discovery', 'decision', 'refactor', 'insight')),
-        created_at TEXT CHECK ("created_at" IS NULL OR "created_at" GLOB ${ISO_GLOB})
+        type TEXT,
+        created_at INTEGER
       )`,
     );
 

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -366,6 +366,18 @@ function typeDefaultLiteral(colType: string): string {
  * column, returns a SQL CASE expression that produces the canonical value.
  * Rows with already-canonical values pass through unchanged (the ELSE branch).
  *
+ * ## Brain enum normalizations REMOVED (T11647)
+ *
+ * The brain memory family no longer participates in enum normalization. Its
+ * consolidated exodus target now matches the LEGACY RUNTIME shape, which carries
+ * NO SQL CHECK constraints (the `text({ enum })` unions are enforced at the
+ * application layer only). With no CHECK to satisfy, coercing brain enum values
+ * would be data corruption, not a fix — so every brain enum value is copied
+ * VERBATIM. The historical brain rules (`brain_observations.{source_type,type}`,
+ * `brain_decisions.{confirmation_state,decision_category,confidence,outcome,
+ * decided_by}`) were deleted. The TASKS-domain rules below remain because those
+ * consolidated tables keep their CHECK constraints.
+ *
  * ## Design decisions (T11547)
  *
  * - `tasks_task_commits.link_source = 'commit-message'`
@@ -378,40 +390,12 @@ function typeDefaultLiteral(colType: string): string {
  *   `'Accepted (2026-04-18)'` and similar date-suffixed variants → `'accepted'`.
  *   These map cleanly to the existing enum; no schema extension needed.
  *
- * - `brain_observations.source_type`
- *   → `'observer-compressed'` was a legacy compression artefact produced by
- *   the brain observer pipeline when it batch-compressed session observations;
- *   semantically equivalent to `'agent'`. `'sleep-consolidation'` was the
- *   nightly dream-consolidation job; also maps to `'agent'` (closest canonical).
- *
- * - `brain_observations.type`
- *   → `'observation'` was the original catch-all type before the taxonomy was
- *   expanded; `'discovery'` is the closest canonical.
- *   `'proposal'` was used before `'decision'` was split out; maps to `'decision'`.
- *   `'pattern'` was an experimental type; maps to `'refactor'` (structural insight).
- *
- * - `brain_decisions.confirmation_state`
- *   → `'Accepted'`, `'ACCEPTED'`, `'approved'` all → `'accepted'` (same case
- *   normalization as architecture_decisions.status; brain_decisions uses
- *   a separate CHECK with the same three canonical values).
- *
  * ## Additional entries (T11548 — final 285 rows)
  *
  * - `tasks_token_usage.transport`
  *   → `'mcp'` → `'agent'` (CHECK enum: cli/api/agent/unknown). Legacy writers
  *   emitted 'mcp' before the transport taxonomy was consolidated; 'agent' is
  *   the nearest canonical for MCP-originated requests. [194 rows]
- *
- * - `brain_decisions.decision_category`
- *   → `'architecture'` → `'architectural'` (enum: architectural/agent_dispatch/other).
- *   Legacy writers used the unabbreviated form. [31 rows]
- *   → `'process'` → `'other'`, `'technical'` → `'other'` (T11549 zero-loss final mile).
- *   These categories pre-date the enum tightening; no closer canonical exists.
- *
- * - `brain_decisions.confidence`
- *   → `'confirmed'` → `'high'` (T11549: semantically maps to the high tier, not medium).
- *   → any remaining value not in (low/medium/high) → `'medium'` as a safe fallback.
- *   Covers typos, empty strings, and out-of-vocabulary legacy values. [4 rows]
  *
  * - `tasks_commits.conventional_type`
  *   → `'style'` → `'chore'` (enum includes feat/fix/chore/docs/refactor/test/
@@ -436,24 +420,17 @@ function typeDefaultLiteral(colType: string): string {
  *   (enum: direct/satisfies/coverage). Strip the namespace prefix introduced
  *   before the enum was tightened. [3 rows]
  *
- * ## Additional entries (T11550 — last 4 rows, P0 zero-loss final mile)
+ * ## T11550 (last 4 brain rows) — superseded by T11647
  *
- * - `brain_decisions.outcome`
- *   → `'accepted'` → `'success'` (enum: success/failure/mixed/pending). A decision
- *   that was accepted/adopted = successful outcome. `'rejected'` → `'failure'`.
- *   [1 row: D11132]
- *
- * - `brain_decisions.decided_by`
- *   → `'prime'` → `'agent'` (enum: owner/council/agent). 'prime' is the CLEO Prime
- *   agent persona; maps to 'agent'. Any other out-of-vocab value also becomes 'agent'
- *   (the NOT NULL default). [3 rows: T11025-alias-registration, T11027-envelope-compliance,
- *   T11030-integration-test]
+ * The T11550 `brain_decisions.{outcome,decided_by}` rules were removed by T11647
+ * (brain target = runtime shape, no CHECK). Those legacy values (`'accepted'`,
+ * `'rejected'`, `'prime'`) now copy VERBATIM and survive intact.
  *
  * Lookup key: `${targetTable}.${column}` (lowercase, dotted).
  *
  * @since T11547 (P0 data-loss fix)
  * @since T11548 (P0 final enum coverage)
- * @since T11550 (P0 zero-loss final mile — last 4 rows)
+ * @since T11647 (brain target = runtime shape — brain enum coercions removed)
  */
 type NormalizeFn = (srcRef: string) => string;
 
@@ -481,43 +458,19 @@ const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
       ` END`,
   ],
 
-  // --- brain_observations.source_type -------------------------------------
-  // 'observer-compressed' and 'sleep-consolidation' → 'agent'
-  [
-    'brain_observations.source_type',
-    (src: string) =>
-      `CASE ${src}` +
-      ` WHEN 'observer-compressed' THEN 'agent'` +
-      ` WHEN 'sleep-consolidation' THEN 'agent'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- brain_observations.type --------------------------------------------
-  // 'observation' → 'discovery', 'proposal' → 'decision', 'pattern' → 'refactor'
-  [
-    'brain_observations.type',
-    (src: string) =>
-      `CASE ${src}` +
-      ` WHEN 'observation' THEN 'discovery'` +
-      ` WHEN 'proposal' THEN 'decision'` +
-      ` WHEN 'pattern' THEN 'refactor'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- brain_decisions.confirmation_state ---------------------------------
-  // Same case normalization as architecture_decisions.status
-  [
-    'brain_decisions.confirmation_state',
-    (src: string) =>
-      `CASE` +
-      ` WHEN lower(${src}) = 'accepted' OR lower(${src}) = 'approved' THEN 'accepted'` +
-      ` WHEN lower(${src}) = 'proposed' THEN 'proposed'` +
-      ` WHEN lower(${src}) = 'superseded' THEN 'superseded'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
+  // --- brain_* enum normalizations REMOVED (T11647) -----------------------
+  // The brain memory family now lands in the consolidated cleo.db in its LEGACY
+  // RUNTIME shape — INTEGER epoch timestamps and, critically, NO SQL CHECK
+  // constraints (the `text({ enum })` unions are enforced only at the
+  // application layer, exactly as the runtime `drizzle-brain` tables are). With
+  // no brain CHECK constraint to satisfy, exodus MUST copy every brain enum
+  // value VERBATIM — coercing them (e.g. source_type 'observer-compressed'/
+  // 'sleep-consolidation' → 'agent', type 'observation'/'proposal'/'pattern' →
+  // nearest) would now be unnecessary data CORRUPTION, not a constraint fix.
+  // The previous brain entries (brain_observations.{source_type,type},
+  // brain_decisions.{confirmation_state,decision_category,confidence,outcome,
+  // decided_by}) are therefore deleted. The non-brain entries below still apply
+  // because those consolidated tables retain their CHECK constraints.
 
   // --- tasks_token_usage.transport (T11548) --------------------------------
   // 'mcp' → 'agent' (CHECK enum: cli/api/agent/unknown). 194 rows.
@@ -527,34 +480,8 @@ const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
     (src: string) => `CASE ${src} WHEN 'mcp' THEN 'agent' ELSE ${src} END`,
   ],
 
-  // --- brain_decisions.decision_category (T11548 + T11549) -----------------
-  // 'architecture' → 'architectural' (enum: architectural/agent_dispatch/other). 31 rows.
-  // 'process' → 'other', 'technical' → 'other' (T11549: pre-tightening categories). [4 rows]
-  [
-    'brain_decisions.decision_category',
-    (src: string) =>
-      `CASE ${src}` +
-      ` WHEN 'architecture' THEN 'architectural'` +
-      ` WHEN 'process' THEN 'other'` +
-      ` WHEN 'technical' THEN 'other'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- brain_decisions.confidence (T11548 + T11549) -------------------------
-  // 'confirmed' → 'high' (T11549: 'confirmed' is semantically equivalent to 'high').
-  // Any remaining value NOT in (low/medium/high) → 'medium'. 4 rows.
-  // General fallback: if the value is already canonical it passes through the ELSE;
-  // any out-of-vocabulary value (typo, empty-string, etc.) becomes 'medium'.
-  [
-    'brain_decisions.confidence',
-    (src: string) =>
-      `CASE` +
-      ` WHEN ${src} = 'confirmed' THEN 'high'` +
-      ` WHEN ${src} IN ('low', 'medium', 'high') THEN ${src}` +
-      ` ELSE 'medium'` +
-      ` END`,
-  ],
+  // (brain_decisions.{decision_category,confidence} normalizations removed —
+  //  T11647: brain target = runtime shape with no CHECK; copy values verbatim.)
 
   // --- tasks_commits.conventional_type (T11548 + T11578) -------------------
   // The consolidated CHECK enum is feat/fix/chore/docs/refactor/test/build/ci/
@@ -626,39 +553,9 @@ const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
       `CASE` + ` WHEN ${src} LIKE 'validator:%' THEN 'direct'` + ` ELSE ${src}` + ` END`,
   ],
 
-  // --- brain_decisions.outcome (T11550 P0 zero-loss fix) -------------------
-  // Legacy value 'accepted' is not in the consolidated CHECK enum
-  // (success|failure|mixed|pending). A decision that was 'accepted' (adopted,
-  // ratified, acted upon) maps to 'success' — the decision achieved its intended
-  // outcome. Legacy value 'rejected' maps to 'failure'.
-  // Covers 1 row (D11132) in the real-project brain.db.
-  [
-    'brain_decisions.outcome',
-    (src: string) =>
-      `CASE` +
-      ` WHEN ${src} = 'accepted' THEN 'success'` +
-      ` WHEN ${src} = 'rejected' THEN 'failure'` +
-      ` WHEN ${src} IN ('success', 'failure', 'mixed', 'pending') THEN ${src}` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- brain_decisions.decided_by (T11550 P0 zero-loss fix) ----------------
-  // Legacy value 'prime' is not in the consolidated CHECK enum (owner|council|agent).
-  // 'prime' refers to the CLEO Prime agent persona (a system agent); maps to 'agent'.
-  // Covers 3 rows (T11025-alias-registration, T11027-envelope-compliance,
-  // T11030-integration-test) in the real-project brain.db.
-  // The column is NOT NULL with default 'agent' — any out-of-vocab value also
-  // falls back to 'agent' (the safe system default).
-  [
-    'brain_decisions.decided_by',
-    (src: string) =>
-      `CASE` +
-      ` WHEN ${src} = 'prime' THEN 'agent'` +
-      ` WHEN ${src} IN ('owner', 'council', 'agent') THEN ${src}` +
-      ` ELSE 'agent'` +
-      ` END`,
-  ],
+  // (brain_decisions.{outcome,decided_by} normalizations removed — T11647:
+  //  brain target = runtime shape with no CHECK; legacy values like 'accepted',
+  //  'rejected', 'prime' now survive VERBATIM instead of being coerced.)
 ]);
 
 /**

--- a/packages/core/src/store/memory-sqlite.ts
+++ b/packages/core/src/store/memory-sqlite.ts
@@ -59,6 +59,7 @@ import { openDualScopeDb, resolveDualScopeDbPath } from './dual-scope-db.js';
 import {
   createSafetyBackup,
   migrateWithRetry,
+  reconcileBrainMigrationsForConsolidatedDb,
   reconcileJournal,
   tableExists,
 } from './migration-manager.js';
@@ -275,11 +276,45 @@ function establishLegacyBrainSchema(
     );
   }
 
-  // Run the legacy `drizzle-brain` migrations to (re)create the runtime-shaped
-  // brain tables. Their `__drizzle_migrations` journal is shared with the
-  // cleo-project journal in the same `cleo.db`; the hashes are disjoint so the
-  // brain migrations are reconciled/applied independently.
   const migrationsFolder = resolveBrainMigrationsFolder();
+
+  // T11647 — CONSOLIDATED `cleo.db` path. The consolidated `drizzle-cleo-project`
+  // / `drizzle-cleo-global` migration already created every DOMAIN-PREFIXED
+  // `brain_*` table in the LEGACY RUNTIME shape (the exodus target was aligned to
+  // the runtime shape — see `cleo-shared/brain.ts`), so `brain_decisions` exists
+  // and `brainTablesAreConsolidatedShape` is false (no DROP fired above). The
+  // standalone `drizzle-brain` migrations must NOT be re-run wholesale: their
+  // non-`IF NOT EXISTS` `CREATE TABLE`s / table-rebuilds for already-present
+  // prefixed tables (e.g. `brain_observations_staging`) and their ALTER-ADD-COLUMN
+  // for already-present columns would collide.
+  if (tableExists(nativeDb, 'brain_decisions') && !brainTablesAreConsolidatedShape(nativeDb)) {
+    // Additive reconcile-and-apply: for each not-yet-journaled `drizzle-brain`
+    // migration, mark-applied-without-running when its net effect is already
+    // present (the prefixed `brain_*` tables + their final columns the
+    // consolidated migration created), else exec it directly (the UNPREFIXED
+    // runtime tables `deriver_queue`/`sticky_tags`/`session_narrative`/
+    // `brain_task_observations` the consolidated migration omits but the runtime
+    // queries). This NEVER deletes a journal row and never engages drizzle's
+    // shared-handle transaction, so it cannot corrupt the tasks-domain journal
+    // entries that share this consolidated `cleo.db`'s `__drizzle_migrations` —
+    // see reconcileBrainMigrationsForConsolidatedDb for the full rationale. The
+    // exodus-migrated rows in the prefixed tables survive untouched (the
+    // data-loss fix).
+    const { marked, applied } = reconcileBrainMigrationsForConsolidatedDb(
+      nativeDb,
+      migrationsFolder,
+    );
+    log.debug(
+      { marked, applied },
+      'brain consolidated cleo.db reconcile (T11647) — marked already-present migrations applied + executed the missing unprefixed-table migrations directly.',
+    );
+    return;
+  }
+
+  // LEGACY standalone `brain.db` (or brand-new DB) path: no prefixed brain tables
+  // pre-created, so run the full `drizzle-brain` migrate via the generic
+  // reconcile (its Scenario-2 orphan-delete is safe here — a standalone brain.db
+  // journal contains only brain hashes).
   if (tableExists(nativeDb, 'brain_decisions') && _dbPath) {
     createSafetyBackup(_dbPath);
   }
@@ -441,14 +476,17 @@ export async function getBrainDb(cwd?: string): Promise<NodeSQLiteDatabase<typeo
     // existing callers (brainSchema.* queries) continue to work unchanged.
     const db = _getDrizzle()({ client: nativeDb, schema: brainSchema });
 
-    // Establish the LEGACY brain-domain schema inside the consolidated cleo.db.
-    // openDualScopeDb created the brain tables in their exodus-TARGET shape
-    // (ISO-8601 timestamps + enum/format CHECK constraints), which the runtime
-    // brain writers (epoch-ms integers, no CHECKs) cannot use. This drops those
-    // and runs the legacy `drizzle-brain` migrations to recreate them in the
-    // runtime shape — plus `brain_task_observations` (no drizzle-brain migration).
-    // Idempotent: a no-op once the tables are already legacy-shaped. The
-    // consolidated-target cutover is the exodus's job (T11248 / T11553). (T11522)
+    // Reconcile the LEGACY brain-domain schema inside the consolidated cleo.db.
+    // Since T11647 the consolidated `cleo.db` migration already creates every
+    // `brain_*` table in the LEGACY RUNTIME shape (epoch-ms integer timestamps,
+    // no SQL CHECK constraints — the exodus target was aligned to the runtime
+    // shape in `cleo-shared/brain.ts`). So this is now a no-op reconcile: it
+    // marks the `drizzle-brain` lineage applied and skips the migrate, leaving
+    // any exodus-migrated brain rows intact. The legacy standalone-`brain.db`
+    // path (DB with no consolidated brain tables) still runs the full
+    // `drizzle-brain` migrate. The pre-T11647 DROP+recreate path is retained as
+    // a defensive fallback for any DB still carrying the old consolidated shape.
+    // (T11522 · T11647)
     establishLegacyBrainSchema(nativeDb, db);
 
     // Create the vec0 virtual table for embeddings if the extension is loaded

--- a/packages/core/src/store/migration-manager.ts
+++ b/packages/core/src/store/migration-manager.ts
@@ -597,6 +597,158 @@ export function reconcileJournal(
 }
 
 /**
+ * Reconcile + apply the standalone `drizzle-brain` migrations against a CONSOLIDATED
+ * `cleo.db` whose prefixed `brain_*` tables were already created by the
+ * consolidated migration (T11647). For each not-yet-journaled `drizzle-brain`
+ * migration, this either:
+ *
+ *  1. **Marks it applied without running** when its net effect is ALREADY present:
+ *     every `CREATE TABLE` / `RENAME TO` result table exists, OR it is an
+ *     ALTER-ADD-COLUMN-only migration whose columns all already exist (the
+ *     consolidated migration created the prefixed tables with their FINAL
+ *     columns). This avoids the `CREATE TABLE`/rename collisions and
+ *     "duplicate column" errors a wholesale re-run would hit.
+ *  2. **Executes it directly** (native `exec`, then journals it) when it is
+ *     genuinely missing — the UNPREFIXED legacy runtime tables (`deriver_queue`,
+ *     `sticky_tags`, `session_narrative`, `brain_task_observations`) the
+ *     consolidated migration omits but the runtime queries. Those migrations are
+ *     all `IF NOT EXISTS` DDL + idempotent `INSERT OR IGNORE` backfills, so a
+ *     direct exec is safe.
+ *
+ * ## Why NOT {@link reconcileJournal} + drizzle `migrate()`
+ *
+ * The brain `__drizzle_migrations` journal is SHARED with the TASKS domain inside
+ * the same consolidated `cleo.db`. On a first consolidated open the brain hashes
+ * are not yet journaled, so `reconcileJournal`'s Scenario-2 path classifies the
+ * TASKS-domain hashes as "orphans" of the brain migration set and DELETES them —
+ * which forces the tasks domain to re-run its table-rebuild migrations on the
+ * NEXT tasks open and crash (`tasks_new RENAME TO tasks` fires the
+ * `task_relations_non_containment_insert` trigger against a mid-rebuild `tasks`).
+ * And drizzle's `migrate()` wraps the brain DDL in a `BEGIN`/`COMMIT` over the
+ * shared handle. This function is **additive-only** (it never deletes a journal
+ * row) and uses plain `nativeDb.exec()`, so it cannot corrupt the shared journal
+ * or engage the cross-domain transaction.
+ *
+ * Idempotent: dedups by hash (the journal has no UNIQUE on `hash`, so an explicit
+ * presence check is required). On a brand-new / standalone `brain.db` (no
+ * prefixed brain tables yet) every migration is "genuinely missing" and is
+ * executed in order — equivalent to a full migrate.
+ *
+ * @param nativeDb - Native SQLite handle (the consolidated `cleo.db`).
+ * @param migrationsFolder - The `drizzle-brain` migrations folder.
+ * @returns `{ marked, applied }` — counts of migrations journaled-without-running
+ *   vs executed-and-journaled.
+ *
+ * @task T11647
+ */
+export function reconcileBrainMigrationsForConsolidatedDb(
+  nativeDb: DatabaseSync,
+  migrationsFolder: string,
+): { marked: number; applied: number } {
+  nativeDb.exec(`
+    CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+      id INTEGER PRIMARY KEY,
+      hash text NOT NULL,
+      created_at numeric,
+      name text,
+      applied_at TEXT
+    )
+  `);
+  const localMigrations = sanitizeMigrationStatements(readMigrationFiles({ migrationsFolder }));
+  const existingHashes = new Set(
+    (
+      nativeDb.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{ hash: string }>
+    ).map((r) => r.hash),
+  );
+  const createTableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?/gi;
+  const renameRegex = /ALTER\s+TABLE\s+[`"]?(\w+)[`"]?\s+RENAME\s+TO\s+[`"]?(\w+)[`"]?/gi;
+  const addColumnRegex = /ALTER\s+TABLE\s+[`"]?(\w+)[`"]?\s+ADD\s+COLUMN\s+[`"]?(\w+)[`"]?/gi;
+  const columnExists = (table: string, column: string): boolean => {
+    if (!tableExists(nativeDb, table)) return false;
+    const cols = nativeDb.prepare(`PRAGMA table_info("${table}")`).all() as Array<{ name: string }>;
+    return cols.some((c) => c.name === column);
+  };
+  // Strip SQL line (`-- …`) and block (`/* … */`) comments before scanning for
+  // DDL targets. A migration's prose comments routinely contain phrases like
+  // "CREATE TABLE IF NOT EXISTS ensures it exists", which would otherwise make
+  // the CREATE-TABLE regex capture bogus "table" names (`IF`, `ensures`) and
+  // wrongly classify a satisfied migration as missing.
+  const stripSqlComments = (sql: string): string =>
+    sql.replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+  let marked = 0;
+  let applied = 0;
+  for (const m of localMigrations) {
+    if (existingHashes.has(m.hash)) continue;
+    const fullSql = stripSqlComments(m.sql.join('\n'));
+    // Follow the SQLite table-rebuild/rename idiom (`CREATE TABLE x_new …; ALTER
+    // TABLE x_new RENAME TO x`): the migration's RESULT table is the FINAL name,
+    // not the transient intermediate.
+    const renameMap = new Map<string, string>();
+    const renameFinals: string[] = [];
+    for (const match of fullSql.matchAll(renameRegex)) {
+      renameMap.set(match[1] as string, match[2] as string);
+      renameFinals.push(match[2] as string);
+    }
+    const resultTables = new Set<string>(renameFinals);
+    for (const match of fullSql.matchAll(createTableRegex)) {
+      const created = match[1] as string;
+      resultTables.add(renameMap.get(created) ?? created);
+    }
+    const addColumns: Array<{ table: string; column: string }> = [];
+    for (const match of fullSql.matchAll(addColumnRegex)) {
+      addColumns.push({ table: match[1] as string, column: match[2] as string });
+    }
+
+    const tablesSatisfied =
+      resultTables.size > 0 && [...resultTables].every((t) => tableExists(nativeDb, t));
+    const altersSatisfied =
+      resultTables.size === 0 &&
+      addColumns.length > 0 &&
+      addColumns.every(({ table, column }) => columnExists(table, column));
+
+    if (tablesSatisfied || altersSatisfied) {
+      // Net effect (table/columns) already present — journal without re-running
+      // the table/column DDL. BUT first replay any `CREATE [UNIQUE] INDEX IF NOT
+      // EXISTS` statements the migration carries: the consolidated migration may
+      // create a prefixed table with a DIFFERENT (incomplete) index set than the
+      // legacy `drizzle-brain` lineage. A missing UNIQUE index is not cosmetic —
+      // e.g. `idx_transcript_events_session_seq` powers the
+      // `brain_transcript_events` re-ingest dedup; without it, INSERT-OR-IGNORE
+      // re-inserts duplicates. `CREATE … INDEX IF NOT EXISTS` is idempotent (a
+      // no-op when the index already exists), so replaying them is safe and
+      // closes any consolidated-vs-runtime index drift.
+      for (const statement of m.sql) {
+        // Only replay pure `CREATE [UNIQUE] INDEX IF NOT EXISTS` statements (after
+        // stripping any leading comment). A statement that ALSO contains other
+        // DDL (CREATE TABLE / ALTER) is skipped — re-running those would collide.
+        const stripped = stripSqlComments(statement).trim();
+        if (
+          /^CREATE\s+(?:UNIQUE\s+)?INDEX\s+IF\s+NOT\s+EXISTS/i.test(stripped) &&
+          !/CREATE\s+TABLE|ALTER\s+TABLE/i.test(stripped)
+        ) {
+          nativeDb.exec(statement);
+        }
+      }
+      insertJournalEntry(nativeDb, m.hash, m.folderMillis, m.name ?? '');
+      existingHashes.add(m.hash);
+      marked++;
+      continue;
+    }
+
+    // Genuinely missing (an unprefixed runtime table the consolidated migration
+    // omits) — execute its statements directly, then journal it. These migrations
+    // are `IF NOT EXISTS` DDL + idempotent backfills, safe to native-exec.
+    for (const statement of m.sql) {
+      nativeDb.exec(statement);
+    }
+    insertJournalEntry(nativeDb, m.hash, m.folderMillis, m.name ?? '');
+    existingHashes.add(m.hash);
+    applied++;
+  }
+  return { marked, applied };
+}
+
+/**
  * Check whether an error is a SQLite "duplicate column name" error.
  *
  * These are thrown when an ALTER TABLE ADD COLUMN statement is re-executed

--- a/packages/core/src/store/schema/cleo-shared/brain.ts
+++ b/packages/core/src/store/schema/cleo-shared/brain.ts
@@ -43,14 +43,24 @@
  *     (reused from the source module — staged|approved|rolled-back).
  *   (The nexus `sigils.role` non-conformer the report also flags is GLOBAL-only
  *   — it belongs to `nexus_*`, authored in the global batch T11361, not here.)
- * - **§4 epoch → canonical TEXT ISO8601** (these are the ONLY brain epoch
- *   non-conformers; the other ~157 brain timestamps were already TEXT ISO8601):
- *   - `brain_decisions.validator_run_at`        (was INTEGER ms epoch)
- *   - `brain_attention.{created_at,expires_at}`  (was INTEGER ms epoch)
- *   - `brain_session_narrative.last_updated_at`  (was INTEGER ms epoch)
- *   **§8.1 epoch-unit RESOLVED:** all four are MILLISECONDS — the writers use
- *   `Date.now()` / `unixepoch() * 1000`, so the exodus conversion uses the
- *   `/1000` ms divisor: `strftime('%Y-%m-%dT%H:%M:%fZ', col/1000, 'unixepoch')`.
+ * - **§4 timestamps — brain target = LEGACY RUNTIME shape (T11647 reversal).**
+ *   The brain family is the ONE consolidated domain whose RUNTIME schema
+ *   (`../memory-schema.ts`, applied by `drizzle-brain`) remains the source of
+ *   truth (see {@link establishLegacyBrainSchema}). The original T11360 §4 plan
+ *   converted four epoch-ms columns to canonical TEXT ISO8601, but that diverged
+ *   the exodus TARGET shape from the runtime shape — the runtime never moved
+ *   these columns, so on the first brain open it treated the migrated tables as
+ *   "consolidated shape", DROPped them, and destroyed every migrated row (the
+ *   T11647 catastrophic-data-loss bug). They are therefore kept INTEGER epoch-ms
+ *   to MATCH the runtime, so the discriminator returns `false` and no rebuild
+ *   fires:
+ *   - `brain_decisions.validator_run_at`         (INTEGER ms epoch — runtime shape)
+ *   - `brain_attention.{created_at,expires_at}`  (INTEGER ms epoch — runtime shape)
+ *   - `brain_session_narrative.last_updated_at`  (INTEGER ms epoch — runtime shape)
+ *   The remaining brain timestamps were ALREADY TEXT in the runtime schema
+ *   (`text('created_at')` etc.), so they stay TEXT here — that matches the live
+ *   brain.db, and exodus copies those values verbatim. No epoch→ISO coercion is
+ *   applied to any brain column.
  * - **§3 booleans:** every `verified` flag, `brain_learnings.actionable`, and
  *   `brain_consolidation_events.succeeded` are already
  *   `integer({ mode: 'boolean' })` — preserved.
@@ -355,8 +365,19 @@ export const brainDecisions = sqliteTable(
       .default('proposed'),
     /** Decided-by — CHECK-backed via the inline-promoted const below. */
     decidedBy: text('decided_by', { enum: BRAIN_DECISION_DECIDED_BY }).notNull().default('agent'),
-    /** ISO-8601 UTC last validator-run instant (was ms epoch, §4 / §8.1). */
-    validatorRunAt: text('validator_run_at'),
+    /**
+     * Epoch-millisecond timestamp of the most recent LLM-validator run (T1828).
+     *
+     * Kept as `integer` epoch-ms to match the LEGACY RUNTIME shape
+     * (`memory-schema.ts` — `integer('validator_run_at')`). The brain runtime
+     * writers and the `drizzle-brain` migrations never moved this column to TEXT,
+     * so the consolidated exodus target MUST keep it INTEGER too. Aligning the
+     * target shape to the runtime is what lets the first runtime brain open
+     * recognise the migrated tables as already-legacy-shaped — see
+     * {@link brainTablesAreConsolidatedShape} / {@link establishLegacyBrainSchema}
+     * in `../../memory-sqlite.ts` (T11647).
+     */
+    validatorRunAt: integer('validator_run_at'),
     /** Decision category — CHECK-backed via {@link BRAIN_DECISION_CATEGORIES}. */
     decisionCategory: text('decision_category', { enum: BRAIN_DECISION_CATEGORIES })
       .notNull()
@@ -701,10 +722,21 @@ export const brainAttention = sqliteTable(
      * otherwise carry is a `near "(": syntax error` at `CREATE TABLE` time.
      */
     tags: jsonb<string[]>('tags').default(sql`(jsonb('[]'))`),
-    /** ISO-8601 UTC creation instant (was ms epoch, §4 / §8.1). */
-    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
-    /** ISO-8601 UTC hard-TTL instant; NULL = no TTL (was ms epoch, §4 / §8.1). */
-    expiresAt: text('expires_at'),
+    /**
+     * Epoch-millisecond creation instant. Kept as `integer` epoch-ms to match the
+     * LEGACY RUNTIME shape (`memory-schema.ts` —
+     * `integer('created_at').notNull().default(sql\`(unixepoch() * 1000)\`)`).
+     *
+     * This is the column {@link brainTablesAreConsolidatedShape} keys on: a TEXT
+     * affinity here is what made the runtime treat the exodus-migrated brain
+     * tables as "consolidated shape" and DROP+recreate them, destroying every
+     * migrated row on the first `cleo memory find`. Keeping it INTEGER (= runtime
+     * shape) makes that discriminator return `false`, so the DROP never fires and
+     * the migrated data survives (T11647).
+     */
+    createdAt: integer('created_at').notNull().default(sql`(unixepoch() * 1000)`),
+    /** Epoch-millisecond hard-TTL instant; NULL = no TTL (legacy runtime shape, T11647). */
+    expiresAt: integer('expires_at'),
     /** Decay score [0,1]; NULL = no decay applied. */
     decayScore: real('decay_score'),
     /** Lifecycle status — CHECK-backed via {@link BRAIN_ATTENTION_STATUSES}. */
@@ -1205,8 +1237,14 @@ export const brainSessionNarrative = sqliteTable('brain_session_narrative', {
   narrative: text('narrative').notNull().default(''),
   /** Dialectic turn count. */
   turnCount: integer('turn_count').notNull().default(0),
-  /** ISO-8601 UTC last-update instant (was ms epoch, §4 / §8.1). */
-  lastUpdatedAt: text('last_updated_at'),
+  /**
+   * Epoch-millisecond last-update instant. Kept as `integer` epoch-ms to match
+   * the LEGACY RUNTIME shape (`memory-schema.ts` —
+   * `integer('last_updated_at').notNull().default(0)`) so the exodus target
+   * equals the runtime shape and the first runtime open does not rebuild it
+   * (T11647).
+   */
+  lastUpdatedAt: integer('last_updated_at').notNull().default(0),
   /** Topic-pivot count. */
   pivotCount: integer('pivot_count').notNull().default(0),
 });

--- a/scripts/inject-consolidation-checks.mjs
+++ b/scripts/inject-consolidation-checks.mjs
@@ -64,6 +64,33 @@ const BLOCK_HEADER =
   '-- consolidation CHECK constraints (T11363) — derived from schema enum/boolean/timestamp metadata, never hand-typed';
 
 /**
+ * `brain_*` tables are EXCLUDED from CHECK-constraint injection (T11647).
+ *
+ * The brain memory family is the one consolidated domain whose RUNTIME schema
+ * (`packages/core/src/store/schema/memory-schema.ts`, applied by the
+ * `drizzle-brain` migrations) remains the source of truth: on the first brain
+ * open `establishLegacyBrainSchema` (memory-sqlite.ts) reconciles the brain
+ * tables to that runtime shape. The legacy/runtime brain tables carry **zero**
+ * SQL CHECK constraints (the `text({ enum })` unions are enforced only at the
+ * application layer — verified: `grep -c CHECK` over every `drizzle-brain`
+ * migration returns 0). Injecting enum/timestamp CHECKs onto the consolidated
+ * `brain_*` tables therefore DIVERGED the exodus target shape from the runtime
+ * shape, which (a) forced exodus to COERCE legacy enum values to pass the CHECK
+ * (corrupting `source_type`/`type`/… values) and (b) was part of the
+ * "consolidated shape" the runtime then DROPped. Skipping brain here keeps the
+ * consolidated brain DDL byte-aligned with the runtime: enum unions stay typed
+ * in TypeScript, but no SQL CHECK is emitted — so migrated values survive
+ * verbatim and the first runtime open treats the tables as already-legacy.
+ *
+ * @param {string} tableName - Physical consolidated table name.
+ * @returns {boolean} `true` when the table must NOT receive injected CHECKs.
+ * @task T11647
+ */
+function isCheckExemptTable(tableName) {
+  return tableName.startsWith('brain_');
+}
+
+/**
  * @typedef {object} ScopePlan
  * @property {string} schemaModule - Built barrel whose `sqliteTable`s drive the CHECKs.
  * @property {string} migrationsDir - The scope's drizzle `out` directory.
@@ -145,6 +172,11 @@ function buildCheckMap(mod) {
     if (!cfg || typeof cfg.name !== 'string') {
       continue;
     }
+    // brain_* tables keep the runtime shape (no SQL CHECKs) — see
+    // isCheckExemptTable (T11647).
+    if (isCheckExemptTable(cfg.name)) {
+      continue;
+    }
     const { name, checks } = deriveChecks(value);
     if (checks.length > 0) {
       map.set(name, checks);
@@ -180,23 +212,35 @@ function injectChecks(body, checkMap) {
 }
 
 /**
- * Locate the single migration.sql inside a scope's `out` directory
- * (folder-per-migration structure: `<out>/<timestamp_name>/migration.sql`).
+ * Locate the CONSOLIDATION-BASELINE migration.sql inside a scope's `out`
+ * directory (folder-per-migration structure: `<out>/<timestamp_name>/migration.sql`).
+ *
+ * The injected CHECK constraints belong to the squashed consolidation baseline
+ * (the `*_t11363-consolidation-*` folder) — that single migration emits every
+ * `CREATE TABLE`. Post-baseline incremental folders (T11546/T11549/T11538/…)
+ * only ADD a handful of tables and never re-declare the consolidated set, so the
+ * injector targets the baseline folder specifically. (Earlier this required
+ * exactly ONE folder; once incremental migrations landed that assumption broke —
+ * we now select the baseline by name.)
  *
  * @param {string} migrationsDir
- * @returns {string} absolute path to migration.sql
+ * @returns {string} absolute path to the consolidation-baseline migration.sql
  */
 function resolveMigrationSql(migrationsDir) {
   const folders = readdirSync(migrationsDir, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name)
     .sort();
-  if (folders.length !== 1) {
+  if (folders.length === 0) {
+    throw new Error(`no migration folder found in ${migrationsDir}`);
+  }
+  const baseline = folders.find((f) => f.includes('consolidation'));
+  if (!baseline) {
     throw new Error(
-      `expected exactly one migration folder in ${migrationsDir}, found ${folders.length}: ${folders.join(', ')}`,
+      `no consolidation-baseline migration folder found in ${migrationsDir}; folders: ${folders.join(', ')}`,
     );
   }
-  return join(migrationsDir, folders[0], 'migration.sql');
+  return join(migrationsDir, baseline, 'migration.sql');
 }
 
 const checkMode = process.argv.includes('--check');


### PR DESCRIPTION
## Root cause (catastrophic data loss — #1 GO-blocker for the live cutover)

Exodus migrated all brain data into the consolidated project `cleo.db` in the **consolidated-target shape** (TEXT/ISO-8601 timestamps + CHECK enums). But the consolidated brain target shape DIVERGED from the legacy **runtime** brain shape, so the first runtime brain open destroyed it:

- `getBrainDb()` → `openDualScopeDb('project')` → `establishLegacyBrainSchema()`.
- `brainTablesAreConsolidatedShape()` checks `brain_attention.created_at` type; TEXT ⇒ "consolidated shape" ⇒ true.
- It then `DROP TABLE IF EXISTS` every `brain_*` table and re-ran `drizzle-brain` to recreate them EMPTY in the legacy epoch-ms shape.

Net: brain = 6249 right after migrate → **0** after the first `cleo memory find`. Separately, the consolidated CHECK enums forced exodus to COERCE legacy values (`source_type` `observer-compressed`/`sleep-consolidation`→`agent`, `decided_by` `prime`→`agent`, …) = silent corruption.

## Option chosen — (i): align the exodus brain TARGET shape to the runtime/legacy shape

The brain family's RUNTIME schema (`memory-schema.ts`, applied by `drizzle-brain`) is the source of truth (the live `brain.db` has INTEGER epoch-ms `brain_attention.created_at` and **zero** SQL CHECK constraints — the `text({enum})` unions are app-layer only). So the consolidated exodus target was made to match it:

1. **`cleo-shared/brain.ts`** — reverted the 4 epoch→ISO timestamp columns to `integer` epoch-ms (`brain_decisions.validator_run_at`, `brain_attention.{created_at,expires_at}`, `brain_session_narrative.last_updated_at`). `brain_attention.created_at` is the discriminator → now INTEGER → `brainTablesAreConsolidatedShape()` returns **false** → **no DROP fires**.
2. **`inject-consolidation-checks.mjs`** — `brain_*` tables are now CHECK-exempt (matching the runtime, which has none). Regenerated both consolidation `migration.sql` + snapshots.
3. **exodus `migrate.ts`** — removed the brain enum normalizations (no CHECK to satisfy ⇒ copy **verbatim**, zero semantic alteration — the bonus corruption fix).
4. **runtime reconcile** — with no DROP, `establishLegacyBrainSchema` now reconciles the `drizzle-brain` lineage against the populated consolidated `cleo.db` additively (new `reconcileBrainMigrationsForConsolidatedDb`): mark-applied the already-present prefixed `brain_*` migrations (replaying only idempotent `CREATE…INDEX IF NOT EXISTS` so dedup uniques like `idx_transcript_events_session_seq` are restored) and direct-exec only the genuinely-missing UNPREFIXED runtime tables (`deriver_queue`, `sticky_tags`, `session_narrative`, `brain_task_observations`). It is additive-only and bypasses drizzle's shared-handle transaction, so it cannot delete the tasks-domain hashes that share the consolidated `__drizzle_migrations` journal (which would otherwise crash the tasks `tasks_new RENAME TO tasks` rebuild).

Reconciled the parity + exodus tests (the consolidated brain shape is intentionally CHECK-free now; the brain regression tests assert verbatim survival).

## MINI DRY-RUN (real live brain.db copy, sandboxed, `CLEO_DISABLE_EXODUS_ON_OPEN=1`)

| Stage | brain_observations | brain_decisions | brain_learnings | brain_patterns | brain_page_nodes | brain_page_edges | brain_usage_log |
|---|---|---|---|---|---|---|---|
| Source (live brain.db) | 6249 | 118 | 121 | 10816 | 18797 | 117419 | 8684 |
| After `cleo exodus migrate` | 6249 | 118 | 121 | 10816 | 18797 | 117419 | 8684 |
| **After `cleo memory find` (runtime open)** | **6249** | **118** | **121** | **10816** | **18797** | **117419** | **8684** |

`cleo memory find "substrate"` returned 10 real migrated rows. The data **survives the runtime open** (was 6249→0 before the fix). Confirmed: `brain_attention.created_at` = INTEGER; enum values preserved VERBATIM (`decided_by` still has `prime`; 2892 rows keep `source_type='observer-compressed'`); the unprefixed runtime tables (`deriver_queue`/`sticky_tags`/`session_narrative`/`brain_task_observations`) all created.

## Tests / gates

- `consolidated-schema-parity-fk.test.ts` (incl. AC2 declared==written), all `exodus*` + `verify-migration` + `agent-registry-exodus-map-invariant` tests: **green**.
- Full `@cleocode/core` `store/` + `memory/` + `deriver/` + `sessions/` suites: **2851 passed / 0 failed**.
- `@cleocode/runtime`: green (2 cold-start transform timeouts pass with a longer `--testTimeout`; unrelated to brain).
- `pnpm run typecheck` (`tsc -b`) clean; biome clean; DB-Open-Guard (Gate 3, strict) clean; project consolidation-checks gate OK (202 non-brain CHECKs).

Out of scope (not touched): nexus (T11648), transport enum (T11649). The pre-existing global nexus/signaldock consolidation-checks drift is theirs, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)