### PR TITLE
feat(store): E4 — backfill 672 stranded provenance rows bare→prefixed with DHQ-068 coercions (T11883)

### DIFF
--- a/packages/core/migrations/drizzle-cleo-project/20260607000400_t11883-e4-backfill-stranded-provenance/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260607000400_t11883-e4-backfill-stranded-provenance/migration.sql
@@ -1,0 +1,134 @@
+-- T11883 (E4) — Backfill stranded provenance rows from the BARE legacy tables
+-- into the PREFIXED consolidated tables, with DHQ-068 enum coercions.
+--
+-- ## Why this exists
+--
+-- The exodus migration copies the bare provenance tables (`commits`,
+-- `task_commits`, `releases`, …) into their prefixed equivalents (`tasks_commits`,
+-- …). The prefixed tables carry the restored T11363 CHECK constraints that the
+-- no-CHECK legacy tables never enforced (DHQ-068). A handful of legacy rows hold
+-- values OUTSIDE those enums:
+--   • `commits.conventional_type = 'style'`        (1 row — not a CC enum member)
+--   • `task_commits.link_source  = 'commit-message'` (97 rows — the same bug E3
+--     fixed in reconcile.ts; the valid member is 'commit-subject')
+-- Because exodus copies in batched transactions, those CHECK-violating rows abort
+-- their whole batch, stranding ~672 otherwise-valid rows in the bare tables. E5
+-- drops the bare tables, so those rows must be recovered FIRST — this migration
+-- copies every stranded bare row into the prefixed table, coercing the two
+-- out-of-enum columns so the CHECK passes.
+--
+-- ## Safety / idempotency
+--
+-- • `INSERT OR IGNORE` — rows already present in the prefixed table (matched by
+--   PK) are skipped, so re-running is a no-op; only the genuinely-stranded rows
+--   are added.
+-- • `defer_foreign_keys` + parents-first ordering (releases → release_*) so the
+--   `tasks_release_*.release_id → tasks_releases.id` FKs resolve.
+-- • The release-child inserts are guarded with `WHERE EXISTS (… tasks_releases)`
+--   so a child whose parent release exists in NEITHER the prefixed table nor the
+--   bare `releases` being copied is dropped cleanly (orphan) rather than aborting
+--   the migration.
+-- • Column lists are the bare∩prefixed intersection; no prefixed-only NOT NULL
+--   column exists, so no synthetic defaults are needed.
+--
+-- @task T11883
+-- @saga T11242
+
+PRAGMA defer_foreign_keys = ON;
+
+-- 1. releases (parent of release_*) — no coercion; all stranded values in-enum.
+INSERT OR IGNORE INTO `tasks_releases` (
+  id, version, scheme, channel, epic_id, release_kind, status, previous_version,
+  merge_commit_sha, pr_id, workflow_run_url, created_at, planned_at, pr_opened_at,
+  pr_merged_at, published_at, reconciled_at, rolled_back_at, failed_at, cancelled_at,
+  failure_reason, rolled_back_by, project_hash, tasks_json, changelog, notes, git_tag,
+  prepared_at, committed_at, tagged_at, pushed_at
+)
+SELECT
+  id, version, scheme, channel, epic_id, release_kind, status, previous_version,
+  merge_commit_sha, pr_id, workflow_run_url, created_at, planned_at, pr_opened_at,
+  pr_merged_at, published_at, reconciled_at, rolled_back_at, failed_at, cancelled_at,
+  failure_reason, rolled_back_by, project_hash, tasks_json, changelog, notes, git_tag,
+  prepared_at, committed_at, tagged_at, pushed_at
+FROM `releases`;
+
+-- 2. commits — coerce out-of-enum conventional_type to NULL (the column is nullable).
+INSERT OR IGNORE INTO `tasks_commits` (
+  sha, short_sha, author_name, author_email, authored_at, committer_name,
+  committer_email, committed_at, message, subject, conventional_type,
+  is_release_commit, is_merge_commit, parent_shas, signature_verified,
+  branch_at_commit, project_hash, created_at
+)
+SELECT
+  sha, short_sha, author_name, author_email, authored_at, committer_name,
+  committer_email, committed_at, message, subject,
+  CASE
+    WHEN conventional_type IN (
+      'feat','fix','chore','docs','refactor','test','build','ci','perf','revert','breaking'
+    ) THEN conventional_type
+    ELSE NULL
+  END,
+  is_release_commit, is_merge_commit, parent_shas, signature_verified,
+  branch_at_commit, project_hash, created_at
+FROM `commits`;
+
+-- 3. commit_files — change_type values (A/D/M/R) are all in-enum; no coercion.
+INSERT OR IGNORE INTO `tasks_commit_files` (
+  commit_sha, path, old_path, change_type, lines_added, lines_deleted, is_binary
+)
+SELECT
+  commit_sha, path, old_path, change_type, lines_added, lines_deleted, is_binary
+FROM `commit_files`;
+
+-- 4. task_commits — coerce legacy link_source 'commit-message' → 'commit-subject'
+--    (the valid COMMIT_LINK_SOURCES member); any other out-of-enum value → 'manual'.
+INSERT OR IGNORE INTO `tasks_task_commits` (
+  task_id, commit_sha, link_kind, link_source, created_at
+)
+SELECT
+  task_id, commit_sha, link_kind,
+  CASE
+    WHEN link_source IN (
+      'commit-trailer','commit-subject','pr-title','pr-body','branch-name','manual'
+    ) THEN link_source
+    WHEN link_source = 'commit-message' THEN 'commit-subject'
+    ELSE 'manual'
+  END,
+  created_at
+FROM `task_commits`;
+
+-- 5. release_commits (child of releases) — guard FK on tasks_releases.
+INSERT OR IGNORE INTO `tasks_release_commits` (
+  release_id, commit_sha, position, is_first, is_last, is_release_chore
+)
+SELECT
+  rc.release_id, rc.commit_sha, rc.position, rc.is_first, rc.is_last, rc.is_release_chore
+FROM `release_commits` rc
+WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = rc.release_id);
+
+-- 6. release_changes (child of releases) — guard FK.
+INSERT OR IGNORE INTO `tasks_release_changes` (
+  id, release_id, task_id, change_type, summary, description, impact, classified_by, classified_at
+)
+SELECT
+  c.id, c.release_id, c.task_id, c.change_type, c.summary, c.description, c.impact, c.classified_by, c.classified_at
+FROM `release_changes` c
+WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = c.release_id);
+
+-- 7. release_artifacts (child of releases) — guard FK.
+INSERT OR IGNORE INTO `tasks_release_artifacts` (
+  release_id, artifact_type, identifier, version, url, published_at, metadata
+)
+SELECT
+  a.release_id, a.artifact_type, a.identifier, a.version, a.url, a.published_at, a.metadata
+FROM `release_artifacts` a
+WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = a.release_id);
+
+-- 8. brain_release_links (child of releases) — guard FK.
+INSERT OR IGNORE INTO `tasks_brain_release_links` (
+  brain_entry_id, release_id, link_type, created_at, created_by
+)
+SELECT
+  l.brain_entry_id, l.release_id, l.link_type, l.created_at, l.created_by
+FROM `brain_release_links` l
+WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = l.release_id);

--- a/packages/core/migrations/drizzle-cleo-project/20260607000400_t11883-e4-backfill-stranded-provenance/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260607000400_t11883-e4-backfill-stranded-provenance/migration.sql
@@ -30,12 +30,14 @@
 --   the migration.
 -- • Column lists are the bare∩prefixed intersection; no prefixed-only NOT NULL
 --   column exists, so no synthetic defaults are needed.
+-- • Statements are separated by the drizzle statement-breakpoint marker so the
+--   migration runner prepares one statement per chunk (no statement is dropped).
 --
 -- @task T11883
 -- @saga T11242
 
 PRAGMA defer_foreign_keys = ON;
-
+--> statement-breakpoint
 -- 1. releases (parent of release_*) — no coercion; all stranded values in-enum.
 INSERT OR IGNORE INTO `tasks_releases` (
   id, version, scheme, channel, epic_id, release_kind, status, previous_version,
@@ -51,7 +53,7 @@ SELECT
   failure_reason, rolled_back_by, project_hash, tasks_json, changelog, notes, git_tag,
   prepared_at, committed_at, tagged_at, pushed_at
 FROM `releases`;
-
+--> statement-breakpoint
 -- 2. commits — coerce out-of-enum conventional_type to NULL (the column is nullable).
 INSERT OR IGNORE INTO `tasks_commits` (
   sha, short_sha, author_name, author_email, authored_at, committer_name,
@@ -64,14 +66,14 @@ SELECT
   committer_email, committed_at, message, subject,
   CASE
     WHEN conventional_type IN (
-      'feat','fix','chore','docs','refactor','test','build','ci','perf','revert','breaking'
+      'feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'build', 'ci', 'perf', 'revert', 'breaking'
     ) THEN conventional_type
     ELSE NULL
   END,
   is_release_commit, is_merge_commit, parent_shas, signature_verified,
   branch_at_commit, project_hash, created_at
 FROM `commits`;
-
+--> statement-breakpoint
 -- 3. commit_files — change_type values (A/D/M/R) are all in-enum; no coercion.
 INSERT OR IGNORE INTO `tasks_commit_files` (
   commit_sha, path, old_path, change_type, lines_added, lines_deleted, is_binary
@@ -79,7 +81,7 @@ INSERT OR IGNORE INTO `tasks_commit_files` (
 SELECT
   commit_sha, path, old_path, change_type, lines_added, lines_deleted, is_binary
 FROM `commit_files`;
-
+--> statement-breakpoint
 -- 4. task_commits — coerce legacy link_source 'commit-message' → 'commit-subject'
 --    (the valid COMMIT_LINK_SOURCES member); any other out-of-enum value → 'manual'.
 INSERT OR IGNORE INTO `tasks_task_commits` (
@@ -89,14 +91,14 @@ SELECT
   task_id, commit_sha, link_kind,
   CASE
     WHEN link_source IN (
-      'commit-trailer','commit-subject','pr-title','pr-body','branch-name','manual'
+      'commit-trailer', 'commit-subject', 'pr-title', 'pr-body', 'branch-name', 'manual'
     ) THEN link_source
     WHEN link_source = 'commit-message' THEN 'commit-subject'
     ELSE 'manual'
   END,
   created_at
 FROM `task_commits`;
-
+--> statement-breakpoint
 -- 5. release_commits (child of releases) — guard FK on tasks_releases.
 INSERT OR IGNORE INTO `tasks_release_commits` (
   release_id, commit_sha, position, is_first, is_last, is_release_chore
@@ -105,7 +107,7 @@ SELECT
   rc.release_id, rc.commit_sha, rc.position, rc.is_first, rc.is_last, rc.is_release_chore
 FROM `release_commits` rc
 WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = rc.release_id);
-
+--> statement-breakpoint
 -- 6. release_changes (child of releases) — guard FK.
 INSERT OR IGNORE INTO `tasks_release_changes` (
   id, release_id, task_id, change_type, summary, description, impact, classified_by, classified_at
@@ -114,7 +116,7 @@ SELECT
   c.id, c.release_id, c.task_id, c.change_type, c.summary, c.description, c.impact, c.classified_by, c.classified_at
 FROM `release_changes` c
 WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = c.release_id);
-
+--> statement-breakpoint
 -- 7. release_artifacts (child of releases) — guard FK.
 INSERT OR IGNORE INTO `tasks_release_artifacts` (
   release_id, artifact_type, identifier, version, url, published_at, metadata
@@ -123,7 +125,7 @@ SELECT
   a.release_id, a.artifact_type, a.identifier, a.version, a.url, a.published_at, a.metadata
 FROM `release_artifacts` a
 WHERE EXISTS (SELECT 1 FROM `tasks_releases` r WHERE r.id = a.release_id);
-
+--> statement-breakpoint
 -- 8. brain_release_links (child of releases) — guard FK.
 INSERT OR IGNORE INTO `tasks_brain_release_links` (
   brain_entry_id, release_id, link_type, created_at, created_by

--- a/packages/core/migrations/drizzle-cleo-project/20260607000400_t11883-e4-backfill-stranded-provenance/revert.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260607000400_t11883-e4-backfill-stranded-provenance/revert.sql
@@ -1,0 +1,10 @@
+-- Revert T11883 (E4) — intentional near-no-op.
+--
+-- The forward migration is an additive `INSERT OR IGNORE` backfill of stranded
+-- provenance rows. There is no PK-stable marker distinguishing a row that this
+-- migration inserted from one the runtime/exodus inserted, so a precise undo is
+-- not possible (and not desirable — the data is valid, FK-consistent provenance).
+-- The bare source tables remain until E5 drops them, so re-applying E4 is safe.
+--
+-- @task T11883
+SELECT 1;


### PR DESCRIPTION
## What

E4 of the complete-cutover (epic **T11883** · saga **T11242**). Recovers the provenance rows that exodus stranded in the bare tables so they survive into the prefixed consolidated substrate.

The exodus bare→prefixed copy strands **672** otherwise-valid provenance rows because a few CHECK-violating legacy values abort their batches (DHQ-068):
- `commits.conventional_type = 'style'` (1)
- `task_commits.link_source = 'commit-message'` (97 — the same bug E3 fixed in reconcile.ts)

This migration `INSERT OR IGNORE`s every stranded bare row into its prefixed table, coercing the two out-of-enum columns (`'style'`→NULL, `'commit-message'`→`'commit-subject'`) so the restored T11363 CHECKs pass. Parents-first ordering + `WHERE EXISTS` FK guards on the release-child tables. Idempotent.

## Dry-run (on a 695 MB VACUUM-INTO clone of the live cleo.db)
- stranded **672 → 0** (commits +101, commit_files +285, task_commits +97, release_commits +175, releases +2, release_changes +8, release_artifacts +2, brain_release_links +2)
- **0 out-of-enum residue** in both coerced columns; `integrity_check` ok; re-apply is a no-op.
- (Pre-existing, unrelated: 2 orphan `tasks_task_relations` FK rows — separate cleanup.)

## Scope note — the bare-table DROP (E5) is deferred
Runtime `foreign_keys = ON` + the deferred satellites (`audit_log`, `token_usage`, lifecycle/agent/experiments/pipeline_manifest/warp_chain_*) are **still bare-bound** and hold recent live-written rows. Safely dropping bare `tasks` requires completing the full satellite rebind + live-wire backfill first — tracked as a follow-up. This PR ships only the safe, additive provenance backfill.

Epic: T11883 · Saga: T11242

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)