### PR TITLE
fix(T11659): reconcile provenance backfill FK-ordered + skip-with-warn (DHQ-051)

### DIFF
--- a/packages/core/src/release/__tests__/reconcile-fk-cutover.test.ts
+++ b/packages/core/src/release/__tests__/reconcile-fk-cutover.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Post-cutover reconcile FK smoke test (DHQ-051 · T11659).
+ *
+ * Regression guard for the FK-violation that broke `cleo release reconcile`
+ * against a consolidated dual-scope `cleo.db` (T11578 cutover). The provenance
+ * `task_id` foreign keys (`task_commits`, `pr_tasks`, `releases.epic_id`,
+ * `release_changes.task_id`) reference the BARE `tasks` table, which is empty
+ * after the cutover — the live task store moved to `tasks_tasks`. A task valid
+ * in the runtime store but absent from the FK parent used to abort the entire
+ * reconcile with `E_PROVENANCE_FAILED` (same class as DHQ-045).
+ *
+ * The fix reconciles the FK parent in FK order (parent-before-child): missing
+ * parent rows are copied from `tasks_tasks` into the FK parent table BEFORE the
+ * child provenance rows are written, so the links land AND the FK is satisfied.
+ * A task that exists in neither table stays unresolvable and its single link is
+ * skipped-with-warn / NULLed — never the whole reconcile.
+ *
+ * ## Why this test forces `PRAGMA foreign_keys = ON`
+ *
+ * `getDb()` (sqlite.ts) disables FK enforcement under VITEST so existing
+ * fixtures can seed without full referential integrity — which means every
+ * pre-existing reconcile test runs with FKs OFF and CANNOT reproduce the
+ * production failure. This test re-enables FK enforcement after setup,
+ * matching the established `verify-provenance.test.ts` pattern, so the strict
+ * consolidated constraint is actually exercised.
+ *
+ * @task T11659
+ * @epic T11466
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { releaseReconcileV2 } from '../reconcile.js';
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (
+    path: string,
+    opts?: { readonly?: boolean },
+  ) => import('node:sqlite').DatabaseSync;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migrations folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Set up a fully-migrated consolidated cleo.db + git repo in a temp project root. */
+async function setupProject(): Promise<{ projectRoot: string; cleanup: () => void }> {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'cleo-rec-fk-'));
+  const cleoDir = join(projectRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  mkdirSync(join(cleoDir, 'release'), { recursive: true });
+
+  writeFileSync(
+    join(cleoDir, 'config.json'),
+    JSON.stringify({
+      enforcement: {
+        session: { requiredForMutate: false },
+        acceptance: { mode: 'off' },
+      },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+
+  // Apply legacy drizzle-tasks migrations to create the full bare schema (the
+  // `tasks` / `task_commits` / `commits` FK family) — `getDb()` later layers
+  // the prefixed `tasks_tasks` consolidated tables on top of the same handle.
+  const dbPath = join(cleoDir, 'tasks.db');
+  const nativeDb = new DatabaseSync(dbPath);
+  const { drizzle } = await import('drizzle-orm/node-sqlite');
+  const { reconcileJournal, migrateSanitized } = await import('../../store/migration-manager.js');
+  const db = drizzle({ client: nativeDb });
+  reconcileJournal(nativeDb, migrationsDir(), 'tasks', 'tasks');
+  migrateSanitized(db, { migrationsFolder: migrationsDir() });
+  nativeDb.close();
+
+  execFileSync('git', ['init', '-q'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'user.email', 'test@cleo.dev'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'user.name', 'Cleo Test'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: projectRoot });
+
+  return {
+    projectRoot,
+    cleanup: () => rmSync(projectRoot, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Seed a task into the PREFIXED consolidated table ONLY (post-cutover topology).
+ * The bare `tasks` table — the physical FK parent of the provenance `task_id`
+ * columns — is left EMPTY, which is exactly the production split-brain that
+ * triggers the FK violation when FK enforcement is ON.
+ */
+async function seedConsolidatedTaskOnly(projectRoot: string, taskId: string): Promise<void> {
+  const { getDb } = await import('../../store/sqlite.js');
+  const { sql } = await import('drizzle-orm');
+  const db = await getDb(projectRoot);
+  await db.run(
+    sql`INSERT OR IGNORE INTO tasks_tasks (id, title, status, priority, role, scope)
+        VALUES (${taskId}, ${`Task ${taskId}`}, 'pending', 'medium', 'work', 'feature')`,
+  );
+}
+
+/** Commit a file with a subject; returns the SHA. */
+function gitCommit(projectRoot: string, file: string, content: string, subject: string): string {
+  writeFileSync(join(projectRoot, file), content);
+  execFileSync('git', ['add', file], { cwd: projectRoot });
+  execFileSync('git', ['commit', '-q', '-m', subject], { cwd: projectRoot });
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: projectRoot,
+    encoding: 'utf-8',
+  }).trim();
+}
+
+/** Annotated-tag the current HEAD as `<version>`. */
+function gitTag(projectRoot: string, version: string): void {
+  execFileSync('git', ['tag', '-a', version, '-m', `Release ${version}`], { cwd: projectRoot });
+}
+
+/** Write a synthetic plan file matching the v1 schema. */
+function writePlan(
+  projectRoot: string,
+  version: string,
+  taskIds: string[],
+  changesetIds: string[] = [],
+): void {
+  const nowIso = new Date().toISOString();
+  const plan = {
+    $schema: 'https://cleocode.io/schemas/release-plan/v1.json',
+    version,
+    resolvedVersion: version,
+    suffixApplied: false,
+    scheme: 'calver',
+    channel: 'latest',
+    epicId: taskIds[0] ?? 'T9999',
+    releaseKind: 'regular',
+    createdAt: nowIso,
+    createdBy: 'reconcile-fk-cutover-test',
+    previousVersion: null,
+    previousTag: null,
+    previousShippedAt: null,
+    tasks: taskIds.map((id) => ({
+      id,
+      kind: 'feat' as const,
+      impact: 'minor' as const,
+      userFacingSummary: `Ship ${id}`,
+      evidenceAtoms: [],
+      epicAncestor: taskIds[0] ?? 'T9999',
+    })),
+    changelog: { features: taskIds, fixes: [], chores: [], breaking: [] },
+    gates: [],
+    platformMatrix: [{ platform: 'any', publisher: 'npm', package: '@cleocode/cleo', smoke: true }],
+    preflightSummary: {
+      esbuildExternalsDrift: false,
+      lockfileDrift: false,
+      epicCompletenessClean: true,
+      doubleListingClean: true,
+    },
+    workflowRunUrl: null,
+    prUrl: null,
+    mergeCommitSha: null,
+    status: 'published',
+    meta: {
+      firstEverRelease: true,
+      ...(changesetIds.length > 0 ? { changesetIds } : {}),
+    },
+  };
+  writeFileSync(
+    join(projectRoot, '.cleo', 'release', `${version}.plan.json`),
+    JSON.stringify(plan, null, 2),
+  );
+}
+
+/** Count rows in a table for the given project root. */
+async function countRows(projectRoot: string, table: string): Promise<number> {
+  const { getDb } = await import('../../store/sqlite.js');
+  const { sql } = await import('drizzle-orm');
+  const db = await getDb(projectRoot);
+  const rows = await db.all<{ cnt: number }>(sql.raw(`SELECT COUNT(*) AS cnt FROM ${table}`));
+  return rows[0]?.cnt ?? 0;
+}
+
+/**
+ * Re-enable FK enforcement on the live `cleo.db` handle. `getDb()` forces
+ * `foreign_keys=OFF` under VITEST; flipping it back ON reproduces the strict
+ * consolidated constraint that fires in production.
+ */
+async function enableForeignKeys(): Promise<void> {
+  const { getNativeDb } = await import('../../store/sqlite.js');
+  const native = getNativeDb();
+  if (!native) throw new Error('native db not initialized');
+  native.exec('PRAGMA foreign_keys = ON');
+}
+
+afterEach(async () => {
+  const { resetDbState } = await import('../../store/sqlite.js');
+  resetDbState();
+});
+
+describe('releaseReconcileV2 — post-cutover FK safety (DHQ-051 · T11659)', () => {
+  let projectRoot: string;
+  let cleanup: () => void;
+  const VERSION = 'v2026.7.0';
+  const TASK_ID = 'T8101';
+
+  beforeEach(async () => {
+    const env = await setupProject();
+    projectRoot = env.projectRoot;
+    cleanup = env.cleanup;
+    // Seed the task into the consolidated table ONLY — the bare `tasks` FK
+    // parent starts EMPTY, recreating the production split-brain.
+    await seedConsolidatedTaskOnly(projectRoot, TASK_ID);
+    await enableForeignKeys();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does NOT throw E_PROVENANCE_FAILED under strict FK enforcement (the DHQ-051 repro)', async () => {
+    writePlan(projectRoot, VERSION, [TASK_ID]);
+    gitCommit(projectRoot, 'a.txt', '1', `feat(${TASK_ID}): ship a\n\nRefs: ${TASK_ID}`);
+    gitTag(projectRoot, VERSION);
+
+    const result = await releaseReconcileV2(VERSION, { projectRoot });
+
+    // Before the fix this aborted with E_PROVENANCE_FAILED on the `task_commits`
+    // FK. It must now succeed.
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error(
+        `reconcile failed: ${result.error.code} — ${result.error.message} (table=${JSON.stringify((result.error.details as { table?: string })?.table)})`,
+      );
+    }
+  });
+
+  it('backfills the FK parent in FK order so task_commits links are PRESERVED, not dropped', async () => {
+    writePlan(projectRoot, VERSION, [TASK_ID]);
+    gitCommit(projectRoot, 'a.txt', '1', `feat(${TASK_ID}): ship a`);
+    gitTag(projectRoot, VERSION);
+
+    const result = await releaseReconcileV2(VERSION, { projectRoot });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // All provenance tables backfill.
+    expect(await countRows(projectRoot, 'releases')).toBe(1);
+    expect(await countRows(projectRoot, 'release_commits')).toBeGreaterThanOrEqual(1);
+    expect(await countRows(projectRoot, 'release_changes')).toBe(1);
+    expect(await countRows(projectRoot, 'release_artifacts')).toBe(1);
+
+    // The FK-ordered parent shim made the task resolvable → the task_commits
+    // link IS written (provenance preserved) and the task is NOT skipped.
+    expect(await countRows(projectRoot, 'task_commits')).toBe(1);
+    expect(result.data.skippedTaskRefs ?? []).not.toContain(TASK_ID);
+
+    // release_changes keeps its task linkage (task_id NOT nulled).
+    const { getDb } = await import('../../store/sqlite.js');
+    const { sql } = await import('drizzle-orm');
+    const db = await getDb(projectRoot);
+    const changeRows = await db.all<{ task_id: string | null }>(
+      sql`SELECT task_id FROM release_changes`,
+    );
+    expect(changeRows).toHaveLength(1);
+    expect(changeRows[0]?.task_id).toBe(TASK_ID);
+
+    // The FK parent (bare `tasks`) now holds exactly the shimmed row.
+    const fkParentRows = await db.all<{ id: string }>(
+      sql`SELECT id FROM tasks WHERE id = ${TASK_ID}`,
+    );
+    expect(fkParentRows).toHaveLength(1);
+  });
+
+  it('archives this release’s changesets to .changeset/shipped/ after a successful reconcile', async () => {
+    writePlan(projectRoot, VERSION, [TASK_ID], ['ship-fk']);
+    const changesetDir = join(projectRoot, '.changeset');
+    mkdirSync(changesetDir, { recursive: true });
+    writeFileSync(
+      join(changesetDir, 'ship-fk.md'),
+      `---\nid: ship-fk\ntasks: [${TASK_ID}]\nkind: feat\nsummary: Ship via FK-cutover path.\n---\n`,
+    );
+
+    gitCommit(projectRoot, 'a.txt', '1', `feat(${TASK_ID}): ship a`);
+    gitTag(projectRoot, VERSION);
+
+    const result = await releaseReconcileV2(VERSION, { projectRoot });
+    expect(result.success).toBe(true);
+
+    // Changeset archived under the version-scoped shipped/ dir — proving the
+    // post-reconcile archival path is reached (it only runs when reconcile
+    // does not abort).
+    expect(existsSync(join(changesetDir, 'ship-fk.md'))).toBe(false);
+    expect(existsSync(join(changesetDir, 'shipped', VERSION, 'ship-fk.md'))).toBe(true);
+  });
+
+  it('skips-with-warn (does not abort) when a VALID task cannot be shimmed into the FK parent', async () => {
+    // Make the FK-parent shim copy FAIL for a task that IS valid in the runtime
+    // store: seed a `tasks_tasks` row with `status='done'` (accepted there) — the
+    // bare `tasks` table's T877 invariant trigger RAISE(ABORT)s the shim
+    // `INSERT … SELECT` because `pipeline_stage` is NULL (status=done requires a
+    // terminal pipeline_stage). The id therefore stays unresolvable; the single
+    // link is skipped-with-warn and the reconcile must still succeed.
+    const badId = 'T8199';
+    const { getDb, getNativeDb } = await import('../../store/sqlite.js');
+    const { sql } = await import('drizzle-orm');
+    const db = await getDb(projectRoot);
+    const native = getNativeDb();
+    if (!native) throw new Error('native db not initialized');
+    native.exec('PRAGMA foreign_keys = OFF');
+    await db.run(
+      sql`INSERT OR IGNORE INTO tasks_tasks (id, title, status, priority, role, scope)
+          VALUES (${badId}, ${'done task'}, 'done', 'medium', 'work', 'feature')`,
+    );
+    native.exec('PRAGMA foreign_keys = ON');
+
+    writePlan(projectRoot, VERSION, [badId]);
+    gitCommit(projectRoot, 'a.txt', '1', `feat(${badId}): ship a\n\nRefs: ${badId}`);
+    gitTag(projectRoot, VERSION);
+
+    const result = await releaseReconcileV2(VERSION, { projectRoot });
+    // Reconcile still SUCCEEDS — the single unresolvable link is skipped, the
+    // run is not aborted.
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error(
+        `reconcile failed: ${result.error.code} — ${result.error.message} (table=${JSON.stringify((result.error.details as { table?: string })?.table)})`,
+      );
+    }
+    expect(result.data.skippedTaskRefs).toContain(badId);
+    // The dangling task_commits link was skipped (no FK violation).
+    expect(await countRows(projectRoot, 'task_commits')).toBe(0);
+    // release_changes row still exists with a NULLed task_id.
+    const changeRows = await db.all<{ task_id: string | null }>(
+      sql`SELECT task_id FROM release_changes`,
+    );
+    expect(changeRows).toHaveLength(1);
+    expect(changeRows[0]?.task_id).toBeNull();
+  });
+
+  it('links task_commits when the FK parent (bare tasks) ALREADY contains the task', async () => {
+    // Exodus-populated-both case: the bare `tasks` parent already has the row,
+    // so no shim is needed and the link is written directly.
+    const { getDb, getNativeDb } = await import('../../store/sqlite.js');
+    const { sql } = await import('drizzle-orm');
+    const db = await getDb(projectRoot);
+    const native = getNativeDb();
+    if (!native) throw new Error('native db not initialized');
+    native.exec('PRAGMA foreign_keys = OFF');
+    await db.run(
+      sql`INSERT OR IGNORE INTO tasks (id, title, status, priority, role, scope)
+          VALUES (${TASK_ID}, ${`Task ${TASK_ID}`}, 'pending', 'medium', 'work', 'feature')`,
+    );
+    native.exec('PRAGMA foreign_keys = ON');
+
+    writePlan(projectRoot, VERSION, [TASK_ID]);
+    gitCommit(projectRoot, 'a.txt', '1', `feat(${TASK_ID}): ship a`);
+    gitTag(projectRoot, VERSION);
+
+    const result = await releaseReconcileV2(VERSION, { projectRoot });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(await countRows(projectRoot, 'task_commits')).toBe(1);
+    expect(result.data.skippedTaskRefs ?? []).not.toContain(TASK_ID);
+  });
+});

--- a/packages/core/src/release/reconcile.ts
+++ b/packages/core/src/release/reconcile.ts
@@ -45,7 +45,7 @@ import { type EngineResult, engineError, engineSuccess } from '../engine-result.
 import { getLogger } from '../logger.js';
 import { generateProjectHash } from '../nexus/hash.js';
 import { getProjectRoot } from '../paths.js';
-import { getDb, getNativeDb } from '../store/sqlite.js';
+import { type DatabaseSync, getDb, getNativeDb } from '../store/sqlite.js';
 import * as schema from '../store/tasks-schema.js';
 
 const log = getLogger('release:reconcile-v2');
@@ -120,6 +120,14 @@ export interface ReleaseReconcileV2Result {
   reReconciled?: boolean;
   /** T#### tokens encountered that did not validate against `tasks.id` (R-331). */
   unknownTokens?: string[];
+  /**
+   * Task IDs present in the runtime task store but UNRESOLVABLE by the
+   * provenance `task_id` foreign keys (their FK parent — the bare `tasks` table
+   * on a consolidated cleo.db — has no matching row). Their provenance links
+   * were skipped-with-warn or NULLed rather than aborting the reconcile
+   * (DHQ-051 · T11659).
+   */
+  skippedTaskRefs?: string[];
   /** Total wall-clock duration (filled into envelope `meta.durationMs`). */
   durationMs?: number;
   /** Total inserts performed (filled into envelope `meta.txSize`). */
@@ -872,6 +880,126 @@ export function sanitisePrShasForFk(
   };
 }
 
+// ─── Helpers — FK-safe task-id resolution (DHQ-051 · T11659) ────────────────
+
+/** Result of resolving + reconciling the provenance `task_id` FK parent table. */
+export interface FkParentTaskResolution {
+  /** Physical table the provenance `task_id` FK references, or null if absent. */
+  parentTable: string | null;
+  /**
+   * Task IDs the FK can now resolve (FK parent rows present after any
+   * FK-ordered shim backfill). A `task_id` reference to an id in this set is
+   * safe to INSERT under strict FK enforcement.
+   */
+  resolvableIds: Set<string>;
+}
+
+/**
+ * Make the provenance `task_id` foreign keys satisfiable on a consolidated
+ * `cleo.db` by inserting any missing FK-parent rows in FK order (parent-before
+ * -child), then returning the set of IDs the FK can resolve.
+ *
+ * ## Background (DHQ-051 · T11659 — same class as DHQ-045)
+ *
+ * After the dual-scope `cleo.db` cutover (T11578) the runtime task store moved
+ * from the bare `tasks` table to the prefixed `tasks_tasks` table. The drizzle
+ * `schema.tasks` symbol is shadowed at the barrel (`tasks-schema.ts`) onto
+ * `tasks_tasks`, so reconcile's token-validity probe reads the populated
+ * prefixed table. BUT the provenance tables (`task_commits`, `pr_tasks`,
+ * `releases`, `release_changes`) predate the cutover — their `task_id` /
+ * `epic_id` FKs still reference the BARE `tasks` table, which is empty on a
+ * consolidated `cleo.db`. A token validated against `tasks_tasks` therefore
+ * passes the legacy gate yet violates the FK at INSERT time, aborting the
+ * whole reconcile with `E_PROVENANCE_FAILED`.
+ *
+ * ## Strategy — FK-ordered parent backfill (Strategy 1)
+ *
+ * For every task referenced by this release we ensure a row exists in the FK
+ * parent table BEFORE the child provenance rows are written. The parent table
+ * is discovered dynamically via `PRAGMA foreign_key_list('task_commits')` (so
+ * the logic tracks whatever the live schema enforces — including a future
+ * schema that repoints the FK at `tasks_tasks`, where this becomes a no-op).
+ * Missing parent rows are copied from the runtime `tasks_tasks` store via
+ * `INSERT OR IGNORE … SELECT` of only the NOT NULL columns, so the copied rows
+ * satisfy the parent table's own CHECK/NOT NULL constraints. Tasks that exist
+ * in neither table remain unresolvable and are skipped-with-warn by the
+ * callers (the row, never the whole reconcile).
+ *
+ * Idempotent: `INSERT OR IGNORE` never duplicates and never overwrites an
+ * existing parent row. Runs inside the reconcile transaction so a later
+ * failure rolls the shim rows back too.
+ *
+ * @param nativeDb - The consolidated `cleo.db` native handle.
+ * @param referencedIds - Every task id this reconcile may reference (commit
+ *   tokens, PR tokens, plan tasks, epic).
+ * @returns The FK parent table name + the IDs it can now resolve.
+ */
+export function ensureProvenanceTaskFkParents(
+  nativeDb: DatabaseSync,
+  referencedIds: ReadonlySet<string>,
+): FkParentTaskResolution {
+  // Discover the physical parent table the `task_commits.task_id` FK targets.
+  let parentTable = 'tasks';
+  try {
+    const fks = nativeDb.prepare(`PRAGMA foreign_key_list('task_commits')`).all() as Array<{
+      table: string;
+      from: string;
+    }>;
+    const taskFk = fks.find((fk) => fk.from === 'task_id');
+    if (taskFk?.table) parentTable = taskFk.table;
+  } catch {
+    // PRAGMA unavailable (table absent / older sqlite) — keep the bare default.
+  }
+
+  const tableExists = (name: string): boolean =>
+    nativeDb.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(name) !=
+    null;
+
+  // Parent table absent entirely → nothing resolvable, nothing to backfill.
+  if (!tableExists(parentTable)) {
+    return { parentTable: null, resolvableIds: new Set<string>() };
+  }
+
+  // FK-ordered shim backfill: copy any referenced task that lives in the
+  // runtime `tasks_tasks` store but is missing from the FK parent. Only when
+  // the parent is the bare legacy table AND the prefixed store exists (i.e. the
+  // post-cutover split-brain) — when the FK already points at `tasks_tasks`
+  // this is skipped and the parent is read as-is.
+  // Identifiers come from sqlite_master / the FK pragma (verified existing
+  // table names), never user input — safe to interpolate (node:sqlite exposes
+  // no bound-identifier form). All VALUES are bound parameters.
+  if (parentTable !== 'tasks_tasks' && tableExists('tasks_tasks') && referencedIds.size > 0) {
+    const insertShim = nativeDb.prepare(
+      `INSERT OR IGNORE INTO "${parentTable}" (id, title, status, priority, role, scope)
+       SELECT id, title, status, priority, role, scope FROM tasks_tasks WHERE id = ?`,
+    );
+    for (const id of referencedIds) {
+      try {
+        insertShim.run(id);
+      } catch (err) {
+        // A single shim copy that violates the parent's own constraints (e.g. a
+        // NOT NULL / CHECK the prefixed row does not satisfy) must NOT abort the
+        // whole reconcile. Leave the id unresolvable — the writers below
+        // skip-with-warn that one link (Strategy 3). SAVEPOINT-free: the failed
+        // statement is rolled back individually by SQLite, leaving the
+        // surrounding transaction intact.
+        log.warn(
+          { taskId: id, parentTable, err: err instanceof Error ? err.message : String(err) },
+          'reconcile: FK-parent shim copy failed — task_id stays unresolvable, link will be skipped',
+        );
+      }
+    }
+  }
+
+  // Read back what the FK can now resolve.
+  const resolvableIds = new Set<string>();
+  const rows = nativeDb.prepare(`SELECT id FROM "${parentTable}"`).all() as Array<{ id: unknown }>;
+  for (const r of rows) {
+    if (typeof r.id === 'string') resolvableIds.add(r.id);
+  }
+  return { parentTable, resolvableIds };
+}
+
 // ─── Main reconcile entrypoint ──────────────────────────────────────────────
 
 /**
@@ -929,6 +1057,9 @@ export async function releaseReconcileV2(
   const db = await getDb(projectRoot);
 
   // ── 3. Pre-flight: list of valid task IDs for token validation (R-331) ──
+  // `validTaskIds` reads the RUNTIME task store (`schema.tasks` shadows the
+  // prefixed `tasks_tasks` table post-cutover) — this drives the user-facing
+  // "unknown token" report.
   const validTaskIds = new Set<string>();
   {
     const rows = await db.select({ id: schema.tasks.id }).from(schema.tasks).all();
@@ -936,6 +1067,18 @@ export async function releaseReconcileV2(
       if (typeof r.id === 'string') validTaskIds.add(r.id);
     }
   }
+
+  // `fkResolvableTaskIds` (DHQ-051 · T11659) holds the IDs the provenance
+  // `task_id` FKs can resolve. On a consolidated `cleo.db` those FKs reference
+  // the bare `tasks` table (empty post-cutover) while runtime data lives in
+  // `tasks_tasks`. It is FILLED inside the transaction by
+  // `ensureProvenanceTaskFkParents`, which inserts the needed FK-parent rows in
+  // FK order (parent-before-child) so the links can be written; any task that
+  // exists in neither table stays unresolvable and its single link is
+  // skipped-with-warn / NULLed by the writers below — never the whole reconcile.
+  const fkResolvableTaskIds = new Set<string>();
+  /** Task IDs dropped from a provenance link because the FK could not resolve them. */
+  const skippedTaskRefs = new Set<string>();
 
   const unknownTokens = new Set<string>();
   const orphanCommits: string[] = [];
@@ -989,8 +1132,44 @@ export async function releaseReconcileV2(
   let brainLinkCount = 0;
   let brainEntryId: string | null = null;
 
+  // ── 6b. Collect every task id this reconcile may reference, so the FK-parent
+  //        backfill (DHQ-051 · T11659) can pre-seed parent rows in FK order. ──
+  const referencedTaskIds = new Set<string>();
+  for (const c of commits) {
+    for (const tok of extractTaskTokens(c)) {
+      if (validTaskIds.has(tok)) referencedTaskIds.add(tok);
+    }
+  }
+  for (const pr of fetchedPRs) {
+    const prText = `${pr.title}\n${pr.body ?? ''}\n${pr.headRef}`;
+    TASK_TOKEN_RE.lastIndex = 0;
+    let pt: RegExpExecArray | null = TASK_TOKEN_RE.exec(prText);
+    while (pt !== null) {
+      if (validTaskIds.has(pt[0])) referencedTaskIds.add(pt[0]);
+      pt = TASK_TOKEN_RE.exec(prText);
+    }
+  }
+  for (const task of plan.tasks) {
+    if (validTaskIds.has(task.id)) referencedTaskIds.add(task.id);
+  }
+  if (plan.epicId && validTaskIds.has(plan.epicId)) referencedTaskIds.add(plan.epicId);
+
   try {
     await withTransaction(async () => {
+      // ── FK-parent reconciliation (DHQ-051 · T11659) — MUST run first so the
+      //    provenance `task_id` FKs resolve under strict enforcement. Inserts
+      //    any missing FK-parent rows in FK order (parent-before-child) and
+      //    records which ids the FK can now satisfy. ──
+      try {
+        const nativeDbForFk = getNativeDb();
+        if (nativeDbForFk) {
+          const resolution = ensureProvenanceTaskFkParents(nativeDbForFk, referencedTaskIds);
+          for (const id of resolution.resolvableIds) fkResolvableTaskIds.add(id);
+        }
+      } catch (err) {
+        throw new ProvenanceTableError('tasks (fk-parent backfill)', err);
+      }
+
       // ── commits + commit_files ──
       try {
         for (const c of commits) {
@@ -1070,6 +1249,18 @@ export async function releaseReconcileV2(
           for (const tok of tokens) {
             if (!validTaskIds.has(tok)) {
               unknownTokens.add(tok);
+              continue;
+            }
+            // FK safety (DHQ-051 · T11659): `task_commits.task_id` FKs the bare
+            // `tasks` table, which is empty on a consolidated cleo.db. A token
+            // valid in the runtime store but unresolvable by the FK is
+            // skipped-with-warn — dropping the single link, never the reconcile.
+            if (!fkResolvableTaskIds.has(tok)) {
+              skippedTaskRefs.add(tok);
+              log.warn(
+                { taskId: tok, commitSha: c.sha, table: 'task_commits' },
+                'reconcile: task_id unresolvable by FK parent — skipping task_commits link',
+              );
               continue;
             }
             const linkSource = c.subject.includes(tok) ? 'commit-message' : 'commit-trailer';
@@ -1187,6 +1378,16 @@ export async function releaseReconcileV2(
               unknownTokens.add(tok);
               continue;
             }
+            // FK safety (DHQ-051 · T11659): `pr_tasks.task_id` FKs the bare
+            // `tasks` table — skip-with-warn when the FK cannot resolve the id.
+            if (!fkResolvableTaskIds.has(tok)) {
+              skippedTaskRefs.add(tok);
+              log.warn(
+                { taskId: tok, prId, table: 'pr_tasks' },
+                'reconcile: task_id unresolvable by FK parent — skipping pr_tasks link',
+              );
+              continue;
+            }
             let linkSource: schema.PrLinkSource = 'pr-body';
             if (pr.title.includes(tok)) linkSource = 'pr-title';
             else if (pr.headRef.includes(tok)) linkSource = 'branch-name';
@@ -1215,6 +1416,21 @@ export async function releaseReconcileV2(
         // avoid violating the constraint at INSERT time.
         const safeReleaseMergeSha =
           plan.mergeCommitSha && insertedShas.has(plan.mergeCommitSha) ? plan.mergeCommitSha : null;
+        // FK safety (DHQ-051 · T11659): `releases.epic_id` FKs the bare `tasks`
+        // table (ON DELETE SET NULL, nullable). When the epic is unresolvable by
+        // the FK parent, NULL the column rather than violate the constraint.
+        const safeEpicId = plan.epicId && fkResolvableTaskIds.has(plan.epicId) ? plan.epicId : null;
+        if (plan.epicId && safeEpicId === null) {
+          // Only a VALID runtime task that the FK could not resolve is a true
+          // "skipped ref" — an epic id that is not even a known task was never
+          // linkable and is NULLed silently (it surfaces under unknownTokens if
+          // it appeared in commit/PR text).
+          if (validTaskIds.has(plan.epicId)) skippedTaskRefs.add(plan.epicId);
+          log.warn(
+            { epicId: plan.epicId, releaseId, table: 'releases' },
+            'reconcile: epic_id unresolvable by FK parent — nulling releases.epic_id',
+          );
+        }
         await db
           .insert(schema.releases)
           .values({
@@ -1222,7 +1438,7 @@ export async function releaseReconcileV2(
             version,
             scheme: plan.scheme,
             channel: mapChannel(plan.channel),
-            epicId: plan.epicId,
+            epicId: safeEpicId,
             releaseKind: plan.releaseKind,
             status: 'reconciled',
             previousVersion: plan.previousVersion,
@@ -1290,12 +1506,20 @@ export async function releaseReconcileV2(
           // Build deterministic ID so re-running upserts the same row.
           const idSeed = `${releaseId}|${task.id}|${changeType}`;
           const id = createHash('sha256').update(idSeed).digest('hex').slice(0, 32);
+          // FK safety (DHQ-051 · T11659): `release_changes.task_id` FKs the bare
+          // `tasks` table (ON DELETE SET NULL, nullable). NULL the column when
+          // the FK parent cannot resolve the id; the change row still records
+          // the summary/impact, just without the dangling task linkage.
+          const safeTaskId = fkResolvableTaskIds.has(task.id) ? task.id : null;
+          if (safeTaskId === null && validTaskIds.has(task.id)) {
+            skippedTaskRefs.add(task.id);
+          }
           await db
             .insert(schema.releaseChanges)
             .values({
               id,
               releaseId,
-              taskId: validTaskIds.has(task.id) ? task.id : null,
+              taskId: safeTaskId,
               changeType,
               summary: task.userFacingSummary || `${task.id}: ${task.kind}`,
               description: null,
@@ -1455,6 +1679,7 @@ export async function releaseReconcileV2(
     brainLinkCount,
     orphanCommits,
     ...(unknownTokens.size > 0 ? { unknownTokens: Array.from(unknownTokens) } : {}),
+    ...(skippedTaskRefs.size > 0 ? { skippedTaskRefs: Array.from(skippedTaskRefs) } : {}),
     ...(reReconciled ? { reReconciled: true } : {}),
     durationMs,
     txSize,


### PR DESCRIPTION
## Root cause
`cleo release reconcile` threw `E_PROVENANCE_FAILED` on the consolidated cleo.db. The failing FK is `task_commits.task_id → tasks.id` (`store/schema/provenance/commits.ts:184`; confirmed live via `PRAGMA foreign_key_list`). Post-cutover (T11578), `schema.tasks` is shadowed onto the prefixed `tasks_tasks` table where runtime data lives, but the provenance FKs still point at the **bare `tasks` table, which is empty**. Reconcile validated tokens against `tasks_tasks` (found), then INSERTed into `task_commits` whose FK checks the empty bare `tasks` → `FOREIGN KEY constraint failed` → full rollback (no provenance backfill, no changeset archival). Same class affects `pr_tasks.task_id`, `releases.epic_id`, `release_changes.task_id`.

**Why no test caught it:** `getDb()` forces `PRAGMA foreign_keys=OFF` under VITEST (`sqlite.ts:480-482`), so every prior reconcile test ran with FKs disabled.

## Fix (Strategy 1 FK-ordered parent insert + Strategy 3 skip-with-warn)
- New `ensureProvenanceTaskFkParents()` discovers the real FK parent table and, **first inside the reconcile transaction**, copies any referenced task missing from the parent out of `tasks_tasks` via `INSERT OR IGNORE … SELECT` (per-row failures are caught — that id just stays unresolvable).
- `task_commits` + `pr_tasks` writers skip-with-warn the single unresolvable link; `releases.epic_id` + `release_changes.task_id` NULL the nullable FK when unresolvable.
- Never disables FK enforcement globally; never silent-drops — every skip logs and surfaces in `ReleaseReconcileV2Result.skippedTaskRefs`.
- Forward-compatible: if a future migration repoints these FKs at `tasks_tasks`, the shim becomes a no-op automatically.

## Validation
- `tsc -b` (full repo, CI oracle) → **exit 0**.
- New `reconcile-fk-cutover.test.ts` (5 cases) — forces `PRAGMA foreign_keys=ON` to reproduce production; covers no-throw repro, FK-order link preservation, changeset archival to `.changeset/shipped/`, skip-with-warn for an unshimmable valid task, and direct-link when the parent is already populated → **5/5 pass** (and genuinely catches the bug: **3 failed** against the unpatched reconcile).
- `vitest run src/release` → **352 passed / 2 pre-existing skips (40 files)**; biome clean.

## Notes
- Changeset `.changeset/shipped/` archival is exercised by the test, not a live release — worth confirming against a real consolidated cleo.db reconcile.
- Leaves the schema split-brain (provenance FKs → dead bare `tasks`) in place and works around it at write time; a follow-up schema task to repoint the FKs would let the shim be removed.

Closes T11659 (DHQ-051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)