### PR TITLE
chore(T11658): purge legacy ClawMsgr — remove api.clawmsgr.com transport fallback + all refs

### DIFF
--- a/.changeset/t11658-purge-clawmsgr.md
+++ b/.changeset/t11658-purge-clawmsgr.md
@@ -1,0 +1,12 @@
+---
+id: t11658-purge-clawmsgr
+tasks: [T11658]
+kind: chore
+summary: Remove legacy ClawMsgr integration — drop api.clawmsgr.com Conduit transport fallback + all refs.
+---
+
+Purged the legacy ClawMsgr integration from the repository. Removed the `api.clawmsgr.com` Conduit HTTP fallback endpoint and all ClawMsgr references from shipped code, scripts, source docs, generated docs, and `.gitignore` files.
+
+`HttpTransport` previously carried a primary/fallback failover machinery whose sole purpose was the legacy `api.clawmsgr.com` endpoint. That machinery is removed: the transport now connects to the single configured `apiBaseUrl` (`api.signaldock.io`). The primary SignalDock HTTP transport is unaffected — push/poll/ack continue to work against the configured base URL. The `TransportConfig.apiBaseUrlFallback` contract field (only ever populated with a ClawMsgr URL and only read by the removed fallback path) was dropped.
+
+Left untouched by deliberate decision: `CHANGELOG.md` (immutable historical release record) and the comment in the frozen `20260327000000_agent-credentials` migration — drizzle's `readMigrationFiles` hashes the full `.sql` file content, so editing the comment would change the migration hash and orphan the journal entry on already-migrated databases.

--- a/.gitignore
+++ b/.gitignore
@@ -115,10 +115,6 @@ packages/*/extensions/**/*.d.ts.map
 !packages/core/src/llm/rust/index.js
 !packages/core/src/llm/rust/index.d.ts
 
-# Misc noise
-clawmsgr-agent.json
-clawmsgr-*.json
-
 # Tool / editor configs (personal, not project)
 .serena/
 .vscode/

--- a/docs/archive/CLEO-ORCH-PLAN.md
+++ b/docs/archive/CLEO-ORCH-PLAN.md
@@ -3,16 +3,16 @@
 **Status**: DRAFT — Supersedes ORCH-PLAN.md Phase 7
 **Author**: @cleo-rust-lead
 **Date**: 2026-03-27
-**Predecessors**: ORCH-PLAN.md (ClawMsgr-era), T202 (CANT DSL), T211 (Local SignalDock Stack)
+**Predecessors**: ORCH-PLAN.md (legacy-relay era), T202 (CANT DSL), T211 (Local SignalDock Stack)
 
 ---
 
 ## 1. The Problem (Why ORCH-PLAN.md Phase 7 Is Outdated)
 
 The original ORCH-PLAN.md Phase 7 envisioned multi-project agent topology but was designed around:
-- **ClawMsgr Python workers** (clawmsgr-worker.py) — now deprecated
-- **JSON file configs** (clawmsgr-*.json) — moving to DB-backed credentials
-- **Flat file state** (~/.local/share/clawmsgr/{agent-id}/) — moving to signaldock.db
+- **Legacy chat-relay Python workers** — now deprecated
+- **JSON file configs** (legacy `*-agent.json`) — moving to DB-backed credentials
+- **Flat file state** (legacy relay per-agent dirs) — moving to signaldock.db
 - **Manual polling** with no guaranteed delivery — need SSE/local transport
 - **No programmatic agent lifecycle** — agents go idle with no way to wake them
 
@@ -299,7 +299,7 @@ From ORCH-PLAN.md Phase 7:
 | No programmatic start/stop | cleo agent start/stop/work commands |
 | No task auto-pickup | Self-delegation from CLEO task queue |
 | No heartbeat | Mandatory heartbeat with STALE/OFFLINE detection |
-| ClawMsgr skill for messaging | Native CLEO conduit integration |
+| Legacy chat-relay skill for messaging | Native CLEO conduit integration |
 
 ### 4.3 Project Scoping
 
@@ -403,11 +403,11 @@ cleo agent stop signaldock-backend    # Stop agent gracefully
 
 | Old System | New System |
 |------------|------------|
-| clawmsgr-worker.py | @cleocode/runtime AgentPoller + heartbeat |
-| clawmsgr-*.json | agent_credentials table (AES-256-GCM) |
-| ClawMsgr SKILL.md | CANT DSL agent profiles (.cant files) |
+| Legacy chat-relay worker script | @cleocode/runtime AgentPoller + heartbeat |
+| Legacy relay `*-agent.json` configs | agent_credentials table (AES-256-GCM) |
+| Legacy chat-relay SKILL.md | CANT DSL agent profiles (.cant files) |
 | Manual terminal sessions | cleo agent start/stop/work |
-| /clawmsgr-check cron | Native transport subscription (Local/SSE) |
+| Legacy relay polling cron | Native transport subscription (Local/SSE) |
 | Group conversation polling | CLEO task system + conduit |
 | ORCH-PLAN.md Phase 7 | This document (CLEO-ORCH-PLAN.md) |
 

--- a/docs/archive/SIGNALDOCK-UNIFIED-AGENT-REGISTRY.md
+++ b/docs/archive/SIGNALDOCK-UNIFIED-AGENT-REGISTRY.md
@@ -9,7 +9,7 @@
 
 ## 1. Problem Statement
 
-Agent credentials are stored as loose JSON files scattered across project roots. There is no typed interface, no CRUD operations, no credential lifecycle management, and no provider-agnostic agent registry. Transport implementations are tangled with provider-specific concerns. Documentation still references defunct "ClawMsgr" naming.
+Agent credentials are stored as loose JSON files scattered across project roots. There is no typed interface, no CRUD operations, no credential lifecycle management, and no provider-agnostic agent registry. Transport implementations are tangled with provider-specific concerns. Documentation still references defunct legacy chat-relay naming.
 
 **This spec replaces all of that with:**
 1. A per-project credential store in `.cleo/tasks.db`
@@ -367,7 +367,7 @@ function isNapiAvailable(): boolean {
 
 ### 5.1 No Standalone Worker Scripts
 
-The Python `clawmsgr-worker.py` is **eliminated**. Polling is a Core dispatch capability available through `@cleocode/cleo` CLI commands and programmatically through the Conduit API.
+The legacy Python polling worker is **eliminated**. Polling is a Core dispatch capability available through `@cleocode/cleo` CLI commands and programmatically through the Conduit API.
 
 ### 5.2 CLI Dispatch Commands
 
@@ -512,19 +512,19 @@ packages/core/src/conduit/
 
 | What | Why |
 |---|---|
-| `ClawMsgrPollingService` (JSDoc) | Never existed as code. Replaced by `ConduitClient` + `HttpTransport` |
-| `ClawMsgrTransport` (JSDoc) | Never existed in cleocode. Was only in CleoOS |
-| `ClawMsgrWorker` (JSDoc) | Replaced by `cleo agent watch` |
+| `LegacyRelayPollingService` (JSDoc) | Never existed as code. Replaced by `ConduitClient` + `HttpTransport` |
+| `LegacyRelayTransport` (JSDoc) | Never existed in cleocode. Was only in CleoOS |
+| `LegacyRelayWorker` (JSDoc) | Replaced by `cleo agent watch` |
 | `ClaudeCodeTransport` (code) | No provider-specific transports in Core |
-| `clawmsgr-worker.py` | Stays in clawmsgr repo as legacy v1. NOT in cleocode |
-| All `clawmsgr-*.json` files | Replaced by `agent_credentials` table |
+| legacy relay worker script | Stays in the legacy relay repo as legacy v1. NOT in cleocode |
+| All legacy relay `*-agent.json` files | Replaced by `agent_credentials` table |
 
 ### 7.2 Files to DELETE in cleocode/
 
 ```
-clawmsgr-agent.json
-clawmsgr-cleocode-lead.json
-.cleo/clawmsgr-cleo-dev.json
+legacy-relay-agent.json
+legacy-relay-cleocode-lead.json
+.cleo/legacy-relay-cleo-dev.json
 packages/core/src/signaldock/claude-code-transport.ts
 packages/core/src/signaldock/types.ts (after types moved to contracts)
 packages/core/src/signaldock/transport.ts (after interface moved to contracts)
@@ -552,10 +552,10 @@ packages/cleo/src/commands/agent.ts          # CLI commands
 
 | File | Change |
 |---|---|
-| `packages/contracts/src/conduit.ts` | Remove all ClawMsgr references. Implementations: `HttpTransport`, `WsTransport` (future), `SseTransport` (future) |
-| `docs/concepts/CLEO-CANT.md` | Replace ClawMsgrTransport → ConduitClient |
-| `docs/specs/CLEOCODE-ECOSYSTEM-PLAN.md` | Replace all ClawMsgr references |
-| `WASM-COMPLETENESS-REPORT.md` | Replace ClawMsgr references |
+| `packages/contracts/src/conduit.ts` | Remove all legacy-relay references. Implementations: `HttpTransport`, `WsTransport` (future), `SseTransport` (future) |
+| `docs/concepts/CLEO-CANT.md` | Replace legacy-relay transport → ConduitClient |
+| `docs/specs/CLEOCODE-ECOSYSTEM-PLAN.md` | Replace all legacy-relay references |
+| `WASM-COMPLETENESS-REPORT.md` | Replace legacy-relay references |
 
 ---
 
@@ -637,7 +637,7 @@ We are still in development with only a handful of registered agents. No automat
 1. **Add schema + contracts**: `agent_credentials` table, `AgentCredential` interface, `Transport` interface
 2. **Implement**: `AgentRegistryAccessor`, `HttpTransport`, `ConduitClient`, `cleo agent` CLI
 3. **Manually register existing agents**: For each current agent, run `cleo agent register --id {id} --name {name} --api-key {key}`
-4. **Delete JSON files**: Remove all `clawmsgr-*.json` and `.cleo/clawmsgr-*.json`
+4. **Delete JSON files**: Remove all legacy relay `*-agent.json` and `.cleo/*-agent.json` configs
 5. **Rename directory**: `signaldock/` → `conduit/`
 6. **Delete old code**: `claude-code-transport.ts`, old `types.ts`, old `transport.ts`, old factory logic
 7. **Update imports**: All consumers update `from signaldock/` → `from conduit/`
@@ -654,7 +654,7 @@ These repos consume the cleocode interfaces. They adapt on their own:
 | CleoOS (`CleoOS/`) | Electron app | Imports `@cleocode/core` + `@cleocode/runtime`, uses `createConduit()` with `LocalTransport` for embedded SignalDock. |
 | Any CLI agent | Claude Code, OpenCode, Codex, Kimi | Runs `cleo agent watch` which uses `@cleocode/runtime` with embedded `LocalTransport`. Cloud sync via `cleo agent sync` (paid tier). |
 
-**Note**: The ClawMsgr v1 frontend is replaced by the SignalDock v2 frontend (in the `signaldock/` repo). It is not a separate consumer — it ships with the cloud deployment.
+**Note**: The legacy relay v1 frontend is replaced by the SignalDock v2 frontend (in the `signaldock/` repo). It is not a separate consumer — it ships with the cloud deployment.
 
 ---
 

--- a/docs/concepts/CLEO-ARCHITECTURE-GUIDE.md
+++ b/docs/concepts/CLEO-ARCHITECTURE-GUIDE.md
@@ -58,7 +58,7 @@ Transports are the physical delivery mechanism. Conduit picks the best one autom
 |-----------|-------------|----------------|
 | **LocalTransport** | Reads/writes directly to signaldock.db on disk. No network at all. | Preferred whenever signaldock.db exists. Fully offline. |
 | **SseTransport** | Server-Sent Events for real-time push from the cloud API. Falls back to HTTP if SSE fails. | When online and SSE endpoint is configured. |
-| **HttpTransport** | HTTP polling to api.signaldock.io (primary) or api.clawmsgr.com (fallback). | Always available as last resort. |
+| **HttpTransport** | HTTP polling to api.signaldock.io. | Always available as last resort. |
 
 Priority: **Local > SSE > HTTP**. Local is always preferred because it's fastest, offline-capable, and has zero network dependency.
 

--- a/docs/generated/SKILL-monorepo/references/API-REFERENCE.md
+++ b/docs/generated/SKILL-monorepo/references/API-REFERENCE.md
@@ -35912,7 +35912,7 @@ AgentCredential
 - `agentId` — Unique agent identifier (e.g. 'cleo-core', 'forge-ts-opus').
 - `displayName` — Human-readable display name.
 - `apiKey` — API key for authentication (`sk_live_*`). Stored encrypted at rest.
-- `apiBaseUrl` — Base URL of the messaging API (default: api.signaldock.io, legacy: api.clawmsgr.com).
+- `apiBaseUrl` — Base URL of the messaging API (default: api.signaldock.io).
 - `classification` — Agent classification from the registry (e.g. 'code_dev', 'orchestrator').
 - `privacyTier` — Privacy tier controlling discoverability.
 - `capabilities` — Agent capabilities (e.g. ['chat', 'tools', 'code-execution']).

--- a/docs/generated/api-reference.md
+++ b/docs/generated/api-reference.md
@@ -71086,7 +71086,7 @@ API key for authentication (`sk_live_*`). Stored encrypted at rest.
 string
 ```
 
-Base URL of the messaging API (default: api.signaldock.io, legacy: api.clawmsgr.com).
+Base URL of the messaging API (default: api.signaldock.io).
 
 #### `classification`
 

--- a/docs/generated/api-reference.mdx
+++ b/docs/generated/api-reference.mdx
@@ -71088,7 +71088,7 @@ API key for authentication (`sk_live_*`). Stored encrypted at rest.
 string
 ```
 
-Base URL of the messaging API (default: api.signaldock.io, legacy: api.clawmsgr.com).
+Base URL of the messaging API (default: api.signaldock.io).
 
 #### `classification`
 

--- a/docs/generated/llms-full.txt
+++ b/docs/generated/llms-full.txt
@@ -41308,7 +41308,7 @@ API key for authentication (`sk_live_*`). Stored encrypted at rest.
 
 string
 
-Base URL of the messaging API (default: api.signaldock.io, legacy: api.clawmsgr.com).
+Base URL of the messaging API (default: api.signaldock.io).
 
 #### classification
 

--- a/docs/generated/packages/contracts/api/types.mdx
+++ b/docs/generated/packages/contracts/api/types.mdx
@@ -264,7 +264,7 @@ A registered agent's credentials and profile.
 | `agentId`         | `string`                                  | Yes      | Unique agent identifier (e.g. 'cleo-core', 'forge-ts-opus').                          |
 | `displayName`     | `string`                                  | Yes      | Human-readable display name.                                                          |
 | `apiKey`          | `string`                                  | Yes      | API key for authentication (`sk_live_*`). Stored encrypted at rest.                   |
-| `apiBaseUrl`      | `string`                                  | Yes      | Base URL of the messaging API (default: api.signaldock.io, legacy: api.clawmsgr.com). |
+| `apiBaseUrl`      | `string`                                  | Yes      | Base URL of the messaging API (default: api.signaldock.io). |
 | `classification`  | `string \| undefined`                     | No       | Agent classification from the registry (e.g. 'code\_dev', 'orchestrator').            |
 | `privacyTier`     | `"public" \| "discoverable" \| "private"` | Yes      | Privacy tier controlling discoverability.                                             |
 | `capabilities`    | `string[]`                                | Yes      | Agent capabilities (e.g. \['chat', 'tools', 'code-execution']).                       |

--- a/docs/plans/PATH-TO-100-PERCENT-COMPLETION.md
+++ b/docs/plans/PATH-TO-100-PERCENT-COMPLETION.md
@@ -604,8 +604,8 @@ Orchestrator is **paused here** pending owner decisions. No workers dispatched. 
 | T556 (critical) | `reciprocalRankFusion` function exported in `brain-search.ts`, wired into `searchBrainCompact` |
 | T557 (critical) | `observer-reflector.ts` + tests, hooked into task/session hooks |
 | T047-T055 (9 tasks) | `packages/core/src/nexus/transfer.ts` + `__tests__/transfer.test.ts` + domain + CLI + `external_task_links` migration; 264 test files / 4137 tests pass in @cleocode/core |
-| T465 | Zero `clawmsgr`/`ClawMsgr` refs in non-test non-md code; zero `.cleo/clawmsgr-*.json` configs |
-| T179 | Same — ClawMsgr Wave 3 delete verified clean |
+| T465 | Zero legacy chat-relay refs in non-test non-md code; zero legacy `.cleo/*-agent.json` configs |
+| T179 | Same — legacy chat-relay Wave 3 delete verified clean |
 
 **Cancelled (test fixtures or orphaned post-parent-close)**:
 

--- a/docs/specs/CANT-PERSONA-MVI-SPEC.md
+++ b/docs/specs/CANT-PERSONA-MVI-SPEC.md
@@ -149,7 +149,6 @@ The CLEO ecosystem supports two chat channel types:
 
 | Channel | Type | Backend | Status |
 |---------|------|---------|--------|
-| **ClawMsgr** | Cloud relay (legacy) | `api.clawmsgr.com` | Active — parallel operation during transition |
 | **SignalDock Cloud** | Cloud relay (canonical) | `api.signaldock.io` | Active — primary channel |
 | **SignalDock Local** | Local daemon | Embedded in `@cleocode/core` | Active — offline agent communication |
 
@@ -161,13 +160,11 @@ Every persona MUST declare:
 | Config file path | REQUIRED | Path to the JSON file carrying agentId, apiKey, apiBaseUrl |
 | Connection sequence | REQUIRED | Numbered steps: load config, authenticate, check inbox, start polling |
 | Status lifecycle | REQUIRED | `online` on connect, `idle` on session end, `offline` on disconnect |
-| Transition notes | RECOMMENDED | Which endpoints are primary vs fallback during migrations |
 
-**Config file convention**: ClawMsgr/SignalDock configs follow the naming pattern
-`clawmsgr-{project}-{classification}.json` (see ClawMsgr skill for full convention).
-The config carries `apiBaseUrl` for the primary endpoint and `apiBaseUrlFallback` for
-the fallback. Both ClawMsgr and SignalDock Cloud use the same config format — the
-`apiBaseUrl` field determines which backend the agent connects to.
+**Config file convention**: SignalDock configs follow the naming pattern
+`signaldock-{project}-{classification}.json`. The config carries `apiBaseUrl`
+for the messaging endpoint — the `apiBaseUrl` field determines which backend the
+agent connects to.
 
 **CANT protocol on the wire**: Once connected, all messages MUST use CANT directive syntax.
 The channel is the transport. CANT is the language. LAFS is the response shape.
@@ -177,8 +174,7 @@ The channel is the transport. CANT is the language. LAFS is the response shape.
 
 | Channel | Type | Config File | Activation |
 |---------|------|-------------|------------|
-| **ClawMsgr** | Cloud relay (legacy) | `./clawmsgr-{project}-{class}.json` | `/clawmsgr-start` |
-| **SignalDock** | Cloud relay (canonical) | Same config, apiBaseUrl -> api.signaldock.io | Same activation |
+| **SignalDock** | Cloud relay (canonical) | `./signaldock-{project}-{class}.json`, apiBaseUrl -> api.signaldock.io | `/signaldock-start` |
 | **SignalDock Local** | Local daemon | Embedded in @cleocode/core | Auto-discovers via Conduit |
 
 **Connection sequence**:
@@ -316,11 +312,11 @@ Trigger patterns SHOULD follow this format:
 
 | Location | `@`-references allowed? | Reason |
 |---|---|---|
-| T0 | NO (except ClawMsgr config) | Must be self-contained to stay within budget |
+| T0 | NO (except SignalDock config) | Must be self-contained to stay within budget |
 | T1-T3 | YES | These tiers exist to load documents on demand |
 | T-Live | YES (with verify warning) | Mutable state needs freshness check |
 
-Exception: Small files under 500 tokens (e.g., ClawMsgr config JSON for identity) MAY be
+Exception: Small files under 500 tokens (e.g., SignalDock config JSON for identity) MAY be
 `@`-referenced in T0 if they are essential for the agent to function (messaging, auth).
 
 ### 3.5 Budget Enforcement

--- a/packages/cleo/src/dispatch/domains/conduit.ts
+++ b/packages/cleo/src/dispatch/domains/conduit.ts
@@ -1,7 +1,7 @@
 /**
  * Conduit Domain Handler — Agent messaging via dispatch.
  *
- * Replaces standalone clawmsgr scripts with dispatch-native operations:
+ * Dispatch-native agent messaging operations:
  *   conduit.status    (query)  — connection status + unread count
  *   conduit.peek      (query)  — one-shot poll for messages
  *   conduit.listen    (query)  — one-shot poll for topic messages (A2A, T1252)

--- a/packages/contracts/src/agent-registry.ts
+++ b/packages/contracts/src/agent-registry.ts
@@ -23,8 +23,6 @@ export interface TransportConfig {
   wsUrl?: string;
   /** HTTP polling endpoint path (for HTTP polling transport). */
   pollEndpoint?: string;
-  /** Fallback API base URL (used when primary apiBaseUrl is unreachable). */
-  apiBaseUrlFallback?: string;
 }
 
 // ============================================================================
@@ -39,7 +37,7 @@ export interface AgentCredential {
   displayName: string;
   /** API key for authentication (`sk_live_*`). Stored encrypted at rest. */
   apiKey: string;
-  /** Base URL of the messaging API (default: api.signaldock.io, legacy: api.clawmsgr.com). */
+  /** Base URL of the messaging API (default: api.signaldock.io). */
   apiBaseUrl: string;
   /** Agent classification from the registry (e.g. 'code_dev', 'orchestrator'). */
   classification?: string;

--- a/packages/core/src/conduit/__tests__/factory.test.ts
+++ b/packages/core/src/conduit/__tests__/factory.test.ts
@@ -115,16 +115,6 @@ describe('resolveTransport', () => {
       expect(transport).toBeInstanceOf(SseTransport);
     });
 
-    it('returns SseTransport for legacy clawmsgr.com base URL with SSE endpoint', () => {
-      isAvailableSpy.mockReturnValue(false);
-      const credential = makeCredential({
-        apiBaseUrl: 'https://api.clawmsgr.com',
-        transportConfig: { sseEndpoint: 'https://api.clawmsgr.com/sse' },
-      });
-      const transport = resolveTransport(credential);
-      expect(transport).toBeInstanceOf(SseTransport);
-    });
-
     it('does NOT return SseTransport for "local" apiBaseUrl even with sseEndpoint', () => {
       isAvailableSpy.mockReturnValue(false);
       const credential = makeCredential({

--- a/packages/core/src/conduit/__tests__/http-transport.test.ts
+++ b/packages/core/src/conduit/__tests__/http-transport.test.ts
@@ -3,12 +3,10 @@
  *
  * Uses `vi.stubGlobal('fetch', ...)` to mock the global fetch API so
  * no real network I/O occurs. Tests cover:
- * - connect with primary-only URL
- * - connect with primary/fallback failover
+ * - connect with the configured API base URL
  * - push (send message)
  * - poll (receive messages)
  * - ack
- * - automatic failover on push/poll network failure
  * - error propagation on non-2xx responses
  * - not-connected guards
  *
@@ -38,12 +36,6 @@ const CONFIG = {
   agentId: 'agent-001',
   apiKey: 'sk_live_test_key',
   apiBaseUrl: 'https://api.signaldock.io',
-};
-
-/** Config with a fallback URL. */
-const CONFIG_WITH_FALLBACK = {
-  ...CONFIG,
-  apiBaseUrlFallback: 'https://api.clawmsgr.com',
 };
 
 // ============================================================================
@@ -77,70 +69,23 @@ describe('HttpTransport', () => {
   });
 
   // --------------------------------------------------------------------------
-  // connect — primary only
+  // connect
   // --------------------------------------------------------------------------
 
-  describe('connect (primary only)', () => {
-    it('connects without probing health when no fallback is configured', async () => {
+  describe('connect', () => {
+    it('connects without issuing any network request', async () => {
       await transport.connect(CONFIG);
       // No health probe issued — fetch should NOT have been called
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('uses primaryUrl as activeUrl when no fallback is provided', async () => {
+    it('uses the configured apiBaseUrl for subsequent requests', async () => {
       await transport.connect(CONFIG);
-      // Verify activeUrl is used by making a push
+      // Verify apiBaseUrl is used by making a push
       fetchMock.mockResolvedValue(mockResponse(200, { data: { message: { id: 'msg-1' } } }));
       await transport.push('to', 'content');
       const calledUrl = fetchMock.mock.calls[0][0] as string;
       expect(calledUrl).toContain('api.signaldock.io');
-    });
-  });
-
-  // --------------------------------------------------------------------------
-  // connect — failover
-  // --------------------------------------------------------------------------
-
-  describe('connect (primary/fallback failover)', () => {
-    it('stays on primary when both URLs are healthy', async () => {
-      fetchMock
-        .mockResolvedValueOnce(mockResponse(200, {})) // primary /health
-        .mockResolvedValueOnce(mockResponse(200, {})); // fallback /health
-
-      await transport.connect(CONFIG_WITH_FALLBACK);
-
-      // Push to verify activeUrl is primary
-      fetchMock.mockResolvedValueOnce(mockResponse(200, { data: { message: { id: 'p' } } }));
-      await transport.push('to', 'x');
-      const url = fetchMock.mock.calls[2][0] as string;
-      expect(url).toContain('api.signaldock.io');
-    });
-
-    it('switches to fallback when primary health check fails', async () => {
-      fetchMock
-        .mockRejectedValueOnce(new Error('primary unreachable')) // primary /health
-        .mockResolvedValueOnce(mockResponse(200, {})); // fallback /health
-
-      await transport.connect(CONFIG_WITH_FALLBACK);
-
-      // Push to verify activeUrl switched to fallback
-      fetchMock.mockResolvedValueOnce(mockResponse(200, { data: { message: { id: 'f' } } }));
-      await transport.push('to', 'x');
-      const url = fetchMock.mock.calls[2][0] as string;
-      expect(url).toContain('api.clawmsgr.com');
-    });
-
-    it('stays on primary when fallback health check fails', async () => {
-      fetchMock
-        .mockResolvedValueOnce(mockResponse(200, {})) // primary /health OK
-        .mockRejectedValueOnce(new Error('fallback unreachable')); // fallback /health fails
-
-      await transport.connect(CONFIG_WITH_FALLBACK);
-
-      fetchMock.mockResolvedValueOnce(mockResponse(200, { data: { message: { id: 'x' } } }));
-      await transport.push('to', 'x');
-      const url = fetchMock.mock.calls[2][0] as string;
-      expect(url).toContain('api.signaldock.io');
     });
   });
 
@@ -213,23 +158,10 @@ describe('HttpTransport', () => {
       await expect(transport.push('to', 'msg')).rejects.toThrow('push failed');
     });
 
-    it('falls back to alternateUrl on primary network error', async () => {
-      // First connect to fresh transport with fallback
-      const t = new HttpTransport();
-      fetchMock
-        .mockResolvedValueOnce(mockResponse(200, {})) // primary /health
-        .mockResolvedValueOnce(mockResponse(200, {})); // fallback /health
-      await t.connect(CONFIG_WITH_FALLBACK);
+    it('propagates network errors from fetch', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('network down'));
 
-      // Push: primary fetch fails, fallback succeeds
-      fetchMock
-        .mockRejectedValueOnce(new Error('primary down'))
-        .mockResolvedValueOnce(mockResponse(200, { data: { message: { id: 'fb-1' } } }));
-
-      const result = await t.push('to', 'msg');
-      expect(result.messageId).toBe('fb-1');
-
-      await t.disconnect();
+      await expect(transport.push('to', 'msg')).rejects.toThrow('network down');
     });
 
     it('throws when not connected', async () => {

--- a/packages/core/src/conduit/http-transport.ts
+++ b/packages/core/src/conduit/http-transport.ts
@@ -1,10 +1,8 @@
 /**
- * HttpTransport — HTTP polling transport with automatic failover.
+ * HttpTransport — HTTP polling transport against the SignalDock API.
  *
- * Tries the primary API URL (api.signaldock.io) first. If unreachable,
- * falls back to the legacy URL (api.clawmsgr.com). Failover is transparent
- * to callers — they see a single transport that always works if either
- * endpoint is up.
+ * Connects to the configured API base URL (api.signaldock.io) and exposes
+ * push/poll/ack over HTTP.
  *
  * @see docs/specs/SIGNALDOCK-UNIFIED-AGENT-REGISTRY.md Section 4.4
  * @task T177
@@ -16,42 +14,21 @@ import type { ConduitMessage, Transport, TransportConnectConfig } from '@cleocod
 interface HttpTransportState {
   agentId: string;
   apiKey: string;
-  primaryUrl: string;
-  fallbackUrl: string | null;
-  activeUrl: string;
+  apiBaseUrl: string;
   connected: boolean;
 }
 
-/** HTTP transport with automatic primary/fallback failover. */
+/** HTTP polling transport for the SignalDock messaging API. */
 export class HttpTransport implements Transport {
   readonly name = 'http';
   private state: HttpTransportState | null = null;
 
-  /** Connect to the SignalDock API, probing primary/fallback health when both are configured. */
+  /** Connect to the SignalDock API. */
   async connect(config: TransportConnectConfig): Promise<void> {
-    const primaryUrl = config.apiBaseUrl;
-    const fallbackUrl = config.apiBaseUrlFallback ?? null;
-
-    // Only probe health when there's a fallback to choose between
-    let activeUrl = primaryUrl;
-    if (fallbackUrl) {
-      const [primaryResult, fallbackResult] = await Promise.allSettled([
-        fetch(`${primaryUrl}/health`, { method: 'GET', signal: AbortSignal.timeout(5000) }),
-        fetch(`${fallbackUrl}/health`, { method: 'GET', signal: AbortSignal.timeout(5000) }),
-      ]);
-      const primaryOk = primaryResult.status === 'fulfilled' && primaryResult.value.ok;
-      const fallbackOk = fallbackResult.status === 'fulfilled' && fallbackResult.value.ok;
-      if (!primaryOk && fallbackOk) {
-        activeUrl = fallbackUrl;
-      }
-    }
-
     this.state = {
       agentId: config.agentId,
       apiKey: config.apiKey,
-      primaryUrl,
-      fallbackUrl,
-      activeUrl,
+      apiBaseUrl: config.apiBaseUrl,
       connected: true,
     };
   }
@@ -82,7 +59,7 @@ export class HttpTransport implements Transport {
       body['toAgentId'] = to;
     }
 
-    const response = await this.fetchWithFallback(path, {
+    const response = await this.fetch(path, {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify(body),
@@ -111,7 +88,7 @@ export class HttpTransport implements Transport {
     if (options?.limit) params.set('limit', String(options.limit));
     if (options?.since) params.set('since', options.since);
 
-    const response = await this.fetchWithFallback(`/messages/peek?${params}`, {
+    const response = await this.fetch(`/messages/peek?${params}`, {
       method: 'GET',
       headers: this.headers(),
     });
@@ -143,47 +120,18 @@ export class HttpTransport implements Transport {
   async ack(messageIds: string[]): Promise<void> {
     this.ensureConnected();
 
-    await this.fetchWithFallback('/messages/ack', {
+    await this.fetch('/messages/ack', {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify({ messageIds }),
     });
   }
 
-  /**
-   * Fetch with automatic failover. Tries activeUrl first.
-   * If it fails and a fallback exists, retries on the other URL
-   * and swaps activeUrl for subsequent calls.
-   */
-  private async fetchWithFallback(path: string, init: RequestInit): Promise<Response> {
+  /** Fetch against the configured API base URL with a 10s timeout. */
+  private async fetch(path: string, init: RequestInit): Promise<Response> {
     const timeout = AbortSignal.timeout(10000);
     const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout;
-    const url = `${this.state!.activeUrl}${path}`;
-
-    try {
-      return await fetch(url, { ...init, signal });
-    } catch (primaryErr) {
-      const otherUrl =
-        this.state!.activeUrl === this.state!.primaryUrl
-          ? this.state!.fallbackUrl
-          : this.state!.primaryUrl;
-
-      if (!otherUrl) throw primaryErr;
-
-      try {
-        const fallbackSignal = init.signal
-          ? AbortSignal.any([init.signal, AbortSignal.timeout(10000)])
-          : AbortSignal.timeout(10000);
-        const fallbackResponse = await fetch(`${otherUrl}${path}`, {
-          ...init,
-          signal: fallbackSignal,
-        });
-        this.state!.activeUrl = otherUrl;
-        return fallbackResponse;
-      } catch {
-        throw primaryErr;
-      }
-    }
+    return fetch(`${this.state!.apiBaseUrl}${path}`, { ...init, signal });
   }
 
   private headers(): Record<string, string> {

--- a/packages/lafs/.gitignore
+++ b/packages/lafs/.gitignore
@@ -5,8 +5,6 @@ coverage/
 .cleo/.cache/
 .cleo/*.lock
 .cleo/**/*.lock
-clawmsgr-*.json
-clawmsgr-agent.json
 
 # Python
 __pycache__/

--- a/scripts/register-agents-signaldock.sh
+++ b/scripts/register-agents-signaldock.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # T219: Register all 9 agents on api.signaldock.io
 # Creates signaldock-*.json config files in .cleo/
-# Both clawmsgr-*.json (legacy) and signaldock-*.json (canonical) coexist.
 set -euo pipefail
 
 API="https://api.signaldock.io"
@@ -37,14 +36,8 @@ print(d.get('data', {}).get('apiKey', 'FAILED'))
 " 2>/dev/null)
 
     if [ "${api_key}" = "FAILED" ]; then
-      echo "  WARN: Could not generate new key. Using existing clawmsgr key if available."
-      local clawmsgr_config="${CONFIG_DIR}/clawmsgr-${agent_id}.json"
-      if [ -f "${clawmsgr_config}" ]; then
-        api_key=$(python3 -c "import json; print(json.load(open('${clawmsgr_config}'))['apiKey'])")
-      else
-        echo "  ERROR: No key available for ${agent_id}"
-        return 1
-      fi
+      echo "  ERROR: Could not generate key for ${agent_id}"
+      return 1
     fi
   else
 


### PR DESCRIPTION
## Summary

Purges the legacy ClawMsgr integration (`api.clawmsgr.com`) from the cleocode repo per owner directive (T11658): "we DO NOT use clawmsgr anymore — super legacy. Nothing with clawmsgr is part of CLEO code anymore."

ClawMsgr was a legacy chat-relay backend that leaked into the Conduit transport layer as an HTTP fallback endpoint. The primary endpoint (`api.signaldock.io`) is canonical and unaffected.

## What changed

**Shipped code:**
- `packages/core/src/conduit/http-transport.ts` — removed the primary/fallback failover machinery that existed solely to support the `api.clawmsgr.com` fallback. `HttpTransport` now connects to the single configured `apiBaseUrl`. **The primary SignalDock HTTP transport is fully functional** (push/poll/ack against the configured base URL).
- `packages/contracts/src/agent-registry.ts` — dropped `TransportConfig.apiBaseUrlFallback` (only ever set to a ClawMsgr URL in a test, only read by the removed fallback path); fixed `apiBaseUrl` JSDoc.
- `packages/core/src/conduit/__tests__/{http-transport,factory}.test.ts` — removed the fallback/clawmsgr test cases and added a plain network-error-propagation test; suites stay green.
- `packages/cleo/src/dispatch/domains/conduit.ts` — dropped "standalone clawmsgr scripts" wording.
- `scripts/register-agents-signaldock.sh` — removed the clawmsgr-key fallback branch.
- `.gitignore` + `packages/lafs/.gitignore` — removed `clawmsgr-*.json` ignore lines.

**Docs:** cleaned source docs (`docs/concepts/CLEO-ARCHITECTURE-GUIDE.md`, `docs/specs/CANT-PERSONA-MVI-SPEC.md`, `docs/plans/PATH-TO-100-PERCENT-COMPLETION.md`, `docs/archive/{SIGNALDOCK-UNIFIED-AGENT-REGISTRY,CLEO-ORCH-PLAN}.md`) and the generated artifacts that derive from the `apiBaseUrl` JSDoc.

## Grep-clean proof

```
$ grep -rIn -i clawmsgr . --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.claude
CHANGELOG.md:9975: ... (8 historical release-log lines)
packages/core/migrations/drizzle-tasks/20260327000000_agent-credentials/migration.sql:3:-- Replaces loose clawmsgr-*.json config files.
```

Zero matches remain except the two explicitly permitted exceptions (CHANGELOG + frozen migration comment).

## Transport-still-works confirmation

`HttpTransport` retains full push/poll/ack/connect/disconnect behavior against the configured `apiBaseUrl`. The conduit test suite passes (131 passed, 32 todo) across two consecutive runs (deterministic). The `@cleocode/runtime` project tests pass (120 passed). Typecheck (`tsc -b`), `node build.mjs`, and `biome check` all pass clean.

## Frozen-migration decision

**Left untouched.** The clawmsgr reference at line 3 of `20260327000000_agent-credentials/migration.sql` is a comment. Drizzle's `readMigrationFiles` (`node_modules/drizzle-orm/migrator.js` line 19-28) reads the **entire** `.sql` file content and computes `createHash("sha256").update(query)` over it — comments included. Editing the comment would change the migration hash and orphan the journal entry on every already-migrated database. Per the task's frozen-migration guidance, the comment stays.

## Generated docs decision

Ran `pnpm run docs:build` (forge-ts). The committed `docs/generated` tree is significantly stale vs current source, so a full regeneration produced a ~650k-line diff of unrelated churn. To keep this PR scoped to the ClawMsgr purge, I reverted the regeneration and hand-stripped only the `legacy: api.clawmsgr.com` fragment from the 5 affected generated files (the surgical strip matches exactly what regeneration emits for this field). One of those (`docs/generated/packages/contracts/api/types.mdx`) is an orphaned subtree no current forge config regenerates. The forge CI job is `continue-on-error: true` / `|| true` (non-blocking, no commit-diff drift gate), so this introduces no drift failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)