### PR TITLE
fix(T11809): exodus verify applies source-side coercion (hashMatch on equal data) + real-data nexus/signaldock audit

### DIFF
--- a/packages/core/src/store/__tests__/exodus-verify-source-coercion.test.ts
+++ b/packages/core/src/store/__tests__/exodus-verify-source-coercion.test.ts
@@ -1,0 +1,388 @@
+/**
+ * AC2 regression guard — `verifyMigration` digests the SOURCE side through the
+ * SAME value transforms `runExodusMigrate` applied, so equal logical data
+ * digests EQUAL (`hashMatch === true`) on a coerced column (T11809).
+ *
+ * ## The bug this proves fixed
+ *
+ * The migration TRANSFORMS source values before they land in the consolidated
+ * `cleo.db`: epoch-INTEGER timestamps → ISO-8601 TEXT (for ISO-GLOB target
+ * columns), legacy enum aliases → canonical members, `Inf`/`-Inf`/`NaN` →
+ * finite. Before T11809 the parity verifier digested the RAW source value
+ * (integer `1717200000`) against the TRANSFORMED target value (ISO
+ * `'2024-06-01T…'`), so every coerced column reported `hashMatch === false`
+ * even on a perfectly lossless migration. That false-negative aborted the
+ * exodus cutover and lost the writes accumulated during the migrating open —
+ * the exact mechanism behind the reported nexus/signaldock "row drop".
+ *
+ * ## What this test asserts
+ *
+ *   (a) A source table with BOTH an epoch-INTEGER column mapped to an ISO-GLOB
+ *       target AND a legacy enum-drift column migrates with
+ *       `rowsCopied === sourceCount` (zero deficit — AC1).
+ *   (b) `verifyMigration` returns `ok === true` AND `hashMatch === true` for
+ *       that equal data — the digest now reflects the canonical (transformed)
+ *       values on both sides (AC2).
+ *
+ * @task T11809 (exodus verify applies source-side coercion — hashMatch on equal data)
+ * @epic T11249 (E6)
+ * @saga T11242
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync as DatabaseSyncType } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExodusPlan, LegacyDbDescriptor } from '../exodus/types.js';
+import { verifyMigration } from '../exodus/verify-migration.js';
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (
+    path: string,
+    options?: { readOnly?: boolean; open?: boolean },
+  ) => DatabaseSyncType;
+};
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// runExodusMigrate (FIX D) opens the TARGET DBs on a dedicated connection via
+// openDualScopeDbAtPath — wire it to the pre-built fixture handles.
+vi.mock('../dual-scope-db.js', () => ({
+  openDualScopeDb: vi.fn(),
+  openDualScopeDbAtPath: vi.fn(),
+  resolveDualScopeDbPath: vi.fn(),
+}));
+
+/** ISO-8601 GLOB pattern the production CHECK constraints use (T11363). */
+const ISO_GLOB = "'[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'";
+
+const SOURCE_ROWS = 24;
+
+/**
+ * Seed a legacy `tasks.db` whose `architecture_decisions` table carries BOTH:
+ *   - `decided_at` epoch-INTEGER (seconds + milliseconds mixed) → an ISO-GLOB
+ *     `decided_at` target column (the exact real nexus/signaldock coercion shape
+ *     — epoch INTEGER → ISO TEXT), and
+ *   - `status` already-CANONICAL enum values that the consolidated CHECK accepts
+ *     verbatim. They are present to prove the enum-normalize code path does not
+ *     break the source-side digest, NOT to exercise enum DRIFT (which is a
+ *     separate, pre-existing diagnostic gate orthogonal to the AC2 hashMatch
+ *     coercion this test targets).
+ */
+function buildSource(path: string): void {
+  const db = new DatabaseSync(path);
+  try {
+    db.exec(
+      `CREATE TABLE "architecture_decisions" (id INTEGER PRIMARY KEY, status TEXT, decided_at INTEGER)`,
+    );
+    // All canonical members of the target CHECK enum — no drift.
+    const statuses = ['accepted', 'proposed', 'superseded', 'deprecated'];
+    for (let i = 1; i <= SOURCE_ROWS; i++) {
+      const s = statuses[i % statuses.length];
+      // Alternate seconds (≈1.7e9) and milliseconds (≈1.7e12) so the per-row
+      // magnitude heuristic is exercised on both branches.
+      const epoch = i % 2 === 0 ? 1_717_200_000 + i : 1_717_200_000_000 + i * 1000;
+      db.exec(`INSERT INTO "architecture_decisions" VALUES (${i}, '${s}', ${epoch})`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Build the consolidated TARGET with the REAL CHECK + ISO-GLOB constraints the
+ * production `tasks_architecture_decisions` declares.
+ */
+function buildTarget(projectPath: string, globalPath: string): void {
+  const db = new DatabaseSync(projectPath);
+  try {
+    db.exec(
+      `CREATE TABLE "tasks_architecture_decisions" (
+        id INTEGER PRIMARY KEY,
+        status TEXT CHECK ("status" IN ('accepted', 'proposed', 'superseded', 'deprecated')),
+        decided_at TEXT CHECK ("decided_at" IS NULL OR "decided_at" GLOB ${ISO_GLOB})
+      )`,
+    );
+  } finally {
+    db.close();
+  }
+  new DatabaseSync(globalPath).close();
+}
+
+/**
+ * Seed a legacy `tasks.db` whose `architecture_decisions` carries BOTH an
+ * epoch-INTEGER `decided_at` (→ ISO-GLOB target) AND a `status` column with
+ * legacy enum DRIFT aliases (`'Accepted'`/`'ACCEPTED'`/`'approved'`) that the
+ * migration NORMALISES to `'accepted'`. Exercises the AC1 invariant
+ * (`rowsCopied === sourceCount` despite both coercion classes) + the AC2
+ * hashMatch on the coerced+normalized column.
+ */
+function buildDriftSource(path: string): void {
+  const db = new DatabaseSync(path);
+  try {
+    db.exec(
+      `CREATE TABLE "architecture_decisions" (id INTEGER PRIMARY KEY, status TEXT, decided_at INTEGER)`,
+    );
+    const statuses = ['accepted', 'Accepted', 'ACCEPTED', 'approved', 'proposed', 'superseded'];
+    for (let i = 1; i <= SOURCE_ROWS; i++) {
+      const s = statuses[i % statuses.length];
+      const epoch = i % 2 === 0 ? 1_717_200_000 + i : 1_717_200_000_000 + i * 1000;
+      db.exec(`INSERT INTO "architecture_decisions" VALUES (${i}, '${s}', ${epoch})`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+describe('exodus verify source-side coercion (T11809 · AC2)', () => {
+  let tmpDir: string;
+  let stagingDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cleo-exodus-coercion-'));
+    stagingDir = join(tmpDir, 'staging');
+    mkdirSync(stagingDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('epoch-coerced table: rowsCopied==sourceCount (AC1) AND verify hashMatch=true (AC2)', async () => {
+    const tasksDbPath = join(tmpDir, 'tasks.db');
+    const projectDbPath = join(tmpDir, 'cleo-project.db');
+    const globalDbPath = join(tmpDir, 'cleo-global.db');
+    buildSource(tasksDbPath);
+    buildTarget(projectDbPath, globalDbPath);
+
+    const projectDb = new DatabaseSync(projectDbPath);
+    const globalDb = new DatabaseSync(globalDbPath);
+    const makeFakeHandle = (native: DatabaseSyncType) => ({
+      db: { $client: native },
+      close: () => {
+        /* keep open for assertions */
+      },
+    });
+
+    const dualScope = await import('../dual-scope-db.js');
+    vi.mocked(dualScope.openDualScopeDbAtPath).mockImplementation(
+      (scope: string, dbPath: string) => {
+        const native = dbPath === globalDbPath || scope === 'global' ? globalDb : projectDb;
+        return Promise.resolve(makeFakeHandle(native) as never);
+      },
+    );
+    vi.mocked(dualScope.resolveDualScopeDbPath).mockImplementation((scope: string) =>
+      scope === 'project' ? projectDbPath : globalDbPath,
+    );
+
+    const { runExodusMigrate } = await import('../exodus/migrate.js');
+
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'tasks', path: tasksDbPath, targetScope: 'project' },
+    ];
+    const plan: ExodusPlan = {
+      sources,
+      totalSourceBytes: 0,
+      availableBytes: 100_000_000,
+      diskPreflight: true,
+      stagingDir,
+      resumeFromStaging: false,
+      projectDbPath,
+      globalDbPath,
+    };
+
+    const migrateResult = await runExodusMigrate(plan, false, undefined);
+    expect(migrateResult.ok, migrateResult.error ?? '').toBe(true);
+
+    // AC1: zero deficit — every source row landed despite epoch + enum coercion.
+    const decisions = migrateResult.tables.find(
+      (t) => t.sourceDb === 'tasks' && t.tableName === 'architecture_decisions',
+    );
+    expect(decisions, 'architecture_decisions copy result missing').toBeDefined();
+    expect(decisions?.skipped).toBe(false);
+    expect(decisions?.reason, 'no row-drop reason expected').toBeUndefined();
+    expect(decisions?.rowsCopied).toBe(SOURCE_ROWS);
+
+    const targetCount = (
+      projectDb.prepare(`SELECT COUNT(*) AS c FROM "tasks_architecture_decisions"`).get() as {
+        c: number;
+      }
+    ).c;
+    expect(targetCount).toBe(SOURCE_ROWS);
+
+    // AC2: verify confirms ok AND hashMatch=true — the source digest now reflects
+    // the SAME canonical (epoch→ISO, enum-normalized) values the target stores.
+    const verify = verifyMigration(sources, projectDbPath, globalDbPath);
+    expect(verify.ok, verify.error ?? '').toBe(true);
+    expect(verify.enumDrift).toHaveLength(0);
+
+    const entry = verify.tables.find((t) => t.targetTable === 'tasks_architecture_decisions');
+    expect(entry, 'verify entry for tasks_architecture_decisions missing').toBeDefined();
+    expect(entry?.sourceCount).toBe(SOURCE_ROWS);
+    expect(entry?.targetCount).toBe(SOURCE_ROWS);
+    expect(entry?.countMatch, 'count parity').toBe(true);
+    // The crux of T11809: BEFORE the fix this was FALSE (raw epoch/enum source vs
+    // coerced target). AFTER the fix the source is digested through the same
+    // transforms, so equal data digests equal.
+    expect(entry?.hashMatch, 'hashMatch on equal coerced data').toBe(true);
+
+    projectDb.close();
+    globalDb.close();
+  });
+
+  it('a GENUINE content drift on a coerced column still fails hashMatch (no over-masking)', async () => {
+    // Same fixture, but corrupt ONE target enum value AFTER migration so the
+    // canonical values genuinely diverge. The source-side transform must NOT
+    // mask a real content difference.
+    const tasksDbPath = join(tmpDir, 'tasks.db');
+    const projectDbPath = join(tmpDir, 'cleo-project.db');
+    const globalDbPath = join(tmpDir, 'cleo-global.db');
+    buildSource(tasksDbPath);
+    buildTarget(projectDbPath, globalDbPath);
+
+    const projectDb = new DatabaseSync(projectDbPath);
+    const globalDb = new DatabaseSync(globalDbPath);
+    const makeFakeHandle = (native: DatabaseSyncType) => ({
+      db: { $client: native },
+      close: () => {
+        /* keep open */
+      },
+    });
+    const dualScope = await import('../dual-scope-db.js');
+    vi.mocked(dualScope.openDualScopeDbAtPath).mockImplementation(
+      (scope: string, dbPath: string) => {
+        const native = dbPath === globalDbPath || scope === 'global' ? globalDb : projectDb;
+        return Promise.resolve(makeFakeHandle(native) as never);
+      },
+    );
+    vi.mocked(dualScope.resolveDualScopeDbPath).mockImplementation((scope: string) =>
+      scope === 'project' ? projectDbPath : globalDbPath,
+    );
+
+    const { runExodusMigrate } = await import('../exodus/migrate.js');
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'tasks', path: tasksDbPath, targetScope: 'project' },
+    ];
+    const plan: ExodusPlan = {
+      sources,
+      totalSourceBytes: 0,
+      availableBytes: 100_000_000,
+      diskPreflight: true,
+      stagingDir,
+      resumeFromStaging: false,
+      projectDbPath,
+      globalDbPath,
+    };
+    const migrateResult = await runExodusMigrate(plan, false, undefined);
+    expect(migrateResult.ok, migrateResult.error ?? '').toBe(true);
+
+    // Corrupt one target row's status to a DIFFERENT canonical value (still
+    // passes the CHECK) so the content genuinely differs from the source.
+    projectDb.exec(`UPDATE "tasks_architecture_decisions" SET status = 'deprecated' WHERE id = 1`);
+
+    const verify = verifyMigration(sources, projectDbPath, globalDbPath);
+    const entry = verify.tables.find((t) => t.targetTable === 'tasks_architecture_decisions');
+    expect(entry?.countMatch).toBe(true);
+    // Genuine content drift on a coerced column is NOT masked by the transform.
+    expect(entry?.hashMatch).toBe(false);
+    expect(verify.ok).toBe(false);
+
+    projectDb.close();
+    globalDb.close();
+  });
+
+  it('epoch + ENUM-DRIFT column: rowsCopied==sourceCount (AC1) AND coerced+normalized hashMatch=true (AC2)', async () => {
+    // Source carries BOTH an epoch-INTEGER column (→ ISO-GLOB target) AND legacy
+    // enum DRIFT aliases ('Accepted'/'ACCEPTED'/'approved') that migrate
+    // NORMALISES to 'accepted'. This is the task's exact AC1 shape. The enumDrift
+    // DIAGNOSTIC (a separate, pre-existing gate) reports the raw source aliases,
+    // so verify.ok is expected to be false — but the AC1 zero-deficit invariant
+    // and the AC2 per-table hashMatch (source digested through the SAME
+    // epoch→ISO + enum-normalize transforms) both hold.
+    const tasksDbPath = join(tmpDir, 'tasks.db');
+    const projectDbPath = join(tmpDir, 'cleo-project.db');
+    const globalDbPath = join(tmpDir, 'cleo-global.db');
+    buildDriftSource(tasksDbPath);
+    buildTarget(projectDbPath, globalDbPath);
+
+    const projectDb = new DatabaseSync(projectDbPath);
+    const globalDb = new DatabaseSync(globalDbPath);
+    const makeFakeHandle = (native: DatabaseSyncType) => ({
+      db: { $client: native },
+      close: () => {
+        /* keep open */
+      },
+    });
+    const dualScope = await import('../dual-scope-db.js');
+    vi.mocked(dualScope.openDualScopeDbAtPath).mockImplementation(
+      (scope: string, dbPath: string) => {
+        const native = dbPath === globalDbPath || scope === 'global' ? globalDb : projectDb;
+        return Promise.resolve(makeFakeHandle(native) as never);
+      },
+    );
+    vi.mocked(dualScope.resolveDualScopeDbPath).mockImplementation((scope: string) =>
+      scope === 'project' ? projectDbPath : globalDbPath,
+    );
+
+    const { runExodusMigrate } = await import('../exodus/migrate.js');
+    const sources: LegacyDbDescriptor[] = [
+      { name: 'tasks', path: tasksDbPath, targetScope: 'project' },
+    ];
+    const plan: ExodusPlan = {
+      sources,
+      totalSourceBytes: 0,
+      availableBytes: 100_000_000,
+      diskPreflight: true,
+      stagingDir,
+      resumeFromStaging: false,
+      projectDbPath,
+      globalDbPath,
+    };
+    const migrateResult = await runExodusMigrate(plan, false, undefined);
+    expect(migrateResult.ok, migrateResult.error ?? '').toBe(true);
+
+    // AC1: zero deficit — every source row landed despite epoch + enum coercion.
+    const decisions = migrateResult.tables.find(
+      (t) => t.sourceDb === 'tasks' && t.tableName === 'architecture_decisions',
+    );
+    expect(decisions?.skipped).toBe(false);
+    expect(decisions?.reason).toBeUndefined();
+    expect(decisions?.rowsCopied).toBe(SOURCE_ROWS);
+    const targetCount = (
+      projectDb.prepare(`SELECT COUNT(*) AS c FROM "tasks_architecture_decisions"`).get() as {
+        c: number;
+      }
+    ).c;
+    expect(targetCount).toBe(SOURCE_ROWS);
+
+    const verify = verifyMigration(sources, projectDbPath, globalDbPath);
+
+    // AC2: the per-table content digest MATCHES — the source side was digested
+    // through the same epoch→ISO + enum-normalize transforms the target stores.
+    const entry = verify.tables.find((t) => t.targetTable === 'tasks_architecture_decisions');
+    expect(entry?.countMatch).toBe(true);
+    expect(entry?.hashMatch, 'hashMatch on coerced + normalized data').toBe(true);
+
+    // The enum-drift DIAGNOSTIC still flags the raw source aliases (a separate,
+    // pre-existing gate orthogonal to the AC2 hashMatch coercion). This documents
+    // that interaction — it is NOT a row deficit.
+    const drift = verify.enumDrift.find(
+      (d) => d.targetTable === 'tasks_architecture_decisions' && d.column === 'status',
+    );
+    expect(drift, 'enum-drift diagnostic still reports raw source aliases').toBeDefined();
+
+    projectDb.close();
+    globalDb.close();
+  });
+});

--- a/packages/core/src/store/exodus/column-transforms.ts
+++ b/packages/core/src/store/exodus/column-transforms.ts
@@ -1,0 +1,513 @@
+/**
+ * Shared column-value transform layer for the exodus migration.
+ *
+ * The exodus copy (`migrate.ts`) does not move source values byte-for-byte into
+ * the consolidated `cleo.db`: a handful of columns are TRANSFORMED on the way in
+ * so they satisfy the consolidated schema's CHECK constraints (which the legacy
+ * runtime DBs did not carry). Three transform classes exist:
+ *
+ *   1. **Epoch INTEGER → ISO-8601 TEXT** ({@link buildEpochToIsoExpr}) — for any
+ *      target column carrying an ISO-GLOB CHECK ({@link detectIsoGlobColumns}).
+ *      A per-row magnitude heuristic ({@link EPOCH_SECONDS_THRESHOLD}) classifies
+ *      seconds vs milliseconds.
+ *   2. **Legacy enum → canonical member** ({@link ENUM_NORMALIZATIONS} +
+ *      {@link enumNormExpr}) — maps pre-tightening enum aliases (e.g.
+ *      `tasks_commits.conventional_type` `'style'`/`'merge'` → `'chore'`).
+ *   3. **Non-finite REAL → finite** ({@link NUMERIC_CLAMPS} +
+ *      {@link numericClampExpr}) — `Inf`/`-Inf`/`NaN` → a finite in-range value
+ *      (`brain_weight_history.delta_weight`).
+ *
+ * ## Why this module exists (T11809 · AC2)
+ *
+ * Before T11809 these transforms lived ONLY in `migrate.ts`. The parity verifier
+ * (`verify-migration.ts`) digested RAW source values against the TRANSFORMED
+ * target values, so every coerced column (epoch INTEGER vs ISO TEXT, legacy enum
+ * vs canonical, Inf vs clamped) produced a `hashMatch === false` even on a
+ * perfectly lossless migration — a false-negative that aborted the cutover and
+ * lost the batch writes accumulated during the migrating open.
+ *
+ * Extracting the transform logic into ONE shared module lets the verifier digest
+ * the SOURCE side **through the same transforms migrate applied**
+ * ({@link buildDigestExpr}), so equal logical data digests equal. `migrate.ts`
+ * re-imports these primitives so its copy behaviour stays byte-identical; the
+ * verifier imports {@link buildDigestExpr} for the digest-oriented variant.
+ *
+ * @task T11809 (exodus verify applies source-side coercion — hashMatch on equal data)
+ * @task T11546 (epoch→ISO coercion — original)
+ * @task T11547 (enum normalization — original)
+ * @task T11782 (non-finite numeric clamp — original)
+ * @epic T11249 (E6)
+ * @saga T11242
+ */
+
+import type { DatabaseSync } from 'node:sqlite';
+
+// ---------------------------------------------------------------------------
+// NOT NULL default-literal helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine a safe SQL literal default for a NOT NULL column with no schema
+ * default, given its SQLite type affinity.
+ *
+ * Used by `migrate.ts` to coalesce NULL source values for target-only NOT NULL
+ * columns so that rows are not silently dropped by `INSERT OR IGNORE` when a
+ * source value is NULL (T11533 ROOT CAUSE 2 fix).
+ *
+ * @param colType - Raw `type` string from `PRAGMA table_info` (e.g. `"INTEGER"`,
+ *   `"TEXT"`, `"REAL"`, `"BLOB"`, or compound forms like `"text NOT NULL"`).
+ * @returns A SQL literal string suitable for embedding in a `COALESCE()` call.
+ */
+export function typeDefaultLiteral(colType: string): string {
+  const upper = colType.toUpperCase();
+  if (upper.includes('INT')) return '0';
+  if (upper.includes('REAL') || upper.includes('FLOAT') || upper.includes('DOUBLE')) return '0.0';
+  if (upper.includes('BLOB')) return "x''";
+  // TEXT and any other affinity (SQLite permissive) → empty string
+  return "''";
+}
+
+// ---------------------------------------------------------------------------
+// Enum-value normalization layer (ROOT CAUSE fix — T11547)
+// ---------------------------------------------------------------------------
+
+/**
+ * Function shape for an enum-normalization rule: given the `srcRef` SQL
+ * expression for a column, return a SQL expression that produces the canonical
+ * value.
+ */
+export type NormalizeFn = (srcRef: string) => string;
+
+/**
+ * Per-(targetTable, column) normalization rules that map legacy enum values to
+ * the canonical enum accepted by the consolidated schema CHECK constraints.
+ *
+ * Each entry is a function that, given the `srcRef` SQL expression for the
+ * column, returns a SQL CASE expression that produces the canonical value.
+ * Rows with already-canonical values pass through unchanged (the ELSE branch).
+ *
+ * ## Brain enum normalizations REMOVED (T11647)
+ *
+ * The brain memory family no longer participates in enum normalization. Its
+ * consolidated exodus target now matches the LEGACY RUNTIME shape, which carries
+ * NO SQL CHECK constraints (the `text({ enum })` unions are enforced at the
+ * application layer only). With no CHECK to satisfy, coercing brain enum values
+ * would be data corruption, not a fix — so every brain enum value is copied
+ * VERBATIM. The historical brain rules (`brain_observations.{source_type,type}`,
+ * `brain_decisions.{confirmation_state,decision_category,confidence,outcome,
+ * decided_by}`) were deleted. The TASKS-domain rules below remain because those
+ * consolidated tables keep their CHECK constraints.
+ *
+ * ## nexus/signaldock enum-drift audit (T11809 · AC1)
+ *
+ * A real-data audit of `nexus.db` (106 MB) and `signaldock.db` (280 KB) against
+ * the consolidated CHECK enums found ZERO out-of-enum values for every
+ * CHECK-constrained column that has source data: `nexus_nodes.kind` (24,482
+ * rows), `nexus_relations.type` (39,163 rows), `nexus_contracts.type` (0 rows),
+ * `nexus_sigils.role` (8 rows), `agent_registry_agents.status` (19 rows),
+ * `agent_registry_users.role` (0 rows). No new normalization entry was required.
+ * The reported "nexus/signaldock drop rows" symptom was in fact the AC2 verify
+ * false-negative (epoch→ISO coercion makes the source digest differ from the
+ * target digest), which fixing {@link buildDigestExpr} resolves — NOT a CHECK
+ * drop. See the T11809 return notes for the full per-column row counts.
+ *
+ * Lookup key: `${targetTable}.${column}` (lowercase, dotted).
+ *
+ * @since T11547 (P0 data-loss fix)
+ * @since T11548 (P0 final enum coverage)
+ * @since T11647 (brain target = runtime shape — brain enum coercions removed)
+ */
+export const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
+  // --- task_commits.link_source -------------------------------------------
+  // 'commit-message' → 'commit-subject' (pre-T9506 legacy value)
+  [
+    'tasks_task_commits.link_source',
+    (src: string) => `CASE ${src} WHEN 'commit-message' THEN 'commit-subject' ELSE ${src} END`,
+  ],
+
+  // --- architecture_decisions.status (case + date-suffix normalization) ----
+  // 'Accepted', 'ACCEPTED', 'approved', 'Accepted (2026-04-18)', … → 'accepted'
+  // 'Proposed', 'PROPOSED' → 'proposed'
+  // 'Superseded', 'SUPERSEDED' → 'superseded'
+  [
+    'tasks_architecture_decisions.status',
+    (src: string) =>
+      `CASE` +
+      ` WHEN lower(${src}) = 'accepted' OR lower(${src}) LIKE 'accepted %' OR lower(${src}) = 'approved' THEN 'accepted'` +
+      ` WHEN lower(${src}) = 'proposed' THEN 'proposed'` +
+      ` WHEN lower(${src}) = 'superseded' THEN 'superseded'` +
+      ` WHEN lower(${src}) = 'deprecated' THEN 'deprecated'` +
+      ` ELSE ${src}` +
+      ` END`,
+  ],
+
+  // --- brain_* enum normalizations REMOVED (T11647) -----------------------
+  // The brain memory family now lands in the consolidated cleo.db in its LEGACY
+  // RUNTIME shape — INTEGER epoch timestamps and, critically, NO SQL CHECK
+  // constraints (the `text({ enum })` unions are enforced only at the
+  // application layer, exactly as the runtime `drizzle-brain` tables are). With
+  // no brain CHECK constraint to satisfy, exodus MUST copy every brain enum
+  // value VERBATIM — coercing them (e.g. source_type 'observer-compressed'/
+  // 'sleep-consolidation' → 'agent', type 'observation'/'proposal'/'pattern' →
+  // nearest) would now be unnecessary data CORRUPTION, not a constraint fix.
+  // The previous brain entries (brain_observations.{source_type,type},
+  // brain_decisions.{confirmation_state,decision_category,confidence,outcome,
+  // decided_by}) are therefore deleted. The non-brain entries below still apply
+  // because those consolidated tables retain their CHECK constraints.
+
+  // --- tasks_token_usage.transport (T11548 → REMOVED T11649) ---------------
+  // NO normalization. 'mcp' is a first-class transport origin (MCP-gateway
+  // requests) and is preserved verbatim. The consolidated CHECK enum was WIDENED
+  // to include 'mcp' (canonical TOKEN_USAGE_TRANSPORTS SSoT + forward migration
+  // 20260602000002_t11649-token-usage-transport-mcp), so the value lands without
+  // coercion. The earlier 'mcp' → 'agent' mapping was a silent semantic alteration
+  // of ~194 rows (count-preserving, NOT integrity-preserving) — see T11649.
+
+  // (brain_decisions.{decision_category,confidence} normalizations removed —
+  //  T11647: brain target = runtime shape with no CHECK; copy values verbatim.)
+
+  // --- tasks_commits.conventional_type (T11548 + T11578) -------------------
+  // The consolidated CHECK enum is feat/fix/chore/docs/refactor/test/build/ci/
+  // perf/revert/breaking. Real git history carries non-conventional subjects:
+  //   - 'style'           → 'chore' (pre-T11548 mapping; no 'style' in enum).
+  //   - 'merge'/'release' → 'chore' (T11578): merge + release commits are
+  //     maintenance-class; the precise semantic is preserved by the dedicated
+  //     `is_merge_commit` / `is_release_commit` boolean columns, so collapsing
+  //     `conventional_type` to the maintenance catch-all 'chore' is lossless at
+  //     the row grain. Without this the 'merge'/'release' rows violate the CHECK,
+  //     `INSERT OR IGNORE` drops the WHOLE commits table, and the exodus-on-open
+  //     data-continuity gate aborts the cutover (T11578 CI regression).
+  //   - any OTHER out-of-enum value → 'chore' (defensive: future non-conventional
+  //     subjects must never re-break the zero-deficit gate; the boolean flags and
+  //     raw subject text remain the precise provenance).
+  [
+    'tasks_commits.conventional_type',
+    (src: string) =>
+      `CASE` +
+      ` WHEN ${src} IS NULL THEN NULL` +
+      ` WHEN ${src} IN ('feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'build', 'ci', 'perf', 'revert', 'breaking') THEN ${src}` +
+      ` ELSE 'chore'` +
+      ` END`,
+  ],
+
+  // --- tasks_task_relations.relation_type (T11548) -------------------------
+  // 'grouped-by' → 'groups' (enum: related/blocks/duplicates/absorbs/fixes/extends/
+  // supersedes/groups). 4 rows.
+  [
+    'tasks_task_relations.relation_type',
+    (src: string) => `CASE ${src} WHEN 'grouped-by' THEN 'groups' ELSE ${src} END`,
+  ],
+
+  // --- tasks_lifecycle_stages.stage_name (T11548) --------------------------
+  // Legacy camelCase / past-tense values → canonical snake_case stage names.
+  // 'implemented' → 'implementation', 'qaPassed' → 'validation',
+  // 'testsPassed' → 'testing'. 3 rows.
+  [
+    'tasks_lifecycle_stages.stage_name',
+    (src: string) =>
+      `CASE ${src}` +
+      ` WHEN 'implemented' THEN 'implementation'` +
+      ` WHEN 'qaPassed' THEN 'validation'` +
+      ` WHEN 'testsPassed' THEN 'testing'` +
+      ` ELSE ${src}` +
+      ` END`,
+  ],
+
+  // --- tasks_architecture_decisions.gate_status (T11548) ------------------
+  // 'passed (T5313 consensus)' → 'passed', 'approved' → 'passed'
+  // (enum: pending/passed/failed/waived). 2 rows.
+  [
+    'tasks_architecture_decisions.gate_status',
+    (src: string) =>
+      `CASE` +
+      ` WHEN ${src} LIKE 'passed%' THEN 'passed'` +
+      ` WHEN ${src} = 'approved' THEN 'passed'` +
+      ` ELSE ${src}` +
+      ` END`,
+  ],
+
+  // --- tasks_evidence_ac_bindings.binding_type (T11548) -------------------
+  // Values with a 'validator:...' prefix → 'direct'
+  // (enum: direct/satisfies/coverage). 3 rows.
+  // Strip the namespace prefix introduced before the enum was tightened.
+  [
+    'tasks_evidence_ac_bindings.binding_type',
+    (src: string) =>
+      `CASE` + ` WHEN ${src} LIKE 'validator:%' THEN 'direct'` + ` ELSE ${src}` + ` END`,
+  ],
+
+  // (brain_decisions.{outcome,decided_by} normalizations removed — T11647:
+  //  brain target = runtime shape with no CHECK; legacy values like 'accepted',
+  //  'rejected', 'prime' now survive VERBATIM instead of being coerced.)
+]);
+
+/**
+ * Return a SQL CASE expression that normalises legacy enum values for `col` in
+ * `targetTableName` to the canonical values accepted by the consolidated CHECK,
+ * or return `null` when no normalization rule exists for this (table, column).
+ *
+ * @param targetTableName - Physical consolidated target table name.
+ * @param col             - Column name.
+ * @param srcRef          - SQL expression referencing the source column.
+ * @returns A SQL CASE expression string, or `null` if no rule applies.
+ */
+export function enumNormExpr(targetTableName: string, col: string, srcRef: string): string | null {
+  const key = `${targetTableName}.${col}`;
+  const fn = ENUM_NORMALIZATIONS.get(key);
+  return fn ? fn(srcRef) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Non-finite numeric clamp layer (ROOT CAUSE fix — T11782 · FIX B)
+// ---------------------------------------------------------------------------
+
+/**
+ * Function shape for a numeric-clamp rule: given the `srcRef` SQL expression for
+ * a column, return a SQL expression that maps non-finite values to finite ones.
+ */
+export type NumericClampFn = (srcRef: string) => string;
+
+/**
+ * Per-(targetTable, column) numeric-clamp rules that coerce non-finite legacy
+ * REAL values (`Inf` / `-Inf` / `NaN`) to a finite in-range value so the row is
+ * NOT silently dropped by `INSERT OR IGNORE`.
+ *
+ * ## Why this exists (T11782)
+ *
+ * 188,926 of 697,780 legacy `brain_weight_history` rows carry
+ * `delta_weight = Inf`/`-Inf` (the R-STDP plasticity writer saturated the delta
+ * before the value was clamped at write time). SQLite stores ±Inf as the IEEE-754
+ * float, but the consolidated `brain_weight_history.delta_weight` column is a
+ * plain `real NOT NULL` with NO CHECK — so a verbatim copy would land the Inf
+ * value. The historical deficit, however, was that those rows tripped a constraint
+ * elsewhere in the copy chain and `INSERT OR IGNORE` dropped them, yielding a
+ * deficit that fired the parity-gate abort. Clamping the non-finite value to a
+ * finite member of the column's domain guarantees every row lands.
+ *
+ * The clamp mirrors the {@link ENUM_NORMALIZATIONS} shape: each entry is a
+ * function `(srcRef) => CASE …`. Finite values pass through unchanged via the
+ * ELSE branch. The `col != col` self-comparison is the canonical SQL NaN guard
+ * (NaN is the only value not equal to itself); `9e999` is the SQLite literal that
+ * evaluates to `+Infinity` (and `-9e999` to `-Infinity`).
+ *
+ * Lookup key: `${targetTable}.${column}` (lowercase, dotted).
+ *
+ * @since T11782 (P0 — brain_weight_history Inf recovery)
+ */
+export const NUMERIC_CLAMPS: ReadonlyMap<string, NumericClampFn> = new Map([
+  // --- brain_weight_history.delta_weight (T11782) -------------------------
+  // +Inf → 1.0 (max canonical reinforcement), -Inf → -1.0 (max canonical
+  // depression), NaN → 0.0 (no-op delta). Finite values pass through.
+  [
+    'brain_weight_history.delta_weight',
+    (src: string) =>
+      `CASE` +
+      ` WHEN ${src} = 9e999 THEN 1.0` +
+      ` WHEN ${src} = -9e999 THEN -1.0` +
+      ` WHEN ${src} != ${src} THEN 0.0` +
+      ` ELSE ${src}` +
+      ` END`,
+  ],
+]);
+
+/**
+ * Return a SQL CASE expression that clamps non-finite legacy REAL values for
+ * `col` in `targetTableName` to a finite in-range value, or `null` when no
+ * clamp rule exists for this (table, column).
+ *
+ * @param targetTableName - Physical consolidated target table name.
+ * @param col             - Column name.
+ * @param srcRef          - SQL expression referencing the source column.
+ * @returns A SQL CASE expression string, or `null` if no rule applies.
+ */
+export function numericClampExpr(
+  targetTableName: string,
+  col: string,
+  srcRef: string,
+): string | null {
+  const key = `${targetTableName}.${col}`;
+  const fn = NUMERIC_CLAMPS.get(key);
+  return fn ? fn(srcRef) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Epoch-to-ISO coercion layer (ROOT CAUSE 1 fix — T11546)
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex to detect ISO GLOB CHECK constraints in DDL SQL.
+ * Matches: `CHECK ("colname" IS NULL OR "colname" GLOB '[0-9]...')`
+ * Uses `\[0-9` to match the literal `[0-9` at the start of the GLOB pattern.
+ */
+const ISO_CHECK_REGEX = /CHECK\s*\(\s*"([^"]+)"\s+IS\s+NULL\s+OR\s+"[^"]+"\s+GLOB\s+'\[0-9/gi;
+
+/**
+ * Magnitude threshold distinguishing epoch SECONDS from epoch MILLISECONDS.
+ *
+ * A Unix epoch value for years 2020–2100 is roughly 1.6e9 – 4.1e9 seconds,
+ * or 1.6e12 – 4.1e12 milliseconds. The safe boundary is 1e11 (100 billion):
+ * any value BELOW 1e11 is in seconds (even year 2100 seconds ≈ 4.1e9 < 1e11);
+ * any value AT OR ABOVE 1e11 is in milliseconds (year 2020 ms ≈ 1.6e12 > 1e11).
+ *
+ * This constant is embedded directly in the generated SQL CASE expression so
+ * it is evaluated per-row — each row's epoch is classified independently.
+ */
+export const EPOCH_SECONDS_THRESHOLD = 100_000_000_000 as const; // 1e11
+
+/**
+ * Build a SQL expression that converts an INTEGER epoch column to ISO-8601 TEXT,
+ * automatically detecting whether the stored value is in seconds or milliseconds
+ * using a magnitude heuristic (T11549 correctness fix).
+ *
+ * ## Heuristic
+ *
+ * A per-row CASE checks whether the column value is below {@link EPOCH_SECONDS_THRESHOLD}
+ * (100 billion). If so, the value is treated as seconds and passed directly to
+ * `strftime(..., 'unixepoch')`. If at or above the threshold, it is divided by
+ * 1000.0 first (milliseconds → seconds).
+ *
+ * This replaces the previous per-source heuristic which failed when individual
+ * columns within a source DB used a different epoch unit than the majority of that
+ * source's columns. The specific bug: `nexus.user_profile.{first_observed_at,
+ * last_reinforced_at}` stores SECONDS (value ≈ 1.78e9) but the nexus source was
+ * labeled `milliseconds`, causing these values to be divided by 1000 and converted
+ * to a 1970 date.
+ *
+ * ## NULL handling
+ *
+ * A NULL source value is preserved as NULL so it passes the `IS NULL` branch of
+ * the ISO GLOB CHECK constraint on the target column.
+ *
+ * @param srcRef - SQL expression referencing the source column value.
+ * @returns A SQL CASE expression producing an ISO-8601 TEXT timestamp.
+ */
+export function buildEpochToIsoExpr(srcRef: string): string {
+  return (
+    `CASE` +
+    ` WHEN ${srcRef} IS NULL THEN NULL` +
+    ` WHEN ${srcRef} < ${EPOCH_SECONDS_THRESHOLD}` +
+    ` THEN strftime('%Y-%m-%dT%H:%M:%fZ', ${srcRef}, 'unixepoch')` +
+    ` ELSE strftime('%Y-%m-%dT%H:%M:%fZ', ${srcRef}/1000.0, 'unixepoch')` +
+    ` END`
+  );
+}
+
+/**
+ * Parse the DDL for a given table from `sqlite_master` and return the set of
+ * column names that have an ISO GLOB CHECK constraint.
+ *
+ * Reads the raw DDL text and uses a regex to extract column names appearing in
+ * `CHECK ("colname" IS NULL OR "colname" GLOB '[0-9]...')` patterns. This is
+ * robust to Drizzle's generated CHECK format (all CHECK constraints generated
+ * by T11363 follow this exact pattern).
+ *
+ * @param db           - Target DB with the consolidated schema.
+ * @param tableName    - Physical table name (consolidated, e.g. `conduit_messages`).
+ * @param targetSchema - Schema name the target table lives in (`'main'`, or an
+ *   ATTACH alias for cross-scope routing — ADR-090 nexus graph residency, T11539).
+ * @returns Set of column names that require ISO GLOB validation.
+ */
+export function detectIsoGlobColumns(
+  db: DatabaseSync,
+  tableName: string,
+  targetSchema = 'main',
+): Set<string> {
+  const escapedTable = tableName.replace(/'/g, "''");
+  const row = db
+    .prepare(
+      `SELECT sql FROM "${targetSchema}".sqlite_master WHERE type='table' AND name='${escapedTable}'`,
+    )
+    .get() as { sql: string } | null;
+
+  if (!row?.sql) return new Set();
+
+  const isoColumns = new Set<string>();
+  // Pattern: CHECK ("colname" IS NULL OR "colname" GLOB '[0-9]...')
+  // The column name appears TWICE — we capture the first occurrence.
+  // Use matchAll to avoid the biome no-assign-in-expressions rule.
+  ISO_CHECK_REGEX.lastIndex = 0; // reset before reuse (global regex stateful)
+  for (const match of row.sql.matchAll(ISO_CHECK_REGEX)) {
+    isoColumns.add(match[1]);
+  }
+  return isoColumns;
+}
+
+// ---------------------------------------------------------------------------
+// Digest-oriented transform expression (T11809 · AC2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return `true` when the source column's type affinity is INTEGER-like, so an
+ * epoch→ISO coercion applies when the matching target column carries an ISO GLOB
+ * CHECK. Empty affinity and `NUMERIC` are treated as integer-like (matching the
+ * historical `buildSelectExpr` behaviour — legacy epoch columns sometimes carry
+ * no declared type or a `NUMERIC` affinity).
+ *
+ * @param srcType - Raw `type` string from the source `PRAGMA table_info`.
+ * @returns `true` if the source column should be considered an INTEGER epoch.
+ */
+function isIntegerSourceType(srcType: string): boolean {
+  const upper = srcType.toUpperCase();
+  return upper.includes('INT') || upper === '' || upper === 'NUMERIC';
+}
+
+/**
+ * Build the SQL expression a column's SOURCE value must pass through so it
+ * matches the canonical value the migration STORES in the target — for use by
+ * the parity verifier's content digest (T11809 · AC2).
+ *
+ * This is the digest-oriented sibling of migrate's `buildSelectExpr`. It applies
+ * the SAME value transforms the migration actually performs — and ONLY those:
+ *
+ *   1. **Epoch→ISO-8601** ({@link buildEpochToIsoExpr}) — when the target has an
+ *      ISO GLOB CHECK and the source column is INTEGER-typed.
+ *   2. **Non-finite numeric clamp** ({@link numericClampExpr}).
+ *   3. **Enum-value normalization** ({@link enumNormExpr}).
+ *   4. **Plain column reference** otherwise.
+ *
+ * Crucially it does NOT add the NOT-NULL `COALESCE(..., type_default)` wrapping
+ * that `buildSelectExpr` uses: that wrapping only ever fires on a NULL source
+ * value that the target stores as a type-default, which is a NULL→default value
+ * CHANGE the digest should not paper over (a genuine NULL→'' divergence remains a
+ * real, visible content difference, not a coercion artifact). The verifier
+ * intentionally omits it so the digest reflects the canonical value transforms
+ * (epoch/enum/clamp) WITHOUT masking a true NULL→default substitution.
+ *
+ * The returned expression is a bare SQL value expression (no `AS "col"` alias)
+ * suitable for embedding directly in a `SELECT <expr> ... ORDER BY ...` digest
+ * query. When no transform applies, a plain quoted column reference is returned.
+ *
+ * @param targetTableName - Physical consolidated target table name (transform
+ *   lookup key).
+ * @param col             - Column name (present in BOTH source and target).
+ * @param srcType         - Raw `type` string from the source `PRAGMA table_info`.
+ * @param isoGlobCols     - Set of target columns carrying an ISO GLOB CHECK.
+ * @returns A SQL value expression that maps the raw source value to the canonical
+ *   value the target stores.
+ */
+export function buildDigestExpr(
+  targetTableName: string,
+  col: string,
+  srcType: string,
+  isoGlobCols: ReadonlySet<string>,
+): string {
+  const srcRef = `"${col}"`;
+
+  // Priority 1: Epoch→ISO coercion — applies when the target has an ISO GLOB
+  // CHECK and the source column is INTEGER (epoch) typed. Mirrors migrate's
+  // per-row magnitude heuristic exactly.
+  if (isoGlobCols.has(col) && isIntegerSourceType(srcType)) {
+    return buildEpochToIsoExpr(srcRef);
+  }
+
+  // Priority 2: Non-finite numeric clamp (Inf/-Inf/NaN → finite in-range).
+  const clampExpr = numericClampExpr(targetTableName, col, srcRef);
+  if (clampExpr !== null) return clampExpr;
+
+  // Priority 3: Enum-value normalization (legacy value → canonical member).
+  const normExpr = enumNormExpr(targetTableName, col, srcRef);
+  if (normExpr !== null) return normExpr;
+
+  // Priority 4: plain column reference (no transform migrate would have applied).
+  return srcRef;
+}

--- a/packages/core/src/store/exodus/migrate.ts
+++ b/packages/core/src/store/exodus/migrate.ts
@@ -128,6 +128,15 @@ import { getCleoVersion } from '../../scaffold/ensure-config.js';
 import type { DualScopeDbHandle } from '../dual-scope-db.js';
 import { openDualScopeDbAtPath } from '../dual-scope-db.js';
 import { openCleoDbSnapshot } from '../open-cleo-db.js';
+import {
+  buildEpochToIsoExpr,
+  detectIsoGlobColumns,
+  ENUM_NORMALIZATIONS,
+  enumNormExpr,
+  NUMERIC_CLAMPS,
+  numericClampExpr,
+  typeDefaultLiteral,
+} from './column-transforms.js';
 import { resolveConsolidatedTableName, resolveTableTargetScope } from './table-name-map.js';
 import type {
   ExodusJournal,
@@ -334,328 +343,16 @@ interface CopyTableResult {
   readonly reason?: string;
 }
 
-/**
- * Determine a safe SQL literal default for a NOT NULL column with no schema
- * default, given its SQLite type affinity.
- *
- * Used to coalesce NULL source values for target-only NOT NULL columns so that
- * rows are not silently dropped by `INSERT OR IGNORE` when a source value is
- * NULL (T11533 ROOT CAUSE 2 fix).
- *
- * @param colType - Raw `type` string from `PRAGMA table_info` (e.g. `"INTEGER"`,
- *   `"TEXT"`, `"REAL"`, `"BLOB"`, or compound forms like `"text NOT NULL"`).
- * @returns A SQL literal string suitable for embedding in a `COALESCE()` call.
- */
-function typeDefaultLiteral(colType: string): string {
-  const upper = colType.toUpperCase();
-  if (upper.includes('INT')) return '0';
-  if (upper.includes('REAL') || upper.includes('FLOAT') || upper.includes('DOUBLE')) return '0.0';
-  if (upper.includes('BLOB')) return "x''";
-  // TEXT and any other affinity (SQLite permissive) → empty string
-  return "''";
-}
-
-// ---------------------------------------------------------------------------
-// Enum-value normalization layer (ROOT CAUSE fix — T11547)
-// ---------------------------------------------------------------------------
-
-/**
- * Per-(targetTable, column) normalization rules that map legacy enum values to
- * the canonical enum accepted by the consolidated schema CHECK constraints.
- *
- * Each entry is a function that, given the `srcRef` SQL expression for the
- * column, returns a SQL CASE expression that produces the canonical value.
- * Rows with already-canonical values pass through unchanged (the ELSE branch).
- *
- * ## Brain enum normalizations REMOVED (T11647)
- *
- * The brain memory family no longer participates in enum normalization. Its
- * consolidated exodus target now matches the LEGACY RUNTIME shape, which carries
- * NO SQL CHECK constraints (the `text({ enum })` unions are enforced at the
- * application layer only). With no CHECK to satisfy, coercing brain enum values
- * would be data corruption, not a fix — so every brain enum value is copied
- * VERBATIM. The historical brain rules (`brain_observations.{source_type,type}`,
- * `brain_decisions.{confirmation_state,decision_category,confidence,outcome,
- * decided_by}`) were deleted. The TASKS-domain rules below remain because those
- * consolidated tables keep their CHECK constraints.
- *
- * ## Design decisions (T11547)
- *
- * - `tasks_task_commits.link_source = 'commit-message'`
- *   → mapped to `'commit-subject'` (nearest canonical; legacy writers used
- *   'commit-message' as the name for subject-line scanning before the enum
- *   was tightened in T9506).
- *
- * - `tasks_architecture_decisions.status` (case normalization)
- *   → `'Accepted'`, `'ACCEPTED'`, `'approved'` all → `'accepted'`;
- *   `'Accepted (2026-04-18)'` and similar date-suffixed variants → `'accepted'`.
- *   These map cleanly to the existing enum; no schema extension needed.
- *
- * ## Additional entries (T11548 — final 285 rows)
- *
- * - `tasks_token_usage.transport` (T11649 — coercion REMOVED, value PRESERVED)
- *   → `'mcp'` is NOT coerced. It is a first-class transport origin (MCP-gateway
- *   requests, `source: "mcp"`), semantically distinct from `'agent'`. The earlier
- *   T11548 mapping (`'mcp'` → `'agent'`) was count-preserving but NOT
- *   integrity-preserving — it silently altered the true origin of ~194 telemetry
- *   rows with no column capturing the lost value. T11649 instead WIDENS the
- *   consolidated CHECK enum to `cli/api/agent/mcp/unknown` (canonical SSoT
- *   `TOKEN_USAGE_TRANSPORTS` in `schema/audit.ts` + forward migration
- *   `20260602000002_t11649-token-usage-transport-mcp`) so exodus stores `'mcp'`
- *   verbatim — zero semantic loss.
- *
- * - `tasks_commits.conventional_type`
- *   → `'style'` → `'chore'` (enum includes feat/fix/chore/docs/refactor/test/
- *   build/ci/perf/revert/breaking but NOT style; nearest canonical). [33 rows]
- *
- * - `tasks_task_relations.relation_type`
- *   → `'grouped-by'` → `'groups'` (enum: related/blocks/duplicates/absorbs/
- *   fixes/extends/supersedes/groups). [4 rows]
- *
- * - `tasks_lifecycle_stages.stage_name`
- *   → `'implemented'`→`'implementation'`, `'qaPassed'`→`'validation'`,
- *   `'testsPassed'`→`'testing'` (enum: research/consensus/architecture_decision/
- *   specification/decomposition/implementation/validation/testing/release/
- *   contribution). [3 rows]
- *
- * - `tasks_architecture_decisions.gate_status`
- *   → `'passed (T5313 consensus)'`→`'passed'`, `'approved'`→`'passed'`
- *   (enum: pending/passed/failed/waived). [2 rows]
- *
- * - `tasks_evidence_ac_bindings.binding_type`
- *   → values with a `'validator:...'` prefix → `'direct'`
- *   (enum: direct/satisfies/coverage). Strip the namespace prefix introduced
- *   before the enum was tightened. [3 rows]
- *
- * ## T11550 (last 4 brain rows) — superseded by T11647
- *
- * The T11550 `brain_decisions.{outcome,decided_by}` rules were removed by T11647
- * (brain target = runtime shape, no CHECK). Those legacy values (`'accepted'`,
- * `'rejected'`, `'prime'`) now copy VERBATIM and survive intact.
- *
- * Lookup key: `${targetTable}.${column}` (lowercase, dotted).
- *
- * @since T11547 (P0 data-loss fix)
- * @since T11548 (P0 final enum coverage)
- * @since T11647 (brain target = runtime shape — brain enum coercions removed)
- */
-type NormalizeFn = (srcRef: string) => string;
-
-const ENUM_NORMALIZATIONS: ReadonlyMap<string, NormalizeFn> = new Map([
-  // --- task_commits.link_source -------------------------------------------
-  // 'commit-message' → 'commit-subject' (pre-T9506 legacy value)
-  [
-    'tasks_task_commits.link_source',
-    (src: string) => `CASE ${src} WHEN 'commit-message' THEN 'commit-subject' ELSE ${src} END`,
-  ],
-
-  // --- architecture_decisions.status (case + date-suffix normalization) ----
-  // 'Accepted', 'ACCEPTED', 'approved', 'Accepted (2026-04-18)', … → 'accepted'
-  // 'Proposed', 'PROPOSED' → 'proposed'
-  // 'Superseded', 'SUPERSEDED' → 'superseded'
-  [
-    'tasks_architecture_decisions.status',
-    (src: string) =>
-      `CASE` +
-      ` WHEN lower(${src}) = 'accepted' OR lower(${src}) LIKE 'accepted %' OR lower(${src}) = 'approved' THEN 'accepted'` +
-      ` WHEN lower(${src}) = 'proposed' THEN 'proposed'` +
-      ` WHEN lower(${src}) = 'superseded' THEN 'superseded'` +
-      ` WHEN lower(${src}) = 'deprecated' THEN 'deprecated'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- brain_* enum normalizations REMOVED (T11647) -----------------------
-  // The brain memory family now lands in the consolidated cleo.db in its LEGACY
-  // RUNTIME shape — INTEGER epoch timestamps and, critically, NO SQL CHECK
-  // constraints (the `text({ enum })` unions are enforced only at the
-  // application layer, exactly as the runtime `drizzle-brain` tables are). With
-  // no brain CHECK constraint to satisfy, exodus MUST copy every brain enum
-  // value VERBATIM — coercing them (e.g. source_type 'observer-compressed'/
-  // 'sleep-consolidation' → 'agent', type 'observation'/'proposal'/'pattern' →
-  // nearest) would now be unnecessary data CORRUPTION, not a constraint fix.
-  // The previous brain entries (brain_observations.{source_type,type},
-  // brain_decisions.{confirmation_state,decision_category,confidence,outcome,
-  // decided_by}) are therefore deleted. The non-brain entries below still apply
-  // because those consolidated tables retain their CHECK constraints.
-
-  // --- tasks_token_usage.transport (T11548 → REMOVED T11649) ---------------
-  // NO normalization. 'mcp' is a first-class transport origin (MCP-gateway
-  // requests) and is preserved verbatim. The consolidated CHECK enum was WIDENED
-  // to include 'mcp' (canonical TOKEN_USAGE_TRANSPORTS SSoT + forward migration
-  // 20260602000002_t11649-token-usage-transport-mcp), so the value lands without
-  // coercion. The earlier 'mcp' → 'agent' mapping was a silent semantic alteration
-  // of ~194 rows (count-preserving, NOT integrity-preserving) — see T11649.
-
-  // (brain_decisions.{decision_category,confidence} normalizations removed —
-  //  T11647: brain target = runtime shape with no CHECK; copy values verbatim.)
-
-  // --- tasks_commits.conventional_type (T11548 + T11578) -------------------
-  // The consolidated CHECK enum is feat/fix/chore/docs/refactor/test/build/ci/
-  // perf/revert/breaking. Real git history carries non-conventional subjects:
-  //   - 'style'           → 'chore' (pre-T11548 mapping; no 'style' in enum).
-  //   - 'merge'/'release' → 'chore' (T11578): merge + release commits are
-  //     maintenance-class; the precise semantic is preserved by the dedicated
-  //     `is_merge_commit` / `is_release_commit` boolean columns, so collapsing
-  //     `conventional_type` to the maintenance catch-all 'chore' is lossless at
-  //     the row grain. Without this the 'merge'/'release' rows violate the CHECK,
-  //     `INSERT OR IGNORE` drops the WHOLE commits table, and the exodus-on-open
-  //     data-continuity gate aborts the cutover (T11578 CI regression).
-  //   - any OTHER out-of-enum value → 'chore' (defensive: future non-conventional
-  //     subjects must never re-break the zero-deficit gate; the boolean flags and
-  //     raw subject text remain the precise provenance).
-  [
-    'tasks_commits.conventional_type',
-    (src: string) =>
-      `CASE` +
-      ` WHEN ${src} IS NULL THEN NULL` +
-      ` WHEN ${src} IN ('feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'build', 'ci', 'perf', 'revert', 'breaking') THEN ${src}` +
-      ` ELSE 'chore'` +
-      ` END`,
-  ],
-
-  // --- tasks_task_relations.relation_type (T11548) -------------------------
-  // 'grouped-by' → 'groups' (enum: related/blocks/duplicates/absorbs/fixes/extends/
-  // supersedes/groups). 4 rows.
-  [
-    'tasks_task_relations.relation_type',
-    (src: string) => `CASE ${src} WHEN 'grouped-by' THEN 'groups' ELSE ${src} END`,
-  ],
-
-  // --- tasks_lifecycle_stages.stage_name (T11548) --------------------------
-  // Legacy camelCase / past-tense values → canonical snake_case stage names.
-  // 'implemented' → 'implementation', 'qaPassed' → 'validation',
-  // 'testsPassed' → 'testing'. 3 rows.
-  [
-    'tasks_lifecycle_stages.stage_name',
-    (src: string) =>
-      `CASE ${src}` +
-      ` WHEN 'implemented' THEN 'implementation'` +
-      ` WHEN 'qaPassed' THEN 'validation'` +
-      ` WHEN 'testsPassed' THEN 'testing'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- tasks_architecture_decisions.gate_status (T11548) ------------------
-  // 'passed (T5313 consensus)' → 'passed', 'approved' → 'passed'
-  // (enum: pending/passed/failed/waived). 2 rows.
-  [
-    'tasks_architecture_decisions.gate_status',
-    (src: string) =>
-      `CASE` +
-      ` WHEN ${src} LIKE 'passed%' THEN 'passed'` +
-      ` WHEN ${src} = 'approved' THEN 'passed'` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-
-  // --- tasks_evidence_ac_bindings.binding_type (T11548) -------------------
-  // Values with a 'validator:...' prefix → 'direct'
-  // (enum: direct/satisfies/coverage). 3 rows.
-  // Strip the namespace prefix introduced before the enum was tightened.
-  [
-    'tasks_evidence_ac_bindings.binding_type',
-    (src: string) =>
-      `CASE` + ` WHEN ${src} LIKE 'validator:%' THEN 'direct'` + ` ELSE ${src}` + ` END`,
-  ],
-
-  // (brain_decisions.{outcome,decided_by} normalizations removed — T11647:
-  //  brain target = runtime shape with no CHECK; legacy values like 'accepted',
-  //  'rejected', 'prime' now survive VERBATIM instead of being coerced.)
-]);
-
-/**
- * Return a SQL CASE expression that normalises legacy enum values for `col` in
- * `targetTableName` to the canonical values accepted by the consolidated CHECK,
- * or return `null` when no normalization rule exists for this (table, column).
- *
- * @param targetTableName - Physical consolidated target table name.
- * @param col             - Column name.
- * @param srcRef          - SQL expression referencing the source column.
- * @returns A SQL CASE expression string, or `null` if no rule applies.
- */
-function enumNormExpr(targetTableName: string, col: string, srcRef: string): string | null {
-  const key = `${targetTableName}.${col}`;
-  const fn = ENUM_NORMALIZATIONS.get(key);
-  return fn ? fn(srcRef) : null;
-}
-
-// ---------------------------------------------------------------------------
-// Non-finite numeric clamp layer (ROOT CAUSE fix — T11782 · FIX B)
-// ---------------------------------------------------------------------------
-
-/**
- * Per-(targetTable, column) numeric-clamp rules that coerce non-finite legacy
- * REAL values (`Inf` / `-Inf` / `NaN`) to a finite in-range value so the row is
- * NOT silently dropped by `INSERT OR IGNORE`.
- *
- * ## Why this exists (T11782)
- *
- * 188,926 of 697,780 legacy `brain_weight_history` rows carry
- * `delta_weight = Inf`/`-Inf` (the R-STDP plasticity writer saturated the delta
- * before the value was clamped at write time). SQLite stores ±Inf as the IEEE-754
- * float, but the consolidated `brain_weight_history.delta_weight` column is a
- * plain `real NOT NULL` with NO CHECK — so a verbatim copy would land the Inf
- * value. The historical deficit, however, was that those rows tripped a constraint
- * elsewhere in the copy chain and `INSERT OR IGNORE` dropped them, yielding a
- * deficit that fired the parity-gate abort. Clamping the non-finite value to a
- * finite member of the column's domain guarantees every row lands.
- *
- * The clamp mirrors the {@link ENUM_NORMALIZATIONS} shape: each entry is a
- * function `(srcRef) => CASE …`. Finite values pass through unchanged via the
- * ELSE branch. The `col != col` self-comparison is the canonical SQL NaN guard
- * (NaN is the only value not equal to itself); `9e999` is the SQLite literal that
- * evaluates to `+Infinity` (and `-9e999` to `-Infinity`).
- *
- * Lookup key: `${targetTable}.${column}` (lowercase, dotted).
- *
- * @since T11782 (P0 — brain_weight_history Inf recovery)
- */
-type NumericClampFn = (srcRef: string) => string;
-
-const NUMERIC_CLAMPS: ReadonlyMap<string, NumericClampFn> = new Map([
-  // --- brain_weight_history.delta_weight (T11782) -------------------------
-  // +Inf → 1.0 (max canonical reinforcement), -Inf → -1.0 (max canonical
-  // depression), NaN → 0.0 (no-op delta). Finite values pass through.
-  [
-    'brain_weight_history.delta_weight',
-    (src: string) =>
-      `CASE` +
-      ` WHEN ${src} = 9e999 THEN 1.0` +
-      ` WHEN ${src} = -9e999 THEN -1.0` +
-      ` WHEN ${src} != ${src} THEN 0.0` +
-      ` ELSE ${src}` +
-      ` END`,
-  ],
-]);
-
-/**
- * Return a SQL CASE expression that clamps non-finite legacy REAL values for
- * `col` in `targetTableName` to a finite in-range value, or `null` when no
- * clamp rule exists for this (table, column).
- *
- * @param targetTableName - Physical consolidated target table name.
- * @param col             - Column name.
- * @param srcRef          - SQL expression referencing the source column.
- * @returns A SQL CASE expression string, or `null` if no rule applies.
- */
-function numericClampExpr(targetTableName: string, col: string, srcRef: string): string | null {
-  const key = `${targetTableName}.${col}`;
-  const fn = NUMERIC_CLAMPS.get(key);
-  return fn ? fn(srcRef) : null;
-}
-
 // ---------------------------------------------------------------------------
 // Epoch-to-ISO coercion layer (ROOT CAUSE 1 fix — T11546)
 // ---------------------------------------------------------------------------
-
-/**
- * Regex to detect ISO GLOB CHECK constraints in DDL SQL.
- * Matches: `CHECK ("colname" IS NULL OR "colname" GLOB '[0-9]...')`
- * Uses `\[0-9` to match the literal `[0-9` at the start of the GLOB pattern.
- */
-const ISO_CHECK_REGEX = /CHECK\s*\(\s*"([^"]+)"\s+IS\s+NULL\s+OR\s+"[^"]+"\s+GLOB\s+'\[0-9/gi;
+//
+// The epoch/enum/clamp transform primitives below were extracted to the shared
+// `column-transforms.ts` module (T11809 · AC2) so the parity verifier can digest
+// the SOURCE side through the SAME transforms the migration applies (otherwise a
+// coerced column — epoch INTEGER vs ISO TEXT — produces a spurious hashMatch
+// false-negative that aborts the cutover). `migrate.ts` re-imports them so its
+// copy behaviour stays byte-identical.
 
 /**
  * Epoch unit: seconds (Unix seconds) vs milliseconds (Date.now() / unixepoch * 1000).
@@ -719,97 +416,6 @@ function epochUnitForSource(sourceName: string): EpochUnit {
 }
 
 /**
- * Magnitude threshold distinguishing epoch SECONDS from epoch MILLISECONDS.
- *
- * A Unix epoch value for years 2020–2100 is roughly 1.6e9 – 4.1e9 seconds,
- * or 1.6e12 – 4.1e12 milliseconds. The safe boundary is 1e11 (100 billion):
- * any value BELOW 1e11 is in seconds (even year 2100 seconds ≈ 4.1e9 < 1e11);
- * any value AT OR ABOVE 1e11 is in milliseconds (year 2020 ms ≈ 1.6e12 > 1e11).
- *
- * This constant is embedded directly in the generated SQL CASE expression so
- * it is evaluated per-row — each row's epoch is classified independently.
- */
-const EPOCH_SECONDS_THRESHOLD = 100_000_000_000 as const; // 1e11
-
-/**
- * Build a SQL expression that converts an INTEGER epoch column to ISO-8601 TEXT,
- * automatically detecting whether the stored value is in seconds or milliseconds
- * using a magnitude heuristic (T11549 correctness fix).
- *
- * ## Heuristic
- *
- * A per-row CASE checks whether the column value is below {@link EPOCH_SECONDS_THRESHOLD}
- * (100 billion). If so, the value is treated as seconds and passed directly to
- * `strftime(..., 'unixepoch')`. If at or above the threshold, it is divided by
- * 1000.0 first (milliseconds → seconds).
- *
- * This replaces the previous per-source heuristic which failed when individual
- * columns within a source DB used a different epoch unit than the majority of that
- * source's columns. The specific bug: `nexus.user_profile.{first_observed_at,
- * last_reinforced_at}` stores SECONDS (value ≈ 1.78e9) but the nexus source was
- * labeled `milliseconds`, causing these values to be divided by 1000 and converted
- * to a 1970 date.
- *
- * ## NULL handling
- *
- * A NULL source value is preserved as NULL so it passes the `IS NULL` branch of
- * the ISO GLOB CHECK constraint on the target column.
- *
- * @param srcRef       - SQL expression referencing the source column value.
- * @returns A SQL CASE expression producing an ISO-8601 TEXT timestamp.
- */
-function buildEpochToIsoExpr(srcRef: string): string {
-  return (
-    `CASE` +
-    ` WHEN ${srcRef} IS NULL THEN NULL` +
-    ` WHEN ${srcRef} < ${EPOCH_SECONDS_THRESHOLD}` +
-    ` THEN strftime('%Y-%m-%dT%H:%M:%fZ', ${srcRef}, 'unixepoch')` +
-    ` ELSE strftime('%Y-%m-%dT%H:%M:%fZ', ${srcRef}/1000.0, 'unixepoch')` +
-    ` END`
-  );
-}
-
-/**
- * Parse the DDL for a given table from `sqlite_master` and return the set of
- * column names that have an ISO GLOB CHECK constraint.
- *
- * Reads the raw DDL text and uses a regex to extract column names appearing in
- * `CHECK ("colname" IS NULL OR "colname" GLOB '[0-9]...')` patterns. This is
- * robust to Drizzle's generated CHECK format (all CHECK constraints generated
- * by T11363 follow this exact pattern).
- *
- * @param db          - Target DB with the consolidated schema.
- * @param tableName   - Physical table name (consolidated, e.g. `conduit_messages`).
- * @param targetSchema - Schema name the target table lives in (`'main'`, or an
- *   ATTACH alias for cross-scope routing — ADR-090 nexus graph residency, T11539).
- * @returns Set of column names that require ISO GLOB validation.
- */
-function detectIsoGlobColumns(
-  db: DatabaseSync,
-  tableName: string,
-  targetSchema = 'main',
-): Set<string> {
-  const escapedTable = tableName.replace(/'/g, "''");
-  const row = db
-    .prepare(
-      `SELECT sql FROM "${targetSchema}".sqlite_master WHERE type='table' AND name='${escapedTable}'`,
-    )
-    .get() as { sql: string } | null;
-
-  if (!row?.sql) return new Set();
-
-  const isoColumns = new Set<string>();
-  // Pattern: CHECK ("colname" IS NULL OR "colname" GLOB '[0-9]...')
-  // The column name appears TWICE — we capture the first occurrence.
-  // Use matchAll to avoid the biome no-assign-in-expressions rule.
-  ISO_CHECK_REGEX.lastIndex = 0; // reset before reuse (global regex stateful)
-  for (const match of row.sql.matchAll(ISO_CHECK_REGEX)) {
-    isoColumns.add(match[1]);
-  }
-  return isoColumns;
-}
-
-/**
  * Build a SQL SELECT expression for a shared column, applying (in priority order):
  *
  * 1. **Epoch→ISO-8601 coercion** (T11546): when the target has an ISO GLOB CHECK
@@ -824,10 +430,10 @@ function detectIsoGlobColumns(
  *    target is NOT NULL with no schema default.
  * 5. **Plain column reference** otherwise.
  *
- * The epoch→ISO conversion uses `buildEpochToIsoExpr` which detects the epoch
- * scale (seconds vs milliseconds) per-row using a magnitude heuristic: values
- * below {@link EPOCH_SECONDS_THRESHOLD} (1e11) are treated as seconds; values at
- * or above are treated as milliseconds and divided by 1000.0 before conversion
+ * The epoch→ISO conversion uses `buildEpochToIsoExpr` (from `column-transforms.ts`)
+ * which detects the epoch scale (seconds vs milliseconds) per-row using a magnitude
+ * heuristic: values below `EPOCH_SECONDS_THRESHOLD` (1e11) are treated as seconds;
+ * values at or above are treated as milliseconds and divided by 1000.0 before conversion
  * (T11549 correctness fix — the previous per-source unit was incorrect for
  * individual columns that diverged from the source default, e.g.
  * `nexus.user_profile.first_observed_at` stores SECONDS even though most nexus

--- a/packages/core/src/store/exodus/verify-migration.ts
+++ b/packages/core/src/store/exodus/verify-migration.ts
@@ -53,6 +53,7 @@ import type {
 import { MIGRATION_ENUM_DRIFT_SAMPLE_LIMIT } from '@cleocode/contracts';
 import { getLogger } from '../../logger.js';
 import { openCleoDbSnapshot } from '../open-cleo-db.js';
+import { buildDigestExpr, detectIsoGlobColumns } from './column-transforms.js';
 import { resolveConsolidatedTableName, resolveTableTargetScope } from './table-name-map.js';
 import type { ExodusScope, LegacyDbDescriptor } from './types.js';
 
@@ -97,6 +98,27 @@ function orderByClause(db: DatabaseSync, tableName: string): string {
 }
 
 /**
+ * Source-side digest-transform specification (T11809 · AC2).
+ *
+ * When digesting a SOURCE table, the verifier must apply the SAME value
+ * transforms the migration applied (epoch INTEGER → ISO-8601 TEXT, legacy enum →
+ * canonical member, `Inf`/`-Inf`/`NaN` → finite) so the source digest reflects
+ * the canonical values the target actually STORES. Without it, every coerced
+ * column digests differently on the two sides — a false `hashMatch === false`
+ * that aborts an otherwise-lossless cutover.
+ *
+ * The TARGET side passes `null` (it already holds canonical values).
+ */
+interface DigestTransformSpec {
+  /** Physical consolidated target table name — the transform lookup key. */
+  readonly targetTableName: string;
+  /** Map of source column name → raw `PRAGMA table_info` type string. */
+  readonly srcTypeByCol: ReadonlyMap<string, string>;
+  /** Target columns carrying an ISO-8601 GLOB CHECK (drives epoch→ISO coercion). */
+  readonly isoGlobCols: ReadonlySet<string>;
+}
+
+/**
  * Compute an ordered canonical-JSON SHA-256 digest (32 hex chars) for all rows
  * in a table, restricted to the given column list.
  *
@@ -106,23 +128,48 @@ function orderByClause(db: DatabaseSync, tableName: string): string {
  * 4). Returns `{ count: 0, hash: '' }` for virtual tables that cannot be
  * selected from, rather than throwing.
  *
+ * ## Source-side coercion (T11809 · AC2)
+ *
+ * When `transform` is provided (SOURCE side only), each column is SELECTed
+ * through {@link buildDigestExpr} — the SAME epoch→ISO / enum-normalize /
+ * non-finite-clamp transforms the migration applied — and aliased back to its
+ * original name so the canonical-key serialisation matches the (already
+ * canonical) target row. The TARGET side passes `transform === undefined` and
+ * digests its stored values raw.
+ *
  * @param db         - Database handle to query.
  * @param tableName  - Physical table name.
  * @param columns    - Explicit column list in canonical order, or `null` for
  *   `SELECT *` (used when there is no counterpart table to intersect with).
+ * @param transform  - Source-side transform spec, or `undefined` for the raw
+ *   (target-side) digest.
  * @returns `{ count, hash }` for the table.
  */
 function computeTableDigest(
   db: DatabaseSync,
   tableName: string,
   columns: readonly string[] | null,
+  transform?: DigestTransformSpec,
 ): { count: number; hash: string } {
   const { createHash } = _require('node:crypto') as typeof import('node:crypto');
   const hasher = createHash('sha256');
 
   const orderBy = orderByClause(db, tableName);
-  const selectClause =
-    columns !== null && columns.length > 0 ? columns.map((c) => `"${c}"`).join(', ') : '*';
+  let selectClause: string;
+  if (columns !== null && columns.length > 0) {
+    selectClause = columns
+      .map((c) => {
+        if (transform === undefined) return `"${c}"`;
+        // SOURCE side: route the raw value through the SAME transform migrate
+        // applied, aliased back to `c` so the row key matches the target side.
+        const srcType = transform.srcTypeByCol.get(c) ?? '';
+        const expr = buildDigestExpr(transform.targetTableName, c, srcType, transform.isoGlobCols);
+        return `${expr} AS "${c}"`;
+      })
+      .join(', ');
+  } else {
+    selectClause = '*';
+  }
 
   let rows: unknown[];
   try {
@@ -189,6 +236,43 @@ function sharedColumnsSorted(
     return srcCols.filter((c) => tgtColSet.has(c)).sort();
   } catch {
     return null;
+  }
+}
+
+/**
+ * Build the source-side {@link DigestTransformSpec} for a source→target table
+ * pair: the source column type affinities and the target's ISO-GLOB columns,
+ * keyed by the consolidated target name (the transform lookup key).
+ *
+ * Returns `undefined` (raw digest, no transform) when the source `PRAGMA
+ * table_info` cannot be read — best-effort, biased to surfacing a real
+ * difference rather than masking one.
+ *
+ * @param srcDb           - Source database handle.
+ * @param srcTable        - Physical legacy source table name.
+ * @param tgtDb           - Target database handle (consolidated cleo.db).
+ * @param targetTableName - Physical consolidated target table name.
+ * @returns A transform spec, or `undefined` when source metadata is unavailable.
+ */
+function buildSourceDigestTransform(
+  srcDb: DatabaseSync,
+  srcTable: string,
+  tgtDb: DatabaseSync,
+  targetTableName: string,
+): DigestTransformSpec | undefined {
+  try {
+    const srcTypeByCol = new Map<string, string>(
+      (
+        srcDb.prepare(`PRAGMA table_info("${srcTable}")`).all() as Array<{
+          name: string;
+          type: string;
+        }>
+      ).map((r) => [r.name, r.type]),
+    );
+    const isoGlobCols = detectIsoGlobColumns(tgtDb, targetTableName);
+    return { targetTableName, srcTypeByCol, isoGlobCols };
+  } catch {
+    return undefined;
   }
 }
 
@@ -683,7 +767,17 @@ export function verifyMigration(
             targetSnap.db,
             targetTableName,
           );
-          const srcDigest = computeTableDigest(srcSnap.db, legacyTableName, cols);
+          // Source-side coercion spec (T11809 · AC2): digest the SOURCE through
+          // the SAME transforms migrate applied (epoch→ISO, enum-normalize,
+          // non-finite clamp) so equal logical data digests EQUAL. The target
+          // side already holds canonical values and is digested raw.
+          const srcTransform = buildSourceDigestTransform(
+            srcSnap.db,
+            legacyTableName,
+            targetSnap.db,
+            targetTableName,
+          );
+          const srcDigest = computeTableDigest(srcSnap.db, legacyTableName, cols, srcTransform);
           const tgtDigest = computeTableDigest(targetSnap.db, targetTableName, cols);
           const countMatch = srcDigest.count === tgtDigest.count;
           const hashMatch = srcDigest.hash === tgtDigest.hash;


### PR DESCRIPTION
## Root cause (AC2 — the actual blocker)
`verify-migration.computeTableDigest` digested **RAW source** values against the **TRANSFORMED target**. Migrate coerces source values before INSERT — epoch `INTEGER` → ISO-8601 `TEXT`, legacy enum → canonical member, `Inf`/`-Inf`/`NaN` → finite — so for every coerced column the source digest (e.g. integer `1717200000`) never matched the target digest (e.g. `'2024-06-01T…'`), producing a false `hashMatch === false`. The parity gate then aborted an otherwise **lossless** cutover → batch writes lost. The prior "FIX A" (sorting JSON keys) only fixed key *order*, not value *representation*.

**This is the real mechanism behind the reported nexus/signaldock "row drop": no rows are dropped — the verify false-negative aborts the cutover.**

## Fix
- Extract the epoch/enum/clamp transform primitives into a shared **`column-transforms.ts`** imported by BOTH `migrate.ts` and `verify-migration.ts` (DRY). `migrate.ts` is a pure extraction — behavior byte-identical (−434 local defs → import).
- Add `buildDigestExpr` (a digest-oriented variant that applies the epoch/enum/clamp transforms but **omits** the NOT-NULL `COALESCE` wrapping, so a genuine `NULL→default` change still surfaces as real drift).
- `computeTableDigest` digests the **SOURCE** side through `buildDigestExpr` (the same transforms migrate applied); the **TARGET** side stays raw (already canonical). Equal logical data now digests equal; a real content drift on a coerced column still fails `hashMatch`.

## AC1 — real-data audit (read-only)
Cross-checked every CHECK-enum column in the real `nexus.db` (106M) + `signaldock.db` (280K) against the consolidated target enums: **ZERO out-of-enum values** on all of them (`nexus_nodes.kind` 24,482 rows, `nexus_relations.type` 39,163, `nexus_sigils.role` 8, `agent_registry_agents.status` 19, …). No `ENUM_NORMALIZATIONS` entry or CHECK widening was needed — confirming the "drop" was the AC2 verify false-negative (5 tables have epoch→ISO coerced columns). A full real-data dry-run of `runExodusMigrate` over **copies** reported `ok=true` with **zero deficits**; post-fix verify returns `ok=true`, all tables `hashMatch=true`.

## Validation
- `pnpm --filter @cleocode/core run build` → exit 0; `tsc -b` (CI oracle) → exit 0.
- New `exodus-verify-source-coercion.test.ts` (3 tests) → pass.
- Full store regression `vitest run src/store/exodus src/store/__tests__/` → **1523 passed / 1 pre-existing skip (126 files)**.
- DB-Open Guard `--strict` → OK; no real DB written (read-only + temp copies only; `.cleo/brain.db` 1.7G untouched).

## Kill-switch readiness & one caveat
With this fix, real-data exodus of nexus/signaldock/brain/skills verifies cleanly — clearing the blocker that kept `CLEO_DISABLE_EXODUS_ON_OPEN=1` on. **Owner action still required** to actually run the full real-data migration and drop the kill-switch (per the standing "don't migrate 1.7G brain.db without owner" guard).

⚠️ Caveat (pre-existing, left untouched): the separate `detectTableEnumDrift` *diagnostic* still sets `verify.ok=false` on any raw source enum value the migration normalizes (e.g. tasks `'Accepted'→'accepted'`), even when the row is lossless and `hashMatch=true`. The current nexus/signaldock data has no such drift, so it does not block their cutover; whether normalized-enum drift should stop failing the gate is a separate decision.

Closes T11809 (code-complete + validated; kill-switch removal is the owner's runtime step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)