### PR TITLE
feat(doctor): add `cleo doctor repair` malformed-DB entry point (T11829, DHQ-060)

### DIFF
--- a/packages/cleo/src/cli/commands/doctor-repair.ts
+++ b/packages/cleo/src/cli/commands/doctor-repair.ts
@@ -1,0 +1,102 @@
+/**
+ * `cleo doctor repair` — detect malformed CLEO databases and restore each from
+ * its freshest validated snapshot (T11829 · DHQ-060).
+ *
+ * Thin CLI surface over {@link repairMalformedDbs} (CORE) which itself delegates
+ * every actual repair to the existing {@link recoverMalformedDb} pipeline
+ * (quarantine → snapshot-restore → `PRAGMA quick_check`). NO recovery logic lives
+ * here — this command only collects flags, runs the core orchestrator, and emits
+ * the LAFS envelope.
+ *
+ * Default: probe EVERY present DB in `DB_INVENTORY` and repair only what is
+ * malformed. `--role <role>` narrows to one role. `--dry-run` reports what would
+ * be repaired without touching any files. Exits non-zero when a needed repair
+ * could not complete so CI / operators can gate on it.
+ *
+ * @task T11829 (DHQ-060)
+ * @epic T11833
+ * @saga T11242 (SG-DB-SUBSTRATE-V2)
+ * @see packages/core/src/store/repair-malformed-dbs.ts — the orchestrator
+ */
+
+import { DB_INVENTORY, type DbRole, ExitCode } from '@cleocode/contracts';
+import { getLogger, getProjectRoot } from '@cleocode/core';
+import { repairMalformedDbs } from '@cleocode/core/store/repair-malformed-dbs.js';
+import { defineCommand } from '../lib/define-cli-command.js';
+import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
+
+/**
+ * `cleo doctor repair` subcommand.
+ *
+ * @task T11829
+ */
+export const doctorRepairCommand = defineCommand({
+  meta: {
+    name: 'repair',
+    description:
+      'Detect malformed CLEO databases (PRAGMA quick_check) and restore each from its ' +
+      'freshest validated snapshot via the recovery pipeline (quarantine → restore → verify). ' +
+      'Defaults to every present DB; use --role to narrow, --dry-run to plan without mutating.',
+  },
+  args: {
+    role: {
+      type: 'string',
+      description: `Repair only this DB role (one of: ${DB_INVENTORY.map((e) => e.role).join(', ')})`,
+      default: '',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description:
+        'Detect + plan only — report what would be repaired without quarantining/restoring',
+      default: false,
+    },
+  },
+  run({ args }) {
+    const roleArg = typeof args.role === 'string' ? args.role.trim() : '';
+    const dryRun = args['dry-run'] === true;
+
+    // Validate an explicit --role against the inventory before doing any work.
+    if (roleArg.length > 0 && !DB_INVENTORY.some((e) => e.role === roleArg)) {
+      const validRoles = DB_INVENTORY.map((e) => e.role).join(', ');
+      cliError(
+        `Unknown DB role "${roleArg}". Valid roles: ${validRoles}.`,
+        ExitCode.VALIDATION_ERROR,
+        {
+          name: 'E_VALIDATION',
+          fix: 'Run `cleo doctor repair --help` for the list of valid roles.',
+        },
+        { command: 'doctor repair' },
+      );
+      process.exitCode = ExitCode.VALIDATION_ERROR;
+      return;
+    }
+
+    const result = repairMalformedDbs({
+      projectRoot: getProjectRoot(),
+      roles: roleArg.length > 0 ? [roleArg as DbRole] : undefined,
+      dryRun,
+      logger: getLogger('doctor-repair'),
+    });
+
+    for (const r of result.roles) {
+      if (!r.healthy) {
+        humanInfo(`  [${r.action.toUpperCase()}] ${r.role} — ${r.detail}`);
+      }
+    }
+
+    const verb = dryRun ? 'would repair' : 'repaired';
+    cliOutput(result, {
+      command: 'doctor repair',
+      message:
+        result.malformedCount === 0
+          ? `All ${result.roles.length} inspected DB(s) healthy — nothing to repair.`
+          : `${result.malformedCount} malformed DB(s): ${verb} ${result.repairedCount}, ` +
+            `${result.failedCount} failed.`,
+    });
+
+    // Non-zero exit when a needed repair could not complete.
+    if (result.failedCount > 0) {
+      process.exitCode = ExitCode.GENERAL_ERROR;
+    }
+  },
+});

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -35,6 +35,7 @@ import { doctorExodusResidueCommand } from './doctor-exodus-residue.js';
 import { doctorLegacyBackupsCommand } from './doctor-legacy-backups.js';
 import { runDoctorProjects } from './doctor-projects.js';
 import { doctorReleaseReadinessCommand } from './doctor-release-readiness.js';
+import { doctorRepairCommand } from './doctor-repair.js';
 import { readMigrationConflicts } from './migrate-agents-v2.js';
 
 // ============================================================================
@@ -237,6 +238,8 @@ export const doctorCommand = defineCommand({
     'exodus-residue': doctorExodusResidueCommand,
     // T11837 / Saga T11242 / Epic T11833 — read-only exodus health report
     'exodus-health': doctorExodusCommand,
+    // T11829 / Saga T11242 / Epic T11833 — DHQ-060 malformed-DB repair entry point
+    repair: doctorRepairCommand,
     // T10458 / Saga T10431 / Epic T10436 — Release-readiness preflight
     'release-readiness': doctorReleaseReadinessCommand,
   },

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,7 +28,6 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
-
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -45,7 +44,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description:
+      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,8 +63,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description:
+      'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () =>
+      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -82,7 +84,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -105,26 +108,31 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description:
+      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description:
+      'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description:
+      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () =>
+      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -147,7 +155,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description:
+      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -207,7 +216,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'classifyCommand',
     name: 'classify',
-    description: 'Classify a task: readiness verdict (proceed|grill) + persona routing (agent, confidence)',
+    description:
+      'Classify a task: readiness verdict (proceed|grill) + persona routing (agent, confidence)',
     load: async () => (await import('../commands/classify.js')).classifyCommand as CommandDef,
   },
   {
@@ -243,7 +253,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description:
+      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -262,7 +273,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -285,14 +297,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description:
+      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -316,7 +330,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -327,13 +342,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description:
+      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
     exportName: '_llmOutputCommand',
     name: 'llm-output',
-    description: 'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
+    description:
+      'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
     load: async () => (await import('../commands/docs.js'))._llmOutputCommand as CommandDef,
   },
   {
@@ -346,43 +363,57 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorExodusResidueCommand',
     name: 'exodus-residue',
-    description: 'Detect legacy exodus source DBs still present after a cutover (stranded residue that ',
-    load: async () => (await import('../commands/doctor-exodus-residue.js')).doctorExodusResidueCommand as CommandDef,
+    description:
+      'Detect legacy exodus source DBs still present after a cutover (stranded residue that ',
+    load: async () =>
+      (await import('../commands/doctor-exodus-residue.js'))
+        .doctorExodusResidueCommand as CommandDef,
   },
   {
     exportName: 'doctorExodusCommand',
     name: 'exodus-health',
-    description: 'Read-only exodus health report: per-scope migration state, legacy DB sizes, completion ',
-    load: async () => (await import('../commands/doctor-exodus.js')).doctorExodusCommand as CommandDef,
+    description:
+      'Read-only exodus health report: per-scope migration state, legacy DB sizes, completion ',
+    load: async () =>
+      (await import('../commands/doctor-exodus.js')).doctorExodusCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
+    description:
+      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () =>
+      (await import('../commands/doctor-legacy-backups.js'))
+        .doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorReleaseReadinessCommand',
     name: 'release-readiness',
-    description: 'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
-    load: async () => (await import('../commands/doctor-release-readiness.js')).doctorReleaseReadinessCommand as CommandDef,
+    description:
+      'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
+    load: async () =>
+      (await import('../commands/doctor-release-readiness.js'))
+        .doctorReleaseReadinessCommand as CommandDef,
   },
   {
     exportName: 'doctorRepairCommand',
     name: 'repair',
     description: 'Detect malformed CLEO databases (PRAGMA quick_check) and restore each from its ',
-    load: async () => (await import('../commands/doctor-repair.js')).doctorRepairCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/doctor-repair.js')).doctorRepairCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -417,14 +448,16 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'exodusCommand',
     name: 'exodus',
-    description: '[TRANSITIONAL] Migrate legacy multi-DB fleet to consolidated dual-scope cleo.db (SG-DB-SUBSTRATE-V2)',
+    description:
+      '[TRANSITIONAL] Migrate legacy multi-DB fleet to consolidated dual-scope cleo.db (SG-DB-SUBSTRATE-V2)',
     load: async () => (await import('../commands/exodus.js')).exodusCommand as CommandDef,
   },
   {
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -447,7 +480,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description:
+      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -465,7 +499,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'goalCommand',
     name: 'goal',
-    description: 'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/advance/subgoal/append).',
+    description:
+      'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/advance/subgoal/append).',
     load: async () => (await import('../commands/goal.js')).goalCommand as CommandDef,
   },
   {
@@ -496,7 +531,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -519,14 +555,17 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description:
+      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () =>
+      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -555,7 +594,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description:
+      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -591,20 +631,24 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'memoryCommand',
     name: 'memory',
-    description: 'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
+    description:
+      'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
     load: async () => (await import('../commands/memory.js')).memoryCommand as CommandDef,
   },
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description:
+      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () =>
+      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -633,7 +677,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description:
+      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -645,13 +690,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
+    description:
+      'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description:
+      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -700,7 +747,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () =>
+      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -711,7 +759,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description:
+      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -747,7 +796,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description:
+      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -759,7 +809,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description:
+      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -771,7 +822,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description:
+      'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -819,13 +871,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description:
+      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description:
+      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -897,7 +951,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description:
+      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -909,7 +964,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description:
+      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -921,13 +977,15 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description:
+      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description:
+      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -28,6 +28,7 @@ export interface CommandManifestEntry {
   readonly load: () => Promise<CommandDef>;
 }
 
+
 export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'adapterCommand',
@@ -44,8 +45,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'addCommand',
     name: 'add',
-    description:
-      'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
+    description: 'Create a new task (requires active session)\nFor 2+ tasks at once: cleo add-batch --file tasks.json (single transaction, atomic rollback)',
     load: async () => (await import('../commands/add.js')).addCommand as CommandDef,
   },
   {
@@ -63,10 +63,8 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'agentOutputsCommand',
     name: 'agent-outputs',
-    description:
-      'Agent output document management — find/search via DocsAccessor (find subcommand)',
-    load: async () =>
-      (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
+    description: 'Agent output document management — find/search via DocsAccessor (find subcommand)',
+    load: async () => (await import('../commands/agent-outputs.js')).agentOutputsCommand as CommandDef,
   },
   {
     exportName: 'agentCommand',
@@ -84,8 +82,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'archiveStatsCommand',
     name: 'archive-stats',
     description: 'Generate analytics and insights from archived tasks',
-    load: async () =>
-      (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
+    load: async () => (await import('../commands/archive-stats.js')).archiveStatsCommand as CommandDef,
   },
   {
     exportName: 'archiveCommand',
@@ -108,31 +105,26 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'authCommand',
     name: 'auth',
-    description:
-      'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
+    description: 'Unified credential view across all seeded sources (cleo llm list is the LLM-scoped sister command).',
     load: async () => (await import('../commands/auth.js')).authCommand as CommandDef,
   },
   {
     exportName: 'backfillCommand',
     name: 'backfill',
-    description:
-      'Retroactively add acceptance criteria and verification metadata to existing tasks',
+    description: 'Retroactively add acceptance criteria and verification metadata to existing tasks',
     load: async () => (await import('../commands/backfill.js')).backfillCommand as CommandDef,
   },
   {
     exportName: 'backupInspectSubCommand',
     name: 'inspect',
     description: 'Show bundle manifest without extracting or modifying anything',
-    load: async () =>
-      (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
+    load: async () => (await import('../commands/backup-inspect.js')).backupInspectSubCommand as CommandDef,
   },
   {
     exportName: 'backupRecoverSubCommand',
     name: 'recover',
-    description:
-      'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
-    load: async () =>
-      (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
+    description: 'Recover a malformed CLEO database from snapshot — accepts any role from DB_INVENTORY (T10318)',
+    load: async () => (await import('../commands/backup-recover.js')).backupRecoverSubCommand as CommandDef,
   },
   {
     exportName: 'backupCommand',
@@ -155,8 +147,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'briefingCommand',
     name: 'briefing',
-    description:
-      'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
+    description: 'Session resume context: last handoff, current task, next tasks, bugs, blockers, epics, and memory. Use at session start to restore context.',
     load: async () => (await import('../commands/briefing.js')).briefingCommand as CommandDef,
   },
   {
@@ -216,8 +207,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'classifyCommand',
     name: 'classify',
-    description:
-      'Classify a task: readiness verdict (proceed|grill) + persona routing (agent, confidence)',
+    description: 'Classify a task: readiness verdict (proceed|grill) + persona routing (agent, confidence)',
     load: async () => (await import('../commands/classify.js')).classifyCommand as CommandDef,
   },
   {
@@ -253,8 +243,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'configCommand',
     name: 'config',
-    description:
-      'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
+    description: 'CleoConfig SSoT registry surface (show, get, set, validate, drift-check) + legacy presets/list',
     load: async () => (await import('../commands/config.js')).configCommand as CommandDef,
   },
   {
@@ -273,8 +262,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'contributionCommand',
     name: 'contribution',
     description: 'Validate contribution protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/contribution.js')).contributionCommand as CommandDef,
+    load: async () => (await import('../commands/contribution.js')).contributionCommand as CommandDef,
   },
   {
     exportName: 'curatorCommand',
@@ -297,16 +285,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'dashCommand',
     name: 'dash',
-    description:
-      'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
+    description: 'Project health dashboard: status summary, phase progress, recent activity, high priority tasks. Use for overall project status.',
     load: async () => (await import('../commands/dash.js')).dashCommand as CommandDef,
   },
   {
     exportName: 'decompositionCommand',
     name: 'decomposition',
     description: 'Validate decomposition protocol compliance (alias for ',
-    load: async () =>
-      (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
+    load: async () => (await import('../commands/decomposition.js')).decompositionCommand as CommandDef,
   },
   {
     exportName: 'deleteCommand',
@@ -330,8 +316,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'detectDriftCommand',
     name: 'detect-drift',
     description: 'Detect documentation drift against TypeScript source of truth',
-    load: async () =>
-      (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
+    load: async () => (await import('../commands/detect-drift.js')).detectDriftCommand as CommandDef,
   },
   {
     exportName: 'detectCommand',
@@ -342,15 +327,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'diagnosticsCommand',
     name: 'diagnostics',
-    description:
-      'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
+    description: 'Autonomous self-improvement telemetry — opt-in command analytics that feed BRAIN observations',
     load: async () => (await import('../commands/diagnostics.js')).diagnosticsCommand as CommandDef,
   },
   {
     exportName: '_llmOutputCommand',
     name: 'llm-output',
-    description:
-      'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
+    description: 'Unified LLM output: task export (rich Markdown with frontmatter + body + attachments + memory refs) ',
     load: async () => (await import('../commands/docs.js'))._llmOutputCommand as CommandDef,
   },
   {
@@ -363,50 +346,43 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'doctorDbSubstrateCommand',
     name: 'db-substrate',
     description: 'Walk every DB in the inventory + report integrity, row counts, orphan dirs. ',
-    load: async () =>
-      (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-db-substrate.js')).doctorDbSubstrateCommand as CommandDef,
   },
   {
     exportName: 'doctorExodusResidueCommand',
     name: 'exodus-residue',
-    description:
-      'Detect legacy exodus source DBs still present after a cutover (stranded residue that ',
-    load: async () =>
-      (await import('../commands/doctor-exodus-residue.js'))
-        .doctorExodusResidueCommand as CommandDef,
+    description: 'Detect legacy exodus source DBs still present after a cutover (stranded residue that ',
+    load: async () => (await import('../commands/doctor-exodus-residue.js')).doctorExodusResidueCommand as CommandDef,
   },
   {
     exportName: 'doctorExodusCommand',
     name: 'exodus-health',
-    description:
-      'Read-only exodus health report: per-scope migration state, legacy DB sizes, completion ',
-    load: async () =>
-      (await import('../commands/doctor-exodus.js')).doctorExodusCommand as CommandDef,
+    description: 'Read-only exodus health report: per-scope migration state, legacy DB sizes, completion ',
+    load: async () => (await import('../commands/doctor-exodus.js')).doctorExodusCommand as CommandDef,
   },
   {
     exportName: 'doctorLegacyBackupsCommand',
     name: 'legacy-backups',
-    description:
-      'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
-    load: async () =>
-      (await import('../commands/doctor-legacy-backups.js'))
-        .doctorLegacyBackupsCommand as CommandDef,
+    description: 'Enumerate legacy *-pre-cleo.db.bak / brain.db.PRE-DUP-FIX-* / pre-untrack / rotation-overflow ',
+    load: async () => (await import('../commands/doctor-legacy-backups.js')).doctorLegacyBackupsCommand as CommandDef,
   },
   {
     exportName: 'doctorProjectsCommand',
     name: 'doctor-projects',
     description: 'Probe every registered project (nexus.db) for DB + config health',
-    load: async () =>
-      (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
+    load: async () => (await import('../commands/doctor-projects.js')).doctorProjectsCommand as CommandDef,
   },
   {
     exportName: 'doctorReleaseReadinessCommand',
     name: 'release-readiness',
-    description:
-      'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
-    load: async () =>
-      (await import('../commands/doctor-release-readiness.js'))
-        .doctorReleaseReadinessCommand as CommandDef,
+    description: 'Pre-flight release readiness check — lint matrix + changelog + changeset + npm OIDC + tag-trigger sanity (T10458)',
+    load: async () => (await import('../commands/doctor-release-readiness.js')).doctorReleaseReadinessCommand as CommandDef,
+  },
+  {
+    exportName: 'doctorRepairCommand',
+    name: 'repair',
+    description: 'Detect malformed CLEO databases (PRAGMA quick_check) and restore each from its ',
+    load: async () => (await import('../commands/doctor-repair.js')).doctorRepairCommand as CommandDef,
   },
   {
     exportName: 'doctorCommand',
@@ -441,16 +417,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'exodusCommand',
     name: 'exodus',
-    description:
-      '[TRANSITIONAL] Migrate legacy multi-DB fleet to consolidated dual-scope cleo.db (SG-DB-SUBSTRATE-V2)',
+    description: '[TRANSITIONAL] Migrate legacy multi-DB fleet to consolidated dual-scope cleo.db (SG-DB-SUBSTRATE-V2)',
     load: async () => (await import('../commands/exodus.js')).exodusCommand as CommandDef,
   },
   {
     exportName: 'exportTasksCommand',
     name: 'export-tasks',
     description: 'Export tasks to portable .cleo-export.json package for cross-project transfer',
-    load: async () =>
-      (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
+    load: async () => (await import('../commands/export-tasks.js')).exportTasksCommand as CommandDef,
   },
   {
     exportName: 'exportCommand',
@@ -473,8 +447,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'focusCommand',
     name: 'focus',
-    description:
-      'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
+    description: 'Single-envelope orientation for a task, epic, or saga — replaces 8 separate calls with one',
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
@@ -492,8 +465,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'goalCommand',
     name: 'goal',
-    description:
-      'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/advance/subgoal/append).',
+    description: 'DB-persisted, per-agent, evidence-gate-aware goal loop (set/status/advance/subgoal/append).',
     load: async () => (await import('../commands/goal.js')).goalCommand as CommandDef,
   },
   {
@@ -524,8 +496,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'importTasksCommand',
     name: 'import-tasks',
     description: 'Import tasks from .cleo-export.json package with ID remapping',
-    load: async () =>
-      (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
+    load: async () => (await import('../commands/import-tasks.js')).importTasksCommand as CommandDef,
   },
   {
     exportName: 'importCommand',
@@ -548,17 +519,14 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'installGlobalCommand',
     name: 'install-global',
-    description:
-      'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
-    load: async () =>
-      (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
+    description: 'Run the global bootstrap manually (install templates, ~/.cleo symlink, agents, skills). Same as npm postinstall.',
+    load: async () => (await import('../commands/install-global.js')).installGlobalCommand as CommandDef,
   },
   {
     exportName: 'intelligenceCommand',
     name: 'intelligence',
     description: 'Predictive intelligence and quality analysis',
-    load: async () =>
-      (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
+    load: async () => (await import('../commands/intelligence.js')).intelligenceCommand as CommandDef,
   },
   {
     exportName: 'issueCommand',
@@ -587,8 +555,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'costCommand',
     name: 'cost',
-    description:
-      'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
+    description: 'Compute cumulative USD cost for an LLM session from recorded token_usage entries. ',
     load: async () => (await import('../commands/llm-cost.js')).costCommand as CommandDef,
   },
   {
@@ -624,24 +591,20 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'memoryCommand',
     name: 'memory',
-    description:
-      'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
+    description: 'BRAIN memory operations (patterns, learnings, decisions — use decision-store/-find for architectural decisions)',
     load: async () => (await import('../commands/memory.js')).memoryCommand as CommandDef,
   },
   {
     exportName: 'migrateAgentsV2Command',
     name: 'agents-v2',
-    description:
-      'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
-    load: async () =>
-      (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
+    description: 'Register existing .cant agent files into signaldock.db (idempotent, conflict-safe)',
+    load: async () => (await import('../commands/migrate-agents-v2.js')).migrateAgentsV2Command as CommandDef,
   },
   {
     exportName: 'migrateClaudeMemCommand',
     name: 'migrate',
     description: 'Data migration utilities',
-    load: async () =>
-      (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
+    load: async () => (await import('../commands/migrate-claude-mem.js')).migrateClaudeMemCommand as CommandDef,
   },
   {
     exportName: 'nextCommand',
@@ -670,8 +633,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'otelCommand',
     name: 'otel',
-    description:
-      'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
+    description: 'Lightweight token metrics from .cleo/metrics/TOKEN_USAGE.jsonl (session-level, spawn-level events)',
     load: async () => (await import('../commands/otel.js')).otelCommand as CommandDef,
   },
   {
@@ -683,15 +645,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'pivotCommand',
     name: 'pivot',
-    description:
-      'Record an audited context switch from one task to another (replaces silent reframes)',
+    description: 'Record an audited context switch from one task to another (replaces silent reframes)',
     load: async () => (await import('../commands/pivot.js')).pivotCommand as CommandDef,
   },
   {
     exportName: 'planCommand',
     name: 'plan',
-    description:
-      'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
+    description: 'Task prioritization view: in-progress epics, ready tasks, blocked tasks, open bugs with scoring. Use when deciding what to work on next.',
     load: async () => (await import('../commands/plan.js')).planCommand as CommandDef,
   },
   {
@@ -740,8 +700,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     exportName: 'refreshMemoryCommand',
     name: 'refresh-memory',
     description: 'Regenerate .cleo/memory-bridge.md from brain.db',
-    load: async () =>
-      (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
+    load: async () => (await import('../commands/refresh-memory.js')).refreshMemoryCommand as CommandDef,
   },
   {
     exportName: 'relatesCommand',
@@ -752,8 +711,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'releaseCommand',
     name: 'release',
-    description:
-      'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
+    description: 'Release lifecycle management — 4-verb pipeline: plan → open → reconcile / rollback. ',
     load: async () => (await import('../commands/release.js')).releaseCommand as CommandDef,
   },
   {
@@ -789,8 +747,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'reqCommand',
     name: 'req',
-    description:
-      'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
+    description: 'Manage REQ-ID-addressable acceptance gates on tasks (in-task gates only). For cross-task dependency edges, use ',
     load: async () => (await import('../commands/req.js')).reqCommand as CommandDef,
   },
   {
@@ -802,8 +759,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'restoreCommand',
     name: 'restore',
-    description:
-      'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
+    description: 'Restore from backup or restore tasks from terminal states (archived, cancelled, completed)',
     load: async () => (await import('../commands/restore.js')).restoreCommand as CommandDef,
   },
   {
@@ -815,8 +771,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'roadmapCommand',
     name: 'roadmap',
-    description:
-      'Generate project roadmap from task provenance — epics grouped by status with progress',
+    description: 'Generate project roadmap from task provenance — epics grouped by status with progress',
     load: async () => (await import('../commands/roadmap.js')).roadmapCommand as CommandDef,
   },
   {
@@ -864,15 +819,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'setupCommand',
     name: 'setup',
-    description:
-      'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
+    description: 'Interactive setup wizard — runs all 8 sections in canonical order (identity → llm → sentient → harness → brain → project-conventions → integrations → verification). Use --section <name> for a single section, --non-interactive with section-specific flags to configure without prompts, --config-json for fully scripted setup, or --reset to reconfigure already-set sections.',
     load: async () => (await import('../commands/setup.js')).setupCommand as CommandDef,
   },
   {
     exportName: 'showCommand',
     name: 'show',
-    description:
-      'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
+    description: 'Show task details by ID. MVI-projected (id + title + status + key metadata) by default; pass --verbose / --full to receive the complete record with description, acceptance, verification, evidence, etc. (T9922)',
     load: async () => (await import('../commands/show.js')).showCommand as CommandDef,
   },
   {
@@ -944,8 +897,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'templatesCommand',
     name: 'templates',
-    description:
-      'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
+    description: 'TemplateManifest SSoT registry surface (list, show, install, upgrade, diff, validate)',
     load: async () => (await import('../commands/templates.js')).templatesCommand as CommandDef,
   },
   {
@@ -957,8 +909,7 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'tokenCommand',
     name: 'token',
-    description:
-      'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
+    description: 'Provider-aware token telemetry from tasks.db (historical, per-operation tracking)',
     load: async () => (await import('../commands/token.js')).tokenCommand as CommandDef,
   },
   {
@@ -970,15 +921,13 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   {
     exportName: 'updateCommand',
     name: 'update',
-    description:
-      'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
+    description: 'Update a task. Safe under concurrent invocation — retries on SQLITE_BUSY up to 4 attempts (gh#391).',
     load: async () => (await import('../commands/update.js')).updateCommand as CommandDef,
   },
   {
     exportName: 'upgradeCommand',
     name: 'upgrade',
-    description:
-      'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
+    description: 'Unified project maintenance (storage migration, schema repair, structural fixes, doc refresh)',
     load: async () => (await import('../commands/upgrade.js')).upgradeCommand as CommandDef,
   },
   {

--- a/packages/contracts/src/db-recovery.ts
+++ b/packages/contracts/src/db-recovery.ts
@@ -142,3 +142,68 @@ export interface BackupRecoverResult {
    */
   dryRun: boolean;
 }
+
+/**
+ * Per-role outcome of a `cleo doctor repair` pass (T11829 · DHQ-060).
+ *
+ * `doctor repair` first PROBES each role's live DB via `PRAGMA quick_check`
+ * (the same probe the recovery pipeline runs on snapshot candidates) and only
+ * invokes the {@link recoverMalformedDb} → quarantine → restore-from-snapshot →
+ * verify pipeline for roles that are actually malformed. This record captures
+ * what was observed and done for one role.
+ *
+ * @task T11829
+ * @epic T11833
+ * @saga T11242
+ * @public
+ */
+export interface DoctorRepairRoleResult {
+  /** Canonical role inspected. */
+  role: DbRole;
+  /** Absolute path to the role's live DB file (resolved from `DB_INVENTORY`). */
+  dbPath: string;
+  /** `true` when the live DB file exists on disk. */
+  present: boolean;
+  /**
+   * `true` when the live DB passed `PRAGMA quick_check` (or was absent) — i.e.
+   * NO repair was needed. `false` when corruption was detected.
+   */
+  healthy: boolean;
+  /**
+   * `'skipped'` — healthy or absent, nothing done;
+   * `'would-repair'` — `--dry-run`, corruption detected, repair NOT performed;
+   * `'repaired'` — corruption detected and snapshot restore succeeded;
+   * `'failed'` — corruption detected but recovery could not complete.
+   */
+  action: 'skipped' | 'would-repair' | 'repaired' | 'failed';
+  /** Absolute path to the snapshot restored (or that would be), when applicable. */
+  restoredFrom: string | null;
+  /** Absolute path to the quarantined corrupt DB, when a repair was performed. */
+  quarantinedTo: string | null;
+  /** Approximate data-loss window in hours, when a snapshot timestamp was parsed. */
+  dataLossWindowHours: number | null;
+  /** Human-readable detail (probe outcome, error reason, or restore summary). */
+  detail: string;
+}
+
+/**
+ * Aggregate result of a `cleo doctor repair` invocation across one or more roles
+ * (T11829 · DHQ-060).
+ *
+ * @task T11829
+ * @epic T11833
+ * @saga T11242
+ * @public
+ */
+export interface DoctorRepairResult {
+  /** `true` when the run was a `--dry-run` (no files mutated). */
+  dryRun: boolean;
+  /** Per-role outcomes. */
+  roles: DoctorRepairRoleResult[];
+  /** Count of roles found malformed (`!healthy`). */
+  malformedCount: number;
+  /** Count of roles actually repaired this run. */
+  repairedCount: number;
+  /** Count of roles where a needed repair FAILED. */
+  failedCount: number;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -346,6 +346,8 @@ export type {
   BackupRecoverResult,
   DbRecoveredRowCounts,
   DbRecoveryResult,
+  DoctorRepairResult,
+  DoctorRepairRoleResult,
 } from './db-recovery.js';
 // === Dependency Registry Contracts ===
 export type {

--- a/packages/core/src/store/__tests__/repair-malformed-dbs.test.ts
+++ b/packages/core/src/store/__tests__/repair-malformed-dbs.test.ts
@@ -1,0 +1,150 @@
+/**
+ * `cleo doctor repair` orchestrator suite (T11829 · DHQ-060).
+ *
+ * Proves {@link repairMalformedDbs} — the entry point behind `cleo doctor repair`
+ * — DETECTS malformed live DBs via `PRAGMA quick_check` and REPAIRS them through
+ * the existing {@link recoverMalformedDb} / {@link runBackupRecover} pipeline,
+ * while leaving healthy/absent DBs untouched. No recovery logic is re-implemented;
+ * the orchestrator only probes + delegates.
+ *
+ * @task T11829 (DHQ-060)
+ * @epic T11833
+ * @saga T11242
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync as DatabaseSyncType } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { repairMalformedDbs } from '../repair-malformed-dbs.js';
+
+const _require = createRequire(import.meta.url);
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (path: string) => DatabaseSyncType;
+};
+
+const logger = { warn: vi.fn(), error: vi.fn() };
+
+/** Write a minimal, integrity-clean SQLite DB carrying the `tasks` table. */
+function writeHealthyTasksDb(path: string, rows: number): void {
+  const db = new DatabaseSync(path);
+  try {
+    db.exec('CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT)');
+    for (let i = 0; i < rows; i++) {
+      db.prepare('INSERT INTO tasks (id, title) VALUES (?, ?)').run(`T${i}`, `task ${i}`);
+    }
+    // Checkpoint so the snapshot file is self-contained (no WAL dependency).
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    db.close();
+  }
+}
+
+describe('repairMalformedDbs (T11829)', () => {
+  let projectRoot: string;
+  let cleoDir: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'cleo-repair-test-'));
+    cleoDir = join(projectRoot, '.cleo');
+    mkdirSync(cleoDir, { recursive: true });
+    logger.warn.mockClear();
+    logger.error.mockClear();
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('skips a healthy DB (quick_check passes) without quarantining', () => {
+    writeHealthyTasksDb(join(cleoDir, 'tasks.db'), 3);
+
+    const result = repairMalformedDbs({ projectRoot, roles: ['tasks'], logger });
+
+    expect(result.malformedCount).toBe(0);
+    expect(result.repairedCount).toBe(0);
+    const tasks = result.roles.find((r) => r.role === 'tasks');
+    expect(tasks?.healthy).toBe(true);
+    expect(tasks?.action).toBe('skipped');
+  });
+
+  it('reports an absent DB as skipped/healthy (nothing to repair)', () => {
+    const result = repairMalformedDbs({ projectRoot, roles: ['tasks'], logger });
+    const tasks = result.roles.find((r) => r.role === 'tasks');
+    expect(tasks?.present).toBe(false);
+    expect(tasks?.action).toBe('skipped');
+    expect(result.malformedCount).toBe(0);
+  });
+
+  it('detects a malformed DB and restores it from the freshest valid snapshot', () => {
+    // Live DB = garbage bytes → PRAGMA quick_check fails ("disk image malformed").
+    writeFileSync(join(cleoDir, 'tasks.db'), Buffer.from('not a sqlite file at all, corrupt'));
+
+    // A valid VACUUM-INTO snapshot the pipeline can restore from:
+    // <cleoDir>/backups/sqlite/tasks-YYYYMMDD-HHmmss.db.
+    const vacuumDir = join(cleoDir, 'backups', 'sqlite');
+    mkdirSync(vacuumDir, { recursive: true });
+    writeHealthyTasksDb(join(vacuumDir, 'tasks-20260101-120000.db'), 5);
+
+    const result = repairMalformedDbs({ projectRoot, roles: ['tasks'], logger });
+
+    expect(result.malformedCount).toBe(1);
+    expect(result.repairedCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    const tasks = result.roles.find((r) => r.role === 'tasks');
+    expect(tasks?.healthy).toBe(false);
+    expect(tasks?.action).toBe('repaired');
+    expect(tasks?.restoredFrom).toContain('tasks-20260101-120000.db');
+    expect(tasks?.quarantinedTo).toBeTruthy();
+
+    // Post-repair the live DB is readable again with the snapshot's rows.
+    const restored = new DatabaseSync(join(cleoDir, 'tasks.db'));
+    try {
+      const row = restored.prepare('SELECT COUNT(*) AS n FROM tasks').get() as { n: number };
+      expect(row.n).toBe(5);
+    } finally {
+      restored.close();
+    }
+  });
+
+  it('--dry-run detects corruption but performs no quarantine/restore', () => {
+    writeFileSync(join(cleoDir, 'tasks.db'), Buffer.from('corrupt bytes here'));
+    const vacuumDir = join(cleoDir, 'backups', 'sqlite');
+    mkdirSync(vacuumDir, { recursive: true });
+    writeHealthyTasksDb(join(vacuumDir, 'tasks-20260101-120000.db'), 7);
+
+    const result = repairMalformedDbs({ projectRoot, roles: ['tasks'], dryRun: true, logger });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.malformedCount).toBe(1);
+    expect(result.repairedCount).toBe(0);
+    const tasks = result.roles.find((r) => r.role === 'tasks');
+    expect(tasks?.action).toBe('would-repair');
+    expect(tasks?.quarantinedTo).toBeNull();
+
+    // Live DB is STILL the corrupt file — dry-run mutated nothing.
+    const live = new DatabaseSync(join(cleoDir, 'tasks.db'));
+    let threw = false;
+    try {
+      live.prepare('SELECT 1').get();
+    } catch {
+      threw = true;
+    } finally {
+      live.close();
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('reports failed when a malformed DB has no valid snapshot to restore from', () => {
+    writeFileSync(join(cleoDir, 'tasks.db'), Buffer.from('corrupt, no snapshots exist'));
+
+    const result = repairMalformedDbs({ projectRoot, roles: ['tasks'], logger });
+
+    expect(result.malformedCount).toBe(1);
+    expect(result.repairedCount).toBe(0);
+    expect(result.failedCount).toBe(1);
+    expect(result.roles.find((r) => r.role === 'tasks')?.action).toBe('failed');
+  });
+});

--- a/packages/core/src/store/repair-malformed-dbs.ts
+++ b/packages/core/src/store/repair-malformed-dbs.ts
@@ -1,0 +1,229 @@
+/**
+ * `cleo doctor repair` orchestrator — detect malformed CLEO databases and
+ * restore each from its freshest validated snapshot (T11829 · DHQ-060).
+ *
+ * ## Why this exists
+ *
+ * The corruption-resilience pipeline ALREADY existed before T11829:
+ *
+ *  - {@link recoverMalformedDb} (quarantine → snapshot-restore → `quick_check`),
+ *  - `autoRecoverFromBackup` (catches `"database disk image is malformed"` at
+ *    open and restores the freshest VACUUM snapshot), and
+ *  - the operator verb `cleo backup recover <role>` ({@link runBackupRecover}).
+ *
+ * The ONLY gap vs the DHQ-060 ask was a discoverable `cleo doctor` entry point
+ * that DETECTS corruption across the fleet and repairs only what is broken. This
+ * module is that orchestrator — it adds NO new recovery logic. It probes each
+ * role's live DB with `PRAGMA quick_check` (the same probe the pipeline runs on
+ * snapshot candidates, via {@link probeSnapshot}) and delegates every actual
+ * repair to {@link runBackupRecover} → {@link recoverMalformedDb}.
+ *
+ * ## WAL-specific corruption is covered
+ *
+ * A torn WAL frame surfaces as `"database disk image is malformed"` and makes
+ * `PRAGMA quick_check` return a non-`ok` result — so {@link probeSnapshot}
+ * detects it. The quarantine step ({@link quarantineCorruptDb}) already moves the
+ * `-wal`/`-shm` sidecars alongside the main file, so the WAL case is fully
+ * handled by the existing pipeline; this orchestrator does not need to special-case it.
+ *
+ * @module
+ * @task T11829 (DHQ-060 — `cleo doctor repair` entry point over the recovery pipeline)
+ * @epic T11833
+ * @saga T11242 (SG-DB-SUBSTRATE-V2)
+ * @see packages/core/src/store/recover-malformed-db.ts — the recovery pipeline
+ * @see packages/core/src/store/backup-recover.ts — `cleo backup recover <role>` wrapper
+ */
+
+import { existsSync } from 'node:fs';
+import { DB_INVENTORY, type DbRole, type DoctorRepairResult } from '@cleocode/contracts';
+import { BackupRecoverError, runBackupRecover } from './backup-recover.js';
+import { probeSnapshot, type RecoveryLogger, resolveRoleDbPath } from './recover-malformed-db.js';
+
+/**
+ * Options accepted by {@link repairMalformedDbs}.
+ *
+ * @task T11829
+ * @public
+ */
+export interface RepairMalformedDbsOptions {
+  /** Absolute path to the project root (resolves `<projectRoot>` inventory tokens). */
+  projectRoot: string;
+  /**
+   * Roles to inspect. When omitted, EVERY role in {@link DB_INVENTORY} whose live
+   * file exists is probed. An explicit single-role list (from `--role`) is probed
+   * even when absent (so the operator gets a clear "not present" report).
+   */
+  roles?: DbRole[];
+  /**
+   * When `true`, detect + plan only — corruption is reported with
+   * `action: 'would-repair'` but NO quarantine/restore is performed.
+   *
+   * @default false
+   */
+  dryRun?: boolean;
+  /** Pino-shaped logger for recovery announcements. */
+  logger: RecoveryLogger;
+}
+
+/**
+ * Probe a single role's live DB and, when malformed, repair it from snapshot.
+ *
+ * Pure delegation: detection via {@link probeSnapshot} (`PRAGMA quick_check`),
+ * repair via {@link runBackupRecover}. Never throws — a recovery failure is
+ * captured in the returned record's `action: 'failed'`.
+ *
+ * @internal
+ */
+function repairOneRole(
+  role: DbRole,
+  opts: RepairMalformedDbsOptions,
+): DoctorRepairResult['roles'][number] {
+  const dbPath = resolveRoleDbPath(role, { projectRoot: opts.projectRoot });
+  const present = existsSync(dbPath);
+
+  if (!present) {
+    return {
+      role,
+      dbPath,
+      present: false,
+      healthy: true,
+      action: 'skipped',
+      restoredFrom: null,
+      quarantinedTo: null,
+      dataLossWindowHours: null,
+      detail: 'live DB file not present on disk (nothing to repair)',
+    };
+  }
+
+  // DETECT — the same `PRAGMA quick_check` the pipeline runs on snapshots. A
+  // torn WAL frame ("database disk image is malformed") fails this probe.
+  const probe = probeSnapshot(dbPath);
+  if (probe.ok) {
+    return {
+      role,
+      dbPath,
+      present: true,
+      healthy: true,
+      action: 'skipped',
+      restoredFrom: null,
+      quarantinedTo: null,
+      dataLossWindowHours: null,
+      detail: 'PRAGMA quick_check passed — DB is healthy',
+    };
+  }
+
+  // MALFORMED — plan or repair.
+  if (opts.dryRun === true) {
+    try {
+      // Dry-run delegates to the SAME pipeline (no mutation) for an honest plan.
+      const plan = runBackupRecover({
+        role,
+        projectRoot: opts.projectRoot,
+        logger: opts.logger,
+        dryRun: true,
+      });
+      return {
+        role,
+        dbPath,
+        present: true,
+        healthy: false,
+        action: 'would-repair',
+        restoredFrom: plan.restoredFrom || null,
+        quarantinedTo: null,
+        dataLossWindowHours: plan.dataLossWindowHours,
+        detail: `malformed — would restore from ${plan.restoredFrom} (re-run without --dry-run to repair)`,
+      };
+    } catch (err) {
+      return {
+        role,
+        dbPath,
+        present: true,
+        healthy: false,
+        action: 'failed',
+        restoredFrom: null,
+        quarantinedTo: null,
+        dataLossWindowHours: null,
+        detail: `malformed but NO valid snapshot to restore from: ${
+          err instanceof BackupRecoverError ? err.message : String(err)
+        }`,
+      };
+    }
+  }
+
+  // EXECUTE — quarantine + restore + verify via the existing pipeline.
+  try {
+    const result = runBackupRecover({
+      role,
+      projectRoot: opts.projectRoot,
+      logger: opts.logger,
+      dryRun: false,
+    });
+    return {
+      role,
+      dbPath,
+      present: true,
+      healthy: false,
+      action: 'repaired',
+      restoredFrom: result.restoredFrom || null,
+      quarantinedTo: result.quarantinedTo || null,
+      dataLossWindowHours: result.dataLossWindowHours,
+      detail: `repaired — restored from ${result.restoredFrom}; corrupt DB quarantined at ${result.quarantinedTo}`,
+    };
+  } catch (err) {
+    return {
+      role,
+      dbPath,
+      present: true,
+      healthy: false,
+      action: 'failed',
+      restoredFrom: null,
+      quarantinedTo: null,
+      dataLossWindowHours: null,
+      detail: `malformed — recovery FAILED: ${
+        err instanceof BackupRecoverError ? err.message : String(err)
+      }`,
+    };
+  }
+}
+
+/**
+ * Detect and repair malformed CLEO databases across the fleet (T11829 · DHQ-060).
+ *
+ * For each requested role (or every present role in {@link DB_INVENTORY} when none
+ * are specified) this probes the live DB with `PRAGMA quick_check` and, when
+ * corruption is found, restores the freshest validated snapshot via the existing
+ * {@link runBackupRecover} pipeline. No new recovery logic is introduced — this is
+ * the discoverable `cleo doctor repair` entry point requested by DHQ-060.
+ *
+ * @param opts - Repair inputs (project root, optional role filter, dry-run, logger).
+ * @returns A {@link DoctorRepairResult} aggregate with per-role outcomes.
+ *
+ * @example
+ * ```ts
+ * const report = repairMalformedDbs({ projectRoot: '/repo', logger });
+ * if (report.failedCount > 0) process.exitCode = 1;
+ * ```
+ *
+ * @task T11829
+ * @epic T11833
+ * @saga T11242
+ * @public
+ */
+export function repairMalformedDbs(opts: RepairMalformedDbsOptions): DoctorRepairResult {
+  const explicit = opts.roles !== undefined && opts.roles.length > 0;
+  const candidateRoles: DbRole[] = explicit
+    ? (opts.roles as DbRole[])
+    : DB_INVENTORY.map((e) => e.role).filter((role) =>
+        existsSync(resolveRoleDbPath(role, { projectRoot: opts.projectRoot })),
+      );
+
+  const roles = candidateRoles.map((role) => repairOneRole(role, opts));
+
+  return {
+    dryRun: opts.dryRun === true,
+    roles,
+    malformedCount: roles.filter((r) => !r.healthy).length,
+    repairedCount: roles.filter((r) => r.action === 'repaired').length,
+    failedCount: roles.filter((r) => r.action === 'failed').length,
+  };
+}


### PR DESCRIPTION
## What

Corruption resilience already existed in CLEO:
- `recoverMalformedDb` (quarantine → snapshot-restore → `PRAGMA quick_check`),
- `autoRecoverFromBackup` (catches `"database disk image is malformed"` at open),
- the `cleo backup recover <role>` operator verb.

The **only** DHQ-060 gap was a discoverable `cleo doctor` entry point that DETECTS corruption across the fleet and repairs only what is broken.

## How (reuse, do not reimplement)

- **CORE** `store/repair-malformed-dbs.ts` — probes each role's live DB with `PRAGMA quick_check` (the same probe the pipeline runs on snapshot candidates) and, when malformed, delegates the actual repair to the existing `runBackupRecover` → `recoverMalformedDb` pipeline. No recovery logic is reimplemented.
- **CLI** thin `cleo doctor repair [--role <role>] [--dry-run]` wraps the orchestrator: default probes every present DB, `--role` narrows to one, `--dry-run` plans without mutating, non-zero exit when a needed repair fails.
- New contracts `DoctorRepairResult` / `DoctorRepairRoleResult`.

### WAL-specific corruption is covered

A torn WAL frame surfaces as `"database disk image is malformed"` and fails `PRAGMA quick_check`, so `probeSnapshot` detects it; `quarantineCorruptDb` already moves the `-wal`/`-shm` sidecars. No new detection needed.

## Tests

`repair-malformed-dbs.test.ts` — 5 cases: healthy skip, absent skip, detect+restore (restored rows verified), `--dry-run` performs no mutation, no-snapshot ⇒ `failed`. Also verified **end-to-end on the built CLI** against a corrupt `tasks.db` + a valid snapshot (dry-run plan → execute repair → 2 rows restored).

## Gates

- `pnpm --filter @cleocode/{contracts,core} run build` ✅ · `cleo` typecheck ✅
- DB Open Guard (Gate 3, `--strict`) ✅ · CLI boundary (Gate 6, `--check`) ✅ baseline=33, zero net-new (`doctor-repair.ts` not flagged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)