### PR TITLE
fix(T11818): release plan/open provenance writes FK-safe (DHQ-051 plan slice)

### DIFF
--- a/packages/core/src/release/__tests__/plan-fk-cutover.test.ts
+++ b/packages/core/src/release/__tests__/plan-fk-cutover.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Post-cutover plan FK smoke test (DHQ-051 · T11818 — plan/open slice).
+ *
+ * Sibling of `reconcile-fk-cutover.test.ts` (T11659). `cleo release plan` UPSERTs
+ * a `releases` row whose `epic_id` is a nullable FK → `tasks.id`. On a
+ * consolidated dual-scope `cleo.db` (T11578 cutover) the bare `tasks` table is
+ * empty — the live task store moved to `tasks_tasks`. For the `--tasks` scope
+ * `plan.epicId` is the first task's `parentId` (a real `tasks.id`); for
+ * `--epic` / `--saga` it is the epic / saga id. Any of those exist only in
+ * `tasks_tasks`, so inserting them straight into `epic_id` violated the FK at
+ * INSERT time and aborted the whole plan with a "FOREIGN KEY constraint failed"
+ * `E_INTERNAL` (the same class as the reconcile DHQ-051 failure).
+ *
+ * The fix reuses the reconcile shim {@link ensureProvenanceTaskFkParents}: the
+ * FK parent is backfilled in FK order (the referenced task is copied from
+ * `tasks_tasks` into the bare `tasks` table) BEFORE the `releases` UPSERT, so
+ * the row lands with `epic_id` populated. An epic that exists in neither table
+ * stays unresolvable and `epic_id` is NULLed — never a hard-fail.
+ *
+ * ## Why this test forces `PRAGMA foreign_keys = ON`
+ *
+ * `getDb()` (sqlite.ts) disables FK enforcement under VITEST so existing
+ * fixtures can seed without full referential integrity — which means the
+ * pre-existing plan tests run with FKs OFF and CANNOT reproduce the production
+ * failure. This test re-enables FK enforcement after setup (matching the
+ * `reconcile-fk-cutover.test.ts` pattern) so the strict consolidated constraint
+ * is actually exercised.
+ *
+ * @task T11818
+ * @epic T11466
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ReleasePlan } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { __test__ } from '../plan.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migrations folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Set up a fully-migrated consolidated cleo.db + git repo in a temp project root. */
+async function setupProject(): Promise<{ projectRoot: string; cleanup: () => void }> {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'cleo-plan-fk-'));
+  const cleoDir = join(projectRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  mkdirSync(join(cleoDir, 'release'), { recursive: true });
+
+  writeFileSync(
+    join(cleoDir, 'config.json'),
+    JSON.stringify({
+      enforcement: {
+        session: { requiredForMutate: false },
+        acceptance: { mode: 'off' },
+      },
+      lifecycle: { mode: 'off' },
+      verification: { enabled: false },
+    }),
+  );
+
+  // Apply legacy drizzle-tasks migrations to create the full bare schema (the
+  // `tasks` / `releases` FK family) — `getDb()` later layers the prefixed
+  // `tasks_tasks` consolidated tables on top of the same handle.
+  const { createRequire } = await import('node:module');
+  const _require = createRequire(import.meta.url);
+  const { DatabaseSync } = _require('node:sqlite') as {
+    DatabaseSync: new (path: string) => import('node:sqlite').DatabaseSync;
+  };
+  const dbPath = join(cleoDir, 'tasks.db');
+  const nativeDb = new DatabaseSync(dbPath);
+  const { drizzle } = await import('drizzle-orm/node-sqlite');
+  const { reconcileJournal, migrateSanitized } = await import('../../store/migration-manager.js');
+  const db = drizzle({ client: nativeDb });
+  reconcileJournal(nativeDb, migrationsDir(), 'tasks', 'tasks');
+  migrateSanitized(db, { migrationsFolder: migrationsDir() });
+  nativeDb.close();
+
+  execFileSync('git', ['init', '-q'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'user.email', 'test@cleo.dev'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'user.name', 'Cleo Test'], { cwd: projectRoot });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: projectRoot });
+
+  return {
+    projectRoot,
+    cleanup: () => rmSync(projectRoot, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Seed a task into the PREFIXED consolidated table ONLY (post-cutover topology).
+ * The bare `tasks` table — the physical FK parent of `releases.epic_id` — is
+ * left EMPTY, which is exactly the production split-brain that triggers the FK
+ * violation when FK enforcement is ON.
+ */
+async function seedConsolidatedTaskOnly(projectRoot: string, taskId: string): Promise<void> {
+  const { getDb } = await import('../../store/sqlite.js');
+  const { sql } = await import('drizzle-orm');
+  const db = await getDb(projectRoot);
+  await db.run(
+    sql`INSERT OR IGNORE INTO tasks_tasks (id, title, status, priority, role, scope)
+        VALUES (${taskId}, ${`Task ${taskId}`}, 'pending', 'medium', 'work', 'feature')`,
+  );
+}
+
+/**
+ * Re-enable FK enforcement on the live `cleo.db` handle. `getDb()` forces
+ * `foreign_keys=OFF` under VITEST; flipping it back ON reproduces the strict
+ * consolidated constraint that fires in production.
+ */
+async function enableForeignKeys(): Promise<void> {
+  const { getNativeDb } = await import('../../store/sqlite.js');
+  const native = getNativeDb();
+  if (!native) throw new Error('native db not initialized');
+  native.exec('PRAGMA foreign_keys = ON');
+}
+
+/** Build a minimal v1 ReleasePlan with `epicId` set to the given task. */
+function makePlan(version: string, epicId: string): ReleasePlan {
+  const nowIso = new Date().toISOString();
+  return {
+    $schema: 'https://cleocode.io/schemas/release-plan/v1.json',
+    version,
+    resolvedVersion: version,
+    suffixApplied: false,
+    scheme: 'calver',
+    channel: 'latest',
+    epicId,
+    releaseKind: 'regular',
+    createdAt: nowIso,
+    createdBy: 'plan-fk-cutover-test',
+    previousVersion: null,
+    previousTag: null,
+    previousShippedAt: null,
+    tasks: [
+      {
+        id: epicId,
+        kind: 'feat',
+        impact: 'minor',
+        userFacingSummary: `Ship ${epicId}`,
+        evidenceAtoms: [],
+        epicAncestor: epicId,
+      },
+    ],
+    changelog: { features: [epicId], fixes: [], chores: [], breaking: [] },
+    gates: [],
+    platformMatrix: [{ platform: 'any', publisher: 'npm', package: '@cleocode/cleo', smoke: true }],
+    preflightSummary: {
+      esbuildExternalsDrift: false,
+      lockfileDrift: false,
+      epicCompletenessClean: true,
+      doubleListingClean: true,
+    },
+    workflowRunUrl: null,
+    prUrl: null,
+    mergeCommitSha: null,
+    status: 'planned',
+    meta: { firstEverRelease: true },
+  };
+}
+
+/** Read the `releases` row for a version (epic_id projection). */
+async function readReleaseEpicId(
+  projectRoot: string,
+  version: string,
+): Promise<{ count: number; epicId: string | null }> {
+  const { getDb } = await import('../../store/sqlite.js');
+  const { sql } = await import('drizzle-orm');
+  const db = await getDb(projectRoot);
+  const rows = await db.all<{ epic_id: string | null }>(
+    sql`SELECT epic_id FROM releases WHERE version = ${version}`,
+  );
+  return { count: rows.length, epicId: rows[0]?.epic_id ?? null };
+}
+
+afterEach(async () => {
+  const { resetDbState } = await import('../../store/sqlite.js');
+  resetDbState();
+});
+
+describe('release plan upsertReleasesRow — post-cutover FK safety (DHQ-051 · T11818)', () => {
+  let projectRoot: string;
+  let cleanup: () => void;
+  const VERSION = 'v2026.6.6';
+  const TASK_ID = 'T8801';
+
+  beforeEach(async () => {
+    const env = await setupProject();
+    projectRoot = env.projectRoot;
+    cleanup = env.cleanup;
+    // Seed the task into the consolidated table ONLY — the bare `tasks` FK
+    // parent starts EMPTY, recreating the production split-brain.
+    await seedConsolidatedTaskOnly(projectRoot, TASK_ID);
+    await enableForeignKeys();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does NOT throw a FK-constraint error under strict FK enforcement (the DHQ-051 plan repro)', async () => {
+    const plan = makePlan(VERSION, TASK_ID);
+
+    // Before the fix this threw "FOREIGN KEY constraint failed" on the
+    // `releases.epic_id` insert. It must now succeed.
+    await expect(__test__.upsertReleasesRow(plan, 'latest', projectRoot)).resolves.toBeUndefined();
+  });
+
+  it('backfills the FK parent so the releases row keeps its epic_id (not NULLed)', async () => {
+    const plan = makePlan(VERSION, TASK_ID);
+    await __test__.upsertReleasesRow(plan, 'latest', projectRoot);
+
+    const { count, epicId } = await readReleaseEpicId(projectRoot, VERSION);
+    expect(count).toBe(1);
+    // The FK-ordered parent shim made the epic resolvable → epic_id is preserved.
+    expect(epicId).toBe(TASK_ID);
+
+    // The FK parent (bare `tasks`) now holds exactly the shimmed row.
+    const { getDb } = await import('../../store/sqlite.js');
+    const { sql } = await import('drizzle-orm');
+    const db = await getDb(projectRoot);
+    const fkParentRows = await db.all<{ id: string }>(
+      sql`SELECT id FROM tasks WHERE id = ${TASK_ID}`,
+    );
+    expect(fkParentRows).toHaveLength(1);
+  });
+
+  it('NULLs epic_id (does not abort) when the epic exists in NEITHER table', async () => {
+    // An epicId that is not a known task anywhere — e.g. the `--tasks` literal
+    // fallback `'explicit-tasks'`, or a task absent from both stores. It is not
+    // FK-resolvable, so epic_id must be NULLed and the plan row still written.
+    const plan = makePlan(VERSION, 'explicit-tasks');
+
+    await expect(__test__.upsertReleasesRow(plan, 'latest', projectRoot)).resolves.toBeUndefined();
+
+    const { count, epicId } = await readReleaseEpicId(projectRoot, VERSION);
+    expect(count).toBe(1);
+    expect(epicId).toBeNull();
+  });
+
+  it('writes epic_id directly when the bare tasks parent ALREADY contains the epic', async () => {
+    // Exodus-populated-both case: the bare `tasks` parent already has the row,
+    // so no shim is needed and epic_id is written directly.
+    const { getDb, getNativeDb } = await import('../../store/sqlite.js');
+    const { sql } = await import('drizzle-orm');
+    const db = await getDb(projectRoot);
+    const native = getNativeDb();
+    if (!native) throw new Error('native db not initialized');
+    native.exec('PRAGMA foreign_keys = OFF');
+    await db.run(
+      sql`INSERT OR IGNORE INTO tasks (id, title, status, priority, role, scope)
+          VALUES (${TASK_ID}, ${`Task ${TASK_ID}`}, 'pending', 'medium', 'work', 'feature')`,
+    );
+    native.exec('PRAGMA foreign_keys = ON');
+
+    const plan = makePlan(VERSION, TASK_ID);
+    await __test__.upsertReleasesRow(plan, 'latest', projectRoot);
+
+    const { count, epicId } = await readReleaseEpicId(projectRoot, VERSION);
+    expect(count).toBe(1);
+    expect(epicId).toBe(TASK_ID);
+  });
+
+  it('is idempotent on re-run with identical inputs', async () => {
+    const plan = makePlan(VERSION, TASK_ID);
+    await __test__.upsertReleasesRow(plan, 'latest', projectRoot);
+    await __test__.upsertReleasesRow(plan, 'latest', projectRoot);
+
+    const { count, epicId } = await readReleaseEpicId(projectRoot, VERSION);
+    expect(count).toBe(1);
+    expect(epicId).toBe(TASK_ID);
+  });
+});

--- a/packages/core/src/release/plan.ts
+++ b/packages/core/src/release/plan.ts
@@ -58,7 +58,7 @@ import { isSagaShape } from '../sagas/enforcement.js';
 import { resolveSagaMemberIds } from '../sagas/storage.js';
 import { atomicWrite } from '../store/atomic.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
-import { getDb } from '../store/sqlite.js';
+import { getDb, getNativeDb } from '../store/sqlite.js';
 import {
   type NewReleaseChangesetRow,
   type NewReleaseRow,
@@ -69,6 +69,7 @@ import {
 import { resolveToolCommand } from '../tasks/tool-resolver.js';
 import { aggregateChangesetsForRelease } from './changesets-aggregator.js';
 import { runGitWithLockRetry } from './engine-ops.js';
+import { ensureProvenanceTaskFkParents } from './provenance-fk.js';
 import { loadReleaseConfig } from './release-config.js';
 
 const log = getLogger('release:plan');
@@ -1191,6 +1192,23 @@ function escapeChangelogRegex(str: string): string {
  * Uses `INSERT … ON CONFLICT(version) DO UPDATE` so re-running the verb with
  * identical inputs is a no-op modulo timestamps (R-042).
  *
+ * ## FK safety (DHQ-051 · T11818 — plan/open slice of the reconcile fix T11659)
+ *
+ * `releases.epic_id` is a nullable FK → `tasks.id` (`ON DELETE SET NULL`). On a
+ * consolidated dual-scope `cleo.db` (post-T11578 cutover) the bare `tasks`
+ * table is empty — runtime task data lives in the prefixed `tasks_tasks` table.
+ * For the `--tasks` scope `plan.epicId` is the first task's `parentId` (a real
+ * `tasks.id`, see {@link releasePlan}); for `--epic` / `--saga` it is the epic /
+ * saga id. Any of those exist only in `tasks_tasks`, so inserting them straight
+ * into `epic_id` violates the FK at INSERT time and aborts the whole plan.
+ *
+ * We mirror reconcile's fix: backfill the FK parent in FK order via
+ * {@link ensureProvenanceTaskFkParents} (copies the referenced task from
+ * `tasks_tasks` into the bare `tasks` table when needed), then NULL `epic_id`
+ * only if the FK still cannot resolve it — never hard-fail. The literal
+ * `'explicit-tasks'` fallback id (no parent + no resolvable task) is not a real
+ * task and is NULLed silently.
+ *
  * @internal
  */
 async function upsertReleasesRow(
@@ -1204,12 +1222,32 @@ async function upsertReleasesRow(
   const id = `${projectHash ?? 'unknown'}:${plan.resolvedVersion}`;
   const scheme = plan.scheme === 'calver-suffix' ? 'calver-suffix' : plan.scheme;
   const releaseKind = plan.releaseKind;
+
+  // FK safety (DHQ-051 · T11818): make `releases.epic_id` satisfiable before the
+  // UPSERT. The plan row's only `tasks.id` FK is `epic_id`; the bare `tasks`
+  // parent is empty post-cutover, so backfill it from `tasks_tasks` in FK order
+  // and NULL the column when the epic remains unresolvable.
+  let safeEpicId: string | null = plan.epicId;
+  if (plan.epicId) {
+    const nativeDb = getNativeDb();
+    if (nativeDb) {
+      const resolution = ensureProvenanceTaskFkParents(nativeDb, new Set([plan.epicId]));
+      if (!resolution.resolvableIds.has(plan.epicId)) {
+        safeEpicId = null;
+        log.warn(
+          { epicId: plan.epicId, version: plan.resolvedVersion, table: 'releases' },
+          'plan: epic_id unresolvable by FK parent — nulling releases.epic_id (DHQ-051 · T11818)',
+        );
+      }
+    }
+  }
+
   const row: NewReleaseRow = {
     id,
     version: plan.resolvedVersion,
     scheme,
     channel: dbChannel,
-    epicId: plan.epicId,
+    epicId: safeEpicId,
     releaseKind,
     status: 'planned',
     previousVersion: plan.previousVersion,
@@ -1838,6 +1876,7 @@ export const __test__ = {
   resolvePreviousVersion,
   resolveSagaTasks,
   serializeAtom,
+  upsertReleasesRow,
   validateChannelScheme,
   validateCleanTree,
   writeChangelogSection,

--- a/packages/core/src/release/provenance-fk.ts
+++ b/packages/core/src/release/provenance-fk.ts
@@ -1,0 +1,149 @@
+/**
+ * Post-cutover provenance `task_id` / `epic_id` FK reconciliation (DHQ-051).
+ *
+ * Shared between `cleo release reconcile` ({@link releaseReconcileV2}) and
+ * `cleo release plan` ({@link releasePlan} → `upsertReleasesRow`). Both verbs
+ * write provenance rows (`task_commits`, `pr_tasks`, `releases`,
+ * `release_changes`) whose `task_id` / `epic_id` foreign keys reference the
+ * BARE `tasks` table — which is empty on a consolidated dual-scope `cleo.db`
+ * after the T11578 cutover (runtime task data moved to the prefixed
+ * `tasks_tasks` table). A row inserted with an `epicId` / `taskId` that exists
+ * only in `tasks_tasks` violates the FK at INSERT time, aborting the verb.
+ *
+ * This module is the single source of truth for the FK-ordered parent backfill
+ * that makes those FKs satisfiable. `reconcile.ts` re-exports both symbols so
+ * its public surface is unchanged.
+ *
+ * @task T11659 — reconcile slice (original)
+ * @task T11818 — plan/open slice (DRY hoist)
+ * @epic T11466
+ */
+
+import { getLogger } from '../logger.js';
+import type { DatabaseSync } from '../store/sqlite.js';
+
+const log = getLogger('release:provenance-fk');
+
+/** Result of resolving + reconciling the provenance `task_id` FK parent table. */
+export interface FkParentTaskResolution {
+  /** Physical table the provenance `task_id` FK references, or null if absent. */
+  parentTable: string | null;
+  /**
+   * Task IDs the FK can now resolve (FK parent rows present after any
+   * FK-ordered shim backfill). A `task_id` reference to an id in this set is
+   * safe to INSERT under strict FK enforcement.
+   */
+  resolvableIds: Set<string>;
+}
+
+/**
+ * Make the provenance `task_id` foreign keys satisfiable on a consolidated
+ * `cleo.db` by inserting any missing FK-parent rows in FK order (parent-before
+ * -child), then returning the set of IDs the FK can resolve.
+ *
+ * ## Background (DHQ-051 · T11659 / T11818 — same class as DHQ-045)
+ *
+ * After the dual-scope `cleo.db` cutover (T11578) the runtime task store moved
+ * from the bare `tasks` table to the prefixed `tasks_tasks` table. The drizzle
+ * `schema.tasks` symbol is shadowed at the barrel (`tasks-schema.ts`) onto
+ * `tasks_tasks`, so token-validity probes read the populated prefixed table.
+ * BUT the provenance tables (`task_commits`, `pr_tasks`, `releases`,
+ * `release_changes`) predate the cutover — their `task_id` / `epic_id` FKs
+ * still reference the BARE `tasks` table, which is empty on a consolidated
+ * `cleo.db`. A token validated against `tasks_tasks` therefore passes the
+ * legacy gate yet violates the FK at INSERT time, aborting the whole verb with
+ * `E_PROVENANCE_FAILED` (reconcile) or `E_INTERNAL` (plan).
+ *
+ * ## Strategy — FK-ordered parent backfill (Strategy 1)
+ *
+ * For every task referenced by this release we ensure a row exists in the FK
+ * parent table BEFORE the child provenance rows are written. The parent table
+ * is discovered dynamically via `PRAGMA foreign_key_list('task_commits')` (so
+ * the logic tracks whatever the live schema enforces — including a future
+ * schema that repoints the FK at `tasks_tasks`, where this becomes a no-op).
+ * Missing parent rows are copied from the runtime `tasks_tasks` store via
+ * `INSERT OR IGNORE … SELECT` of only the NOT NULL columns, so the copied rows
+ * satisfy the parent table's own CHECK/NOT NULL constraints. Tasks that exist
+ * in neither table remain unresolvable and are skipped-with-warn / NULLed by
+ * the callers (the row, never the whole verb).
+ *
+ * Idempotent: `INSERT OR IGNORE` never duplicates and never overwrites an
+ * existing parent row. Callers run it inside their write transaction so a later
+ * failure rolls the shim rows back too.
+ *
+ * @param nativeDb - The consolidated `cleo.db` native handle.
+ * @param referencedIds - Every task id this verb may reference (commit tokens,
+ *   PR tokens, plan tasks, epic).
+ * @returns The FK parent table name + the IDs it can now resolve.
+ */
+export function ensureProvenanceTaskFkParents(
+  nativeDb: DatabaseSync,
+  referencedIds: ReadonlySet<string>,
+): FkParentTaskResolution {
+  // Discover the physical parent table the `task_commits.task_id` FK targets.
+  let parentTable = 'tasks';
+  try {
+    const fks = nativeDb.prepare(`PRAGMA foreign_key_list('task_commits')`).all() as Array<{
+      table: string;
+      from: string;
+    }>;
+    const taskFk = fks.find((fk) => fk.from === 'task_id');
+    if (taskFk?.table) parentTable = taskFk.table;
+  } catch {
+    // PRAGMA unavailable (table absent / older sqlite) — keep the bare default.
+  }
+
+  const tableExists = (name: string): boolean =>
+    nativeDb.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(name) !=
+    null;
+
+  // Parent table absent entirely → nothing resolvable, nothing to backfill.
+  if (!tableExists(parentTable)) {
+    return { parentTable: null, resolvableIds: new Set<string>() };
+  }
+
+  // FK-ordered shim backfill: copy any referenced task that lives in the
+  // runtime `tasks_tasks` store but is missing from the FK parent. Only when
+  // the parent is the bare legacy table AND the prefixed store exists (i.e. the
+  // post-cutover split-brain) — when the FK already points at `tasks_tasks`
+  // this is skipped and the parent is read as-is.
+  // Identifiers come from sqlite_master / the FK pragma (verified existing
+  // table names), never user input — safe to interpolate (node:sqlite exposes
+  // no bound-identifier form). All VALUES are bound parameters.
+  if (parentTable !== 'tasks_tasks' && tableExists('tasks_tasks') && referencedIds.size > 0) {
+    // `pipeline_stage` is copied alongside the NOT NULL columns so the bare
+    // `tasks` table's T877 invariant trigger (status='done' ⇒ pipeline_stage IN
+    // ('contribution','cancelled'); status='cancelled' ⇒ pipeline_stage=
+    // 'cancelled') is satisfied. A released epic is typically status='done', so
+    // omitting `pipeline_stage` would RAISE(ABORT) the shim copy and leave the
+    // epic unresolvable (DHQ-051 · T11818).
+    const insertShim = nativeDb.prepare(
+      `INSERT OR IGNORE INTO "${parentTable}" (id, title, status, priority, role, scope, pipeline_stage)
+       SELECT id, title, status, priority, role, scope, pipeline_stage FROM tasks_tasks WHERE id = ?`,
+    );
+    for (const id of referencedIds) {
+      try {
+        insertShim.run(id);
+      } catch (err) {
+        // A single shim copy that violates the parent's own constraints (e.g. a
+        // NOT NULL / CHECK the prefixed row does not satisfy) must NOT abort the
+        // whole verb. Leave the id unresolvable — the writers below
+        // skip-with-warn that one link (Strategy 3). SAVEPOINT-free: the failed
+        // statement is rolled back individually by SQLite, leaving the
+        // surrounding transaction intact.
+        log.warn(
+          { taskId: id, parentTable, err: err instanceof Error ? err.message : String(err) },
+          'provenance: FK-parent shim copy failed — task_id stays unresolvable, link will be skipped',
+        );
+      }
+    }
+  }
+
+  // Read back what the FK can now resolve.
+  const resolvableIds = new Set<string>();
+  const rows = nativeDb.prepare(`SELECT id FROM "${parentTable}"`).all() as Array<{ id: unknown }>;
+  for (const r of rows) {
+    if (typeof r.id === 'string') resolvableIds.add(r.id);
+  }
+  return { parentTable, resolvableIds };
+}

--- a/packages/core/src/release/reconcile.ts
+++ b/packages/core/src/release/reconcile.ts
@@ -45,8 +45,15 @@ import { type EngineResult, engineError, engineSuccess } from '../engine-result.
 import { getLogger } from '../logger.js';
 import { generateProjectHash } from '../nexus/hash.js';
 import { getProjectRoot } from '../paths.js';
-import { type DatabaseSync, getDb, getNativeDb } from '../store/sqlite.js';
+import { getDb, getNativeDb } from '../store/sqlite.js';
 import * as schema from '../store/tasks-schema.js';
+import { ensureProvenanceTaskFkParents, type FkParentTaskResolution } from './provenance-fk.js';
+
+// Re-export the FK-parent reconciliation surface so existing consumers of
+// `reconcile.js` keep working after the DRY hoist into `provenance-fk.ts`
+// (T11818). The implementation now lives in the shared module, used by both
+// `cleo release reconcile` and `cleo release plan`.
+export { ensureProvenanceTaskFkParents, type FkParentTaskResolution };
 
 const log = getLogger('release:reconcile-v2');
 const execFileAsync = promisify(execFile);
@@ -880,125 +887,13 @@ export function sanitisePrShasForFk(
   };
 }
 
-// ─── Helpers — FK-safe task-id resolution (DHQ-051 · T11659) ────────────────
-
-/** Result of resolving + reconciling the provenance `task_id` FK parent table. */
-export interface FkParentTaskResolution {
-  /** Physical table the provenance `task_id` FK references, or null if absent. */
-  parentTable: string | null;
-  /**
-   * Task IDs the FK can now resolve (FK parent rows present after any
-   * FK-ordered shim backfill). A `task_id` reference to an id in this set is
-   * safe to INSERT under strict FK enforcement.
-   */
-  resolvableIds: Set<string>;
-}
-
-/**
- * Make the provenance `task_id` foreign keys satisfiable on a consolidated
- * `cleo.db` by inserting any missing FK-parent rows in FK order (parent-before
- * -child), then returning the set of IDs the FK can resolve.
- *
- * ## Background (DHQ-051 · T11659 — same class as DHQ-045)
- *
- * After the dual-scope `cleo.db` cutover (T11578) the runtime task store moved
- * from the bare `tasks` table to the prefixed `tasks_tasks` table. The drizzle
- * `schema.tasks` symbol is shadowed at the barrel (`tasks-schema.ts`) onto
- * `tasks_tasks`, so reconcile's token-validity probe reads the populated
- * prefixed table. BUT the provenance tables (`task_commits`, `pr_tasks`,
- * `releases`, `release_changes`) predate the cutover — their `task_id` /
- * `epic_id` FKs still reference the BARE `tasks` table, which is empty on a
- * consolidated `cleo.db`. A token validated against `tasks_tasks` therefore
- * passes the legacy gate yet violates the FK at INSERT time, aborting the
- * whole reconcile with `E_PROVENANCE_FAILED`.
- *
- * ## Strategy — FK-ordered parent backfill (Strategy 1)
- *
- * For every task referenced by this release we ensure a row exists in the FK
- * parent table BEFORE the child provenance rows are written. The parent table
- * is discovered dynamically via `PRAGMA foreign_key_list('task_commits')` (so
- * the logic tracks whatever the live schema enforces — including a future
- * schema that repoints the FK at `tasks_tasks`, where this becomes a no-op).
- * Missing parent rows are copied from the runtime `tasks_tasks` store via
- * `INSERT OR IGNORE … SELECT` of only the NOT NULL columns, so the copied rows
- * satisfy the parent table's own CHECK/NOT NULL constraints. Tasks that exist
- * in neither table remain unresolvable and are skipped-with-warn by the
- * callers (the row, never the whole reconcile).
- *
- * Idempotent: `INSERT OR IGNORE` never duplicates and never overwrites an
- * existing parent row. Runs inside the reconcile transaction so a later
- * failure rolls the shim rows back too.
- *
- * @param nativeDb - The consolidated `cleo.db` native handle.
- * @param referencedIds - Every task id this reconcile may reference (commit
- *   tokens, PR tokens, plan tasks, epic).
- * @returns The FK parent table name + the IDs it can now resolve.
- */
-export function ensureProvenanceTaskFkParents(
-  nativeDb: DatabaseSync,
-  referencedIds: ReadonlySet<string>,
-): FkParentTaskResolution {
-  // Discover the physical parent table the `task_commits.task_id` FK targets.
-  let parentTable = 'tasks';
-  try {
-    const fks = nativeDb.prepare(`PRAGMA foreign_key_list('task_commits')`).all() as Array<{
-      table: string;
-      from: string;
-    }>;
-    const taskFk = fks.find((fk) => fk.from === 'task_id');
-    if (taskFk?.table) parentTable = taskFk.table;
-  } catch {
-    // PRAGMA unavailable (table absent / older sqlite) — keep the bare default.
-  }
-
-  const tableExists = (name: string): boolean =>
-    nativeDb.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(name) !=
-    null;
-
-  // Parent table absent entirely → nothing resolvable, nothing to backfill.
-  if (!tableExists(parentTable)) {
-    return { parentTable: null, resolvableIds: new Set<string>() };
-  }
-
-  // FK-ordered shim backfill: copy any referenced task that lives in the
-  // runtime `tasks_tasks` store but is missing from the FK parent. Only when
-  // the parent is the bare legacy table AND the prefixed store exists (i.e. the
-  // post-cutover split-brain) — when the FK already points at `tasks_tasks`
-  // this is skipped and the parent is read as-is.
-  // Identifiers come from sqlite_master / the FK pragma (verified existing
-  // table names), never user input — safe to interpolate (node:sqlite exposes
-  // no bound-identifier form). All VALUES are bound parameters.
-  if (parentTable !== 'tasks_tasks' && tableExists('tasks_tasks') && referencedIds.size > 0) {
-    const insertShim = nativeDb.prepare(
-      `INSERT OR IGNORE INTO "${parentTable}" (id, title, status, priority, role, scope)
-       SELECT id, title, status, priority, role, scope FROM tasks_tasks WHERE id = ?`,
-    );
-    for (const id of referencedIds) {
-      try {
-        insertShim.run(id);
-      } catch (err) {
-        // A single shim copy that violates the parent's own constraints (e.g. a
-        // NOT NULL / CHECK the prefixed row does not satisfy) must NOT abort the
-        // whole reconcile. Leave the id unresolvable — the writers below
-        // skip-with-warn that one link (Strategy 3). SAVEPOINT-free: the failed
-        // statement is rolled back individually by SQLite, leaving the
-        // surrounding transaction intact.
-        log.warn(
-          { taskId: id, parentTable, err: err instanceof Error ? err.message : String(err) },
-          'reconcile: FK-parent shim copy failed — task_id stays unresolvable, link will be skipped',
-        );
-      }
-    }
-  }
-
-  // Read back what the FK can now resolve.
-  const resolvableIds = new Set<string>();
-  const rows = nativeDb.prepare(`SELECT id FROM "${parentTable}"`).all() as Array<{ id: unknown }>;
-  for (const r of rows) {
-    if (typeof r.id === 'string') resolvableIds.add(r.id);
-  }
-  return { parentTable, resolvableIds };
-}
+// ─── Helpers — FK-safe task-id resolution (DHQ-051 · T11659 / T11818) ───────
+//
+// `ensureProvenanceTaskFkParents` + `FkParentTaskResolution` were hoisted to
+// the shared `./provenance-fk.ts` module (T11818) so `cleo release plan` can
+// reuse the identical FK-ordered parent backfill. They are imported and
+// re-exported at the top of this file — reconcile's public surface and runtime
+// behavior are unchanged.
 
 // ─── Main reconcile entrypoint ──────────────────────────────────────────────
 


### PR DESCRIPTION
## What
The **plan/open slice of DHQ-051** — sibling of **T11659** (which fixed `reconcile.ts` only). After the dual-`cleo.db` cutover, `cleo release plan` aborted with `FOREIGN KEY constraint failed` because `upsertReleasesRow` inserts a `releases` row whose `epic_id → tasks.id` FK targets the **empty bare `tasks`** table (runtime data lives in `tasks_tasks`). Confirmed live: `cleo release plan v2026.6.6 --tasks T11783,T11809,T11659` → E_INTERNAL.

## Fix (reuse + DRY-hoist the T11659 shim)
- **New `release/provenance-fk.ts`** — hoists `ensureProvenanceTaskFkParents` out of `reconcile.ts` (DRY). `reconcile.ts` now imports + re-exports it; **reconcile behaviour byte-identical** (all 6 `reconcile-fk-cutover` cases + full reconcile suite pass).
- **`plan.ts:upsertReleasesRow`** backfills the FK parent from `tasks_tasks → tasks` before the `releases` UPSERT, then **NULLs `epic_id`** only if still unresolvable (`epic_id` is nullable, FK `ON DELETE SET NULL`). For `--tasks`, `plan.epicId` = the first task's `parentId` (a real epic id) → shimmed; the `'explicit-tasks'` placeholder never resolves → silently NULLed (correct). One fix covers `--tasks`/`--epic`/`--saga`.
- **`open.ts` needs no change** — it only `UPDATE`s an existing `releases` row, never sets a `tasks.id` FK.

## Bonus hardening (flagged by the agent)
The shim copied `(id,title,status,priority,role,scope)` but **omitted `pipeline_stage`**. A released epic is `status='done'`, and the bare-`tasks` T877 trigger requires a terminal `pipeline_stage` for terminal-status rows — so the shim copy aborted and the epic was wrongly NULLed (regressed `plan.test.ts`). Added `pipeline_stage` to the copied columns; this **hardens reconcile too** (its prior tests only used `pending` tasks).

## Validation
- `vitest run src/release` → **357 pass / 2 skip (41 files)** + new `plan-fk-cutover.test.ts` **5/5** (FK enforcement forced ON to reproduce production).
- `tsc -b` → exit 0; biome clean; DB-Open-Guard strict OK.

Closes T11818 (DHQ-051 plan slice). After merge, `cleo release plan/open` succeeds on a consolidated cleo.db and v2026.6.6 provenance can be backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)