### PR TITLE
fix(T11836): classify NULL→NOT-NULL-default substitution as a non-fatal exodus verify diagnostic

### DIFF
--- a/packages/core/src/store/__tests__/verify-migration.test.ts
+++ b/packages/core/src/store/__tests__/verify-migration.test.ts
@@ -729,3 +729,99 @@ describe('verifyMigration — streamed content digest at scale (T11834)', () => 
     expect(entry?.hashMatch).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// T11836 — a NULL source value migrate substituted with a type default for a
+// target NOT-NULL-without-default column is a NON-FATAL diagnostic, NOT a false
+// hashMatch=false. The verifier mirrors migrate's COALESCE(expr, type_default)
+// in the source digest so a FAITHFUL fresh migration digests as a MATCH.
+// ---------------------------------------------------------------------------
+
+describe('verifyMigration — NULL→NOT-NULL-default substitution is non-fatal (T11836)', () => {
+  let tmpDir: string;
+  let sourcePath: string;
+  let projectPath: string;
+  let globalPath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourcePath = join(tmpDir, 'tasks.db');
+    projectPath = join(tmpDir, 'cleo-project.db');
+    globalPath = join(tmpDir, 'cleo-global.db');
+    new DatabaseSync(globalPath).close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function sources(): LegacyDbDescriptor[] {
+    return [{ name: 'tasks', path: sourcePath, targetScope: 'project' }];
+  }
+
+  it('hashMatch=true when a NULL source value is stored as the type default in a NOT-NULL-without-default target column', () => {
+    // Source: legacy 'tasks' where `label` is NULLABLE and one row carries NULL.
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(`CREATE TABLE "tasks" (id INTEGER PRIMARY KEY, label TEXT)`);
+      src.exec(`INSERT INTO "tasks" VALUES (1, 'alpha')`);
+      src.exec(`INSERT INTO "tasks" (id, label) VALUES (2, NULL)`); // NULL source value
+      src.exec(`INSERT INTO "tasks" VALUES (3, 'gamma')`);
+    } finally {
+      src.close();
+    }
+
+    // Target: consolidated 'tasks_tasks' where `label` is NOT NULL WITHOUT a
+    // schema default — exactly the shape migrate's buildSelectExpr coalesces to
+    // the TEXT type default (''). A FAITHFUL migration therefore stores '' for
+    // the row-2 NULL, which is precisely what we seed here.
+    const tgt = new DatabaseSync(projectPath);
+    try {
+      tgt.exec(`CREATE TABLE "tasks_tasks" (id INTEGER PRIMARY KEY, label TEXT NOT NULL)`);
+      tgt.exec(`INSERT INTO "tasks_tasks" VALUES (1, 'alpha')`);
+      tgt.exec(`INSERT INTO "tasks_tasks" VALUES (2, '')`); // type-default substitution
+      tgt.exec(`INSERT INTO "tasks_tasks" VALUES (3, 'gamma')`);
+    } finally {
+      tgt.close();
+    }
+
+    const r = verifyMigration(sources(), projectPath, globalPath);
+
+    // BEFORE T11836: the source digest read NULL while the target stored '' →
+    // hashMatch=false at equal counts (a false content-corruption failure).
+    // AFTER T11836: the source digest mirrors migrate's COALESCE → MATCH.
+    const entry = r.tables.find((t) => t.targetTable === 'tasks_tasks');
+    expect(entry?.countMatch).toBe(true);
+    expect(entry?.hashMatch).toBe(true);
+    expect(r.ok, r.error ?? '').toBe(true);
+    expect(r.error).toBeUndefined();
+  });
+
+  it('STILL FAILS: a NULL source value stored as a NON-default value in the target is a real content mismatch', () => {
+    // Same NOT-NULL-without-default target column, but the target stored a value
+    // migrate would never produce for a NULL source ('UNEXPECTED' ≠ the '' type
+    // default). This is genuine content drift and MUST stay a hashMatch=false.
+    const src = new DatabaseSync(sourcePath);
+    try {
+      src.exec(`CREATE TABLE "tasks" (id INTEGER PRIMARY KEY, label TEXT)`);
+      src.exec(`INSERT INTO "tasks" VALUES (1, 'alpha')`);
+      src.exec(`INSERT INTO "tasks" (id, label) VALUES (2, NULL)`);
+    } finally {
+      src.close();
+    }
+
+    const tgt = new DatabaseSync(projectPath);
+    try {
+      tgt.exec(`CREATE TABLE "tasks_tasks" (id INTEGER PRIMARY KEY, label TEXT NOT NULL)`);
+      tgt.exec(`INSERT INTO "tasks_tasks" VALUES (1, 'alpha')`);
+      tgt.exec(`INSERT INTO "tasks_tasks" VALUES (2, 'UNEXPECTED')`); // NOT the type default
+    } finally {
+      tgt.close();
+    }
+
+    const r = verifyMigration(sources(), projectPath, globalPath);
+    const entry = r.tables.find((t) => t.targetTable === 'tasks_tasks');
+    expect(entry?.countMatch).toBe(true);
+    expect(entry?.hashMatch).toBe(false);
+  });
+});

--- a/packages/core/src/store/exodus/column-transforms.ts
+++ b/packages/core/src/store/exodus/column-transforms.ts
@@ -452,6 +452,50 @@ function isIntegerSourceType(srcType: string): boolean {
 }
 
 /**
+ * Target-column metadata a {@link buildDigestExpr} caller passes so the digest
+ * can mirror migrate's NOT-NULL `COALESCE(..., type_default)` substitution
+ * (T11836).
+ *
+ * Keyed by column name, this carries the consolidated target's NOT-NULL flag and
+ * declared schema default for every column the digest visits, sourced from the
+ * target `PRAGMA table_info`. A column is NOT-NULL-without-default when
+ * `notnull === 1 && dflt_value === null` — exactly the condition under which
+ * migrate's `buildSelectExpr` wraps the value in `COALESCE(expr, type_default)`.
+ */
+export interface TargetColumnInfo {
+  /** `PRAGMA table_info.notnull` — `1` for a NOT NULL column, `0` otherwise. */
+  readonly notnull: number;
+  /** `PRAGMA table_info.dflt_value` — the column's schema default, or `null`. */
+  readonly dflt_value: string | null;
+  /** `PRAGMA table_info.type` — raw affinity string (drives {@link typeDefaultLiteral}). */
+  readonly type: string;
+}
+
+/**
+ * Wrap a digest value expression in the SAME `COALESCE(expr, type_default)`
+ * substitution migrate's `buildSelectExpr` applies, when (and only when) the
+ * matching TARGET column is NOT NULL without a schema default (T11836).
+ *
+ * On a faithful FRESH migration a NULL source value in such a column is stored
+ * as the type default (`''`/`0`/`0.0`/`x''`) by migrate; digesting the source
+ * raw would read NULL and diverge from the stored default — a false
+ * `hashMatch === false` at equal row counts. Mirroring the COALESCE here makes
+ * the source digest reflect what migrate actually stored, so the substitution is
+ * a NON-FATAL diagnostic class rather than a content-corruption failure.
+ *
+ * @param expr   - The value expression produced by an upstream transform branch.
+ * @param tgtCol - Target column metadata, or `undefined` when unavailable (no
+ *   COALESCE applied — best-effort, biased to surfacing a real difference).
+ * @returns The expression, COALESCE-wrapped when the target is NOT-NULL-without-default.
+ */
+function maybeCoalesceNotNull(expr: string, tgtCol: TargetColumnInfo | undefined): string {
+  if (tgtCol === undefined) return expr;
+  const isNotNullWithoutDefault = tgtCol.notnull === 1 && tgtCol.dflt_value === null;
+  if (!isNotNullWithoutDefault) return expr;
+  return `COALESCE(${expr}, ${typeDefaultLiteral(tgtCol.type)})`;
+}
+
+/**
  * Build the SQL expression a column's SOURCE value must pass through so it
  * matches the canonical value the migration STORES in the target — for use by
  * the parity verifier's content digest (T11809 · AC2).
@@ -465,13 +509,19 @@ function isIntegerSourceType(srcType: string): boolean {
  *   3. **Enum-value normalization** ({@link enumNormExpr}).
  *   4. **Plain column reference** otherwise.
  *
- * Crucially it does NOT add the NOT-NULL `COALESCE(..., type_default)` wrapping
- * that `buildSelectExpr` uses: that wrapping only ever fires on a NULL source
- * value that the target stores as a type-default, which is a NULL→default value
- * CHANGE the digest should not paper over (a genuine NULL→'' divergence remains a
- * real, visible content difference, not a coercion artifact). The verifier
- * intentionally omits it so the digest reflects the canonical value transforms
- * (epoch/enum/clamp) WITHOUT masking a true NULL→default substitution.
+ * ## NOT-NULL default substitution mirroring (T11836)
+ *
+ * After the value transform, the result is wrapped in the SAME
+ * `COALESCE(expr, type_default)` substitution migrate's `buildSelectExpr` uses
+ * for a TARGET column that is NOT NULL without a schema default (see
+ * {@link maybeCoalesceNotNull}). migrate stores the type default (`''`/`0`/
+ * `0.0`/`x''`) for a NULL source value in such a column; without mirroring it
+ * here the source digest would read NULL and diverge from the stored default — a
+ * false `hashMatch === false` on a faithful FRESH migration (the exact T11836
+ * symptom). Mirroring it makes a NULL→NOT-NULL-default substitution a NON-FATAL
+ * diagnostic class rather than a hash failure. The target metadata is supplied
+ * via the `tgtColByCol` map; when it is absent (best-effort) no COALESCE is
+ * applied and a genuine NULL→'' divergence remains visible as before.
  *
  * The returned expression is a bare SQL value expression (no `AS "col"` alias)
  * suitable for embedding directly in a `SELECT <expr> ... ORDER BY ...` digest
@@ -482,6 +532,8 @@ function isIntegerSourceType(srcType: string): boolean {
  * @param col             - Column name (present in BOTH source and target).
  * @param srcType         - Raw `type` string from the source `PRAGMA table_info`.
  * @param isoGlobCols     - Set of target columns carrying an ISO GLOB CHECK.
+ * @param tgtCol          - Target column metadata (NOT-NULL flag + default +
+ *   affinity) for `col`, or `undefined` when unavailable.
  * @returns A SQL value expression that maps the raw source value to the canonical
  *   value the target stores.
  */
@@ -490,6 +542,7 @@ export function buildDigestExpr(
   col: string,
   srcType: string,
   isoGlobCols: ReadonlySet<string>,
+  tgtCol?: TargetColumnInfo,
 ): string {
   const srcRef = `"${col}"`;
 
@@ -497,17 +550,18 @@ export function buildDigestExpr(
   // CHECK and the source column is INTEGER (epoch) typed. Mirrors migrate's
   // per-row magnitude heuristic exactly.
   if (isoGlobCols.has(col) && isIntegerSourceType(srcType)) {
-    return buildEpochToIsoExpr(srcRef);
+    return maybeCoalesceNotNull(buildEpochToIsoExpr(srcRef), tgtCol);
   }
 
   // Priority 2: Non-finite numeric clamp (Inf/-Inf/NaN → finite in-range).
   const clampExpr = numericClampExpr(targetTableName, col, srcRef);
-  if (clampExpr !== null) return clampExpr;
+  if (clampExpr !== null) return maybeCoalesceNotNull(clampExpr, tgtCol);
 
   // Priority 3: Enum-value normalization (legacy value → canonical member).
   const normExpr = enumNormExpr(targetTableName, col, srcRef);
-  if (normExpr !== null) return normExpr;
+  if (normExpr !== null) return maybeCoalesceNotNull(normExpr, tgtCol);
 
-  // Priority 4: plain column reference (no transform migrate would have applied).
-  return srcRef;
+  // Priority 4: plain column reference, COALESCE-wrapped when the target is
+  // NOT NULL without a default (mirrors migrate's T11533 substitution — T11836).
+  return maybeCoalesceNotNull(srcRef, tgtCol);
 }

--- a/packages/core/src/store/exodus/verify-migration.ts
+++ b/packages/core/src/store/exodus/verify-migration.ts
@@ -53,7 +53,11 @@ import type {
 import { MIGRATION_ENUM_DRIFT_SAMPLE_LIMIT } from '@cleocode/contracts';
 import { getLogger } from '../../logger.js';
 import { openCleoDbSnapshot } from '../open-cleo-db.js';
-import { buildDigestExpr, detectIsoGlobColumns } from './column-transforms.js';
+import {
+  buildDigestExpr,
+  detectIsoGlobColumns,
+  type TargetColumnInfo,
+} from './column-transforms.js';
 import { resolveConsolidatedTableName, resolveTableTargetScope } from './table-name-map.js';
 import type { ExodusScope, LegacyDbDescriptor } from './types.js';
 
@@ -116,6 +120,14 @@ interface DigestTransformSpec {
   readonly srcTypeByCol: ReadonlyMap<string, string>;
   /** Target columns carrying an ISO-8601 GLOB CHECK (drives epoch→ISO coercion). */
   readonly isoGlobCols: ReadonlySet<string>;
+  /**
+   * Map of target column name → its NOT-NULL flag + schema default + affinity
+   * (from the target `PRAGMA table_info`). Drives the NULL→NOT-NULL-default
+   * `COALESCE` substitution migrate applies, so a faithful FRESH migration that
+   * stored a type default for a NULL source value digests as a MATCH rather than
+   * a false `hashMatch === false` (T11836).
+   */
+  readonly tgtColByCol: ReadonlyMap<string, TargetColumnInfo>;
 }
 
 /**
@@ -184,7 +196,14 @@ function computeTableDigest(
         // SOURCE side: route the raw value through the SAME transform migrate
         // applied, aliased back to `c` so the row key matches the target side.
         const srcType = transform.srcTypeByCol.get(c) ?? '';
-        const expr = buildDigestExpr(transform.targetTableName, c, srcType, transform.isoGlobCols);
+        const tgtCol = transform.tgtColByCol.get(c);
+        const expr = buildDigestExpr(
+          transform.targetTableName,
+          c,
+          srcType,
+          transform.isoGlobCols,
+          tgtCol,
+        );
         return `${expr} AS "${c}"`;
       })
       .join(', ');
@@ -262,8 +281,10 @@ function sharedColumnsSorted(
 
 /**
  * Build the source-side {@link DigestTransformSpec} for a source→target table
- * pair: the source column type affinities and the target's ISO-GLOB columns,
- * keyed by the consolidated target name (the transform lookup key).
+ * pair: the source column type affinities, the target's ISO-GLOB columns, and
+ * the target column metadata (NOT-NULL flag + default + affinity), keyed by the
+ * consolidated target name (the transform lookup key). The target metadata
+ * drives the NULL→NOT-NULL-default `COALESCE` mirroring (T11836).
  *
  * Returns `undefined` (raw digest, no transform) when the source `PRAGMA
  * table_info` cannot be read — best-effort, biased to surfacing a real
@@ -291,7 +312,23 @@ function buildSourceDigestTransform(
       ).map((r) => [r.name, r.type]),
     );
     const isoGlobCols = detectIsoGlobColumns(tgtDb, targetTableName);
-    return { targetTableName, srcTypeByCol, isoGlobCols };
+    // Target column metadata (notnull + dflt_value + type) — drives the
+    // NULL→NOT-NULL-default COALESCE migrate applies, so a stored type default
+    // for a NULL source value digests as a MATCH (T11836).
+    const tgtColByCol = new Map<string, TargetColumnInfo>(
+      (
+        tgtDb.prepare(`PRAGMA table_info("${targetTableName}")`).all() as Array<{
+          name: string;
+          type: string;
+          notnull: number;
+          dflt_value: string | null;
+        }>
+      ).map((r) => [
+        r.name,
+        { notnull: r.notnull, dflt_value: r.dflt_value, type: r.type } satisfies TargetColumnInfo,
+      ]),
+    );
+    return { targetTableName, srcTypeByCol, isoGlobCols, tgtColByCol };
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What

A faithful FRESH exodus migration that has NULLs in now-NOT-NULL columns reported a false `hashMatch=false` at equal row counts.

**Root cause:** `migrate.ts` `buildSelectExpr` wraps `COALESCE(expr, type_default)` for NOT-NULL-without-default target columns (storing `''`/`0`/`0.0`/`x''` for a NULL source value), but `column-transforms.ts` `buildDigestExpr` deliberately OMITTED that COALESCE. So the migrate side stored the type default while the verify digest read NULL — the two digests diverged even on a lossless migration.

## Change (the simpler, lower-risk option)

- `buildDigestExpr` now mirrors migrate's `COALESCE(expr, type_default)` for NOT-NULL-without-default target columns, via a new optional `TargetColumnInfo` parameter and a `maybeCoalesceNotNull` helper.
- `DigestTransformSpec` / `buildSourceDigestTransform` (`verify-migration.ts`) now read the target `PRAGMA table_info` (`notnull` + `dflt_value` + `type`) and thread it through to the digest transform.
- Builds on #966's streamed `computeTableDigest` (`COUNT(*)` + `stmt.iterate()`).

A NULL→NOT-NULL-default substitution is now a non-fatal diagnostic class rather than a hash failure; a genuine NULL→non-default divergence stays a visible content mismatch.

## Tests

`packages/core/src/store/__tests__/verify-migration.test.ts`:
- NEW: a NULL source value in a target NOT-NULL-without-default column + the target storing the type default → `hashMatch=true` (was `false`).
- NEW: a NULL source value stored as a NON-default value → still `hashMatch=false` (real content drift unmasked).
- All 15 existing verify-migration tests stay green (17 total pass).

Gates: `biome check` clean, `@cleocode/core` build clean, scoped vitest 17/17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)