### PR TITLE
feat(docs): give ADR display-aliases real storage decoupled from the slug (T11875)

### DIFF
--- a/packages/cleo/src/cli/commands/docs.ts
+++ b/packages/cleo/src/cli/commands/docs.ts
@@ -47,6 +47,8 @@ import { cliError, cliOutput, humanInfo } from '../renderers/index.js';
 import { auditCommand } from './docs/audit.js';
 // T10164 — DocProvenanceResponse-typed graph verb (`--root <slug>|<taskId>`).
 import { graphCommand as provenanceGraphCommand } from './docs/graph.js';
+// T11875 — display-alias assignment verb (`set-alias <slug> <number>`).
+import { setAliasCommand } from './docs/set-alias.js';
 import { docsViewerSubcommands } from './docs-viewer.js';
 
 const docsOutputFlagHelp =
@@ -2861,6 +2863,8 @@ export const docsCommand = defineCommand({
     merge: mergeCommand,
     // T10164 — DocProvenanceResponse-typed graph (`--root <slug>|<taskId>`).
     graph: provenanceGraphCommand,
+    // T11875 — display-alias assignment (`set-alias <slug> <number>`), decoupled from slug.
+    'set-alias': setAliasCommand,
     // Legacy aliases (use `query` for new work — retained for backward compatibility)
     search: searchCommand,
     find: findCommand,

--- a/packages/cleo/src/cli/commands/docs/set-alias.ts
+++ b/packages/cleo/src/cli/commands/docs/set-alias.ts
@@ -1,0 +1,111 @@
+/**
+ * `cleo docs set-alias <slug> <number>` — assign an explicit DISPLAY ALIAS
+ * number to a doc, DECOUPLED from its slug.
+ *
+ * Under the slug-primary model (saga T11778 · ADR reconcile T11676) the kebab
+ * slug is the canonical handle and the rendered number (e.g. ADR "051") is a
+ * display alias only. This verb writes the real `attachments.display_alias`
+ * column via the CORE SDK chokepoint so renderers/`cleo docs fetch|list` show a
+ * STABLE number even when several docs share a slug-derived number. The number
+ * must be UNIQUE among `type='adr'` docs (rejected with `E_ALIAS_TAKEN`).
+ *
+ * Pass `--clear` to remove an existing alias (revert to slug-derived rendering).
+ *
+ * Thin CLI boundary — all transaction + uniqueness logic lives in
+ * {@link import('@cleocode/core/internal').setDisplayAlias}.
+ *
+ * @see setDisplayAlias — packages/core/src/docs/display-alias.ts
+ * @see resolveDisplayNumber — packages/core/src/docs/numbering.ts
+ *
+ * @task T11875 (Epic T11781 / Saga T11778)
+ * @adr ADR-078
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { CleoError, getProjectRoot, setDisplayAlias } from '@cleocode/core/internal'; // core-first-allowed: T11875 setDisplayAlias not yet promoted to public barrel
+import { defineCommand } from '../../lib/define-cli-command.js';
+import { cliError, cliOutput } from '../../renderers/index.js';
+
+/**
+ * `cleo docs set-alias` — display-alias assignment verb (T11875).
+ *
+ * @task T11875
+ */
+export const setAliasCommand = defineCommand({
+  meta: {
+    name: 'set-alias',
+    description:
+      'Assign an explicit display-alias number to a doc, decoupled from its ' +
+      'slug (e.g. `cleo docs set-alias adr-051-override-patterns 091`). The ' +
+      'number must be unique among type=adr docs. Pass --clear to remove an ' +
+      'existing alias (revert to the slug-derived number).',
+  },
+  args: {
+    slug: {
+      type: 'positional',
+      description: 'Canonical doc slug to alias (e.g. adr-051-override-patterns). Required.',
+      required: true,
+    },
+    number: {
+      type: 'positional',
+      description: 'The display-alias number to assign (positive integer). Omit with --clear.',
+      required: false,
+    },
+    clear: {
+      type: 'boolean',
+      description: 'Clear any existing alias instead of setting one (revert to slug-derived).',
+    },
+  },
+  async run({ args }) {
+    const slug = String(args.slug);
+    const clear = Boolean(args.clear);
+
+    let displayAlias: number | null;
+    if (clear) {
+      displayAlias = null;
+    } else {
+      const raw = args.number;
+      if (raw === undefined || raw === null || String(raw).trim() === '') {
+        cliError(
+          'a positive integer <number> is required (or pass --clear to remove the alias)',
+          ExitCode.VALIDATION_ERROR,
+          { name: 'E_VALIDATION' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+        return;
+      }
+      const parsed = Number.parseInt(String(raw), 10);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        cliError(
+          `<number> must be a positive integer (got '${String(raw)}')`,
+          ExitCode.VALIDATION_ERROR,
+          { name: 'E_VALIDATION' },
+        );
+        process.exit(ExitCode.VALIDATION_ERROR);
+        return;
+      }
+      displayAlias = parsed;
+    }
+
+    try {
+      const result = await setDisplayAlias(getProjectRoot(), { slug, displayAlias });
+      cliOutput(result, { command: 'docs set-alias', operation: 'docs.set-alias' });
+    } catch (err) {
+      if (err instanceof CleoError) {
+        cliError(err.message, err.code, {
+          name:
+            typeof err.details?.['code'] === 'string' ? err.details['code'] : 'E_DOCS_SET_ALIAS',
+          ...(err.fix ? { fix: err.fix } : {}),
+          ...(err.details ? { details: err.details } : {}),
+        });
+        process.exit(err.code);
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(`docs set-alias failed: ${message}`, ExitCode.GENERAL_ERROR, {
+        name: 'E_DOCS_SET_ALIAS_FAILED',
+      });
+      process.exit(ExitCode.GENERAL_ERROR);
+    }
+  },
+});

--- a/packages/cleo/src/dispatch/domains/docs.ts
+++ b/packages/cleo/src/dispatch/domains/docs.ts
@@ -547,6 +547,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
         refCount: doc.refCount,
         ...(doc.slug ? { slug: doc.slug } : {}),
         ...(doc.kind ? { type: doc.kind as DocsType } : {}),
+        ...(doc.displayNumber !== null ? { displayNumber: doc.displayNumber } : {}),
         ownerId: doc.ownerId,
         ownerType: doc.ownerType as AttachmentRef['ownerType'],
       }));
@@ -603,6 +604,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
       refCount: doc.refCount,
       ...(doc.slug ? { slug: doc.slug } : {}),
       ...(doc.kind ? { type: doc.kind as DocsType } : {}),
+      ...(doc.displayNumber !== null ? { displayNumber: doc.displayNumber } : {}),
     }));
 
     projectedOwner.sort((a, b) =>
@@ -837,6 +839,7 @@ const _docsTypedHandler = defineTypedHandler<DocsTypedOps>('docs', {
           refCount: 0,
           ...(doc.slug ? { slug: doc.slug } : {}),
           ...(doc.kind ? { type: doc.kind as DocsType } : {}),
+          ...(doc.displayNumber !== null ? { displayNumber: doc.displayNumber } : {}),
         },
         path: storagePath,
         sizeBytes: contentBytes.length,

--- a/packages/contracts/src/operations/docs.ts
+++ b/packages/contracts/src/operations/docs.ts
@@ -137,6 +137,20 @@ export interface DocsAttachmentRow {
    */
   type?: DocsType;
   /**
+   * Optional DISPLAY number for the doc (e.g. ADR "051"), decoupled from the
+   * slug string (T11875 · ADR reconcile T11676).
+   *
+   * Resolved by the read model via `resolveDisplayNumber`: the stored
+   * `attachments.display_alias` wins when set, otherwise the number derived
+   * from the slug, otherwise omitted for non-numbered / slug-less docs. Set via
+   * `cleo docs set-alias <slug> <number>`. Surfaced so renderers and the
+   * Obsidian plugin display a STABLE number even when several docs share a
+   * slug-derived number.
+   *
+   * @task T11875 (Epic T11781 / Saga T11778)
+   */
+  displayNumber?: number;
+  /**
    * When the attachment is project-scoped (no specific entity owner), this
    * row's owner ID / type still reflect how the attachment was registered.
    * The `--project` list view simply unions all owner-types.

--- a/packages/core/migrations/drizzle-tasks/20260606000001_t11875-attachments-display-alias/migration.sql
+++ b/packages/core/migrations/drizzle-tasks/20260606000001_t11875-attachments-display-alias/migration.sql
@@ -1,0 +1,46 @@
+-- T11875 — give ADR display-aliases real storage DECOUPLED from the slug.
+--
+-- Background (ADR reconcile T11676 · ratified slug-primary model, saga T11778):
+--   Under the slug-primary model the kebab `slug` is the canonical handle and
+--   the displayed number (e.g. ADR "051") is a DISPLAY ALIAS only. Until now
+--   that number was DERIVED by parsing the digits out of the slug string
+--   (`adr-051-*` → 051), so three DISTINCT ADRs that all slug as `adr-051-*`
+--   (override-patterns ≠ programmatic-gate-integrity ≠ worktree-extension)
+--   rendered the same "051" with no way to disambiguate. The collision cannot
+--   be resolved by renumbering a slug (that would break the canonical handle).
+--
+--   This migration adds a real, nullable `display_alias` INTEGER column to
+--   `attachments` so a doc can carry an explicit display number independent of
+--   its slug. `numbering.ts::resolveDisplayNumber` PREFERS the stored alias
+--   when present and falls back to the slug-derived number when null — so docs
+--   that never get an alias keep their historical rendering byte-for-byte.
+--
+--   Uniqueness among `type='adr'` docs is enforced at the DISPATCH layer
+--   (`display-alias.ts::setDisplayAlias`), NOT via a SQL UNIQUE constraint:
+--   the constraint is scoped to one kind, and dispatch-validation matches the
+--   discipline already used for `lifecycle_status` / `docs_wikilinks.relation`
+--   so future taxonomy changes never require another schema migration.
+--
+-- Additive + forward-only: the new column is nullable, so SQLite ALTER TABLE
+-- ADD COLUMN does NOT rewrite the table and existing rows pass through with
+-- NULL (i.e. "no alias — derive from slug"). No data migration of legacy rows
+-- is required; the `cleo docs set-alias` verb populates aliases going forward.
+--
+-- Changes (idempotent — safe to re-run):
+--   1. ALTER TABLE attachments ADD COLUMN display_alias integer  (nullable).
+--   2. CREATE INDEX idx_attachments_display_alias — speeds the per-type
+--      uniqueness scan performed by setDisplayAlias.
+--
+-- DEPENDS ON: 20260416000000_t796-attachments (creates `attachments`)
+-- SAFE FOR:   SQLite 3.35+ (ALTER TABLE ADD COLUMN nullable is atomic)
+--
+-- @task T11875
+-- @epic T11781 (E3-OBSIDIAN-INTEGRATION)
+-- @saga T11778 (SG-DOCS-SSOT-VAULT)
+-- @closes (display-alias half of) T11676 ADR reconcile plan
+
+ALTER TABLE `attachments` ADD COLUMN `display_alias` integer;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `idx_attachments_display_alias`
+  ON `attachments` (`display_alias`);

--- a/packages/core/src/docs/__tests__/display-alias.test.ts
+++ b/packages/core/src/docs/__tests__/display-alias.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the display-alias storage subsystem (T11875).
+ *
+ * Three concerns, mirroring the acceptance criteria:
+ *   1. `setDisplayAlias` happy path — assigns / clears the stored alias.
+ *   2. `setDisplayAlias` uniqueness — rejects a number already owned by another
+ *      `type='adr'` doc; non-adr kinds may reuse numbers freely.
+ *   3. `resolveDisplayNumber` precedence — the stored alias wins over the
+ *      slug-derived number; falls back to slug-derived when null.
+ *
+ * Each test uses an isolated temporary `.cleo/` so the tasks.db singleton resets
+ * between runs (same pattern as numbering.test.ts / slug-allocator.test.ts).
+ *
+ * @task T11875
+ * @epic T11781
+ * @saga T11778
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let tempDir: string;
+
+/**
+ * Seed an attachment row with the given `slug` + `type` so subsequent
+ * set-alias / resolver calls see it as a real persisted doc. Uses the canonical
+ * `createAttachmentStore` write path so the row passes the same schema + slug
+ * pre-check that production writes do.
+ */
+async function seedSlug(slug: string, type: string, content: string): Promise<void> {
+  const { createAttachmentStore } = await import('../../store/attachment-store.js');
+  const store = createAttachmentStore();
+  await store.put(
+    Buffer.from(content, 'utf-8'),
+    { kind: 'blob', storageKey: '', mime: 'text/markdown', size: content.length },
+    'task',
+    'T9999',
+    'display-alias-test',
+    undefined,
+    { slug, type },
+  );
+}
+
+/** Read back the stored `display_alias` for a slug via the attachment store. */
+async function readAlias(slug: string): Promise<number | null> {
+  const { createAttachmentStore } = await import('../../store/attachment-store.js');
+  const store = createAttachmentStore();
+  const row = await store.findBySlug(slug, tempDir);
+  return row?.displayAlias ?? null;
+}
+
+describe('setDisplayAlias (T11875)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-display-alias-'));
+    process.env['CLEO_DIR'] = join(tempDir, '.cleo');
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+    delete process.env['CLEO_DIR'];
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('assigns a display alias to an existing ADR slug (happy path)', async () => {
+    const { setDisplayAlias } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-051-override-patterns', 'adr', 'override patterns body');
+
+    const result = await setDisplayAlias(tempDir, {
+      slug: 'adr-051-override-patterns',
+      displayAlias: 91,
+    });
+
+    expect(result.slug).toBe('adr-051-override-patterns');
+    expect(result.displayAlias).toBe(91);
+    expect(result.previousAlias).toBeNull();
+    expect(result.type).toBe('adr');
+    // Persisted to the column.
+    expect(await readAlias('adr-051-override-patterns')).toBe(91);
+  });
+
+  it('clears an existing alias when displayAlias=null (revert to slug-derived)', async () => {
+    const { setDisplayAlias } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-051-worktree-extension', 'adr', 'worktree ext body');
+    await setDisplayAlias(tempDir, { slug: 'adr-051-worktree-extension', displayAlias: 92 });
+    expect(await readAlias('adr-051-worktree-extension')).toBe(92);
+
+    const cleared = await setDisplayAlias(tempDir, {
+      slug: 'adr-051-worktree-extension',
+      displayAlias: null,
+    });
+    expect(cleared.previousAlias).toBe(92);
+    expect(cleared.displayAlias).toBeNull();
+    expect(await readAlias('adr-051-worktree-extension')).toBeNull();
+  });
+
+  it('rejects a number already assigned to another ADR (uniqueness)', async () => {
+    const { setDisplayAlias, SET_ALIAS_TAKEN_CODE } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-051-override-patterns', 'adr', 'a');
+    await seedSlug('adr-051-worktree-extension', 'adr', 'b');
+
+    await setDisplayAlias(tempDir, { slug: 'adr-051-override-patterns', displayAlias: 91 });
+
+    await expect(
+      setDisplayAlias(tempDir, { slug: 'adr-051-worktree-extension', displayAlias: 91 }),
+    ).rejects.toMatchObject({
+      details: { code: SET_ALIAS_TAKEN_CODE },
+    });
+
+    // The losing doc must remain unaliased (transaction rolled back).
+    expect(await readAlias('adr-051-worktree-extension')).toBeNull();
+  });
+
+  it('allows re-assigning the SAME number to the SAME doc (no self-conflict)', async () => {
+    const { setDisplayAlias } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-068-cleo-database-charter', 'adr', 'charter');
+    await setDisplayAlias(tempDir, { slug: 'adr-068-cleo-database-charter', displayAlias: 68 });
+
+    const again = await setDisplayAlias(tempDir, {
+      slug: 'adr-068-cleo-database-charter',
+      displayAlias: 68,
+    });
+    expect(again.displayAlias).toBe(68);
+    expect(again.previousAlias).toBe(68);
+  });
+
+  it('does NOT enforce uniqueness across non-adr kinds (specs may reuse numbers)', async () => {
+    const { setDisplayAlias } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('spec-051-alpha', 'spec', 'a');
+    await seedSlug('spec-051-beta', 'spec', 'b');
+
+    await setDisplayAlias(tempDir, { slug: 'spec-051-alpha', displayAlias: 51 });
+    // Same number on another spec is allowed — uniqueness is adr-scoped.
+    const ok = await setDisplayAlias(tempDir, { slug: 'spec-051-beta', displayAlias: 51 });
+    expect(ok.displayAlias).toBe(51);
+  });
+
+  it('rejects an unknown slug with E_NOT_FOUND', async () => {
+    const { setDisplayAlias } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await expect(
+      setDisplayAlias(tempDir, { slug: 'adr-999-does-not-exist', displayAlias: 5 }),
+    ).rejects.toThrow(/does not match any attachment row/);
+  });
+
+  it('rejects a non-positive / non-integer alias number', async () => {
+    const { setDisplayAlias } = await import('../display-alias.js');
+    const { closeDb } = await import('../../store/sqlite.js');
+    closeDb();
+
+    await seedSlug('adr-070-three-tier-orchestration', 'adr', 'x');
+
+    await expect(
+      setDisplayAlias(tempDir, { slug: 'adr-070-three-tier-orchestration', displayAlias: 0 }),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      setDisplayAlias(tempDir, { slug: 'adr-070-three-tier-orchestration', displayAlias: 1.5 }),
+    ).rejects.toThrow(/positive integer/);
+  });
+});
+
+describe('resolveDisplayNumber — precedence (T11875)', () => {
+  it('prefers the stored alias over the slug-derived number', async () => {
+    const { resolveDisplayNumber } = await import('../numbering.js');
+    // Slug derives 051, but the stored alias is 091 — alias wins.
+    expect(resolveDisplayNumber('adr-051-override-patterns', 91)).toBe(91);
+  });
+
+  it('falls back to the slug-derived number when the alias is null', async () => {
+    const { resolveDisplayNumber } = await import('../numbering.js');
+    expect(resolveDisplayNumber('adr-051-override-patterns', null)).toBe(51);
+    expect(resolveDisplayNumber('adr-051-override-patterns', undefined)).toBe(51);
+  });
+
+  it('returns null when neither alias nor slug yields a number', async () => {
+    const { resolveDisplayNumber } = await import('../numbering.js');
+    expect(resolveDisplayNumber('note-some-handoff', null)).toBeNull();
+    expect(resolveDisplayNumber(null, null)).toBeNull();
+    expect(resolveDisplayNumber(undefined, undefined)).toBeNull();
+  });
+
+  it('ignores a non-positive / non-integer stored alias and falls back to slug', async () => {
+    const { resolveDisplayNumber } = await import('../numbering.js');
+    expect(resolveDisplayNumber('adr-051-override-patterns', 0)).toBe(51);
+    expect(resolveDisplayNumber('adr-051-override-patterns', -3)).toBe(51);
+    expect(resolveDisplayNumber('adr-051-override-patterns', 1.5)).toBe(51);
+  });
+});

--- a/packages/core/src/docs/display-alias.ts
+++ b/packages/core/src/docs/display-alias.ts
@@ -1,0 +1,205 @@
+/**
+ * Set / clear a doc's explicit DISPLAY ALIAS number — decoupled from the slug.
+ *
+ * ## Why this module exists
+ *
+ * Under the ratified slug-primary model (saga T11778, ADR reconcile T11676) the
+ * kebab `slug` is the canonical handle and the rendered number (e.g. ADR "051")
+ * is a DISPLAY ALIAS only. Until T11875 that number was DERIVED by parsing the
+ * digits out of the slug string (`adr-051-*` → 051) — so three DISTINCT ADRs
+ * that all slug as `adr-051-*` rendered the same "051" with no way to
+ * disambiguate. The collision is unresolvable in a slug-primary world because
+ * renumbering a slug would break the canonical handle.
+ *
+ * T11875 adds a real `attachments.display_alias` INTEGER column. This module is
+ * the SDK chokepoint that sets it (and validates uniqueness among `type='adr'`
+ * docs). {@link import('./numbering.js').resolveDisplayNumber} prefers the
+ * stored alias when present and falls back to the slug-derived number when null.
+ *
+ * The transaction lives in CORE (not the CLI / dispatch layer) because:
+ *   1. The CLI boundary gate forbids business logic > 30 LOC in CLI commands.
+ *   2. The DB-open chokepoint (`openCleoDb` / `getNativeTasksDb`) is core-owned
+ *      per ADR-068; raw `DatabaseSync` opens outside `store/` are rejected.
+ *   3. Future callers (HTTP dispatch, MCP, BRAIN bridges) re-use the same
+ *      entry point without re-implementing the all-or-nothing uniqueness check.
+ *
+ * @task T11875 (Epic T11781 / Saga T11778)
+ * @adr ADR-078 — Docs Provenance Graph (display-alias half of T11676 reconcile)
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { CleoError } from '../errors.js';
+
+/** Row shape projected from `attachments` during the set-alias transaction. */
+interface AttachmentAliasRow {
+  id: string;
+  slug: string | null;
+  type: string | null;
+  display_alias: number | null;
+}
+
+/** Row shape for the per-type uniqueness scan. */
+interface AliasConflictRow {
+  slug: string | null;
+}
+
+/** Stable error code surfaced when the target slug does not resolve to a row. */
+export const SET_ALIAS_NOT_FOUND_CODE = 'E_NOT_FOUND';
+/** Stable error code surfaced when the requested number is already taken. */
+export const SET_ALIAS_TAKEN_CODE = 'E_ALIAS_TAKEN';
+/** Stable error code surfaced when the requested number is not a positive int. */
+export const SET_ALIAS_INVALID_CODE = 'E_VALIDATION';
+
+/**
+ * Input to {@link setDisplayAlias} (ADR-057 uniform params shape).
+ */
+export interface SetDisplayAliasParams {
+  /** Slug of the doc to alias (must resolve to an existing `attachments` row). */
+  slug: string;
+  /**
+   * The display-alias number to assign. Must be a positive integer. Pass
+   * `null` to CLEAR an existing alias (revert to slug-derived rendering).
+   */
+  displayAlias: number | null;
+}
+
+/**
+ * Result returned by {@link setDisplayAlias}.
+ */
+export interface SetDisplayAliasResult {
+  /** Echoed slug of the doc that was aliased. */
+  slug: string;
+  /** Resolved `attachments.id` of the aliased doc. */
+  attachmentId: string;
+  /** Doc kind (`type` column) of the aliased doc, echoed for the envelope. */
+  type: string | null;
+  /** The previous alias value (or `null` if none was set). */
+  previousAlias: number | null;
+  /** The newly-assigned alias value (or `null` when cleared). */
+  displayAlias: number | null;
+  /** ISO-8601 timestamp the transaction committed. */
+  updatedAt: string;
+}
+
+/**
+ * Assign (or clear) the explicit display-alias number for the doc identified by
+ * `slug`, decoupled from the slug string.
+ *
+ * Effects (inside a single SQLite `BEGIN IMMEDIATE` transaction — all-or-none):
+ *
+ *   1. Resolve the row whose `slug` matches `params.slug`. `E_NOT_FOUND` when
+ *      no such row exists.
+ *   2. When assigning (non-null) AND the target doc is `type='adr'`, scan every
+ *      OTHER `type='adr'` row for the same `display_alias`. Any conflict throws
+ *      `E_ALIAS_TAKEN` and the transaction rolls back — numbers are unique among
+ *      ADRs. Non-adr kinds skip the uniqueness check (they may reuse numbers).
+ *   3. `UPDATE attachments SET display_alias = ? WHERE id = ?`.
+ *
+ * Uniqueness is enforced HERE (dispatch/SDK layer) rather than via a SQL UNIQUE
+ * constraint because the constraint is scoped to a single `type` value — the
+ * same discipline already used for `lifecycle_status` validation — so future
+ * taxonomy changes never require a schema migration.
+ *
+ * Signature follows ADR-057 — `(projectRoot, params)` is the canonical shape for
+ * core operations consumed by typed dispatch handlers and thin CLI verbs.
+ *
+ * @param projectRoot - Absolute project-root path. Production callers resolve it
+ *   via `getProjectRoot()`; tests pass a temp dir.
+ * @param params - {@link SetDisplayAliasParams}.
+ * @returns {@link SetDisplayAliasResult} describing the before/after alias state.
+ *
+ * @throws {CleoError} `E_VALIDATION` when `displayAlias` is a non-positive /
+ *   non-integer number.
+ * @throws {CleoError} `E_NOT_FOUND` when `slug` resolves to no row.
+ * @throws {CleoError} `E_ALIAS_TAKEN` when an ADR already owns the number.
+ */
+export async function setDisplayAlias(
+  projectRoot: string,
+  params: SetDisplayAliasParams,
+): Promise<SetDisplayAliasResult> {
+  const { slug, displayAlias } = params;
+
+  if (displayAlias !== null && (!Number.isInteger(displayAlias) || displayAlias < 1)) {
+    throw new CleoError(
+      ExitCode.VALIDATION_ERROR,
+      `display alias must be a positive integer — got '${String(displayAlias)}'`,
+    );
+  }
+
+  // E6-L6 (T11526): `attachments` is part of the legacy drizzle-tasks family,
+  // created inside the project `cleo.db` by getDb()'s migrations. Route through
+  // getDb()/getNativeTasksDb() (rather than openCleoDb('project'), which only
+  // runs the consolidated schema) so the table is guaranteed present. The native
+  // handle is a shared singleton — do NOT close it here.
+  const { getDb, getNativeTasksDb } = await import('../store/sqlite.js');
+  await getDb(projectRoot);
+  const db = getNativeTasksDb();
+  if (!db) {
+    throw new CleoError(
+      ExitCode.GENERAL_ERROR,
+      'docs set-alias: project cleo.db could not be opened (no native handle)',
+    );
+  }
+
+  const now = new Date().toISOString();
+
+  // BEGIN IMMEDIATE — acquire the write lock up front so two concurrent
+  // set-alias calls contend at lock-acquisition time rather than after the
+  // uniqueness scan (which would let both writers pass the check and collide).
+  db.exec('BEGIN IMMEDIATE');
+
+  let row: AttachmentAliasRow | undefined;
+  try {
+    row = db
+      .prepare('SELECT id, slug, type, display_alias FROM attachments WHERE slug = ?')
+      .get(slug) as AttachmentAliasRow | undefined;
+
+    if (!row) {
+      throw new CleoError(ExitCode.NOT_FOUND, `slug '${slug}' does not match any attachment row`);
+    }
+
+    // Uniqueness scan — only for ADRs, only when assigning a non-null number.
+    if (displayAlias !== null && row.type === 'adr') {
+      const conflict = db
+        .prepare(
+          "SELECT slug FROM attachments WHERE type = 'adr' AND display_alias = ? AND id <> ?",
+        )
+        .get(displayAlias, row.id) as AliasConflictRow | undefined;
+      if (conflict) {
+        throw new CleoError(
+          ExitCode.VALIDATION_ERROR,
+          `display alias ${displayAlias} is already assigned to ADR '${conflict.slug ?? '(unknown)'}' — ` +
+            'pick a different number (aliases are unique among type=adr docs)',
+          {
+            details: {
+              field: 'displayAlias',
+              code: SET_ALIAS_TAKEN_CODE,
+              actual: displayAlias,
+              conflictingSlug: conflict.slug,
+            },
+          },
+        );
+      }
+    }
+
+    db.prepare('UPDATE attachments SET display_alias = ? WHERE id = ?').run(displayAlias, row.id);
+
+    db.exec('COMMIT');
+  } catch (txErr) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // Rollback is best-effort — propagating the original error matters more.
+    }
+    throw txErr;
+  }
+
+  return {
+    slug,
+    attachmentId: row.id,
+    type: row.type,
+    previousAlias: row.display_alias,
+    displayAlias,
+    updatedAt: now,
+  };
+}

--- a/packages/core/src/docs/docs-read-model.ts
+++ b/packages/core/src/docs/docs-read-model.ts
@@ -32,6 +32,7 @@ import { createAttachmentStore } from '../store/attachment-store.js';
 import type { BlobListEntry } from '../store/blob-ops.js';
 import { blobList, blobRead } from '../store/blob-ops.js';
 import type { AttachmentLifecycleStatus } from '../store/schema/attachments.js';
+import { resolveDisplayNumber } from './numbering.js';
 
 // ---------------------------------------------------------------------------
 // Re-use the publications types from docs-ops via dynamic import to avoid
@@ -74,6 +75,13 @@ export interface ResolvedDoc {
   readonly title: string | null;
   /** Stable human-readable slug from attachments.slug. Null for slug-less blobs. */
   readonly slug: string | null;
+  /**
+   * The DISPLAY number to render for this doc (e.g. ADR "051"), decoupled from
+   * the slug (T11875). Resolved via {@link resolveDisplayNumber}: the stored
+   * `attachments.display_alias` wins when set, else the slug-derived number, else
+   * `null` for non-numbered / slug-less docs.
+   */
+  readonly displayNumber: number | null;
   /** Owner entity ID (task/session/observation ID). */
   readonly ownerId: string;
   /** Owner entity type. */
@@ -207,6 +215,7 @@ export class DocsReadModel {
       type: row.type,
       summary: row.summary,
       lifecycleStatus: row.lifecycleStatus,
+      displayAlias: row.displayAlias,
     });
   }
 
@@ -261,13 +270,14 @@ export class DocsReadModel {
     const store = createAttachmentStore();
     const meta = await store.getMetadata(id, this.projectRoot);
     if (meta) {
-      // Fetch extras (slug, type) from the row
+      // Fetch extras (slug, type, displayAlias) from the row
       const extras = await store.getExtras(id, this.projectRoot);
       return this.enrichFromTasksDb(meta, {
         slug: extras?.slug ?? null,
         type: extras?.type ?? null,
         summary: null,
         lifecycleStatus: 'active',
+        displayAlias: extras?.displayAlias ?? null,
       });
     }
 
@@ -601,6 +611,7 @@ export class DocsReadModel {
         type: extras?.type ?? null,
         summary: null,
         lifecycleStatus: 'active',
+        displayAlias: extras?.displayAlias ?? null,
       });
       results.push(doc);
     }
@@ -623,6 +634,7 @@ export class DocsReadModel {
         kind: (row.type as DocKind) ?? null,
         title: row.slug ?? name ?? null,
         slug: row.slug,
+        displayNumber: resolveDisplayNumber(row.slug, row.displayAlias),
         ownerId: row.ownerId,
         ownerType: row.ownerType,
         blobName: name ?? row.slug ?? row.metadata.id,
@@ -706,12 +718,15 @@ export class DocsReadModel {
   private buildResolvedDocFromBlob(ownerId: string, entry: BlobListEntry): ResolvedDoc {
     // Derive kind from known taxonomy types
     const kind = inferDocKind(entry.name);
+    const blobSlug = kind ? entry.name.replace(/\.md$/, '') : null;
     return {
       id: entry.sha256,
       sha256: entry.sha256,
       kind,
       title: entry.name,
-      slug: kind ? entry.name.replace(/\.md$/, '') : null,
+      slug: blobSlug,
+      // manifest.db blobs carry no display_alias column — derive from slug only.
+      displayNumber: resolveDisplayNumber(blobSlug, null),
       ownerId,
       ownerType: detectOwnerType(ownerId),
       blobName: entry.name,
@@ -748,6 +763,7 @@ export class DocsReadModel {
       type: string | null;
       summary: string | null;
       lifecycleStatus: AttachmentLifecycleStatus | string | null;
+      displayAlias: number | null;
     },
   ): Promise<ResolvedDoc> {
     const blobName = extractBlobName(meta);
@@ -772,6 +788,7 @@ export class DocsReadModel {
       kind: (extras.type as DocKind) ?? null,
       title: extras.slug ?? blobName ?? null,
       slug: extras.slug,
+      displayNumber: resolveDisplayNumber(extras.slug, extras.displayAlias),
       ownerId,
       ownerType: detectOwnerType(ownerId),
       blobName: blobName ?? extras.slug ?? meta.id,

--- a/packages/core/src/docs/index.ts
+++ b/packages/core/src/docs/index.ts
@@ -34,6 +34,14 @@ export {
   DocProvenanceRootNotFoundError,
   renderProvenanceGraphAsDot,
 } from './build-provenance-graph.js';
+// ── T11875 — display-alias storage (decoupled from slug; ADR reconcile T11676) ─
+export type { SetDisplayAliasParams, SetDisplayAliasResult } from './display-alias.js';
+export {
+  SET_ALIAS_INVALID_CODE,
+  SET_ALIAS_NOT_FOUND_CODE,
+  SET_ALIAS_TAKEN_CODE,
+  setDisplayAlias,
+} from './display-alias.js';
 export type { GenerateDocsOptions, GenerateDocsResult } from './docs-generator.js';
 export { generateDocsLlmsTxt } from './docs-generator.js';
 export type {
@@ -73,7 +81,6 @@ export {
   statusDocs,
   syncFromGit,
 } from './docs-ops.js';
-
 export type { ExportDocumentOptions, ExportDocumentResult } from './export-document.js';
 export { exportDocument } from './export-document.js';
 // ── T10361 — slug similarity warn at docs add write-time ────────────────────

--- a/packages/core/src/docs/numbering.ts
+++ b/packages/core/src/docs/numbering.ts
@@ -232,6 +232,51 @@ export function parseSlugSequence(
   return null;
 }
 
+// ─── Display-number resolution (T11875) ───────────────────────────────────────
+
+/**
+ * Resolve the DISPLAY number to render for a doc, preferring the explicitly
+ * stored {@link import('../store/schema/attachments.js').attachments.displayAlias}
+ * over the number derived from the slug string.
+ *
+ * ## Why this exists (T11875 · ADR reconcile T11676)
+ *
+ * Under the slug-primary model the kebab slug is the canonical handle and the
+ * rendered number (e.g. ADR "051") is a DISPLAY ALIAS only. Historically that
+ * number was DERIVED from the slug via {@link parseSlugSequence} — so three
+ * DISTINCT ADRs slugged `adr-051-*` all rendered "051" with no way to
+ * disambiguate. T11875 added a real `display_alias` column; this resolver makes
+ * the stored alias authoritative while preserving byte-for-byte legacy
+ * behaviour for docs that never had one assigned.
+ *
+ * Precedence:
+ *   1. `storedAlias` — when a non-null positive integer is supplied, it wins
+ *      unconditionally (the alias is the decoupled SSoT).
+ *   2. Slug-derived — otherwise parse the numeric portion out of `slug` via the
+ *      canonical numbering patterns ({@link parseSlugSequence}).
+ *   3. `null` — when neither yields a number (non-numbered kind / no alias).
+ *
+ * @param slug - The doc's canonical slug (e.g. `adr-051-override-patterns`), or
+ *   `null` for slug-less docs.
+ * @param storedAlias - The value of `attachments.display_alias` for this doc, or
+ *   `null` when unset.
+ * @returns The display number to render, or `null` when none can be resolved.
+ */
+export function resolveDisplayNumber(
+  slug: string | null | undefined,
+  storedAlias: number | null | undefined,
+): number | null {
+  // (1) Stored alias is the decoupled SSoT — it wins over the slug-derived
+  // number whenever it is a usable positive integer.
+  if (typeof storedAlias === 'number' && Number.isInteger(storedAlias) && storedAlias >= 1) {
+    return storedAlias;
+  }
+  // (2) Fall back to the slug-derived number — unchanged legacy behaviour.
+  if (typeof slug !== 'string' || slug.length === 0) return null;
+  const parsed = parseSlugSequence(slug);
+  return parsed ? parsed.sequence : null;
+}
+
 // ─── DB inspection (atomic) ───────────────────────────────────────────────────
 
 /**

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -153,6 +153,14 @@ export {
   DocProvenanceRootNotFoundError,
   renderProvenanceGraphAsDot,
 } from './docs/build-provenance-graph.js';
+// Display-alias storage (T11875 — decoupled from slug; ADR reconcile T11676)
+export type { SetDisplayAliasParams, SetDisplayAliasResult } from './docs/display-alias.js';
+export {
+  SET_ALIAS_INVALID_CODE,
+  SET_ALIAS_NOT_FOUND_CODE,
+  SET_ALIAS_TAKEN_CODE,
+  setDisplayAlias,
+} from './docs/display-alias.js';
 // ── T11139 — docs audit trail (Saga T10516) ──────────────────────────────────
 export type {
   AuditFinding,
@@ -295,6 +303,7 @@ export {
   allocateAutoSlugForDispatch,
   applyAutoSlug,
   parseSlugSequence,
+  resolveDisplayNumber,
   resolveNextDocNumber,
 } from './docs/numbering.js';
 // Docs publish-pr foundation + new-doc flow (T9716 + T9718 — T9644 / Epic T9630 / Saga T9625)

--- a/packages/core/src/store/__tests__/t11875-attachments-display-alias-schema.test.ts
+++ b/packages/core/src/store/__tests__/t11875-attachments-display-alias-schema.test.ts
@@ -1,0 +1,181 @@
+/**
+ * T11875 — DB schema parity test: `attachments` gains a nullable
+ * `display_alias` INTEGER column (+ one supporting index) so a doc can carry an
+ * explicit display NUMBER decoupled from its slug (ADR reconcile T11676).
+ *
+ * Asserts:
+ *   1. The migration SQL file exists at the canonical drizzle-tasks path and
+ *      contains the ALTER + INDEX statements.
+ *   2. After running every drizzle-tasks migration on a fresh tasks.db, the
+ *      `attachments` table reports the `display_alias` column (nullable) and the
+ *      `idx_attachments_display_alias` index via PRAGMA.
+ *   3. Legacy rows pass through with NULL `display_alias` (no rewrite).
+ *
+ * @task T11875
+ * @epic T11781 (E3-OBSIDIAN-INTEGRATION)
+ * @saga T11778 (SG-DOCS-SSOT-VAULT)
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve path to the drizzle-tasks migration folder. */
+function migrationsDir(): string {
+  return join(__dirname, '..', '..', '..', 'migrations', 'drizzle-tasks');
+}
+
+/** Resolve path to the T11875 migration directory. */
+function t11875MigrationDir(): string {
+  const all = readdirSync(migrationsDir(), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  const match = all.find((name) => name.includes('t11875-attachments-display-alias'));
+  if (!match) {
+    throw new Error('T11875 migration directory not found under drizzle-tasks');
+  }
+  return join(migrationsDir(), match);
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: Migration SQL content checks
+// ---------------------------------------------------------------------------
+
+describe('T11875 attachments display-alias migration SQL', () => {
+  it('migration.sql file is present at the canonical path', () => {
+    const sql = readFileSync(join(t11875MigrationDir(), 'migration.sql'), 'utf-8');
+    expect(sql.length).toBeGreaterThan(0);
+  });
+
+  it('adds a nullable `display_alias` integer column', () => {
+    const sql = readFileSync(join(t11875MigrationDir(), 'migration.sql'), 'utf-8');
+    expect(sql).toMatch(/ADD COLUMN `display_alias` integer/);
+    // No NOT NULL on the new column (must stay nullable for pass-through).
+    expect(sql).not.toMatch(/ADD COLUMN `display_alias` integer NOT NULL/);
+  });
+
+  it('creates the supporting index', () => {
+    const sql = readFileSync(join(t11875MigrationDir(), 'migration.sql'), 'utf-8');
+    expect(sql).toContain('idx_attachments_display_alias');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: End-to-end migration apply on a fresh tasks.db
+// ---------------------------------------------------------------------------
+
+describe('T11875 fresh migration apply — attachments gains display_alias', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cleo-t11875-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies all drizzle-tasks migrations cleanly', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const nativeDb = openNativeDatabase(join(tempDir, 'tasks.db'));
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    expect(() => migrateSanitized(db, { migrationsFolder })).not.toThrow();
+
+    nativeDb.close();
+  });
+
+  it('attachments table has a nullable display_alias column after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const nativeDb = openNativeDatabase(join(tempDir, 'tasks-cols.db'));
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const cols = nativeDb.prepare('PRAGMA table_info(attachments)').all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const colMap = new Map(cols.map((c) => [c.name, c]));
+
+    expect(colMap.has('display_alias')).toBe(true);
+    // Must be nullable so existing rows pass through with NULL.
+    expect(colMap.get('display_alias')?.notnull).toBe(0);
+
+    nativeDb.close();
+  });
+
+  it('attachments table has the display_alias index after migration', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const nativeDb = openNativeDatabase(join(tempDir, 'tasks-idx.db'));
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const indexes = nativeDb.prepare('PRAGMA index_list(attachments)').all() as Array<{
+      name: string;
+    }>;
+    expect(indexes.map((i) => i.name)).toContain('idx_attachments_display_alias');
+
+    nativeDb.close();
+  });
+
+  it('legacy attachment rows survive the migration with NULL display_alias', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { drizzle } = await import('drizzle-orm/node-sqlite');
+    const { reconcileJournal, migrateSanitized } = await import('../migration-manager.js');
+
+    const nativeDb = openNativeDatabase(join(tempDir, 'tasks-passthrough.db'));
+    const db = drizzle({ client: nativeDb });
+    const migrationsFolder = migrationsDir();
+
+    reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'tasks');
+    migrateSanitized(db, { migrationsFolder });
+
+    const now = new Date().toISOString();
+    nativeDb
+      .prepare(
+        `INSERT INTO attachments (id, sha256, attachment_json, created_at, ref_count)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run('att_legacy_alias', 'a'.repeat(64), '{"kind":"note","body":"legacy"}', now, 0);
+
+    const row = nativeDb
+      .prepare('SELECT id, display_alias FROM attachments WHERE id = ?')
+      .get('att_legacy_alias') as { id: string; display_alias: number | null };
+
+    expect(row.id).toBe('att_legacy_alias');
+    expect(row.display_alias).toBeNull();
+
+    nativeDb.close();
+  });
+});

--- a/packages/core/src/store/attachment-store.ts
+++ b/packages/core/src/store/attachment-store.ts
@@ -307,6 +307,8 @@ export interface AttachmentStore {
     type: string | null;
     summary: string | null;
     lifecycleStatus: AttachmentLifecycleStatus;
+    /** Stored display-alias number (T11875), or `null` when unset. */
+    displayAlias: number | null;
   } | null>;
 
   /**
@@ -332,6 +334,8 @@ export interface AttachmentStore {
       ownerId: string;
       summary: string | null;
       lifecycleStatus: AttachmentLifecycleStatus;
+      /** Stored display-alias number (T11875), or `null` when unset. */
+      displayAlias: number | null;
     }>
   >;
 
@@ -346,7 +350,7 @@ export interface AttachmentStore {
   getExtras(
     attachmentId: string,
     cwd?: string,
-  ): Promise<{ slug: string | null; type: string | null } | null>;
+  ): Promise<{ slug: string | null; type: string | null; displayAlias: number | null } | null>;
 
   /**
    * List all attachments associated with a given owner entity.
@@ -836,6 +840,7 @@ export function createAttachmentStore(): AttachmentStore {
         type: row.type ?? null,
         summary: row.summary ?? null,
         lifecycleStatus: row.lifecycleStatus,
+        displayAlias: row.displayAlias ?? null,
       };
     },
 
@@ -843,7 +848,11 @@ export function createAttachmentStore(): AttachmentStore {
       const db = await getDb(cwd);
       const row = await db.select().from(attachments).where(eq(attachments.id, attachmentId)).get();
       if (!row) return null;
-      return { slug: row.slug ?? null, type: row.type ?? null };
+      return {
+        slug: row.slug ?? null,
+        type: row.type ?? null,
+        displayAlias: row.displayAlias ?? null,
+      };
     },
 
     async listAllInProject(cwd, filter) {
@@ -870,6 +879,7 @@ export function createAttachmentStore(): AttachmentStore {
         ownerId: string;
         summary: string | null;
         lifecycleStatus: AttachmentLifecycleStatus;
+        displayAlias: number | null;
       }> = [];
       for (const refRow of rows) {
         const row = await db
@@ -887,6 +897,7 @@ export function createAttachmentStore(): AttachmentStore {
           ownerId: refRow.ownerId,
           summary: row.summary ?? null,
           lifecycleStatus: row.lifecycleStatus,
+          displayAlias: row.displayAlias ?? null,
         });
       }
       return out;

--- a/packages/core/src/store/schema/attachments.ts
+++ b/packages/core/src/store/schema/attachments.ts
@@ -184,11 +184,41 @@ export const attachments = sqliteTable(
      * @task T11181 (Epic T10518 / Saga T10516)
      */
     docVersion: integer('doc_version').notNull().default(1),
+    /**
+     * Optional explicit display-alias NUMBER for the doc, DECOUPLED from the
+     * slug string.
+     *
+     * Background (T11875 · ADR reconcile T11676): under the ratified
+     * slug-primary model the kebab `slug` is the canonical handle and the
+     * displayed number (e.g. ADR "051") is a DISPLAY ALIAS only. Previously
+     * that number was DERIVED by parsing the digits out of the slug
+     * (`adr-051-*` → 051), so three distinct ADRs that all slug as `adr-051-*`
+     * collided on the rendered number with no way to disambiguate.
+     *
+     * When non-null, this column is the authoritative display number and is
+     * PREFERRED over the slug-derived number by
+     * {@link import('../../docs/numbering.js').resolveDisplayNumber}. When null,
+     * rendering falls back to the slug-derived number unchanged — so docs that
+     * never had an alias assigned keep their historical behaviour.
+     *
+     * Uniqueness among `type='adr'` docs is enforced at the dispatch layer (not
+     * via a SQL UNIQUE constraint) by
+     * {@link import('../../docs/display-alias.js').setDisplayAlias}, mirroring
+     * the dispatch-validated discipline used for `lifecycle_status` /
+     * `relation` so future taxonomy changes never require a schema migration.
+     *
+     * @task T11875 (Epic T11781 / Saga T11778)
+     */
+    displayAlias: integer('display_alias'),
   },
   (table) => [
     index('idx_attachments_sha256').on(table.sha256),
     index('idx_attachments_lifecycle_status').on(table.lifecycleStatus),
     index('idx_attachments_supersedes').on(table.supersedes),
+    // Speeds the per-type uniqueness scan in `setDisplayAlias` (T11875). Not a
+    // UNIQUE index — uniqueness is scoped to `type='adr'` and enforced at the
+    // dispatch layer so non-adr kinds may reuse numbers freely.
+    index('idx_attachments_display_alias').on(table.displayAlias),
   ],
 );
 


### PR DESCRIPTION
## What & why (T11875 · ADR reconcile T11676)

Under the ratified **slug-primary** model (saga T11778) the kebab slug is the canonical handle and the displayed number (e.g. ADR "051") is a **display alias only**. Until now that number was **derived** by parsing digits out of the slug string (`numbering.ts` / `adr-allocator.ts`), so three distinct ADRs all slugged `adr-051-*` (override-patterns ≠ programmatic-gate-integrity ≠ worktree-extension) rendered the same "051" with no way to disambiguate — a collision the slug-primary model cannot resolve because renumbering a slug breaks the canonical handle.

Owner decision: **add a real `display_alias` storage column + a verb to set it**, keeping slugs number-stable.

## Changes

- **Schema** (`packages/core/src/store/schema/attachments.ts`): nullable `display_alias` integer column + `idx_attachments_display_alias`.
- **Migration** (`packages/core/migrations/drizzle-tasks/20260606000001_t11875-attachments-display-alias/migration.sql`): forward-only `ALTER TABLE attachments ADD COLUMN display_alias integer` + index, following the just-merged T11826 `docs_wikilinks` template (idempotent, nullable → no table rewrite, applied via the `migrateWithRetry`/`reconcileJournal` chokepoint — never raw `DatabaseSync`).
- **CORE SDK** (`packages/core/src/docs/display-alias.ts`): `setDisplayAlias(projectRoot, params)` — `BEGIN IMMEDIATE` transaction via `getNativeTasksDb()`; rejects a number already owned by another `type='adr'` doc (`E_ALIAS_TAKEN`, dispatch-layer uniqueness so non-adr kinds may reuse numbers); supports clear.
- **Numbering** (`packages/core/src/docs/numbering.ts`): `resolveDisplayNumber(slug, storedAlias)` — **prefers the stored alias**, falls back to the slug-derived number when null (byte-for-byte legacy behaviour for docs with no alias).
- **Read model** (`docs-read-model.ts`, `attachment-store.ts`): `ResolvedDoc.displayNumber` threaded through `findBySlug` / `getExtras` / `listAllInProject`; surfaced as `displayNumber` in `cleo docs fetch` / `list` (additive optional field on `DocsAttachmentRow`).
- **CLI** (`packages/cleo/src/cli/commands/docs/set-alias.ts`): thin `cleo docs set-alias <slug> <number>` verb (`--clear` to remove). All logic in CORE; CLI is dispatch-only.

## Tests (49 green)

- Migration applies on a fresh tasks.db init: `display_alias` column present + **nullable**, index present, legacy rows pass through NULL.
- `set-alias`: happy path, clear, **uniqueness rejection** among ADRs, adr-scoped (non-adr may reuse), unknown-slug `E_NOT_FOUND`, non-positive/non-integer validation.
- `resolveDisplayNumber` precedence: **stored alias wins** over slug-derived; slug fallback when null; null when neither.

## Gates

`pnpm biome check --write` clean · core + cleo build clean · Gate 3 (DB Open Guard, strict) OK · Gate 4 (contracts fan-out) OK · Gate 6 (CLI boundary) — `set-alias.ts` not flagged · Gate 10 (contracts purity) OK · no skill-coverage paths touched.

## Post-merge `set-alias` apply-plan (NOT run — verb isn't merged yet)

Per `.cleo/rcasd/T11676-adr-reconcile-plan-2026-06-05.md`: `adr-051-programmatic-gate-integrity` **keeps 051** (slug-derived, no alias). Per owner instruction, assign aliases sequentially from **091+** (NOT the provisional 040/060/090 pool); `override-patterns`→091, `worktree-extension`→092, then 093+ for the remaining loser-of-collision slugs in the plan's order:

```bash
cleo docs set-alias adr-051-override-patterns                  91
cleo docs set-alias adr-051-worktree-extension                 92
cleo docs set-alias adr-052-caamp-keeps-commander             93
cleo docs set-alias adr-053-project-agnostic-release-pipeline 94
cleo docs set-alias adr-054-manifest-unification              95
cleo docs set-alias adr-068-canonical-agent-system            96
cleo docs set-alias adr-068-per-worktree-handoff              97
cleo docs set-alias adr-070-verifier-backed-ac-auditor-loop   98
cleo docs set-alias adr-072-nexus-db-split                    99
cleo docs set-alias adr-boundary-registry                     100   # = docs/adr ADR-078-boundary-registry
cleo docs set-alias adr-086-nested-nexus-disposition          101
cleo docs set-alias adr-088-release-pipeline-coherence        102
```

Notes: these are the **12 distinct loser slugs** in the disposition table (051×2, 052, 053, 054, 068×2, 070, 072, 078-boundary, 086, 088). The plan's "13 →next-free rows" count includes the retired `adr-079-r2` tombstone, which is handled by **supersession** (Phase 4), not aliasing. Several loser slugs (068×2, 070, 072, 086, 088×1) must be **ingested into the SSoT first** (plan Phase 1) before `set-alias` can target them; `adr-boundary-registry` is already in the SSoT. Owner to confirm OQ-1 (programmatic-gate-integrity keeps 051) before running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)