### PR TITLE
feat(T11756): ProviderProfile gains tier/defaultAuxModel/defaultMaxTokens/fixedTemperature (hermes parity)

### DIFF
--- a/packages/contracts/src/llm/provider-profile.ts
+++ b/packages/contracts/src/llm/provider-profile.ts
@@ -15,6 +15,17 @@ import type { TransportMessage, TransportTool } from './normalized-response.js';
 import type { ProviderOAuthConfig } from './oauth.js';
 
 /**
+ * Coarse provider capability tier used by the system-of-use router (E9).
+ *
+ * Ordered most→least capable: `frontier` (flagship reasoning), `standard`
+ * (general-purpose), `fast` (cheap/low-latency aux), `local` (on-device, e.g.
+ * Ollama). Sourced from the models.dev catalog (E8) when generated.
+ *
+ * @task T11756
+ */
+export type ProviderTier = 'frontier' | 'standard' | 'fast' | 'local';
+
+/**
  * Describes a single LLM provider — its auth capabilities, base URL,
  * default model, and optional live model-discovery hook.
  *
@@ -54,8 +65,56 @@ export interface ProviderProfile {
    * Alternate names that resolve to this profile. Resolution is
    * case-insensitive. Alias conflicts with another profile's primary name
    * cause a `TypeError` at registration time.
+   *
+   * The canonical alias map (`codex`→`openai`, `google`→`gemini`, …) is declared
+   * here as DATA so the resolver never branches on provider name in code
+   * (T11756 AC2 · hermes `ProviderProfile.aliases` parity).
    */
   aliases?: ReadonlyArray<string>;
+
+  /**
+   * Coarse capability tier for system-of-use routing (E9). Sourced from the
+   * models.dev catalog capabilities when generated (E8 join), hand-set for
+   * builtins. Absent = unknown (the router treats it as `standard`).
+   *
+   * Hermes derives this from `model_metadata`; CLEO carries it as profile DATA
+   * so `resolveLLMForSystem` can pick the right tier without a code branch.
+   *
+   * @task T11756
+   */
+  readonly tier?: ProviderTier;
+
+  /**
+   * Cheap/fast auxiliary model for low-stakes calls (title generation, summaries,
+   * the warm/aux tier). Hermes `ProviderProfile.default_aux_model` parity. Absent
+   * (or empty) → fall back to {@link defaultModel}.
+   *
+   * @task T11756
+   */
+  readonly defaultAuxModel?: string;
+
+  /**
+   * Default `maxTokens` for this provider when the caller omits it. Hermes
+   * `ProviderProfile.default_max_tokens` parity. Absent → the transport's own
+   * default applies.
+   *
+   * @task T11756
+   */
+  readonly defaultMaxTokens?: number;
+
+  /**
+   * Temperature handling this provider REQUIRES. Hermes
+   * `ProviderProfile.fixed_temperature` parity:
+   *  - a `number` — the provider only accepts this exact temperature (e.g. the
+   *    OpenAI o-series require `1`); the transport MUST send it and ignore the
+   *    caller's override.
+   *  - `'omit'` — the provider rejects a `temperature` field entirely; the
+   *    transport MUST NOT send one.
+   *  - absent — the caller's temperature (or the transport default) applies.
+   *
+   * @task T11756
+   */
+  readonly fixedTemperature?: number | 'omit';
 
   /**
    * HTTP headers sent with every request to this provider.

--- a/packages/core/src/llm/__tests__/provider-registry.test.ts
+++ b/packages/core/src/llm/__tests__/provider-registry.test.ts
@@ -269,4 +269,29 @@ export function register(api) {
     const profile = await getProviderProfile('anthropic');
     expect(profile).toBeDefined();
   });
+
+  // ── T11756: hermes-parity routing/catalog fields + canonical alias map ──────
+
+  it('carries hermes-parity tier/defaultAuxModel/defaultMaxTokens fields (T11756)', async () => {
+    process.env['CLEO_HOME'] = join(tmpdir(), 'no-such-cleo-home-' + Date.now());
+
+    const openai = await getProviderProfile('openai');
+    expect(openai?.tier).toBe('frontier');
+    expect(openai?.defaultAuxModel).toBe('gpt-5-mini');
+    expect(openai?.defaultMaxTokens).toBe(4096);
+
+    const ollama = await getProviderProfile('ollama');
+    expect(ollama?.tier).toBe('local');
+    expect(ollama?.defaultMaxTokens).toBe(2048);
+  });
+
+  it('declares the canonical alias map as data — codex→openai, google→gemini (T11756)', async () => {
+    process.env['CLEO_HOME'] = join(tmpdir(), 'no-such-cleo-home-' + Date.now());
+
+    const fromCodex = await getProviderProfile('codex');
+    expect(fromCodex?.name).toBe('openai');
+
+    const fromGoogle = await getProviderProfile('google');
+    expect(fromGoogle?.name).toBe('gemini');
+  });
 });

--- a/packages/core/src/llm/provider-registry/builtin/anthropic.ts
+++ b/packages/core/src/llm/provider-registry/builtin/anthropic.ts
@@ -86,6 +86,10 @@ export const anthropicProfile: ProviderProfile = {
   baseUrl: 'https://api.anthropic.com',
   defaultModel: 'claude-haiku-4-5-20251001',
   aliases: ['claude', 'anthropic-api'],
+  // Hermes-parity routing/catalog fields (T11756); catalog-sourced under E8.
+  tier: 'frontier',
+  defaultAuxModel: 'claude-haiku-4-5-20251001',
+  defaultMaxTokens: 4096,
   defaultHeaders: { 'anthropic-version': '2023-06-01' },
   oauth: ANTHROPIC_OAUTH,
 };

--- a/packages/core/src/llm/provider-registry/builtin/gemini.ts
+++ b/packages/core/src/llm/provider-registry/builtin/gemini.ts
@@ -61,6 +61,10 @@ export const geminiProfile: ProviderProfile = {
   baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
   defaultModel: 'gemini-2.0-flash',
   aliases: ['google', 'google-gemini'],
+  // Hermes-parity routing/catalog fields (T11756); catalog-sourced under E8.
+  tier: 'standard',
+  defaultAuxModel: 'gemini-2.0-flash',
+  defaultMaxTokens: 4096,
   envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
 
   /**

--- a/packages/core/src/llm/provider-registry/builtin/ollama.ts
+++ b/packages/core/src/llm/provider-registry/builtin/ollama.ts
@@ -44,6 +44,10 @@ export const ollamaProfile: ProviderProfile = {
   baseUrl: 'http://localhost:11434',
   defaultModel: 'llama3',
   aliases: ['ollama-local'],
+  // Hermes-parity routing/catalog fields (T11756). Local on-device tier.
+  tier: 'local',
+  defaultAuxModel: 'llama3',
+  defaultMaxTokens: 2048,
   envVars: ['OLLAMA_API_KEY', 'OLLAMA_BASE_URL'],
   supportsThinkingBudget: false,
 };

--- a/packages/core/src/llm/provider-registry/builtin/openai.ts
+++ b/packages/core/src/llm/provider-registry/builtin/openai.ts
@@ -81,5 +81,11 @@ export const openaiProfile: ProviderProfile = {
   // to the confirmed latest OpenAI model (catalog release_date 2026-04-23).
   defaultModel: 'gpt-5.5',
   aliases: ['codex', 'chatgpt', 'openai-codex'],
+  // Hermes-parity routing/catalog fields (T11756). tier + defaultAuxModel are
+  // catalog-sourced (E8 join, T11773) when a snapshot is present; these are the
+  // static fallbacks used until the catalog populates them.
+  tier: 'frontier',
+  defaultAuxModel: 'gpt-5-mini',
+  defaultMaxTokens: 4096,
   oauth: OPENAI_CODEX_OAUTH,
 };


### PR DESCRIPTION
## What
Additive **hermes `providers/base.py` parity** fields on `ProviderProfile` (the E2 provider descriptor), prerequisite for the T11767 data-driven transport table:

| Field | Hermes parity | Notes |
|-------|---------------|-------|
| `tier` (`ProviderTier`) | derived from model_metadata | `frontier\|standard\|fast\|local`; catalog-sourced under E8 |
| `defaultAuxModel` | `default_aux_model` | cheap/fast model for low-stakes/aux calls |
| `defaultMaxTokens` | `default_max_tokens` | provider default max tokens |
| `fixedTemperature` (`number \| 'omit'`) | `fixed_temperature` | o-series require an exact temp; `'omit'` = don't send |

## Acceptance (T11756)
- [x] AC1 — `aliases[]` (already present) + `defaultAuxModel`/`defaultMaxTokens`/`fixedTemperature` added (hermes base.py parity)
- [x] AC2 — alias map `codex→openai`, `google→gemini` declared as profile DATA (already present; now **test-locked**)
- [x] AC3 — `tier`/`defaultAuxModel` are catalog-sourced (E8 join); the four core builtins carry static fallbacks, the rest fill from models.dev (NOT hand-curated)
- [x] AC4 — tests (provider-registry 13/13)

All fields optional/additive — **zero behavior change**. Build green; contracts purity preserved (types only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)