### PR TITLE
chore(release): v2026.6.0 — dual cleo.db substrate cutover + provider self-heal + Agent-Registry rename

### DIFF
--- a/.changeset/t11578-dual-db-runtime-cutover.md
+++ b/.changeset/t11578-dual-db-runtime-cutover.md
@@ -1,0 +1,7 @@
+---
+id: t11578-dual-db-runtime-cutover
+tasks: [T11578]
+kind: feat
+summary: Dual cleo.db substrate cutover — tasks/conduit/nexus/agent-registry runtime read+write repointed to prefixed consolidated tables (DHQ-046 fix, migrated data now visible).
+prs: [930, 931, 932, 933]
+---

--- a/.changeset/t11617-llm-credential-self-heal.md
+++ b/.changeset/t11617-llm-credential-self-heal.md
@@ -1,0 +1,7 @@
+---
+id: t11617-llm-credential-self-heal
+tasks: [T11617]
+kind: fix
+summary: LLM credential self-heal (refresh expired OAuth, quarantine 401'd creds, prompt only when none valid) + OpenAI-Codex-OAuth role-executor branch + configurable default profile.
+prs: [929]
+---

--- a/.changeset/t11622-signaldock-agent-registry-rename.md
+++ b/.changeset/t11622-signaldock-agent-registry-rename.md
@@ -1,0 +1,7 @@
+---
+id: t11622-signaldock-agent-registry-rename
+tasks: [T11622]
+kind: feat
+summary: Signaldock subsystem dissolved into Agent Registry — rename to agent_registry_* + registry runtime cutover (external api.signaldock.io kept as a Conduit channel).
+prs: [933]
+---

--- a/.changeset/t11647-brain-cutover-shape.md
+++ b/.changeset/t11647-brain-cutover-shape.md
@@ -1,0 +1,7 @@
+---
+id: t11647-brain-cutover-shape
+tasks: [T11647]
+kind: fix
+summary: Brain cutover — align exodus brain target to the runtime shape so the first runtime open no longer DROPs migrated brain data (zero brain-data loss) + brain enum values preserved verbatim.
+prs: [936]
+---

--- a/.changeset/t11648-nexus-graph-project-scope.md
+++ b/.changeset/t11648-nexus-graph-project-scope.md
@@ -1,0 +1,7 @@
+---
+id: t11648-nexus-graph-project-scope
+tasks: [T11648]
+kind: fix
+summary: Route nexus code-graph reads to project scope (ATTACH global) so the migrated graph is visible post-cutover (nexus search-code/context).
+prs: [935]
+---

--- a/.changeset/t11649-token-usage-mcp-transport.md
+++ b/.changeset/t11649-token-usage-mcp-transport.md
@@ -1,0 +1,7 @@
+---
+id: t11649-token-usage-mcp-transport
+tasks: [T11649]
+kind: fix
+summary: Widen TOKEN_USAGE_TRANSPORTS to preserve transport='mcp' — no silent exodus enum coercion (data-integrity).
+prs: [934]
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [2026.6.0] (2026-06-03)
+
+### Added
+
+- Dual cleo.db substrate cutover — tasks/conduit/nexus/agent-registry runtime read+write repointed to prefixed consolidated tables (DHQ-046 fix, migrated data now visible). _(provenance: [T11578](https://github.com/kryptobaseddev/cleo/search?q=T11578&type=commits); [#930](https://github.com/kryptobaseddev/cleo/pull/930), [#931](https://github.com/kryptobaseddev/cleo/pull/931), [#932](https://github.com/kryptobaseddev/cleo/pull/932), [#933](https://github.com/kryptobaseddev/cleo/pull/933))_
+- Signaldock subsystem dissolved into Agent Registry — rename to agent_registry_* + registry runtime cutover (external api.signaldock.io kept as a Conduit channel). _(provenance: [T11622](https://github.com/kryptobaseddev/cleo/search?q=T11622&type=commits); [#933](https://github.com/kryptobaseddev/cleo/pull/933))_
+
+### Changed
+
+
+
+### Fixed
+
+- LLM credential self-heal (refresh expired OAuth, quarantine 401'd creds, prompt only when none valid) + OpenAI-Codex-OAuth role-executor branch + configurable default profile. _(provenance: [T11617](https://github.com/kryptobaseddev/cleo/search?q=T11617&type=commits); [#929](https://github.com/kryptobaseddev/cleo/pull/929))_
+- Brain cutover — align exodus brain target to the runtime shape so the first runtime open no longer DROPs migrated brain data (zero brain-data loss) + brain enum values preserved verbatim. _(provenance: [T11647](https://github.com/kryptobaseddev/cleo/search?q=T11647&type=commits); [#936](https://github.com/kryptobaseddev/cleo/pull/936))_
+- Route nexus code-graph reads to project scope (ATTACH global) so the migrated graph is visible post-cutover (nexus search-code/context). _(provenance: [T11648](https://github.com/kryptobaseddev/cleo/search?q=T11648&type=commits); [#935](https://github.com/kryptobaseddev/cleo/pull/935))_
+- Widen TOKEN_USAGE_TRANSPORTS to preserve transport='mcp' — no silent exodus enum coercion (data-integrity). _(provenance: [T11649](https://github.com/kryptobaseddev/cleo/search?q=T11649&type=commits); [#934](https://github.com/kryptobaseddev/cleo/pull/934))_
+
+### Deprecated
+
+
+
+### Removed
+
+
+
+### Security
+
+
+
+### BREAKING CHANGES
+
 ## [2026.5.134] (2026-05-31)
 
 ### Added


### PR DESCRIPTION
Release **v2026.6.0**. Ships the dual-`cleo.db` substrate cutover and supporting fixes.

## Contents (6 tasks, 8 merged PRs)
- **T11578** — 4-domain runtime cutover (tasks→`tasks_*`, conduit→`conduit_*`, nexus→`nexus_*`, registry→`agent_registry_*`) — DHQ-046 fix (migrated data now runtime-visible). #930 #931 #932 #933
- **T11622** — Signaldock subsystem dissolved into **Agent Registry** (rename + registry cutover; external `api.signaldock.io` kept as a Conduit channel). #933
- **T11617** — LLM credential self-heal + OpenAI-Codex-OAuth role-executor branch + configurable default profile. #929
- **T11647** — Brain cutover (exodus brain target = runtime shape → zero brain-data loss; enum values preserved verbatim). #936
- **T11648** — Nexus code-graph reads routed to project scope (graph visible post-cutover). #935
- **T11649** — `transport='mcp'` enum preserved (no silent exodus coercion). #934

## Validation
Full real-data dry-run = **GO**: 1,760,346 rows migrated, **0 deficits, 0 migration-introduced FK orphans**, all domains runtime-visible (brain survives runtime open 6249→6249; nexus graph non-empty; transport='mcp' preserved). 229 already-shipped changesets correctly auto-filtered out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)