### PR TITLE
chore(release): v2026.6.1 — installable patch + briefing-hang fix + ClawMsgr purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2026.6.1] (2026-06-03)
+
+### Added
+
+
+
+### Changed
+
+- Remove legacy ClawMsgr integration — drop api.clawmsgr.com Conduit transport fallback + all refs. _(provenance: [T11658](https://github.com/kryptobaseddev/cleo/search?q=T11658&type=commits))_
+
+### Fixed
+
+- Fix v2026.6.0 uninstallable — move private @cleocode/utils to devDependencies in cleo+core (it is esbuild-inlined, not a runtime dep). _(provenance: [T11654](https://github.com/kryptobaseddev/cleo/search?q=T11654&type=commits))_
+- Tear down EmbeddingQueue worker in shutdownCliRuntime + gate opportunistic dream off one-shot CLI — fixes briefing spin/WAL-bloat. _(provenance: [T11655](https://github.com/kryptobaseddev/cleo/search?q=T11655&type=commits))_
+
+### Deprecated
+
+
+
+### Removed
+
+
+
+### Security
+
+
+
+### BREAKING CHANGES
+
 ## [2026.6.0] (2026-06-03)
 
 ### Added


### PR DESCRIPTION
Patch release **v2026.6.1**. Fixes the v2026.6.0 install defect + the briefing hang + removes legacy ClawMsgr.

- **T11654** — v2026.6.0 was published but UNINSTALLABLE (`@cleocode/cleo`+`@cleocode/core` declared the private, esbuild-inlined `@cleocode/utils` as a runtime dep → `npm i -g` hit `404 @cleocode/utils@2026.5.122`). Moved utils→devDependencies in both + narrowed the build.mjs esbuild re-emit (keeps utils inlined; dist 28.85MB/40MB). npm-pack proof: utils no longer in any published `dependencies`. #939
- **T11655** — briefing spin/WAL-bloat: `shutdownCliRuntime` now tears down the EmbeddingQueue worker (the 2nd MessagePort #914 missed); opportunistic dream gated off one-shot reads. #939
- **T11658** — purge legacy ClawMsgr (drop `api.clawmsgr.com` Conduit transport fallback + all refs). #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)