### PR TITLE
feat(T11767): data-driven transport adapter table (Record<ApiMode,TransportCtor>)

### DIFF
--- a/packages/core/src/llm/__tests__/model-runner.test.ts
+++ b/packages/core/src/llm/__tests__/model-runner.test.ts
@@ -14,13 +14,17 @@
  */
 
 import type { ResolvedLLMDescriptor } from '@cleocode/contracts';
+import type { ResolvedCredential } from '@cleocode/contracts/llm/resolved-credential.js';
 import { describe, expect, it } from 'vitest';
 import { deriveApiWire } from '../api-mode.js';
 import { type BuiltModel, ModelRunner } from '../model-runner.js';
 import { AnthropicTransport } from '../transports/anthropic.js';
+import { BedrockTransport } from '../transports/bedrock.js';
 import { ChatCompletionsTransport } from '../transports/chat-completions.js';
 import { CODEX_OAUTH_BASE_URL } from '../transports/codex-oauth-headers.js';
 import { CodexResponsesTransport } from '../transports/codex-responses.js';
+import { GeminiTransport } from '../transports/gemini.js';
+import { OllamaTransport } from '../transports/ollama.js';
 
 /**
  * Build a minimal {@link ResolvedLLMDescriptor} for a test, supplying the
@@ -133,5 +137,90 @@ describe('ModelRunner.build — both surfaces from one descriptor (T11745 step 1
     // codex has no core Vercel binding — caller uses the transport session.
     expect(built.session).toBeDefined();
     expect(built.languageModel).toBeNull();
+  });
+});
+
+describe('ModelRunner data-driven transport adapter table (T11767)', () => {
+  function cred(
+    overrides: Partial<ResolvedCredential> & Pick<ResolvedCredential, 'provider'>,
+  ): ResolvedCredential {
+    return {
+      label: 'default',
+      token: 'sk-test',
+      authType: 'api_key',
+      expiresAt: null,
+      refreshToken: null,
+      extraHeaders: {},
+      baseUrl: null,
+      awsProfile: null,
+      ...overrides,
+    };
+  }
+
+  it('dispatches every ApiMode to its transport class via the adapter table', () => {
+    expect(
+      ModelRunner.buildTransportFromCredential(
+        'anthropic',
+        cred({ provider: 'anthropic' }),
+        'anthropic_messages',
+      ),
+    ).toBeInstanceOf(AnthropicTransport);
+    expect(
+      ModelRunner.buildTransportFromCredential(
+        'openai',
+        cred({ provider: 'openai' }),
+        'chat_completions',
+      ),
+    ).toBeInstanceOf(ChatCompletionsTransport);
+    expect(
+      ModelRunner.buildTransportFromCredential(
+        'gemini',
+        cred({ provider: 'gemini' }),
+        'chat_completions',
+      ),
+    ).toBeInstanceOf(GeminiTransport);
+    expect(
+      ModelRunner.buildTransportFromCredential(
+        'ollama',
+        cred({ provider: 'ollama' }),
+        'ollama_native',
+      ),
+    ).toBeInstanceOf(OllamaTransport);
+    expect(
+      ModelRunner.buildTransportFromCredential(
+        'bedrock',
+        cred({ provider: 'bedrock', authType: 'aws_sdk' }),
+        'bedrock_converse',
+      ),
+    ).toBeInstanceOf(BedrockTransport);
+    expect(
+      ModelRunner.buildTransportFromCredential(
+        'openai',
+        cred({ provider: 'openai', authType: 'oauth', token: 'oauth-tok' }),
+        'codex_responses',
+      ),
+    ).toBeInstanceOf(CodexResponsesTransport);
+  });
+
+  it('routes the kimi-code endpoint quirk under anthropic_messages (zero custom class)', () => {
+    const t = ModelRunner.buildTransportFromCredential(
+      'kimi-code',
+      cred({ provider: 'kimi-code', authType: 'oauth', token: 'sk-kimi-x' }),
+      'anthropic_messages',
+    );
+    expect(t).toBeInstanceOf(AnthropicTransport);
+  });
+
+  it('preserves the no-apiMode provider default: openai+oauth stays chat_completions, NOT codex', () => {
+    // Behaviour-preservation invariant (T11767): a no-apiMode caller (api.ts /
+    // tool-loop.ts) uses the provider's STATIC default mode via
+    // deriveApiWire(provider, null); the codex route requires an EXPLICIT apiMode
+    // stamped by the resolver — it must NOT be auto-derived from authType here.
+    const t = ModelRunner.buildTransportFromCredential(
+      'openai',
+      cred({ provider: 'openai', authType: 'oauth', token: 'oauth-tok' }),
+    );
+    expect(t).toBeInstanceOf(ChatCompletionsTransport);
+    expect(t).not.toBeInstanceOf(CodexResponsesTransport);
   });
 });

--- a/packages/core/src/llm/model-runner.ts
+++ b/packages/core/src/llm/model-runner.ts
@@ -42,6 +42,7 @@ import type { LlmTransport } from '@cleocode/contracts/llm/normalized-response.j
 import type { ResolvedCredential } from '@cleocode/contracts/llm/resolved-credential.js';
 import type { LanguageModel } from 'ai';
 import { getLogger } from '../logger.js';
+import { deriveApiWire } from './api-mode.js';
 import { ConcreteSession } from './concrete-session.js';
 import { getKimiCodeMshHeaders } from './provider-registry/builtin/kimi-code.js';
 import { AnthropicTransport } from './transports/anthropic.js';
@@ -72,6 +73,146 @@ const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding';
  */
 const ANTHROPIC_OAUTH_HEADERS: Readonly<Record<string, string>> = {
   'anthropic-beta': 'oauth-2025-04-20',
+};
+
+// ---------------------------------------------------------------------------
+// Data-driven transport adapter table (T11767)
+// ---------------------------------------------------------------------------
+
+/**
+ * A transport adapter builds the wire transport for ONE {@link ApiMode} from a
+ * resolved credential. Adapters are looked up in {@link TRANSPORT_ADAPTERS} by
+ * the descriptor's `apiMode` — the construction dispatch is DATA (a keyed
+ * table), not a hardcoded provider if/else (T11767 AC1).
+ *
+ * Each apiMode is a DISTINCT wire protocol — `anthropic_messages`, OpenAI
+ * `chat_completions`, the `codex_responses` Responses API, `ollama_native`
+ * NDJSON, and `bedrock_converse` — so each keeps its own protocol class; the
+ * table is the SSoT that maps a mode to its implementation (collapsing five
+ * genuinely-different wire framings into one class would be a giant internal
+ * switch, strictly worse than one class per protocol). Within a mode, the only
+ * remaining provider branch is a same-protocol endpoint quirk expressed as
+ * credential data (kimi-code's coding endpoint + `X-Msh` headers under
+ * `anthropic_messages`; gemini's OpenAI-compat shim under `chat_completions`).
+ *
+ * @task T11767
+ */
+type TransportAdapter = (provider: ModelTransport, credential: ResolvedCredential) => LlmTransport;
+
+/** `codex_responses` — OpenAI Responses API (ChatGPT backend / xAI grok-via-responses). */
+function buildCodexResponsesTransport(
+  provider: ModelTransport,
+  credential: ResolvedCredential,
+): LlmTransport {
+  // OAuth tokens authenticate against the ChatGPT backend with the Cloudflare-
+  // bypass headers; an api_key codex credential carries only its own headers.
+  const defaultHeaders: Record<string, string> =
+    credential.authType === 'oauth'
+      ? { ...credential.extraHeaders, ...buildCodexOAuthHeaders(credential.token) }
+      : { ...credential.extraHeaders };
+  return new CodexResponsesTransport({
+    apiKey: credential.token,
+    baseUrl: credential.baseUrl ?? undefined,
+    defaultHeaders: Object.keys(defaultHeaders).length ? defaultHeaders : undefined,
+    provider,
+  });
+}
+
+/** `anthropic_messages` — native Anthropic SDK (+ the kimi-code coding endpoint quirk). */
+function buildAnthropicMessagesTransport(
+  provider: ModelTransport,
+  credential: ResolvedCredential,
+): LlmTransport {
+  if (provider === 'kimi-code') {
+    // Kimi Code speaks the Anthropic Messages protocol against its own endpoint
+    // (same protocol, different baseUrl + mandatory X-Msh headers — data, not a
+    // separate transport class).
+    return new AnthropicTransport({
+      authToken: credential.token,
+      baseUrl: credential.baseUrl ?? KIMI_CODE_BASE_URL,
+      defaultHeaders: getKimiCodeMshHeaders(),
+    });
+  }
+  // Mirrors the canonical `session-factory.transportForProvider`: OAuth →
+  // authToken slot (+ the required beta header); api_key → apiKey slot.
+  const opts =
+    credential.authType === 'oauth'
+      ? {
+          authToken: credential.token,
+          baseUrl: credential.baseUrl ?? undefined,
+          defaultHeaders: { ...ANTHROPIC_OAUTH_HEADERS, ...credential.extraHeaders },
+        }
+      : {
+          apiKey: credential.token,
+          baseUrl: credential.baseUrl ?? undefined,
+          defaultHeaders: Object.keys(credential.extraHeaders).length
+            ? credential.extraHeaders
+            : undefined,
+        };
+  return new AnthropicTransport(opts);
+}
+
+/** `bedrock_converse` — AWS Bedrock Converse API (SDK-credentialed, no token). */
+function buildBedrockConverseTransport(
+  _provider: ModelTransport,
+  credential: ResolvedCredential,
+): LlmTransport {
+  return new BedrockTransport({ awsProfile: credential.awsProfile ?? undefined });
+}
+
+/** `ollama_native` — Ollama `/api/chat` NDJSON-streaming protocol. */
+function buildOllamaNativeTransport(
+  _provider: ModelTransport,
+  credential: ResolvedCredential,
+): LlmTransport {
+  return new OllamaTransport({
+    baseUrl: credential.baseUrl ?? undefined,
+    apiKey: credential.token || undefined,
+    defaultHeaders: Object.keys(credential.extraHeaders).length
+      ? credential.extraHeaders
+      : undefined,
+  });
+}
+
+/** `chat_completions` — OpenAI-compatible (openai/openrouter/deepseek/xai/groq/moonshot + gemini's compat shim). */
+function buildChatCompletionsTransport(
+  provider: ModelTransport,
+  credential: ResolvedCredential,
+): LlmTransport {
+  if (provider === 'gemini') {
+    // Gemini speaks the OpenAI-compatible shape against its own `/openai`
+    // endpoint via the dedicated GeminiTransport (extra-body thinking config).
+    return new GeminiTransport({
+      apiKey: credential.token,
+      baseUrl: credential.baseUrl ?? undefined,
+    });
+  }
+  const defaultHeaders: Record<string, string> = { ...credential.extraHeaders };
+  if (credential.authType === 'oauth') {
+    defaultHeaders['Authorization'] = `Bearer ${credential.token}`;
+  }
+  return new ChatCompletionsTransport({
+    apiKey: credential.token,
+    baseUrl: credential.baseUrl ?? undefined,
+    defaultHeaders: Object.keys(defaultHeaders).length ? defaultHeaders : undefined,
+    provider,
+  });
+}
+
+/**
+ * The single SSoT adapter table: `ApiMode → TransportAdapter`. Construction of
+ * any provider's transport flows through this table keyed by the descriptor's
+ * resolved `apiMode` (T11767 AC1) — the previous per-provider if/else in
+ * {@link ModelRunner.buildTransportFromCredential} is gone.
+ *
+ * @task T11767
+ */
+const TRANSPORT_ADAPTERS: Readonly<Record<ApiMode, TransportAdapter>> = {
+  codex_responses: buildCodexResponsesTransport,
+  anthropic_messages: buildAnthropicMessagesTransport,
+  bedrock_converse: buildBedrockConverseTransport,
+  ollama_native: buildOllamaNativeTransport,
+  chat_completions: buildChatCompletionsTransport,
 };
 
 /** Ollama's OpenAI-compatible `/v1` shim base URL (Vercel `LanguageModel` path). */
@@ -171,88 +312,16 @@ export const ModelRunner = {
     credential: ResolvedCredential,
     apiMode?: ApiMode,
   ): LlmTransport {
-    // Codex ChatGPT-backend path — keyed purely on apiMode (the whole point of
-    // carrying apiMode in the descriptor). OAuth tokens authenticate against the
-    // ChatGPT backend via the Responses API with the Cloudflare-bypass headers;
-    // an api_key codex credential carries only its own extra headers.
-    if (apiMode === 'codex_responses') {
-      const defaultHeaders: Record<string, string> =
-        credential.authType === 'oauth'
-          ? { ...credential.extraHeaders, ...buildCodexOAuthHeaders(credential.token) }
-          : { ...credential.extraHeaders };
-      return new CodexResponsesTransport({
-        apiKey: credential.token,
-        baseUrl: credential.baseUrl ?? undefined,
-        defaultHeaders: Object.keys(defaultHeaders).length ? defaultHeaders : undefined,
-        provider,
-      });
-    }
-
-    if (provider === 'anthropic') {
-      // Mirrors the canonical `session-factory.transportForProvider` exactly:
-      // OAuth → authToken slot; api_key → apiKey slot + any extra headers.
-      const opts =
-        credential.authType === 'oauth'
-          ? {
-              authToken: credential.token,
-              baseUrl: credential.baseUrl ?? undefined,
-              // OAuth REQUIRES the beta opt-in header. The canonical header is
-              // the default; a caller's own extraHeaders override it if set.
-              defaultHeaders: { ...ANTHROPIC_OAUTH_HEADERS, ...credential.extraHeaders },
-            }
-          : {
-              apiKey: credential.token,
-              baseUrl: credential.baseUrl ?? undefined,
-              defaultHeaders: Object.keys(credential.extraHeaders).length
-                ? credential.extraHeaders
-                : undefined,
-            };
-      return new AnthropicTransport(opts);
-    }
-
-    if (provider === 'kimi-code') {
-      // Kimi Code speaks the Anthropic Messages protocol against its own endpoint.
-      return new AnthropicTransport({
-        authToken: credential.token,
-        baseUrl: credential.baseUrl ?? KIMI_CODE_BASE_URL,
-        defaultHeaders: getKimiCodeMshHeaders(),
-      });
-    }
-
-    if (provider === 'bedrock') {
-      return new BedrockTransport({
-        awsProfile: credential.awsProfile ?? undefined,
-      });
-    }
-
-    if (provider === 'gemini') {
-      return new GeminiTransport({
-        apiKey: credential.token,
-        baseUrl: credential.baseUrl ?? undefined,
-      });
-    }
-
-    if (provider === 'ollama') {
-      return new OllamaTransport({
-        baseUrl: credential.baseUrl ?? undefined,
-        apiKey: credential.token || undefined,
-        defaultHeaders: Object.keys(credential.extraHeaders).length
-          ? credential.extraHeaders
-          : undefined,
-      });
-    }
-
-    // openai (api_key), openrouter, deepseek, xai, groq, moonshot → OpenAI-compat.
-    const defaultHeaders: Record<string, string> = { ...credential.extraHeaders };
-    if (credential.authType === 'oauth') {
-      defaultHeaders['Authorization'] = `Bearer ${credential.token}`;
-    }
-    return new ChatCompletionsTransport({
-      apiKey: credential.token,
-      baseUrl: credential.baseUrl ?? undefined,
-      defaultHeaders: Object.keys(defaultHeaders).length ? defaultHeaders : undefined,
-      provider,
-    });
+    // Construction is DATA-driven (T11767): the resolved `apiMode` selects the
+    // adapter from {@link TRANSPORT_ADAPTERS}. An explicit apiMode (e.g.
+    // `codex_responses` for an openai-oauth ChatGPT token, stamped by the
+    // resolver) wins; otherwise the provider's STATIC default mode is used —
+    // `deriveApiWire(provider, null)` intentionally omits the auth-derived
+    // openai→codex routing so a no-apiMode caller keeps an api_key/oauth openai
+    // on `chat_completions` exactly as before (the codex route requires an
+    // explicit apiMode from the resolver).
+    const mode = apiMode ?? deriveApiWire(provider, null).apiMode;
+    return TRANSPORT_ADAPTERS[mode](provider, credential);
   },
 
   /**


### PR DESCRIPTION
## What
Replaces `ModelRunner.buildTransportFromCredential`'s per-provider **if/else** with a single SSoT **`Record<ApiMode, TransportAdapter>`** table (T11767 AC1). Construction is now pure data: the descriptor's resolved `apiMode` keys the adapter.

```ts
const TRANSPORT_ADAPTERS: Record<ApiMode, TransportAdapter> = {
  codex_responses, anthropic_messages, bedrock_converse, ollama_native, chat_completions,
};
```

## Acceptance (T11767)
- [x] **AC1** — `Record<ApiMode,TransportCtor>` adapter table replaces the dispatch branches; `apiMode` is the data key (carried on the descriptor via `deriveApiWire`, which is the apiMode-as-data source — apiMode is auth-dependent for openai, so it can't be a static profile field).
- [x] **AC3** — codex routes by `codex_responses` apiMode data; **kimi reuses `AnthropicTransport`** (zero custom class) via the `anthropic_messages` adapter + endpoint-quirk data.
- [x] **AC4** — `transportForProvider` duplicates already collapsed onto ModelRunner in #954.
- [x] **AC5** — tests green (958 core LLM tests; +3 new dispatch/invariant tests).
- [~] **AC2** — the **dispatch** is collapsed to one keyed table. The transport **classes** are intentionally kept one-per-protocol: `anthropic_messages`, openai `chat_completions`, codex `Responses`, `ollama_native` NDJSON, and `bedrock_converse` are **five genuinely-distinct wire protocols** — folding them into one `OpenAICompatibleTransport` would be a giant internal `switch`, strictly worse than one class per protocol. The within-mode provider quirks (kimi endpoint, gemini compat shim) are credential data, not branches.

## Behaviour preservation (critical — hot path)
The **no-apiMode** path uses `deriveApiWire(provider, null)` (the provider's *static* default), which **omits** the auth-derived `openai+oauth→codex` routing — so `api.ts`/`tool-loop.ts` callers keep openai on `chat_completions` **exactly as before**; the codex route still requires an explicit apiMode from the resolver. A dedicated test locks this invariant.

- `pnpm --filter @cleocode/core exec vitest run src/llm` → **958 pass (61 files)**, zero failures.
- `tsc -b` (cross-package oracle) → exit 0.

## Note (follow-up)
`OpenAITransport` (`transports/openai.ts`) has **0 live construction sites** (superseded by `ChatCompletionsTransport`) but remains a **public export** with T9362 streaming tests + the `usesMaxCompletionTokens` utility. Removing it is a public-API deprecation (relocate the utility, migrate the test block) — left for a focused follow-up rather than bundled into this hot-path dispatch change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)