### PR TITLE
fix(store): converge shared cleo.db migration journal to stop host OOM (T11829)

### DIFF
--- a/packages/cleo/bin/cleo.js
+++ b/packages/cleo/bin/cleo.js
@@ -7,6 +7,14 @@
  * resolution (before any JS code executes), so it must be suppressed at the
  * Node runtime level, not in application code.
  *
+ * T11829 (fleet OOM fail-safe): the wrapper also caps the V8 old-space heap
+ * (`--max-old-space-size`) so a single runaway `cleo` invocation throws a
+ * recoverable, single-process JavaScript heap OOM instead of growing unbounded
+ * and contributing to a host-wide SIGKILL. The cap is overridable via
+ * `CLEO_MAX_OLD_SPACE_MB` for the rare command (large export/import) that needs
+ * more headroom. This is a process-level guard ABOVE the per-connection SQLite
+ * memory bounding in dual-scope-db.ts — defense in depth.
+ *
  * See: https://github.com/kryptobaseddev/cleo/issues/XXX (T1138)
  */
 
@@ -19,11 +27,25 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliPath = resolve(__dirname, '../dist/cli/index.js');
 const args = process.argv.slice(2);
 
+// T11829: cap V8 old-space so a runaway throws a recoverable single-process OOM
+// rather than a host SIGKILL. Default 1536 MB; override via CLEO_MAX_OLD_SPACE_MB.
+const maxOldSpaceMb = Number.parseInt(process.env.CLEO_MAX_OLD_SPACE_MB ?? '', 10);
+const heapCapMb = Number.isFinite(maxOldSpaceMb) && maxOldSpaceMb > 0 ? maxOldSpaceMb : 1536;
+
 try {
-  execFileSync('node', ['--disable-warning=ExperimentalWarning', cliPath, ...args], {
-    stdio: 'inherit',
-    cwd: process.cwd(),
-  });
+  execFileSync(
+    'node',
+    [
+      `--max-old-space-size=${heapCapMb}`,
+      '--disable-warning=ExperimentalWarning',
+      cliPath,
+      ...args,
+    ],
+    {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    },
+  );
 } catch (error) {
   process.exit(error.status || 1);
 }

--- a/packages/cleo/scripts/install-daemon-service.mjs
+++ b/packages/cleo/scripts/install-daemon-service.mjs
@@ -368,16 +368,29 @@ function buildSystemdUnit(cleoExec, scope) {
       ? `CLEO Sentient Daemon (epic ${scope.scopeEpicId} scoped)`
       : 'CLEO Sentient Daemon (autonomous task hygiene + dream cycles)';
 
+  // T11829 (fleet OOM fail-safe): bound the daemon's blast radius.
+  //   - StartLimitIntervalSec/StartLimitBurst: cap a crash-loop. The prior unit
+  //     respawned every RestartSec=5 with NO ceiling, so — combined with the
+  //     never-converging migration journal — it stacked opens until the host
+  //     OOM-killed. systemd now stops restarting after 5 failures in 60 s.
+  //   - NODE_OPTIONS=--max-old-space-size: a runaway daemon tick throws a
+  //     recoverable single-process JS heap OOM instead of growing unbounded.
+  //   - MemoryMax: best-effort soft cgroup ceiling (enforced only when the user
+  //     manager has memory-cgroup delegation; harmless otherwise).
   return `[Unit]
 Description=${description}
 Documentation=https://github.com/kryptobaseddev/cleocode
 After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart=${cleoExec} daemon start --foreground
 Restart=on-failure
 RestartSec=5
+MemoryMax=2G
+Environment=NODE_OPTIONS=--max-old-space-size=1536
 StandardOutput=append:${logFile}
 StandardError=append:${logFile}
 Environment=CLEO_SENTIENT_DAEMON=1${scopeEnv}

--- a/packages/core/src/store/__tests__/migration-cross-lineage-convergence.test.ts
+++ b/packages/core/src/store/__tests__/migration-cross-lineage-convergence.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Regression tests for the cross-lineage journal-convergence OOM root fix (T11829).
+ *
+ * ## Root cause
+ *
+ * The consolidated `cleo.db` has ONE shared `__drizzle_migrations` journal but is
+ * reconciled by MULTIPLE migration lineages (drizzle-tasks, drizzle-cleo-project,
+ * drizzle-nexus, drizzle-brain, drizzle-conduit, drizzle-agent-registry). Before
+ * this fix, each lineage's `reconcileJournal` built `localHashes` from ONLY its own
+ * folder, so Sub-case B classified EVERY sibling lineage's journal rows as "true
+ * orphans" and DELETEd them. The next sibling open then deleted THIS lineage's rows
+ * — the journal NEVER converged (oscillated), every open re-thrashed the WAL writer
+ * lock under busy_timeout=30000, and uncapped concurrent processes summed past host
+ * RAM → OOM/SIGKILL. The live DB exhibited this: only the 2 nexus rows survived.
+ *
+ * ## What these tests lock
+ *
+ * 1. Two lineages reconciled SEQUENTIALLY against ONE shared journal — BOTH
+ *    lineages' rows SURVIVE. (Without the union-guard fix this FAILS: the second
+ *    lineage deletes the first lineage's rows as orphans.)
+ * 2. A genuine TRUE orphan (a hash belonging to NO lineage) is still deleted —
+ *    the fix must not make the journal a graveyard.
+ * 3. The UNIQUE(hash) index + INSERT OR IGNORE makes a residual re-probe a no-op
+ *    (idempotent convergence): re-running reconcile does not grow the journal.
+ *
+ * @task T11829
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Resolve a drizzle migrations folder relative to this test file. */
+function migFolder(setName: string): string {
+  // Test lives at packages/core/src/store/__tests__/ ; migrations at packages/core/migrations/<set>
+  return join(__dirname, '..', '..', '..', 'migrations', setName);
+}
+
+/**
+ * Create the shared `__drizzle_migrations` journal table in the Drizzle v1-beta
+ * shape (id/hash/created_at/name/applied_at) — the same DDL reconcileJournal
+ * bootstraps.
+ */
+function createJournalTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+      id INTEGER PRIMARY KEY,
+      hash text NOT NULL,
+      created_at numeric,
+      name text,
+      applied_at TEXT
+    )
+  `);
+}
+
+/** Insert every migration of a lineage folder into the journal as already-applied. */
+function seedJournalWithLineage(db: DatabaseSync, folder: string): string[] {
+  const migrations = readMigrationFiles({ migrationsFolder: folder });
+  const seen = new Set<string>();
+  for (const m of migrations) {
+    if (seen.has(m.hash)) continue;
+    seen.add(m.hash);
+    db.exec(
+      `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${m.hash}', ${m.folderMillis}, '${(m.name ?? '').replace(/'/g, "''")}')`,
+    );
+  }
+  return [...seen];
+}
+
+/** Read all hashes currently in the journal. */
+function journalHashes(db: DatabaseSync): Set<string> {
+  const rows = db.prepare('SELECT hash FROM "__drizzle_migrations"').all() as Array<{
+    hash: string;
+  }>;
+  return new Set(rows.map((r) => r.hash));
+}
+
+describe('reconcileJournal — cross-lineage convergence (T11829 OOM root fix)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-xlineage-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('two lineages sharing ONE journal: BOTH lineages rows SURVIVE sequential reconciles', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+
+    const tasksFolder = migFolder('drizzle-tasks');
+    const projectFolder = migFolder('drizzle-cleo-project');
+
+    // Hashes each lineage declares on disk.
+    const tasksHashes = new Set(
+      readMigrationFiles({ migrationsFolder: tasksFolder }).map((m) => m.hash),
+    );
+    const projectHashes = new Set(
+      readMigrationFiles({ migrationsFolder: projectFolder }).map((m) => m.hash),
+    );
+
+    const dbPath = join(tempDir, 'shared-journal.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    try {
+      // The consolidated DB has both lineages' sentinel/existence tables.
+      // `tasks` is the drizzle-tasks existence table; `tasks_tasks` is the
+      // drizzle-cleo-project existence table. Both must exist so Scenario 2 fires.
+      nativeDb.exec('CREATE TABLE IF NOT EXISTS "tasks" ("id" text PRIMARY KEY)');
+      nativeDb.exec('CREATE TABLE IF NOT EXISTS "tasks_tasks" ("id" text PRIMARY KEY)');
+
+      // One shared journal, seeded with BOTH lineages' rows (as a real
+      // consolidated DB would have after both migration sets applied).
+      createJournalTable(nativeDb);
+      seedJournalWithLineage(nativeDb, tasksFolder);
+      seedJournalWithLineage(nativeDb, projectFolder);
+
+      const before = journalHashes(nativeDb);
+      // Sanity: both lineages present before any reconcile.
+      expect([...tasksHashes].every((h) => before.has(h))).toBe(true);
+      expect([...projectHashes].every((h) => before.has(h))).toBe(true);
+
+      // Reconcile lineage A (tasks) WITH the sibling set (the fix). Without the
+      // union-guard this would delete every drizzle-cleo-project row as an orphan.
+      reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', [projectFolder]);
+
+      const afterTasks = journalHashes(nativeDb);
+      // The OTHER lineage's rows must survive the tasks reconcile.
+      expect([...projectHashes].every((h) => afterTasks.has(h))).toBe(true);
+      // This lineage's rows obviously survive too.
+      expect([...tasksHashes].every((h) => afterTasks.has(h))).toBe(true);
+
+      // Reconcile lineage B (project) WITH the sibling set. Symmetrically must not
+      // delete the tasks rows.
+      reconcileJournal(nativeDb, projectFolder, 'tasks_tasks', 'dual-scope-db[project]', [
+        tasksFolder,
+      ]);
+
+      const afterProject = journalHashes(nativeDb);
+      expect([...tasksHashes].every((h) => afterProject.has(h))).toBe(true);
+      expect([...projectHashes].every((h) => afterProject.has(h))).toBe(true);
+    } finally {
+      nativeDb.close();
+    }
+  });
+
+  it('Sub-case B: WITHOUT siblings a real sibling-lineage row IS deleted; WITH siblings it SURVIVES', async () => {
+    // Drives the actual deletion path (Sub-case B) deterministically. Sub-case B
+    // only fires when at least one of THIS lineage's local hashes is MISSING from
+    // the journal (otherwise Sub-case A skips all deletion). We seed the journal
+    // with: this lineage MINUS one hash (→ forces Sub-case B) + a single REAL
+    // sibling-lineage hash. The sibling hash is a genuine drizzle-cleo-project
+    // migration hash that has NO matching DDL in this bare DB, so the post-delete
+    // re-probe cannot re-stamp it — making the deletion observable.
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+
+    const tasksFolder = migFolder('drizzle-tasks');
+    const projectFolder = migFolder('drizzle-cleo-project');
+
+    const tasksMigrations = readMigrationFiles({ migrationsFolder: tasksFolder });
+    const projectMigrations = readMigrationFiles({ migrationsFolder: projectFolder });
+    // A real sibling hash whose DDL is NOT present in our bare DB (so it cannot be
+    // re-stamped by the DDL re-probe after deletion).
+    const siblingHash = projectMigrations[projectMigrations.length - 1]?.hash as string;
+    expect(siblingHash).toBeTruthy();
+
+    /** Build a DB in Sub-case B with this-lineage-minus-one + the sibling row. */
+    const buildSubcaseB = (db: DatabaseSync): void => {
+      db.exec('CREATE TABLE IF NOT EXISTS "tasks" ("id" text PRIMARY KEY)');
+      createJournalTable(db);
+      // Seed all tasks hashes EXCEPT the last one → at least one local hash is
+      // missing from the journal → Sub-case B (true-orphan deletion) fires.
+      const seen = new Set<string>();
+      for (const m of tasksMigrations.slice(0, -1)) {
+        if (seen.has(m.hash)) continue;
+        seen.add(m.hash);
+        db.exec(
+          `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${m.hash}', ${m.folderMillis}, '${(m.name ?? '').replace(/'/g, "''")}')`,
+        );
+      }
+      // The sibling-lineage row that the cross-lineage guard must protect.
+      db.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${siblingHash}', 1, 'sibling-project-row')`,
+      );
+    };
+
+    // (a) WITHOUT siblings — the sibling row is an orphan and is DELETED.
+    const dbNo = openNativeDatabase(join(tempDir, 'subcaseb-no-sib.db'));
+    try {
+      buildSubcaseB(dbNo);
+      expect(journalHashes(dbNo).has(siblingHash)).toBe(true);
+      reconcileJournal(dbNo, tasksFolder, 'tasks', 'sqlite'); // no siblings
+      expect(journalHashes(dbNo).has(siblingHash)).toBe(false); // deleted → the bug
+    } finally {
+      dbNo.close();
+    }
+
+    // (b) WITH siblings — the same row is in the union and SURVIVES (the fix).
+    const dbYes = openNativeDatabase(join(tempDir, 'subcaseb-with-sib.db'));
+    try {
+      buildSubcaseB(dbYes);
+      expect(journalHashes(dbYes).has(siblingHash)).toBe(true);
+      reconcileJournal(dbYes, tasksFolder, 'tasks', 'sqlite', [projectFolder]);
+      expect(journalHashes(dbYes).has(siblingHash)).toBe(true); // survives → fixed
+    } finally {
+      dbYes.close();
+    }
+  });
+
+  it('a GENUINE orphan (hash in no lineage) is still deleted even with siblings (Sub-case B)', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+
+    const tasksFolder = migFolder('drizzle-tasks');
+    const projectFolder = migFolder('drizzle-cleo-project');
+    const tasksMigrations = readMigrationFiles({ migrationsFolder: tasksFolder });
+
+    const dbPath = join(tempDir, 'true-orphan.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    try {
+      nativeDb.exec('CREATE TABLE IF NOT EXISTS "tasks" ("id" text PRIMARY KEY)');
+      createJournalTable(nativeDb);
+      // Seed all-but-one tasks hash → forces Sub-case B (otherwise Sub-case A skips
+      // all deletion when every local hash is present).
+      const seen = new Set<string>();
+      for (const m of tasksMigrations.slice(0, -1)) {
+        if (seen.has(m.hash)) continue;
+        seen.add(m.hash);
+        nativeDb.exec(
+          `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${m.hash}', ${m.folderMillis}, '${(m.name ?? '').replace(/'/g, "''")}')`,
+        );
+      }
+      // A hash that belongs to NEITHER lineage — a true orphan with no DDL to
+      // re-probe, so it must be permanently deleted.
+      nativeDb.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('deadbeef_not_any_lineage', 1, 'phantom')`,
+      );
+      expect(journalHashes(nativeDb).has('deadbeef_not_any_lineage')).toBe(true);
+
+      // Reconcile WITH the sibling set. The true orphan is in no lineage's union,
+      // so it must be deleted even though siblings are protected.
+      reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', [projectFolder]);
+
+      const after = journalHashes(nativeDb);
+      expect(after.has('deadbeef_not_any_lineage')).toBe(false);
+    } finally {
+      nativeDb.close();
+    }
+  });
+});
+
+describe('reconcileJournal — UNIQUE(hash) + INSERT OR IGNORE idempotency (T11829)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cleo-idem-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates a UNIQUE index on hash and a re-probe is a no-op (journal does not grow)', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+
+    const tasksFolder = migFolder('drizzle-tasks');
+
+    const dbPath = join(tempDir, 'idempotent.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    try {
+      nativeDb.exec('CREATE TABLE IF NOT EXISTS "tasks" ("id" text PRIMARY KEY)');
+      createJournalTable(nativeDb);
+      seedJournalWithLineage(nativeDb, tasksFolder);
+
+      // First reconcile establishes the UNIQUE index.
+      reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', []);
+
+      // The UNIQUE index must now exist.
+      const idx = nativeDb
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_drizzle_migrations_hash'`,
+        )
+        .get() as { name: string } | undefined;
+      expect(idx?.name).toBe('idx_drizzle_migrations_hash');
+
+      const countAfterFirst = (
+        nativeDb.prepare('SELECT COUNT(*) AS c FROM "__drizzle_migrations"').get() as { c: number }
+      ).c;
+
+      // Re-run reconcile twice more — the journal row count MUST be stable.
+      reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', []);
+      reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', []);
+
+      const countAfterRepeat = (
+        nativeDb.prepare('SELECT COUNT(*) AS c FROM "__drizzle_migrations"').get() as { c: number }
+      ).c;
+      expect(countAfterRepeat).toBe(countAfterFirst);
+    } finally {
+      nativeDb.close();
+    }
+  });
+
+  it('INSERT OR IGNORE cannot create duplicate-hash rows once the UNIQUE index exists', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+
+    const tasksFolder = migFolder('drizzle-tasks');
+    const firstHash = readMigrationFiles({ migrationsFolder: tasksFolder })[0]?.hash;
+    expect(firstHash).toBeTruthy();
+
+    const dbPath = join(tempDir, 'no-dups.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    try {
+      nativeDb.exec('CREATE TABLE IF NOT EXISTS "tasks" ("id" text PRIMARY KEY)');
+      createJournalTable(nativeDb);
+      seedJournalWithLineage(nativeDb, tasksFolder);
+
+      reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', []);
+
+      // Attempting a duplicate INSERT OR IGNORE for an existing hash is a no-op.
+      nativeDb.exec(
+        `INSERT OR IGNORE INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${firstHash}', 999, 'dup-attempt')`,
+      );
+
+      const dupCount = (
+        nativeDb
+          .prepare('SELECT COUNT(*) AS c FROM "__drizzle_migrations" WHERE hash = ?')
+          .get(firstHash) as { c: number }
+      ).c;
+      expect(dupCount).toBe(1);
+    } finally {
+      nativeDb.close();
+    }
+  });
+
+  it('one-time dedup collapses pre-existing duplicate-hash rows before the UNIQUE index is created', async () => {
+    const { openNativeDatabase } = await import('../sqlite.js');
+    const { reconcileJournal } = await import('../migration-manager.js');
+
+    const tasksFolder = migFolder('drizzle-tasks');
+    const firstHash = readMigrationFiles({ migrationsFolder: tasksFolder })[0]?.hash as string;
+
+    const dbPath = join(tempDir, 'pre-dups.db');
+    const nativeDb = openNativeDatabase(dbPath);
+    try {
+      nativeDb.exec('CREATE TABLE IF NOT EXISTS "tasks" ("id" text PRIMARY KEY)');
+      createJournalTable(nativeDb);
+      // Seed a journal that ALREADY has a duplicate hash (a historically-thrashed
+      // journal). CREATE UNIQUE INDEX would fail on this without the dedup pass.
+      nativeDb.exec(
+        `INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name") VALUES ('${firstHash}', 1, 'a'), ('${firstHash}', 2, 'b')`,
+      );
+      expect(
+        (
+          nativeDb
+            .prepare('SELECT COUNT(*) AS c FROM "__drizzle_migrations" WHERE hash = ?')
+            .get(firstHash) as { c: number }
+        ).c,
+      ).toBe(2);
+
+      // reconcile must dedup, then create the UNIQUE index without throwing.
+      expect(() => reconcileJournal(nativeDb, tasksFolder, 'tasks', 'sqlite', [])).not.toThrow();
+
+      // Exactly one row remains for the duplicated hash; index exists.
+      expect(
+        (
+          nativeDb
+            .prepare('SELECT COUNT(*) AS c FROM "__drizzle_migrations" WHERE hash = ?')
+            .get(firstHash) as { c: number }
+        ).c,
+      ).toBe(1);
+      const idx = nativeDb
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_drizzle_migrations_hash'`,
+        )
+        .get() as { name: string } | undefined;
+      expect(idx?.name).toBe('idx_drizzle_migrations_hash');
+    } finally {
+      nativeDb.close();
+    }
+  });
+});

--- a/packages/core/src/store/agent-registry-store.ts
+++ b/packages/core/src/store/agent-registry-store.ts
@@ -64,7 +64,10 @@ import { getCleoHome } from '../paths.js';
 // health-probe ledger via the drizzle-agent-registry forward migration.
 import { _resetDualScopeDbCache, openDualScopeDb } from './dual-scope-db.js';
 import { migrateSanitized, reconcileJournal } from './migration-manager.js';
-import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
+import {
+  resolveConsolidatedJournalSiblings,
+  resolveCorePackageMigrationsFolder,
+} from './resolve-migrations-folder.js';
 import * as agentRegistrySchema from './schema/cleo-global/agent-registry.js';
 
 /**
@@ -212,7 +215,15 @@ function runAgentRegistryMigrations(nativeDb: DatabaseSync): void {
   // Reconcile the Drizzle journal before running migrations. Sentinel =
   // `_agent_registry_meta` (created by this domain's forward migration), so
   // Scenario 2 orphan-deletion stays dormant on a fresh consolidated open.
-  reconcileJournal(nativeDb, migrationsFolder, '_agent_registry_meta', 'agent-registry');
+  // T11829: agent-registry shares the consolidated GLOBAL cleo.db journal — pass
+  // the OTHER lineages so their rows are not deleted as cross-lineage orphans.
+  reconcileJournal(
+    nativeDb,
+    migrationsFolder,
+    '_agent_registry_meta',
+    'agent-registry',
+    resolveConsolidatedJournalSiblings('drizzle-agent-registry'),
+  );
 
   // Create the drizzle ORM wrapper and run any pending migrations (the
   // health-probe ledger tables). The schema is the prefixed consolidated shape.

--- a/packages/core/src/store/conduit-sqlite.ts
+++ b/packages/core/src/store/conduit-sqlite.ts
@@ -87,7 +87,10 @@ import type { drizzle as drizzleFn } from 'drizzle-orm/node-sqlite';
 // existing callers compile and run without change.
 import { openDualScopeDb, resolveDualScopeDbPath } from './dual-scope-db.js';
 import { migrateSanitized, reconcileJournal } from './migration-manager.js';
-import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
+import {
+  resolveConsolidatedJournalSiblings,
+  resolveCorePackageMigrationsFolder,
+} from './resolve-migrations-folder.js';
 import * as conduitSchema from './schema/cleo-project/conduit.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
 
@@ -255,7 +258,15 @@ function runConduitMigrations(nativeDb: DatabaseSync): void {
   // the schema already matches). Sentinel = `_conduit_meta` (created by the
   // conduit migration itself — see the doc note above on why it must NOT be a
   // consolidated-owned table).
-  reconcileJournal(nativeDb, migrationsFolder, '_conduit_meta', 'conduit');
+  // T11829: conduit shares the consolidated PROJECT cleo.db journal — pass the
+  // OTHER lineages so their rows are not deleted as cross-lineage orphans.
+  reconcileJournal(
+    nativeDb,
+    migrationsFolder,
+    '_conduit_meta',
+    'conduit',
+    resolveConsolidatedJournalSiblings('drizzle-conduit'),
+  );
 
   const db = _getDrizzle()({ client: nativeDb, schema: conduitSchema });
   migrateSanitized(db, { migrationsFolder });

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -59,7 +59,10 @@ import { getLogger } from '../logger.js';
 import { getCleoHome, resolveCleoDir } from '../paths.js';
 import { type ExodusAbortDetail, getRecordedExodusAbort } from './exodus/abort-events.js';
 import { migrateWithRetry, reconcileJournal } from './migration-manager.js';
-import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
+import {
+  resolveConsolidatedJournalSiblings,
+  resolveCorePackageMigrationsFolder,
+} from './resolve-migrations-folder.js';
 import type * as CleoGlobalSchemaTypes from './schema/cleo-global/index.js';
 import type * as CleoProjectSchemaTypes from './schema/cleo-project/index.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
@@ -350,6 +353,44 @@ function existenceTable(scope: DualScope): string {
   return scope === 'project' ? 'tasks_tasks' : 'nexus_project_registry';
 }
 
+// ── Per-connection memory bounding (T11829) ────────────────────────────────────
+
+/**
+ * Per-open pragma overrides that bound a connection's memory footprint for
+ * one-shot CLI invocations and short-lived daemon-tick opens (T11829).
+ *
+ * The canonical SSoT pragmas reserve `cache_size=-64000` (64 MB page cache) +
+ * `mmap_size=268435456` (256 MB mmap window) + `temp_store=MEMORY` per connection
+ * ≈ 320-550 MB of address space PER PROCESS. With many concurrent uncapped
+ * processes (queued `cleo` opens + a respawning daemon + parallel agents), that sum
+ * blows past host RAM and the OOM-killer fires. A one-shot `cleo` command opens,
+ * does a small read/write, and exits — it gains nothing from a 256 MB mmap window
+ * or a 64 MB cache, so we shrink BOTH for these short-lived opens:
+ *
+ *   - `mmap_size = 0`   — disable the memory-mapped read window entirely.
+ *   - `cache_size = -8000` (8 MB) — a modest page cache, plenty for CLI queries.
+ *
+ * The SSoT default in `specs/sqlite-pragmas.json` is UNCHANGED (the long-lived
+ * daemon may legitimately want the larger cache/mmap for its working set). This is
+ * a per-OPEN override only. Neither `cache_size` nor `mmap_size` is in the
+ * `cleo doctor` pragma-drift list (`pragma-ssot.ts#driftPragmas` checks only
+ * journal_mode/busy_timeout/foreign_keys/synchronous/page_size/application_id), so
+ * shrinking them here does NOT trip the drift gate.
+ *
+ * The daemon (`CLEO_SENTIENT_DAEMON=1`) keeps the full SSoT footprint — it is a
+ * single long-lived process whose working set benefits from the larger cache.
+ *
+ * @returns Pragma overrides to pass to {@link applyPerfPragmas}, or `{}` for the
+ *   daemon (full SSoT footprint).
+ */
+function memoryBoundedPragmaOverrides(): { mmapSizeBytes?: number; cacheSizeKb?: number } {
+  // The long-lived sentient daemon keeps the full SSoT footprint.
+  if (process.env.CLEO_SENTIENT_DAEMON === '1') return {};
+  // Allow an explicit opt-out for any caller that wants the full footprint.
+  if (process.env.CLEO_DB_FULL_MEM === '1') return {};
+  return { mmapSizeBytes: 0, cacheSizeKb: 8000 };
+}
+
 // ── Core open logic ──────────────────────────────────────────────────────────
 
 /**
@@ -429,7 +470,8 @@ async function openDedicatedDualScopeDb(
   const DatabaseSyncCtor = getDatabaseSyncCtor();
   const nativeDb = new DatabaseSyncCtor(dbPath, { allowExtension: true });
 
-  applyPerfPragmas(nativeDb);
+  // T11829: bound per-connection memory for one-shot/CLI opens (full SSoT for daemon).
+  applyPerfPragmas(nativeDb, memoryBoundedPragmaOverrides());
 
   const schema = scope === 'project' ? await loadProjectSchema() : await loadGlobalSchema();
   const drizzle = getDrizzle();
@@ -437,7 +479,19 @@ async function openDedicatedDualScopeDb(
   const db = drizzle({ client: nativeDb, schema }) as NodeSQLiteDatabase<any>;
 
   const migrationsFolder = resolveCorePackageMigrationsFolder(migrationsSetName(scope));
-  reconcileJournal(nativeDb, migrationsFolder, existenceTable(scope), `dual-scope-db[${scope}]`);
+  // T11829: pass the OTHER lineages that share this scope's consolidated cleo.db
+  // journal so their rows are never deleted as cross-lineage orphans. Both scopes
+  // are consolidated single-file substrates with multiple coexisting lineages
+  // (project: tasks/cleo-project/nexus/conduit/brain; global:
+  // cleo-global/agent-registry/…). Over-inclusion across scopes is safe — a
+  // sibling hash absent from this file's journal contributes nothing.
+  reconcileJournal(
+    nativeDb,
+    migrationsFolder,
+    existenceTable(scope),
+    `dual-scope-db[${scope}]`,
+    resolveConsolidatedJournalSiblings(migrationsSetName(scope)),
+  );
   migrateWithRetry(
     db,
     migrationsFolder,
@@ -566,8 +620,9 @@ export async function openDualScopeDbAtPath(
     const DatabaseSyncCtor = getDatabaseSyncCtor();
     const nativeDb = new DatabaseSyncCtor(dbPath, { allowExtension: true });
 
-    // Apply canonical pragma set (specs/sqlite-pragmas.json SSoT).
-    applyPerfPragmas(nativeDb);
+    // Apply canonical pragma set (specs/sqlite-pragmas.json SSoT), bounding
+    // per-connection memory for one-shot/CLI opens (full SSoT for daemon) — T11829.
+    applyPerfPragmas(nativeDb, memoryBoundedPragmaOverrides());
 
     // Load the schema barrel for this scope.
     const schema = scope === 'project' ? await loadProjectSchema() : await loadGlobalSchema();
@@ -583,7 +638,17 @@ export async function openDualScopeDbAtPath(
 
     // Reconcile the migration journal (handles WAL/journal divergence across
     // SQLite version upgrades — same pattern as sqlite.ts / memory-sqlite.ts).
-    reconcileJournal(nativeDb, migrationsFolder, existenceTable(scope), `dual-scope-db[${scope}]`);
+    // T11829: pass the OTHER lineages that share this scope's consolidated cleo.db
+    // journal so their rows are not deleted as cross-lineage orphans (the confirmed
+    // OOM root cause: each lineage previously deleted the others' rows so the shared
+    // journal never converged).
+    reconcileJournal(
+      nativeDb,
+      migrationsFolder,
+      existenceTable(scope),
+      `dual-scope-db[${scope}]`,
+      resolveConsolidatedJournalSiblings(migrationsSetName(scope)),
+    );
 
     // Run any pending migrations.
     migrateWithRetry(

--- a/packages/core/src/store/migration-manager.ts
+++ b/packages/core/src/store/migration-manager.ts
@@ -516,6 +516,63 @@ function probeAndMarkApplied(
 }
 
 /**
+ * Read the set of migration hashes for a SIBLING lineage folder (T11829).
+ *
+ * Used to build the cross-lineage orphan-deletion union in {@link reconcileJournal}.
+ * Defensive: a missing/unreadable/empty sibling folder yields an empty set rather
+ * than throwing — a sibling that does not exist in this install simply contributes
+ * no hashes to the union (the reconcile is conservative: fewer known hashes can
+ * only mean MORE deletions, so we never over-delete by failing safe to empty, but
+ * we also never crash the caller's open on a missing sibling).
+ *
+ * @param siblingFolder - Absolute path to a sibling drizzle migrations folder.
+ * @returns The set of migration hashes declared by that folder (empty on failure).
+ */
+function readSiblingMigrationHashes(siblingFolder: string): Set<string> {
+  try {
+    return new Set(readMigrationFiles({ migrationsFolder: siblingFolder }).map((m) => m.hash));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Ensure a UNIQUE index on `__drizzle_migrations(hash)` exists so the shared
+ * consolidated journal converges idempotently (T11829).
+ *
+ * With the UNIQUE index in place, the `INSERT OR IGNORE` emitted by
+ * {@link insertJournalEntry} becomes a true no-op on a re-probe (rather than
+ * appending a duplicate row), so any residual cross-lineage re-probe cannot grow
+ * the journal. Creation is guarded behind a one-time dedup: the live consolidated
+ * journal currently has no duplicate hashes, but a historically-thrashed journal
+ * could, and `CREATE UNIQUE INDEX` would fail on duplicates. We therefore collapse
+ * any duplicate-hash rows (keeping the lowest `id`) BEFORE creating the index.
+ *
+ * Idempotent and cheap: once the index exists, `CREATE UNIQUE INDEX IF NOT EXISTS`
+ * is a no-op and the dedup pass finds nothing.
+ *
+ * @param nativeDb - Native SQLite database handle.
+ */
+function ensureJournalHashUnique(nativeDb: DatabaseSync): void {
+  if (!tableExists(nativeDb, '__drizzle_migrations')) return;
+  try {
+    // One-time dedup: keep the lowest id per hash, delete the rest. A no-op once
+    // the journal is already unique (the live journal has no dups today).
+    nativeDb.exec(
+      'DELETE FROM "__drizzle_migrations" WHERE id NOT IN ' +
+        '(SELECT MIN(id) FROM "__drizzle_migrations" GROUP BY hash)',
+    );
+    nativeDb.exec(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "idx_drizzle_migrations_hash" ON "__drizzle_migrations" ("hash")',
+    );
+  } catch {
+    // Best-effort convergence aid — never block an open on the index/dedup.
+    // INSERT OR IGNORE already guards duplicate inserts at the row level even
+    // without the index (it just cannot enforce uniqueness without it).
+  }
+}
+
+/**
  * Bootstrap and reconcile the Drizzle migration journal.
  *
  * Handles four scenarios:
@@ -531,16 +588,42 @@ function probeAndMarkApplied(
  *    applied migrations to be re-run and fail with "duplicate column name". Backfills
  *    the name from the local migration file matched by hash.
  *
+ * ## Cross-lineage orphan-deletion guard (T11829 — OOM root fix)
+ *
+ * The consolidated `cleo.db` carries ONE shared `__drizzle_migrations` journal but
+ * is reconciled by MULTIPLE physically-coexisting migration lineages
+ * (`drizzle-tasks`, `drizzle-cleo-project`, `drizzle-nexus`, `drizzle-brain`,
+ * `drizzle-agent-registry`, `drizzle-conduit`). Each lineage only knows its OWN
+ * folder, so a naive Sub-case B classified EVERY sibling lineage's journal rows as
+ * "true orphans" and DELETEd them — the next sibling open then deleted THIS
+ * lineage's rows, so the journal NEVER converged (it oscillated and re-ran
+ * BEGIN/COMMIT migrate transactions on every open, holding the WAL writer lock and
+ * stacking 300-550 MB-per-connection opens until the host OOM-killed).
+ *
+ * The fix: an entry is a TRUE orphan only when its hash belongs to NO lineage that
+ * physically shares this DB. Callers that share the journal pass
+ * `siblingMigrationsFolders` (the OTHER lineages' folders); the orphan-DELETE
+ * decision then uses the UNION of every sibling lineage's hashes plus this
+ * lineage's own. A hash present in any sibling is preserved (it is that sibling's
+ * legitimately-applied migration, not an orphan). Standalone DBs (a single
+ * lineage) pass no siblings and behave exactly as before.
+ *
  * @param nativeDb - Native SQLite database handle
  * @param migrationsFolder - Path to the drizzle migrations folder
  * @param existenceTable - A table name used to detect if the DB has data (e.g., 'tasks' or 'brain_decisions')
  * @param logSubsystem - Logger subsystem name for reconciliation warnings
+ * @param siblingMigrationsFolders - OTHER migration-lineage folders that share this
+ *   `__drizzle_migrations` journal inside the same consolidated `cleo.db` (T11829).
+ *   Their hashes are added to the orphan-deletion union so a sibling lineage's rows
+ *   are never deleted as cross-lineage orphans. Omit (or pass `[]`) for a DB with a
+ *   single lineage. Unreadable/empty sibling folders are skipped defensively.
  */
 export function reconcileJournal(
   nativeDb: DatabaseSync,
   migrationsFolder: string,
   existenceTable: string,
   logSubsystem: string,
+  siblingMigrationsFolders: readonly string[] = [],
 ): void {
   // bug #2 (T11553): pre-compute the tables this lineage CREATEs and a LATER
   // migration permanently ELIMINATES (DROP TABLE, no recreate — e.g.
@@ -575,6 +658,11 @@ export function reconcileJournal(
     }
   }
 
+  // T11829: enforce UNIQUE(hash) so the shared consolidated journal converges
+  // idempotently — any residual re-probe's INSERT OR IGNORE becomes a true no-op.
+  // Runs once the journal table exists (Scenario 1 / a prior open created it).
+  ensureJournalHashUnique(nativeDb);
+
   // Scenario 2: Journal has orphaned entries from a previous CLEO version
   //
   // Two distinct sub-cases require different handling:
@@ -604,12 +692,28 @@ export function reconcileJournal(
     const localMigrations = readMigrationFiles({ migrationsFolder });
     const localHashes = new Set(localMigrations.map((m) => m.hash));
 
+    // T11829 (OOM root fix): the orphan-DELETE decision must use the UNION of
+    // every migration lineage that physically shares this DB's `__drizzle_migrations`
+    // journal — NOT just this lineage's folder. A hash belonging to a sibling
+    // lineage (e.g. drizzle-cleo-project's rows seen from the drizzle-tasks open)
+    // is that sibling's legitimately-applied migration, not an orphan. Deleting it
+    // is what made the shared journal oscillate and never converge → host OOM.
+    const knownHashes = new Set(localHashes);
+    for (const siblingFolder of siblingMigrationsFolders) {
+      if (siblingFolder === migrationsFolder) continue;
+      for (const m of readSiblingMigrationHashes(siblingFolder)) {
+        knownHashes.add(m);
+      }
+    }
+
     type JournalRow = { id: number; hash: string };
     const dbEntries = nativeDb
       .prepare('SELECT id, hash FROM "__drizzle_migrations"')
       .all() as JournalRow[];
 
-    const orphanedEntries = dbEntries.filter((e) => !localHashes.has(e.hash));
+    // A row is an orphan ONLY when its hash is unknown to THIS lineage AND every
+    // sibling lineage sharing this journal (T11829 cross-lineage guard).
+    const orphanedEntries = dbEntries.filter((e) => !knownHashes.has(e.hash));
     const hasOrphanedEntries = orphanedEntries.length > 0;
 
     if (hasOrphanedEntries) {
@@ -626,8 +730,9 @@ export function reconcileJournal(
           `Migration journal has ${orphanedEntries.length} entries for migrations not known to this install (DB is ahead). Skipping reconciliation.`,
         );
       } else {
-        // Sub-case B: TRUE ORPHANS — entries whose hash has no local match.
-        // Delete them and re-probe local migrations via DDL.
+        // Sub-case B: TRUE ORPHANS — entries whose hash matches NO known lineage
+        // (this one or any sibling sharing the journal). Delete them and re-probe
+        // local migrations via DDL.
         log.warn(
           { orphaned: orphanedEntries.length },
           `Detected ${orphanedEntries.length} true-orphan journal entries from a previous CLEO lineage. Reconciling via DDL probe.`,

--- a/packages/core/src/store/nexus-sqlite.ts
+++ b/packages/core/src/store/nexus-sqlite.ts
@@ -82,7 +82,10 @@ import { getCleoHome } from '../paths.js';
 // existing callers (nexusSchema.* queries) compile and run without change.
 import { openDualScopeDb, resolveDualScopeDbPath } from './dual-scope-db.js';
 import { ensureColumns, migrateWithRetry, reconcileJournal } from './migration-manager.js';
-import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
+import {
+  resolveConsolidatedJournalSiblings,
+  resolveCorePackageMigrationsFolder,
+} from './resolve-migrations-folder.js';
 import * as nexusSchema from './schema/nexus-schema.js';
 // isSqliteBusy is a pure predicate with no node:sqlite dependency — import it
 // from its canonical leaf home (with-retry.ts) rather than sqlite.ts so this
@@ -638,7 +641,15 @@ function runNexusMigrations(
   // treated as true orphans (Sub-case B) rather than re-run. Sentinel =
   // `_nexus_meta` (created by the nexus delta migration itself — NOT a
   // consolidated-owned table; see the doc note above).
-  reconcileJournal(nativeDb, migrationsFolder, '_nexus_meta', 'nexus');
+  // T11829: nexus shares the consolidated PROJECT cleo.db journal (ADR-090 residency
+  // move) — pass the OTHER lineages so their rows are not deleted as orphans.
+  reconcileJournal(
+    nativeDb,
+    migrationsFolder,
+    '_nexus_meta',
+    'nexus',
+    resolveConsolidatedJournalSiblings('drizzle-nexus'),
+  );
 
   // Run the nexus DELTA migration (FTS5 quartet + nexus_relation_weights +
   // `_nexus_meta`). Wrapped in a busy retry — the GLOBAL `cleo.db` handle is

--- a/packages/core/src/store/resolve-migrations-folder.ts
+++ b/packages/core/src/store/resolve-migrations-folder.ts
@@ -58,6 +58,63 @@ function coreRootFromEntry(entryPath: string): string {
  * // → '/…/node_modules/@cleocode/core/migrations/drizzle-tasks'  (installed)
  * ```
  */
+/**
+ * Every migration lineage that can physically share a consolidated `cleo.db`
+ * `__drizzle_migrations` journal (T11829 · SG-DB-SUBSTRATE-V2).
+ *
+ * The consolidated single-file-per-scope substrate has ONE shared journal per file
+ * but is reconciled by every lineage whose tables coexist in that file. Each
+ * lineage's `reconcileJournal` must treat the OTHER lineages' rows as known (not
+ * orphans) — otherwise the journal never converges and every open re-thrashes the
+ * WAL writer lock under `busy_timeout`, stacking 300-550 MB connection opens until
+ * the host OOM-kills (the confirmed root cause).
+ *
+ * This is the SSoT for that union. It intentionally lists BOTH the project-scope
+ * lineages (`drizzle-tasks`, `drizzle-cleo-project`, `drizzle-nexus`,
+ * `drizzle-brain`, `drizzle-conduit`) and the global-scope lineages
+ * (`drizzle-cleo-global`, `drizzle-agent-registry`, `drizzle-skills`,
+ * `drizzle-telemetry`). Over-inclusion is SAFE and conservative: a sibling whose
+ * hash never appears in a given file's journal contributes nothing, and a hash that
+ * DOES appear can only be a legitimately-applied migration of that lineage — so
+ * adding it to the union only ever PREVENTS a wrongful deletion, never causes one.
+ * Listing a lineage absent from a given install is harmless —
+ * {@link resolveConsolidatedJournalSiblings}'s caller skips folders that read empty.
+ */
+export const CONSOLIDATED_JOURNAL_LINEAGES: readonly string[] = [
+  'drizzle-tasks',
+  'drizzle-cleo-project',
+  'drizzle-nexus',
+  'drizzle-brain',
+  'drizzle-conduit',
+  'drizzle-cleo-global',
+  'drizzle-agent-registry',
+  'drizzle-skills',
+  'drizzle-telemetry',
+] as const;
+
+/**
+ * Resolve the SIBLING migration folders that share the consolidated `cleo.db`
+ * journal with the given lineage (T11829).
+ *
+ * Pass the result as `siblingMigrationsFolders` to `reconcileJournal` so its
+ * cross-lineage orphan-deletion guard knows every hash that legitimately belongs
+ * to a coexisting lineage. The caller's OWN folder is excluded from the result.
+ *
+ * @param ownSetName - The lineage doing the reconcile, e.g. `'drizzle-tasks'`.
+ * @returns Absolute paths to the OTHER consolidated-journal lineage folders.
+ *
+ * @example
+ * ```ts
+ * reconcileJournal(nativeDb, folder, 'tasks', 'sqlite',
+ *   resolveConsolidatedJournalSiblings('drizzle-tasks'));
+ * ```
+ */
+export function resolveConsolidatedJournalSiblings(ownSetName: string): string[] {
+  return CONSOLIDATED_JOURNAL_LINEAGES.filter((name) => name !== ownSetName).map((name) =>
+    resolveCorePackageMigrationsFolder(name),
+  );
+}
+
 export function resolveCorePackageMigrationsFolder(setName: string): string {
   // Strategy 1: ESM-native import.meta.resolve() with parent URL.
   // The two-argument form was stabilised in Node 18.19.0 / 20.x and is the

--- a/packages/core/src/store/sqlite.ts
+++ b/packages/core/src/store/sqlite.ts
@@ -51,7 +51,10 @@ import {
   reconcileJournal,
   tableExists,
 } from './migration-manager.js';
-import { resolveCorePackageMigrationsFolder } from './resolve-migrations-folder.js';
+import {
+  resolveConsolidatedJournalSiblings,
+  resolveCorePackageMigrationsFolder,
+} from './resolve-migrations-folder.js';
 import { listSqliteBackups } from './sqlite-backup.js';
 import { assertDbPathIsNotWorktreeResident } from './worktree-isolation-guard.js';
 
@@ -572,8 +575,16 @@ function runMigrations(nativeDb: DatabaseSync, db: NodeSQLiteDatabase<typeof sch
     createSafetyBackup(_dbPath);
   }
 
-  // Bootstrap baseline + reconcile stale journal entries
-  reconcileJournal(nativeDb, migrationsFolder, 'tasks', 'sqlite');
+  // Bootstrap baseline + reconcile stale journal entries.
+  // T11829: the drizzle-tasks lineage runs against the SHARED consolidated cleo.db
+  // journal — pass the OTHER lineages so their rows are not deleted as orphans.
+  reconcileJournal(
+    nativeDb,
+    migrationsFolder,
+    'tasks',
+    'sqlite',
+    resolveConsolidatedJournalSiblings('drizzle-tasks'),
+  );
 
   // Pre-migration column safety: ensure sessions table has the columns that the
   // wave0-schema-hardening migration SELECTs during its table rebuild. Without


### PR DESCRIPTION
## Root cause (confirmed on the live 707MB cleo.db)

The consolidated `cleo.db` has ONE shared `__drizzle_migrations` journal but is reconciled by MULTIPLE migration lineages on every open: `drizzle-tasks` (sentinel `tasks`), `drizzle-cleo-project` (`tasks_tasks`), `drizzle-nexus` (`_nexus_meta`), `drizzle-conduit` (`_conduit_meta`), `drizzle-agent-registry`, and the additive `drizzle-brain`. `reconcileJournal` built `localHashes` from ONLY the calling lineage's folder, so Sub-case B classified every **sibling** lineage's rows as "true orphans" and `DELETE`d them. The next sibling open then deleted *this* lineage's rows → the journal **never converged** (oscillated). Every open re-thrashed the WAL writer lock under `busy_timeout=30000` (~3m45s wall), and uncapped concurrent processes (respawning daemon + queued `cleo` opens + parallel agents) each reserving 320-550 MB summed past 62 GB → SIGKILL / exit137.

The live DB had **only the 2 nexus rows surviving** — all 57 tasks + 7 project + 32 brain + conduit rows had been deleted.

## Fix (union-guard — lowest blast radius vs per-lineage journal tables)

1. **Stop cross-lineage deletion (root fix).** `reconcileJournal` takes `siblingMigrationsFolders`; the orphan-`DELETE` decision now uses the **union** of every lineage physically sharing this `cleo.db`. An entry is a true orphan only when its hash belongs to NO known lineage. `resolveConsolidatedJournalSiblings` (in `resolve-migrations-folder.ts`) is the SSoT for the sharing set. Wired into all deleting call sites: `sqlite.ts`, `dual-scope-db.ts` (both scopes), `nexus-sqlite.ts`, `conduit-sqlite.ts`, `agent-registry-store.ts`. Brain's additive path never deletes — left as-is.
2. **Idempotent convergence.** `ensureJournalHashUnique` adds `UNIQUE(hash)` (after a one-time dedup) so the existing `INSERT OR IGNORE` makes any residual re-probe a true no-op.
3. **Bound per-connection memory for one-shot/CLI opens.** `dual-scope-db` passes `mmap_size=0` + `cache_size=-8000` per open (daemon keeps full SSoT via `CLEO_SENTIENT_DAEMON=1`). The `specs/sqlite-pragmas.json` default is unchanged; neither pragma is in the `cleo doctor` drift list.
4. **Fleet fail-safes.** `--max-old-space-size=1536` on the cleo bin launcher + daemon `ExecStart` (NODE_OPTIONS); `StartLimitIntervalSec`/`StartLimitBurst` + `MemoryMax` on the generated systemd unit so a crash-loop is bounded.

## Verification (COPY of the live DB, `ulimit -v 4000000`, daemon disabled)

Journal **converges 2 → 68 rows** and **stays at 68 across 3 repeated opens** (all lineages coexist; `UNIQUE(hash)` present; 0 duplicate rows). 1st open 66ms; **2nd/3rd opens 20ms** (sub-second). **Peak RSS 93 MB** (was a multi-GB blow-up). Total wall 0.15s vs the broken 3m45s.

## Tests

New `migration-cross-lineage-convergence.test.ts`:
- Two lineages sharing one journal → BOTH lineages' rows survive sequential reconciles.
- Sub-case B: a real sibling-lineage row is **deleted WITHOUT** the sibling set / **survives WITH** it (fails-without / passes-with the fix).
- A genuine true orphan (hash in no lineage) is still deleted.
- `UNIQUE(hash)` + `INSERT OR IGNORE` idempotency (re-probe = no-op, journal does not grow).
- One-time dedup collapses pre-existing duplicate-hash rows before index creation.

Existing migration/reconcile suites stay green (`migration-reconcile`, `idempotent-migration`, `migration-baseline`, `migration-probe-trigger`, `migration-hash-drift`, `migration-safety`, `migration-v3-columns`, `migration-retry`, `sqlite-pragmas-ssot`, doctor `pragma-ssot`, nexus/brain fresh-no-repair, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)