### PR TITLE
feat(T11745): migrate LLM consumers onto the single ModelRunner chokepoint (E9)

### DIFF
--- a/packages/cleo/src/cli/commands/llm-stream.ts
+++ b/packages/cleo/src/cli/commands/llm-stream.ts
@@ -34,19 +34,13 @@ async function buildSession(
   provider: ModelTransport,
   model: string,
 ): Promise<import('@cleocode/contracts/llm/interfaces.js').LlmSession> {
-  const [
-    { resolveCredentials },
-    { ConcreteSession },
-    { AnthropicTransport },
-    { ChatCompletionsTransport },
-    { GeminiTransport },
-  ] = await Promise.all([
-    import(/* webpackIgnore: true */ '@cleocode/core/llm/credentials.js'),
-    import(/* webpackIgnore: true */ '@cleocode/core/llm/concrete-session.js'),
-    import(/* webpackIgnore: true */ '@cleocode/core/llm/transports/anthropic.js'),
-    import(/* webpackIgnore: true */ '@cleocode/core/llm/transports/chat-completions.js'),
-    import(/* webpackIgnore: true */ '@cleocode/core/llm/transports/gemini.js'),
-  ]);
+  const [{ resolveCredentials }, { ConcreteSession }, { ModelRunner }, { deriveApiWire }] =
+    await Promise.all([
+      import(/* webpackIgnore: true */ '@cleocode/core/llm/credentials.js'),
+      import(/* webpackIgnore: true */ '@cleocode/core/llm/concrete-session.js'),
+      import(/* webpackIgnore: true */ '@cleocode/core/llm/model-runner.js'),
+      import(/* webpackIgnore: true */ '@cleocode/core/llm/api-mode.js'),
+    ]);
 
   const cred = resolveCredentials(provider);
   if (!cred.apiKey) {
@@ -56,18 +50,11 @@ async function buildSession(
     );
   }
 
-  let transport: import('@cleocode/contracts/llm/normalized-response.js').LlmTransport;
-  if (provider === 'anthropic') {
-    transport =
-      cred.authType === 'oauth'
-        ? new AnthropicTransport({ authToken: cred.apiKey })
-        : new AnthropicTransport({ apiKey: cred.apiKey });
-  } else if (provider === 'gemini') {
-    transport = new GeminiTransport({ apiKey: cred.apiKey });
-  } else {
-    transport = new ChatCompletionsTransport({ provider, apiKey: cred.apiKey });
-  }
-
+  // Single SSoT transport construction (E9 · T11745): deriveApiWire stamps the
+  // wire protocol + base URL; the one ModelRunner builds the transport for ANY
+  // provider (anthropic incl. the OAuth beta header, gemini, OpenAI-compat) —
+  // no per-provider branching here.
+  const wire = deriveApiWire(provider, cred.authType);
   const resolvedCredential: import('@cleocode/contracts/llm/resolved-credential.js').ResolvedCredential =
     {
       provider,
@@ -77,9 +64,15 @@ async function buildSession(
       expiresAt: null,
       refreshToken: null,
       extraHeaders: {},
-      baseUrl: null,
+      baseUrl: wire.baseUrl,
       awsProfile: null,
     };
+
+  const transport = ModelRunner.buildTransportFromCredential(
+    provider,
+    resolvedCredential,
+    wire.apiMode,
+  );
 
   return new ConcreteSession({ transport, model, credential: resolvedCredential });
 }

--- a/packages/core/src/llm/auxiliary-fallback.ts
+++ b/packages/core/src/llm/auxiliary-fallback.ts
@@ -20,10 +20,10 @@
 
 import type { SendOptions } from '@cleocode/contracts/llm/interfaces.js';
 import type {
-  LlmTransport,
   NormalizedResponse,
   TransportMessage,
 } from '@cleocode/contracts/llm/normalized-response.js';
+import type { ResolvedCredential } from '@cleocode/contracts/llm/resolved-credential.js';
 import { PoolExhaustedError } from './credential-pool.js';
 import { classifyError } from './error-classifier.js';
 import type { ModelTransport } from './types-config.js';
@@ -380,14 +380,11 @@ async function _defaultAuxiliaryProvider(
   // If no credential exists for this provider, the factory will throw and the
   // outer loop will catch it as a pool-exhaustion signal.
   //
-  // We synthesise a temporary session by using the contracts layer directly:
-  // import the transport factory helpers from session-factory internals via
-  // the concrete-session constructor pattern used in role-executor.
-  const { AnthropicTransport } = await import('./transports/anthropic.js');
-  const { ChatCompletionsTransport } = await import('./transports/chat-completions.js');
-  const { GeminiTransport } = await import('./transports/gemini.js');
+  // We synthesise a temporary session via the single SSoT transport factory.
   const { resolveCredentials } = await import('./credentials.js');
   const { ConcreteSession } = await import('./concrete-session.js');
+  const { ModelRunner } = await import('./model-runner.js');
+  const { deriveApiWire } = await import('./api-mode.js');
 
   const credResult = await resolveCredentials(targetProvider, {});
   if (!credResult.apiKey) {
@@ -395,41 +392,36 @@ async function _defaultAuxiliaryProvider(
     throw new PoolExhaustedError(targetProvider, 0, 0);
   }
 
-  let transport: LlmTransport;
-  if (targetProvider === 'anthropic') {
-    transport =
-      credResult.authType === 'oauth'
-        ? new AnthropicTransport({ authToken: credResult.apiKey })
-        : new AnthropicTransport({ apiKey: credResult.apiKey });
-  } else if (targetProvider === 'gemini') {
-    transport = new GeminiTransport({ apiKey: credResult.apiKey });
-  } else {
-    const defaultHeaders: Record<string, string> = {};
-    if (credResult.authType === 'oauth') {
-      defaultHeaders['Authorization'] = `Bearer ${credResult.apiKey}`;
-    }
-    transport = new ChatCompletionsTransport({
-      provider: targetProvider,
-      apiKey: credResult.apiKey,
-      ...(Object.keys(defaultHeaders).length ? { defaultHeaders } : {}),
-    });
-  }
+  // Single SSoT transport construction (E9 · T11745): `deriveApiWire` stamps the
+  // wire protocol + implied base URL; the one {@link ModelRunner} builds the
+  // transport for ANY provider. This replaces the inline anthropic/gemini/
+  // openai-compat branches that had drifted from `session-factory` — notably the
+  // anthropic-OAuth branch here OMITTED the required `anthropic-beta` header,
+  // which the ModelRunner now injects centrally.
+  const authType: 'api_key' | 'oauth' = credResult.authType === 'oauth' ? 'oauth' : 'api_key';
+  const wire = deriveApiWire(targetProvider, authType);
+  const resolvedCredential: ResolvedCredential = {
+    provider: targetProvider,
+    label: 'fallback',
+    token: credResult.apiKey,
+    authType,
+    expiresAt: null,
+    refreshToken: null,
+    extraHeaders: {},
+    baseUrl: wire.baseUrl,
+    awsProfile: null,
+  };
+  const transport = ModelRunner.buildTransportFromCredential(
+    targetProvider,
+    resolvedCredential,
+    wire.apiMode,
+  );
 
   const model = entry.model ?? resolved.model;
   const session = new ConcreteSession({
     transport,
     model,
-    credential: {
-      provider: targetProvider,
-      label: 'fallback',
-      token: credResult.apiKey,
-      authType: credResult.authType === 'oauth' ? 'oauth' : 'api_key',
-      expiresAt: null,
-      refreshToken: null,
-      extraHeaders: {},
-      baseUrl: null,
-      awsProfile: null,
-    },
+    credential: resolvedCredential,
   });
 
   return session.send(messages, opts);

--- a/packages/core/src/llm/model-runner.ts
+++ b/packages/core/src/llm/model-runner.ts
@@ -58,6 +58,22 @@ const logger = getLogger('llm-model-runner');
 /** Kimi Code chat endpoint — speaks the Anthropic Messages protocol. */
 const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding';
 
+/**
+ * Anthropic OAuth opt-in header. A `sk-ant-oat-` / `sk-ant-ort-` OAuth token is
+ * REJECTED by the Anthropic API unless the request carries
+ * `anthropic-beta: oauth-2025-04-20`. Centralising it here — the single SSoT
+ * transport factory — means EVERY resolver-path caller (session-factory, api,
+ * tool-loop, role-executor, auxiliary-fallback) inherits it automatically,
+ * instead of each call-site re-declaring it (role-executor hardcoded it; the
+ * session-factory / auxiliary-fallback paths OMITTED it → latent OAuth 401s).
+ * The SDK auto-sets `anthropic-version`, so only the beta opt-in is needed here.
+ *
+ * @task T11745
+ */
+const ANTHROPIC_OAUTH_HEADERS: Readonly<Record<string, string>> = {
+  'anthropic-beta': 'oauth-2025-04-20',
+};
+
 /** Ollama's OpenAI-compatible `/v1` shim base URL (Vercel `LanguageModel` path). */
 const OLLAMA_OPENAI_COMPAT_BASE_URL = 'http://localhost:11434/v1';
 
@@ -180,9 +196,9 @@ export const ModelRunner = {
           ? {
               authToken: credential.token,
               baseUrl: credential.baseUrl ?? undefined,
-              defaultHeaders: Object.keys(credential.extraHeaders).length
-                ? credential.extraHeaders
-                : undefined,
+              // OAuth REQUIRES the beta opt-in header. The canonical header is
+              // the default; a caller's own extraHeaders override it if set.
+              defaultHeaders: { ...ANTHROPIC_OAUTH_HEADERS, ...credential.extraHeaders },
             }
           : {
               apiKey: credential.token,

--- a/packages/core/src/llm/role-executor.ts
+++ b/packages/core/src/llm/role-executor.ts
@@ -7,11 +7,12 @@
  *
  *   1. {@link resolveLLMForRole}(role) — picks provider + model + credential
  *      from the standard config chain (roles → default → daemon → fallback).
- *   2. Selects the correct transport based on the resolved provider:
- *        - `'anthropic'` → {@link AnthropicTransport} (anthropic_messages mode)
- *        - everything else → {@link ChatCompletionsTransport} (OpenAI-compat)
- *   3. Maps `cred.authType` to the right SDK auth slot (`apiKey` vs
- *      `authToken` for Anthropic OAuth; Bearer header for OpenAI-compat OAuth).
+ *   2. {@link deriveApiWire}(provider, authType) — stamps the wire protocol +
+ *      implied base URL for the resolved pair (E9 · T11745).
+ *   3. {@link ModelRunner.buildTransportFromCredential} — the single SSoT
+ *      factory builds the exact transport for ANY provider (anthropic incl. the
+ *      OAuth beta header, kimi-code, openai-OAuth/codex, OpenAI-compat) from the
+ *      descriptor data alone — no per-provider branching here.
  *
  * Replaces the hardcoded `fetch('https://api.anthropic.com/v1/messages')`
  * in {@link memory/sleep-consolidation.ts} and {@link memory/observer-reflector.ts}
@@ -35,18 +36,13 @@ import type {
   TransportRequest,
 } from '@cleocode/contracts/llm/normalized-response.js';
 import type { ResolvedCredential } from '@cleocode/contracts/llm/resolved-credential.js';
+import { deriveApiWire } from './api-mode.js';
 import { CredentialPool } from './credential-pool.js';
 import { classifyError } from './error-classifier.js';
 import { ModelRunner } from './model-runner.js';
-import { getKimiCodeMshHeaders, isKimiCodeApiKey } from './provider-registry/builtin/kimi-code.js';
+import { isKimiCodeApiKey } from './provider-registry/builtin/kimi-code.js';
 import { resolveLLMForRole } from './role-resolver.js';
-import { AnthropicTransport } from './transports/anthropic.js';
-import { ChatCompletionsTransport } from './transports/chat-completions.js';
-import { CODEX_OAUTH_BASE_URL } from './transports/codex-oauth-headers.js';
 import type { ModelTransport } from './types-config.js';
-
-/** Kimi Code chat endpoint — speaks Anthropic Messages protocol. */
-const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding';
 
 /**
  * Process-lifetime latch set of `role|provider|label` keys that have already
@@ -178,105 +174,49 @@ export async function executeForRole(
   };
 
   try {
-    if (llm.provider === 'anthropic') {
-      // Anthropic supports two auth schemes — API key vs OAuth bearer.
-      // Pass the credential through the matching SDK slot so the SDK sends
-      // exactly one auth header (avoid x-api-key + Authorization collision).
-      const transport =
-        llm.credential.authType === 'oauth'
-          ? new AnthropicTransport({
-              authToken: llm.credential.apiKey,
-              defaultHeaders: {
-                'anthropic-beta': 'oauth-2025-04-20',
-              },
-            })
-          : new AnthropicTransport({ apiKey: llm.credential.apiKey });
+    // Single SSoT transport construction (E9 · T11745). The resolver gives us
+    // (provider, authType); `deriveApiWire` stamps the wire protocol + implied
+    // base URL; the one {@link ModelRunner} builds the exact transport for ANY
+    // provider — anthropic (incl. the OAuth beta header), kimi-code (Anthropic
+    // protocol + mandatory X-Msh headers), openai-OAuth/codex (codex_responses +
+    // ChatGPT-backend Cloudflare headers), or OpenAI-compatible chat_completions
+    // — with NO per-provider branching here. This replaces the four inline
+    // transport blocks that had each drifted from `session-factory` (the
+    // anthropic block hardcoded the OAuth beta header; the others omitted it).
+    const authType: 'api_key' | 'oauth' = llm.credential.authType === 'oauth' ? 'oauth' : 'api_key';
 
-      const resp = await transport.complete(request);
-      return {
-        content: resp.content ?? '',
-        usage: resp.usage,
-        provider: llm.provider,
-        model: resp.model,
-      };
-    }
-
-    if (llm.provider === 'kimi-code') {
-      // Kimi Code speaks Anthropic Messages protocol against
-      // api.kimi.com/coding. Both `sk-kimi-*` API keys and OAuth bearer
-      // tokens authenticate via `Authorization: Bearer …` — the legacy
-      // Moonshot `mk-*` API-key path lives on the separate `moonshot`
-      // provider, not here. Mandatory `X-Msh-*` headers are merged in.
-      // (Defensive: also check the key prefix in case a misconfigured key
-      // routed to kimi-code despite being a legacy moonshot key.)
-      if (!isKimiCodeApiKey(llm.credential.apiKey) && llm.credential.authType !== 'oauth') {
-        console.warn(
-          `[role-executor] kimi-code credential is not sk-kimi- prefixed and not OAuth; ` +
-            `the request may fail. Configure a coding-plan key from kimi.com/code or ` +
-            `switch the provider to 'moonshot' for legacy mk- keys.`,
-        );
-      }
-      const transport = new AnthropicTransport({
-        authToken: llm.credential.apiKey,
-        baseUrl: KIMI_CODE_BASE_URL,
-        defaultHeaders: getKimiCodeMshHeaders(),
-      });
-      const resp = await transport.complete(request);
-      return {
-        content: resp.content ?? '',
-        usage: resp.usage,
-        provider: llm.provider,
-        model: resp.model,
-      };
-    }
-
-    if (llm.provider === 'openai' && llm.credential.authType === 'oauth') {
-      // OpenAI Codex OAuth path. A ChatGPT-issued OAuth bearer token is NOT
-      // accepted at `api.openai.com`; it authenticates against the Codex
-      // backend (`chatgpt.com/backend-api/codex`) via the Responses API, with
-      // the Cloudflare-bypass headers hermes-agent documented (originator +
-      // ChatGPT-Account-ID). This is the branch the RCA found missing — it lets
-      // a background role be fulfilled by the live `openai/codex-cli` OAuth
-      // credential in the pool. (api_key OpenAI keeps the chat_completions
-      // path below.)
-      //
-      // Transport construction is delegated to the single SSoT factory
-      // (E9 · T11745): a `codex_responses` apiMode + a credential carrying the
-      // ChatGPT-backend `baseUrl` reproduces the exact transport this block
-      // used to build inline. The OAuth Cloudflare headers are added by the
-      // ModelRunner codex branch for `authType: 'oauth'`.
-      const codexCredential: ResolvedCredential = {
-        provider: llm.provider,
-        label: llm.credentialLabel ?? 'default',
-        token: llm.credential.apiKey,
-        authType: 'oauth',
-        expiresAt: null,
-        refreshToken: null,
-        extraHeaders: {},
-        baseUrl: CODEX_OAUTH_BASE_URL,
-        awsProfile: null,
-      };
-      const transport = ModelRunner.buildTransportFromCredential(
-        llm.provider,
-        codexCredential,
-        'codex_responses',
+    // Diagnostic (preserved): a non-`sk-kimi-`, non-OAuth key routed to
+    // kimi-code will likely fail — the legacy Moonshot `mk-*` path lives on the
+    // separate `moonshot` provider.
+    if (
+      llm.provider === 'kimi-code' &&
+      authType !== 'oauth' &&
+      !isKimiCodeApiKey(llm.credential.apiKey)
+    ) {
+      console.warn(
+        `[role-executor] kimi-code credential is not sk-kimi- prefixed and not OAuth; ` +
+          `the request may fail. Configure a coding-plan key from kimi.com/code or ` +
+          `switch the provider to 'moonshot' for legacy mk- keys.`,
       );
-      const resp = await transport.complete(request);
-      return {
-        content: resp.content ?? '',
-        usage: resp.usage,
-        provider: llm.provider,
-        model: resp.model,
-      };
     }
 
-    // openai (api_key) / openrouter / deepseek / xai / groq / moonshot /
-    // gemini-via-shim — all speak OpenAI chat_completions. ChatCompletionsTransport
-    // routes through the OpenAI SDK which sets Authorization: Bearer from apiKey.
-    const transport = new ChatCompletionsTransport({
+    const wire = deriveApiWire(llm.provider, authType);
+    const resolvedCredential: ResolvedCredential = {
       provider: llm.provider,
-      apiKey: llm.credential.apiKey,
-    });
+      label: llm.credentialLabel ?? 'default',
+      token: llm.credential.apiKey,
+      authType,
+      expiresAt: null,
+      refreshToken: null,
+      extraHeaders: {},
+      baseUrl: wire.baseUrl,
+      awsProfile: null,
+    };
+    const transport = ModelRunner.buildTransportFromCredential(
+      llm.provider,
+      resolvedCredential,
+      wire.apiMode,
+    );
     const resp = await transport.complete(request);
     return {
       content: resp.content ?? '',


### PR DESCRIPTION
## What
Lands the **SSoT consumer migrations** on top of PR #954's `ModelRunner`. Collapses the remaining inline transport-construction sites onto the single chokepoint and, in doing so, fixes a latent Anthropic-OAuth header bug.

## The latent bug this fixes
`AnthropicTransport` does not inject the `anthropic-beta: oauth-2025-04-20` opt-in header itself — the caller must supply it. The session-factory family built the OAuth transport from a `ResolvedCredential` with `extraHeaders: {}` (see `session-factory.credentialResultToResolved`), so **Anthropic OAuth requests via session-factory / auxiliary-fallback silently omitted the required beta header**. Only role-executor hardcoded it. This PR centralizes the header in `ModelRunner` (`ANTHROPIC_OAUTH_HEADERS`), so every resolver-path caller now gets it correctly.

## Changes
| File | Change |
|------|--------|
| `model-runner.ts` | anthropic-OAuth branch injects the canonical beta header (caller `extraHeaders` still override). |
| `role-executor.ts` | 4 inline branches (anthropic/kimi/codex/openai-compat) → one `deriveApiWire` + `ModelRunner.buildTransportFromCredential` call (−93 LOC). kimi misconfig diagnostic preserved. |
| `auxiliary-fallback.ts` | anthropic/gemini/openai-compat branches → one ModelRunner call; `resolvedCredential` reused for the `ConcreteSession`. |
| `llm-stream.ts` (CLI) | same collapse; drops 3 transport dynamic-imports. |

Net **−60 lines**; removes the per-call-site divergence that Gate 13 (T11783, PR #956) locks.

## Validation
- `pnpm run build` → green (exit 0).
- `pnpm --filter @cleocode/core exec vitest run src/llm` → **955 tests pass (61 files)**.
- Behavior-equivalent: codex (`codex_responses` + ChatGPT-backend headers), kimi-code (Anthropic protocol + X-Msh headers), and OpenAI-compat all route through ModelRunner exactly as before; anthropic-OAuth now *additionally* carries the beta header (the fix).

## Relationship
- Builds on #954 (T11745 SSoT foundation).
- Lowers the #956 (Gate 13) transport-construction + ai-sdk baselines — both PRs are independent (Gate 13 baseline mode passes on a count *decrease*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)