### PR TITLE
feat(T11626): supervisor IPC accept loop + ChildRegistry (EP-SUPERVISOR-ARBITER R2)

### DIFF
--- a/crates/cleo-supervisor/src/ipc_server.rs
+++ b/crates/cleo-supervisor/src/ipc_server.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/cleo-supervisor in the CleoCode monorepo.
+
+//! IPC accept loop + request dispatch for the supervisor (T11253 / R2).
+//!
+//! This module finishes the R1-deferred IPC loop: it binds the platform
+//! transport (a Unix-domain `UnixListener` on Unix; a named-pipe stub on
+//! Windows — see [`bind_listener`]), accepts clients, and wires each one to a
+//! shared [`ChildRegistry`].
+//!
+//! Three concurrent roles run over one [`tokio`] reactor:
+//!
+//!   * **accept loop** — [`serve`] accepts client connections; for each it
+//!     splits the stream into a read half (request parser) and a write half
+//!     (registered into the broadcast [`Fanout`] and used for direct request
+//!     responses).
+//!   * **per-client reader** — parses one [`IpcEnvelope`] request per NDJSON
+//!     line, dispatches it onto the registry, and writes the correlated
+//!     [`IpcResponse`] back to that client.
+//!   * **event pump** — drains the registry's [`LifecycleEvent`] channel and
+//!     broadcasts each event to *every* connected client via the same
+//!     [`Fanout`] codec, with NO edit to the frozen `ipc.rs` v1.0 message set.
+//!
+//! The wire codec is the exact NDJSON [`IpcEnvelope`] (de)serialization owned by
+//! [`crate::ipc`]; this module adds only transport + dispatch glue.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use crate::ipc::{
+    IpcEnvelope, IpcPayload, IpcRequest, IpcResponse, HealthResult, LifecycleEvent,
+    IPC_PROTOCOL_VERSION,
+};
+use crate::ipc_transport::Fanout;
+use crate::process;
+use crate::supervisor::{ChildRegistry, RegistryError};
+
+/// A write half shared between the per-client responder and the broadcast
+/// [`Fanout`].
+///
+/// Each accepted client's write half is wrapped in an `Arc<Mutex<W>>`; one clone
+/// is registered into the `Fanout` (for unsolicited lifecycle-event broadcasts)
+/// and another is held by the per-client reader (for correlated request
+/// responses). [`SharedWriter`] implements [`AsyncWrite`] by locking the inner
+/// writer per poll, so the existing generic `Fanout<W>` serves it unchanged.
+pub struct SharedWriter<W> {
+    inner: Arc<Mutex<W>>,
+}
+
+impl<W> Clone for SharedWriter<W> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<W> SharedWriter<W> {
+    /// Wrap a write half so it can be shared between direct responses and
+    /// broadcasts.
+    #[must_use]
+    pub fn new(writer: W) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(writer)),
+        }
+    }
+}
+
+impl<W> AsyncWrite for SharedWriter<W>
+where
+    W: AsyncWrite + Unpin + Send,
+{
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        // Acquire the lock without blocking the reactor: if it is momentarily
+        // held by the other clone, register the waker and retry.
+        let mut guard = match self.inner.try_lock() {
+            Ok(g) => g,
+            Err(_) => {
+                cx.waker().wake_by_ref();
+                return std::task::Poll::Pending;
+            }
+        };
+        std::pin::Pin::new(&mut *guard).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let mut guard = match self.inner.try_lock() {
+            Ok(g) => g,
+            Err(_) => {
+                cx.waker().wake_by_ref();
+                return std::task::Poll::Pending;
+            }
+        };
+        std::pin::Pin::new(&mut *guard).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let mut guard = match self.inner.try_lock() {
+            Ok(g) => g,
+            Err(_) => {
+                cx.waker().wake_by_ref();
+                return std::task::Poll::Pending;
+            }
+        };
+        std::pin::Pin::new(&mut *guard).poll_shutdown(cx)
+    }
+}
+
+/// Dispatch a single parsed [`IpcRequest`] onto the registry, returning the
+/// correlated [`IpcResponse`] to send back to the requesting client.
+///
+/// `Spawn`/`Restart`/`Monitor` map onto the matching [`ChildRegistry`]
+/// operations; `Health` synthesizes a [`HealthResult`] from registry state. Any
+/// [`RegistryError`] is lowered into an [`IpcResponse::Error`] carrying the
+/// stable error code — no request ever panics the dispatcher.
+pub async fn dispatch(registry: &ChildRegistry, request: IpcRequest) -> IpcResponse {
+    match request {
+        IpcRequest::Spawn(req) => match registry.spawn(&req).await {
+            Ok(result) => IpcResponse::Spawned(result),
+            Err(e) => error_response(&e),
+        },
+        IpcRequest::Restart(req) => match registry.restart(&req.child_id).await {
+            Ok(result) => IpcResponse::Restarted(result),
+            Err(e) => error_response(&e),
+        },
+        IpcRequest::Monitor(req) => match registry.monitor(req.child_id.as_deref()).await {
+            Ok(result) => IpcResponse::Monitor(result),
+            Err(e) => error_response(&e),
+        },
+        IpcRequest::Health(_) => IpcResponse::Health(HealthResult {
+            pid: process::current_pid(),
+            child_count: registry.child_count().await,
+            uptime_secs: registry.uptime_secs(),
+            protocol_version: IPC_PROTOCOL_VERSION.to_string(),
+        }),
+    }
+}
+
+/// Lower a [`RegistryError`] into the wire [`IpcResponse::Error`].
+fn error_response(err: &RegistryError) -> IpcResponse {
+    IpcResponse::Error(crate::ipc::ErrorResult {
+        code: err.code().to_string(),
+        message: err.to_string(),
+    })
+}
+
+/// Drive the per-client read loop: parse one [`IpcEnvelope`] request per NDJSON
+/// line, dispatch it, and write the correlated response back over `writer`.
+///
+/// Returns when the client closes its end (EOF) or sends an unparseable line
+/// that is not recoverable. Parse errors on a single line are answered with an
+/// `IpcResponse::Error` and the loop continues, so one malformed line does not
+/// drop an otherwise-healthy client.
+async fn client_read_loop<R, W>(read: R, writer: SharedWriter<W>, registry: ChildRegistry)
+where
+    R: tokio::io::AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    let mut lines = BufReader::new(read).lines();
+    let mut writer = writer;
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => break, // clean EOF
+            Err(e) => {
+                tracing::debug!(error = %e, "client read error; dropping connection");
+                break;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match IpcEnvelope::from_ndjson(&line) {
+            Ok(env) => match env.payload {
+                IpcPayload::Request { request } => {
+                    let response = dispatch(&registry, request).await;
+                    let reply = IpcEnvelope::response(env.id, response);
+                    if let Err(e) = write_envelope(&mut writer, &reply).await {
+                        tracing::debug!(error = %e, "failed to write response; dropping client");
+                        break;
+                    }
+                }
+                IpcPayload::Response { .. } => {
+                    // Clients do not send responses; ignore defensively.
+                    tracing::debug!("ignoring unexpected response-direction envelope from client");
+                }
+            },
+            Err(e) => {
+                let reply = IpcEnvelope::response(
+                    "unparseable",
+                    IpcResponse::Error(crate::ipc::ErrorResult {
+                        code: "E_BAD_REQUEST".to_string(),
+                        message: format!("could not parse IPC envelope: {e}"),
+                    }),
+                );
+                if write_envelope(&mut writer, &reply).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Serialize and write one envelope as an NDJSON line + flush.
+async fn write_envelope<W>(
+    writer: &mut SharedWriter<W>,
+    envelope: &IpcEnvelope,
+) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin + Send,
+{
+    let mut line = envelope
+        .to_ndjson()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await
+}
+
+/// Drain the registry's [`LifecycleEvent`] channel, broadcasting each event to
+/// every connected client via the shared [`Fanout`] codec.
+///
+/// Runs until the event sender (held by the [`ChildRegistry`]) is dropped, at
+/// which point the channel closes and the pump exits.
+async fn event_pump<W>(mut events: UnboundedReceiver<LifecycleEvent>, fanout: Fanout<W>)
+where
+    W: AsyncWriteExt + Unpin + Send,
+{
+    while let Some(event) = events.recv().await {
+        let envelope = IpcEnvelope::response(
+            format!("event-{}", event.child_id),
+            IpcResponse::Event(event),
+        );
+        match fanout.broadcast(&envelope).await {
+            Ok(delivered) => {
+                tracing::trace!(delivered, "broadcast lifecycle event");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "failed to serialize lifecycle event");
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+mod unix_serve {
+    use super::*;
+    use tokio::net::UnixListener;
+
+    /// Accept loop body for a Unix-domain listener.
+    ///
+    /// Spawns the event pump once, then accepts clients forever; per connection
+    /// it registers the write half into the broadcast [`Fanout`] and spawns the
+    /// per-client read loop. Returns only on an unrecoverable accept error.
+    pub async fn run(
+        listener: UnixListener,
+        registry: ChildRegistry,
+        events: UnboundedReceiver<LifecycleEvent>,
+    ) -> std::io::Result<()> {
+        let fanout: Fanout<SharedWriter<tokio::net::unix::OwnedWriteHalf>> = Fanout::new();
+        tokio::spawn(event_pump(events, fanout.clone()));
+
+        loop {
+            let (stream, _addr) = listener.accept().await?;
+            let (read, write) = stream.into_split();
+            let shared = SharedWriter::new(write);
+            fanout.add_client(shared.clone()).await;
+            tokio::spawn(client_read_loop(read, shared, registry.clone()));
+        }
+    }
+}
+
+/// Bind the supervisor IPC listener and run the accept loop until it errors.
+///
+/// On Unix this binds a `UnixListener` at `socket_path`, removing any stale
+/// socket file left by a prior crash first (an existing socket file would make
+/// `bind` fail with `EADDRINUSE`). On Windows the named-pipe transport is not
+/// yet implemented in this crate; [`serve`] returns an error so the caller can
+/// degrade gracefully rather than silently no-op (the named-pipe server lands
+/// with the Windows IPC epic).
+///
+/// # Errors
+///
+/// Returns an I/O error if the socket cannot be bound or the accept loop fails.
+#[cfg(unix)]
+pub async fn serve(
+    socket_path: &std::path::Path,
+    registry: ChildRegistry,
+    events: UnboundedReceiver<LifecycleEvent>,
+) -> std::io::Result<()> {
+    use tokio::net::UnixListener;
+
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Remove a stale socket file from a prior unclean shutdown; bind fails with
+    // EADDRINUSE otherwise. A live peer would already hold the pidfile, so the
+    // double-launch guard upstream prevents stomping an active supervisor.
+    match std::fs::remove_file(socket_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    let listener = UnixListener::bind(socket_path)?;
+    tracing::info!(socket = %socket_path.display(), "supervisor IPC listening");
+    unix_serve::run(listener, registry, events).await
+}
+
+/// Windows IPC is not yet implemented in this crate (named-pipe server lands
+/// with the Windows IPC epic); calling [`serve`] returns an error so the binary
+/// can degrade gracefully without a silent no-op.
+///
+/// # Errors
+///
+/// Always returns `ErrorKind::Unsupported` on Windows.
+#[cfg(not(unix))]
+pub async fn serve(
+    _socket_path: &std::path::Path,
+    _registry: ChildRegistry,
+    _events: UnboundedReceiver<LifecycleEvent>,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "named-pipe IPC transport is not yet implemented for Windows in cleo-supervisor",
+    ))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::ipc::{IpcResponse, MonitorRequest, SpawnRequest};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn true_spawn(child_id: &str) -> SpawnRequest {
+        SpawnRequest {
+            child_id: child_id.into(),
+            program: "/bin/true".into(),
+            args: vec![],
+            env: vec![],
+            cwd: None,
+        }
+    }
+
+    /// `dispatch` of a Health request reports the live supervisor pid + the
+    /// frozen protocol version, independent of any clients.
+    #[tokio::test]
+    async fn dispatch_health_reports_protocol_version() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let resp = dispatch(&registry, IpcRequest::Health(crate::ipc::HealthRequest {})).await;
+        match resp {
+            IpcResponse::Health(h) => {
+                assert_eq!(h.protocol_version, IPC_PROTOCOL_VERSION);
+                assert_eq!(h.pid, process::current_pid());
+                assert_eq!(h.child_count, 0);
+            }
+            other => panic!("expected Health, got {other:?}"),
+        }
+    }
+
+    /// `dispatch` of a Restart for an unknown child lowers the registry error
+    /// into a wire `IpcResponse::Error` with the stable code.
+    #[tokio::test]
+    async fn dispatch_restart_unknown_child_is_error() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let resp = dispatch(
+            &registry,
+            IpcRequest::Restart(crate::ipc::RestartRequest {
+                child_id: "ghost".into(),
+            }),
+        )
+        .await;
+        match resp {
+            IpcResponse::Error(e) => assert_eq!(e.code, "E_UNKNOWN_CHILD"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// `dispatch` of a Spawn registers the child and a subsequent Monitor lists
+    /// it.
+    #[tokio::test]
+    async fn dispatch_spawn_then_monitor_lists_child() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let spawned = dispatch(&registry, IpcRequest::Spawn(true_spawn("w1"))).await;
+        match spawned {
+            IpcResponse::Spawned(r) => assert_eq!(r.child_id, "w1"),
+            other => panic!("expected Spawned, got {other:?}"),
+        }
+        let mon = dispatch(
+            &registry,
+            IpcRequest::Monitor(MonitorRequest { child_id: None }),
+        )
+        .await;
+        match mon {
+            IpcResponse::Monitor(m) => {
+                assert_eq!(m.children.len(), 1);
+                assert_eq!(m.children[0].child_id, "w1");
+            }
+            other => panic!("expected Monitor, got {other:?}"),
+        }
+    }
+}

--- a/crates/cleo-supervisor/src/ipc_server.rs
+++ b/crates/cleo-supervisor/src/ipc_server.rs
@@ -346,10 +346,21 @@ mod tests {
     use crate::ipc::{IpcResponse, MonitorRequest, SpawnRequest};
     use tokio::sync::mpsc::unbounded_channel;
 
+    /// Path to the always-available `true` binary. macOS ships it at
+    /// `/usr/bin/true` (no `/bin/true`), Linux at `/bin/true`; probe the
+    /// canonical macOS path first and fall back to the Linux path.
+    fn true_cmd() -> &'static str {
+        if std::path::Path::new("/usr/bin/true").exists() {
+            "/usr/bin/true"
+        } else {
+            "/bin/true"
+        }
+    }
+
     fn true_spawn(child_id: &str) -> SpawnRequest {
         SpawnRequest {
             child_id: child_id.into(),
-            program: "/bin/true".into(),
+            program: true_cmd().into(),
             args: vec![],
             env: vec![],
             cwd: None,

--- a/crates/cleo-supervisor/src/lib.rs
+++ b/crates/cleo-supervisor/src/lib.rs
@@ -17,6 +17,7 @@
 //!   * [`logging`]    — `tracing-appender` rolling file logs under the cleo log dir.
 //!   * [`ipc`]        — FROZEN v1.0 supervisor-ipc contract (mirror of the Zod schemas).
 //!   * [`ipc_transport`] — Unix-socket / Windows-pipe NDJSON fan-out.
+//!   * [`ipc_server`] — bind + accept loop + request dispatch into the registry (R2).
 //!
 //! The binary ([`main`](../main.rs)) is distributed as a standalone executable via
 //! the worktree-napi-style cross-compile + GitHub-Release packaging (T11340),
@@ -29,6 +30,7 @@
 
 pub mod backoff;
 pub mod ipc;
+pub mod ipc_server;
 pub mod ipc_transport;
 pub mod jobobject;
 pub mod logging;

--- a/crates/cleo-supervisor/src/main.rs
+++ b/crates/cleo-supervisor/src/main.rs
@@ -9,7 +9,15 @@
 //! when run with no flags, boots the supervisor runtime: acquire the pidfile
 //! under the CLEO home, initialize rolling-file logging, bind the IPC listener +
 //! accept loop feeding the multi-child registry (R2, T11253), and install the
-//! SIGTERM/SIGINT graceful-shutdown + SIGCHLD reaping signal loop (T11338 AC3).
+//! SIGTERM/SIGINT graceful-shutdown signal loop (T11338 AC3).
+//!
+//! NOTE (T11626): every supervised child is a [`tokio::process::Child`] whose
+//! exit is observed via `Child::wait()` (registry monitor tasks + the stop
+//! cascade). tokio's process driver installs its own `SIGCHLD` handler and owns
+//! reaping for those pids. Running an additional global `waitpid(-1, WNOHANG)`
+//! reaper here would race tokio's driver and steal exit statuses, surfacing as
+//! spurious `ECHILD` from `Child::wait()` (lost exit codes, false stop
+//! failures). The signal loop therefore does NOT reap; tokio owns it.
 
 // Tests in this binary may freely unwrap/expect/panic (matches the lib crate).
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
@@ -141,31 +149,25 @@ async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<(
     Ok(())
 }
 
-/// Wait for a shutdown signal (SIGTERM/SIGINT on Unix, Ctrl-C on Windows),
-/// reaping any zombie children on SIGCHLD in the meantime (Unix).
+/// Wait for a shutdown signal (SIGTERM/SIGINT on Unix, Ctrl-C on Windows).
+///
+/// This loop deliberately does NOT install a `SIGCHLD` reaper (T11626). Every
+/// supervised child is a [`tokio::process::Child`] reaped by tokio's own
+/// process driver; a competing global `waitpid(-1, WNOHANG)` would steal those
+/// exit statuses and make `Child::wait()` fail with `ECHILD`. Letting tokio own
+/// reaping keeps exit codes intact and the stop cascade correct.
 async fn signal_loop() -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use tokio::signal::unix::{SignalKind, signal};
         let mut sigterm = signal(SignalKind::terminate())?;
         let mut sigint = signal(SignalKind::interrupt())?;
-        let mut sigchld = signal(SignalKind::child())?;
-        loop {
-            tokio::select! {
-                _ = sigterm.recv() => {
-                    tracing::info!("received SIGTERM");
-                    break;
-                }
-                _ = sigint.recv() => {
-                    tracing::info!("received SIGINT");
-                    break;
-                }
-                _ = sigchld.recv() => {
-                    let reaped = cleo_supervisor::process::reap_zombies();
-                    if reaped > 0 {
-                        tracing::debug!(reaped, "reaped zombie children on SIGCHLD");
-                    }
-                }
+        tokio::select! {
+            _ = sigterm.recv() => {
+                tracing::info!("received SIGTERM");
+            }
+            _ = sigint.recv() => {
+                tracing::info!("received SIGINT");
             }
         }
     }

--- a/crates/cleo-supervisor/src/main.rs
+++ b/crates/cleo-supervisor/src/main.rs
@@ -7,7 +7,8 @@
 //!
 //! Parses the minimal R1 CLI surface (`--version` / `--help`, T11337 AC5) and,
 //! when run with no flags, boots the supervisor runtime: acquire the pidfile
-//! under the CLEO home, initialize rolling-file logging, and install the
+//! under the CLEO home, initialize rolling-file logging, bind the IPC listener +
+//! accept loop feeding the multi-child registry (R2, T11253), and install the
 //! SIGTERM/SIGINT graceful-shutdown + SIGCHLD reaping signal loop (T11338 AC3).
 
 // Tests in this binary may freely unwrap/expect/panic (matches the lib crate).
@@ -70,12 +71,13 @@ fn parse_cli(args: &[String]) -> CliAction {
     }
 }
 
-/// Boot the supervisor runtime: pidfile, logging, signal loop.
+/// Boot the supervisor runtime: pidfile, logging, IPC accept loop, signal loop.
 ///
-/// R1 stands up the lifecycle primitives. The IPC command surface (spawning
-/// children on request) is consumed by R2 (T11253); here the process simply
-/// holds the pidfile and waits for a shutdown signal, demonstrating the
-/// pidfile + logging + graceful-shutdown integration end-to-end.
+/// R1 stood up the lifecycle primitives; R2 (T11253) finishes the IPC loop. After
+/// the pidfile + logging are in place this binds the IPC listener and runs its
+/// accept loop concurrently with the shutdown-signal loop: clients drive the
+/// multi-child registry over the supervisor-ipc fan-out channel until a
+/// SIGTERM/SIGINT (or Ctrl-C) requests a graceful stop.
 fn run() -> anyhow::Result<()> {
     // Acquire the pidfile before doing anything else — refuse double-launch.
     let pidfile_path = cleo_supervisor::paths::pidfile_path()?;
@@ -95,16 +97,47 @@ fn run() -> anyhow::Result<()> {
         "cleo-supervisor started"
     );
 
-    // Run the signal loop on a current-thread tokio runtime. The supervisor is
-    // I/O-bound and a single reactor is sufficient for R1.
+    // Run the IPC accept loop + signal loop on a current-thread tokio runtime.
+    // The supervisor is I/O-bound and a single reactor is sufficient.
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    runtime.block_on(signal_loop())?;
+    let socket_path = cleo_supervisor::paths::socket_path()?;
+    runtime.block_on(serve_until_shutdown(&socket_path))?;
 
     tracing::info!("cleo-supervisor shutting down");
+    // Best-effort: remove the IPC socket file so the next launch binds cleanly.
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(&socket_path);
+    }
     // Dropping `pidfile` removes the pidfile; dropping `_log_guard` flushes logs.
     drop(pidfile);
+    Ok(())
+}
+
+/// Bind the IPC listener + accept loop and run it concurrently with the
+/// shutdown-signal loop, returning when a shutdown signal is received (or the
+/// accept loop fails irrecoverably).
+async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<()> {
+    use cleo_supervisor::ipc_server;
+    use cleo_supervisor::supervisor::ChildRegistry;
+
+    // Lifecycle events flow registry -> IPC fan-out over this channel.
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let registry = ChildRegistry::new(event_tx);
+
+    tokio::select! {
+        // The accept loop only returns on an unrecoverable transport error;
+        // surface it so the process exits non-zero.
+        res = ipc_server::serve(socket_path, registry, event_rx) => {
+            res.map_err(|e| anyhow::anyhow!("supervisor IPC serve loop failed: {e}"))?;
+        }
+        // Graceful shutdown wins the race on SIGTERM/SIGINT/Ctrl-C.
+        res = signal_loop() => {
+            res?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/cleo-supervisor/src/paths.rs
+++ b/crates/cleo-supervisor/src/paths.rs
@@ -41,6 +41,13 @@ pub const LOG_SUBDIR: &str = "logs";
 /// Filename of the supervisor pidfile written under the CLEO home.
 pub const PIDFILE_NAME: &str = "cleo-supervisor.pid";
 
+/// Filename of the supervisor IPC Unix-domain socket written under the CLEO home.
+///
+/// On Unix the supervisor binds a `UnixListener` here (see
+/// [`crate::ipc_server`]); on Windows a named pipe derived from
+/// [`crate::ipc::IPC_CHANNEL_BASENAME`] is used instead and this path is unused.
+pub const SOCKET_NAME: &str = "cleo-supervisor.sock";
+
 /// Resolve the user's home directory in an OS-appropriate way.
 ///
 /// Returns `None` only when neither `$HOME` (Unix) nor the Windows user-profile
@@ -205,6 +212,19 @@ pub fn pidfile_path() -> anyhow::Result<PathBuf> {
     Ok(cleo_home()?.join(PIDFILE_NAME))
 }
 
+/// Returns the absolute supervisor IPC socket path: `<cleo_home>/cleo-supervisor.sock`.
+///
+/// This is the Unix-domain socket the supervisor binds for the IPC fan-out
+/// channel (T11253). On Windows the transport is a named pipe and this path is
+/// not used.
+///
+/// # Errors
+///
+/// Propagates the error from [`cleo_home`].
+pub fn socket_path() -> anyhow::Result<PathBuf> {
+    Ok(cleo_home()?.join(SOCKET_NAME))
+}
+
 /// Returns the napi binary cache directory: `<cache>/napi-bin`.
 ///
 /// Mirrors the picker target documented in T11340 AC4
@@ -243,6 +263,7 @@ mod tests {
         let home = cleo_home_with_override(Some(&raw)).expect("home");
         assert_eq!(home.join(LOG_SUBDIR), tmp.join(LOG_SUBDIR));
         assert_eq!(home.join(PIDFILE_NAME), tmp.join(PIDFILE_NAME));
+        assert_eq!(home.join(SOCKET_NAME), tmp.join(SOCKET_NAME));
     }
 
     #[test]

--- a/crates/cleo-supervisor/src/supervisor.rs
+++ b/crates/cleo-supervisor/src/supervisor.rs
@@ -15,9 +15,15 @@
 //! The child is spawned with [`tokio::process::Command`]. On Unix the child is
 //! placed in its own process group and signalled via [`crate::process`]; on
 //! Windows it is assigned to the supervisor's [`crate::jobobject::JobObject`] so
-//! it dies when the supervisor exits. SIGCHLD-driven zombie reaping is wired in
-//! the binary's signal loop ([`crate::run`]); this module exposes
-//! [`Supervisor::reap`] for it to call.
+//! it dies when the supervisor exits.
+//!
+//! Reaping is owned exclusively by tokio's process driver. Every supervised
+//! child is a [`tokio::process::Child`] whose exit is observed via
+//! `Child::wait()` (the monitor tasks + the stop cascade); tokio registers its
+//! own `SIGCHLD` handler and reaps those pids. The supervisor therefore does
+//! NOT run a global `waitpid(-1)` reaper alongside `Child::wait()` — doing so
+//! would race tokio's driver and steal exit statuses, surfacing as spurious
+//! `ECHILD` (lost exit codes, false stop failures). See T11626.
 
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -230,7 +236,18 @@ impl Supervisor {
         Ok(status.code())
     }
 
-    /// Reap any zombie children (Unix). No-op on Windows. Returns the count.
+    /// Reap any zombie children via a global `waitpid(-1, WNOHANG)` (Unix).
+    /// No-op on Windows. Returns the count.
+    ///
+    /// # Caution (T11626)
+    ///
+    /// This is a global reaper: it harvests ANY exited child of this process,
+    /// not just this supervisor's. It MUST NOT be invoked while a
+    /// [`tokio::process::Child::wait`] is outstanding for the same children —
+    /// tokio's process driver owns reaping for the children it spawned, and a
+    /// competing `waitpid(-1)` will steal their exit status and surface as
+    /// `ECHILD` from `Child::wait()`. It is retained only for reaping
+    /// inadvertently-inherited grandchildren that are not tokio-managed.
     pub fn reap(&self) -> usize {
         process::reap_zombies()
     }
@@ -339,8 +356,13 @@ impl Supervisor {
                 // Phase 3: grace expired — force kill.
                 tracing::warn!(pid, "grace window expired; sending SIGKILL");
                 let _ = process::force_kill(pid);
-                // Best-effort final reap.
-                let _ = self.reap();
+                // Let tokio's process driver reap the killed child: await its
+                // exit instead of a global waitpid(-1), which would race the
+                // driver and steal exit statuses (T11626). The child is dead, so
+                // this resolves promptly. If the wait future above already took
+                // the child out of the slot it was dropped (kill_on_drop) and
+                // this returns Ok(None) immediately.
+                let _ = self.wait().await;
             }
         }
         Ok(())
@@ -401,6 +423,12 @@ struct ChildBook {
     state: ChildState,
     /// Total restarts observed for this child.
     restart_count: u32,
+    /// Monotonic incarnation token (T11626). Incremented on every (re)spawn so
+    /// each monitor task can identify the exact incarnation it supervises. A
+    /// monitor only writes its exit into the book when `generation` still equals
+    /// the value captured at its spawn — otherwise a newer incarnation already
+    /// replaced it, and the stale monitor must not clobber the live child.
+    generation: u64,
 }
 
 /// One supervised child in a [`ChildRegistry`].
@@ -478,10 +506,13 @@ impl ChildRegistry {
             child_id: child_id.clone(),
             source: anyhow::Error::new(e),
         })?);
+        // Generation 0 is the initial incarnation; each restart bumps it.
+        let generation = 0u64;
         let book = Arc::new(Mutex::new(ChildBook {
             pid: 0,
             state: ChildState::Running,
             restart_count: 0,
+            generation,
         }));
 
         let child = Self::spawn_process(&spec, &job).map_err(|source| RegistryError::Spawn {
@@ -498,7 +529,7 @@ impl ChildRegistry {
         };
         self.children.lock().await.insert(child_id.clone(), managed);
 
-        self.spawn_monitor(child_id.clone(), child, Arc::clone(&book));
+        self.spawn_monitor(child_id.clone(), child, Arc::clone(&book), generation);
         tracing::info!(child_id = %child_id, pid, "registry spawned child");
         Ok(SpawnResult { child_id, pid })
     }
@@ -546,15 +577,19 @@ impl ChildRegistry {
         })?;
         let pid = child.id().unwrap_or(0);
 
-        let restart_count = {
+        let (restart_count, generation) = {
             let mut guard = book.lock().await;
             guard.restart_count = guard.restart_count.saturating_add(1);
             guard.pid = pid;
             guard.state = ChildState::Running;
-            guard.restart_count
+            // Bump the incarnation so the new monitor owns a fresh generation and
+            // the old monitor (still blocked on the killed child's wait()) can no
+            // longer write into the book (T11626).
+            guard.generation = guard.generation.saturating_add(1);
+            (guard.restart_count, guard.generation)
         };
 
-        self.spawn_monitor(child_id.to_string(), child, Arc::clone(&book));
+        self.spawn_monitor(child_id.to_string(), child, Arc::clone(&book), generation);
 
         let _ = self.events.send(LifecycleEvent {
             event: LifecycleEventKind::ChildRestarted,
@@ -652,29 +687,62 @@ impl ChildRegistry {
     /// The task ends after a single exit; a restart spawns a fresh monitor for
     /// the replacement incarnation, so each task supervises exactly one OS
     /// process lifetime.
-    fn spawn_monitor(&self, child_id: String, mut child: Child, book: Arc<Mutex<ChildBook>>) {
+    ///
+    /// `generation` is the incarnation token captured when this monitor was
+    /// spawned (T11626). The monitor only writes the `Stopped`/`pid = 0`
+    /// transition when the book still carries that same generation. A concurrent
+    /// `restart` bumps the generation before this (now-stale) monitor's
+    /// `child.wait()` returns, so the late exit of the killed incarnation cannot
+    /// clobber the freshly-restarted child to `Stopped`/`pid = 0`. Comparing the
+    /// generation (not the coarse `state` enum) is what makes the guard
+    /// incarnation-aware: the new incarnation's state is also `Running`, so a
+    /// state-only check would mis-fire.
+    fn spawn_monitor(
+        &self,
+        child_id: String,
+        mut child: Child,
+        book: Arc<Mutex<ChildBook>>,
+        generation: u64,
+    ) {
         let events = self.events.clone();
         tokio::spawn(async move {
             let status = child.wait().await;
             let code = status.ok().and_then(|s| s.code());
-            // If a restart already moved the book to Restarting/Running for a new
-            // incarnation, do not clobber it; only mark Stopped when this task is
-            // still the owner of the recorded pid.
-            {
+            // Only record the exit when this monitor still owns the live
+            // incarnation. If a restart already bumped the generation, a newer
+            // monitor owns the book and this stale exit must not touch it.
+            let is_current = {
                 let mut guard = book.lock().await;
-                if matches!(guard.state, ChildState::Running) {
-                    guard.state = ChildState::Stopped;
-                    guard.pid = 0;
+                if guard.generation == generation {
+                    if matches!(guard.state, ChildState::Running) {
+                        guard.state = ChildState::Stopped;
+                        guard.pid = 0;
+                    }
+                    true
+                } else {
+                    false
                 }
+            };
+            if is_current {
+                let _ = events.send(LifecycleEvent {
+                    event: LifecycleEventKind::ChildExited,
+                    child_id: child_id.clone(),
+                    exit_code: code,
+                    signal: None,
+                    restart_delay_ms: None,
+                });
+                tracing::info!(child_id = %child_id, code = ?code, "registry child exited");
+            } else {
+                // Stale incarnation exit (superseded by a restart) — record it
+                // for diagnostics but do not emit a child_exited event or mutate
+                // the book; the live incarnation continues running.
+                tracing::debug!(
+                    child_id = %child_id,
+                    code = ?code,
+                    generation,
+                    "ignoring exit of superseded child incarnation"
+                );
             }
-            let _ = events.send(LifecycleEvent {
-                event: LifecycleEventKind::ChildExited,
-                child_id: child_id.clone(),
-                exit_code: code,
-                signal: None,
-                restart_delay_ms: None,
-            });
-            tracing::info!(child_id = %child_id, code = ?code, "registry child exited");
         });
     }
 }
@@ -931,6 +999,46 @@ mod tests {
             .await
             .expect_err("unknown child restart must error");
         assert_eq!(err.code(), "E_UNKNOWN_CHILD");
+    }
+
+    /// Regression (T11626): after a restart, the OLD monitor task (still blocked
+    /// on the SIGKILL-ed first incarnation's `wait()`) must not clobber the live
+    /// NEW incarnation to `Stopped`/pid=0. The incarnation generation guard makes
+    /// the stale exit a no-op. Repeated restarts maximise the chance the stale
+    /// monitor wins the book lock after the generation bump; the live child must
+    /// always be reported `Running` with the current pid.
+    #[tokio::test]
+    async fn registry_restart_does_not_let_stale_monitor_clobber_new_child() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        registry
+            .spawn(&spawn_req_sleep("race", 30))
+            .await
+            .expect("spawn");
+
+        let mut last_pid = 0u32;
+        for _ in 0..5 {
+            let restarted = registry.restart("race").await.expect("restart");
+            last_pid = restarted.pid;
+
+            // Give the stale old monitor ample opportunity to observe its killed
+            // child's exit and (incorrectly) try to write into the book.
+            for _ in 0..10 {
+                let snap = registry.monitor(Some("race")).await.expect("monitor");
+                let row = &snap.children[0];
+                assert_eq!(
+                    row.state,
+                    ChildState::Running,
+                    "live restarted child must stay Running, not be clobbered by the stale monitor"
+                );
+                assert_eq!(
+                    row.pid, restarted.pid,
+                    "live restarted child pid must not be zeroed by the stale monitor"
+                );
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        }
+        let _ = process::force_kill(last_pid);
     }
 
     #[tokio::test]

--- a/crates/cleo-supervisor/src/supervisor.rs
+++ b/crates/cleo-supervisor/src/supervisor.rs
@@ -766,6 +766,17 @@ mod tests {
         if cfg!(windows) { "cmd" } else { "/bin/sh" }
     }
 
+    /// Path to the always-available `true` binary on the host. macOS ships it at
+    /// `/usr/bin/true` (no `/bin/true`), Linux at `/bin/true`; probe the
+    /// canonical macOS path first and fall back to the Linux path.
+    fn true_cmd() -> &'static str {
+        if std::path::Path::new("/usr/bin/true").exists() {
+            "/usr/bin/true"
+        } else {
+            "/bin/true"
+        }
+    }
+
     fn sleep_spec(id: &str, secs: u64) -> ChildSpec {
         // A portable short-lived child: `sh -c 'sleep N'` on unix.
         if cfg!(windows) {
@@ -884,7 +895,7 @@ mod tests {
         } else {
             SpawnRequest {
                 child_id: child_id.into(),
-                program: "/bin/true".into(),
+                program: true_cmd().into(),
                 args: vec![],
                 env: vec![],
                 cwd: None,
@@ -956,7 +967,7 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let registry = ChildRegistry::new(tx);
         registry.spawn(&spawn_req_true("quick")).await.expect("spawn");
-        // /bin/true exits immediately — expect a child_exited event.
+        // `true` exits immediately — expect a child_exited event.
         let event = next_event(&mut rx).await;
         assert_eq!(event.event, LifecycleEventKind::ChildExited);
         assert_eq!(event.child_id, "quick");

--- a/crates/cleo-supervisor/src/supervisor.rs
+++ b/crates/cleo-supervisor/src/supervisor.rs
@@ -19,14 +19,20 @@
 //! the binary's signal loop ([`crate::run`]); this module exposes
 //! [`Supervisor::reap`] for it to call.
 
+use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::backoff::Backoff;
+use crate::ipc::{
+    ChildState, ChildStatus, LifecycleEvent, LifecycleEventKind, MonitorResult, RestartResult,
+    SpawnRequest, SpawnResult,
+};
 use crate::jobobject::JobObject;
 use crate::process;
 
@@ -67,6 +73,26 @@ impl ChildSpec {
             args: Vec::new(),
             env: Vec::new(),
             cwd: None,
+        }
+    }
+}
+
+impl From<&SpawnRequest> for ChildSpec {
+    /// Lower a wire [`SpawnRequest`] into the supervisor's internal [`ChildSpec`].
+    ///
+    /// The IPC env is a `Vec<EnvPair>` (TS-shaped) which is flattened into the
+    /// `Vec<(String, String)>` the [`Command`] builder consumes.
+    fn from(req: &SpawnRequest) -> Self {
+        Self {
+            child_id: req.child_id.clone(),
+            program: req.program.clone(),
+            args: req.args.clone(),
+            env: req
+                .env
+                .iter()
+                .map(|p| (p.key.clone(), p.value.clone()))
+                .collect(),
+            cwd: req.cwd.clone(),
         }
     }
 }
@@ -321,6 +347,349 @@ impl Supervisor {
     }
 }
 
+/// Error raised by [`ChildRegistry`] operations that target a child id.
+///
+/// These map onto the [`crate::ipc::ErrorResult`] codes the IPC server returns
+/// to the client; the `code()` accessor yields the stable machine-readable code.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// The requested `child_id` is not present in the registry.
+    #[error("no such child: {child_id}")]
+    UnknownChild {
+        /// The id that was not found.
+        child_id: String,
+    },
+    /// A `Spawn` referenced a `child_id` that is already registered.
+    #[error("child already registered: {child_id}")]
+    DuplicateChild {
+        /// The id that already exists.
+        child_id: String,
+    },
+    /// Spawning (or respawning) the OS process failed.
+    #[error("spawn failed for {child_id}: {source}")]
+    Spawn {
+        /// The affected child id.
+        child_id: String,
+        /// The underlying spawn error.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl RegistryError {
+    /// The stable machine-readable error code for this error.
+    ///
+    /// Mirrors the `E_*` codes the TS contract peer expects in an
+    /// [`crate::ipc::ErrorResult`].
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnknownChild { .. } => "E_UNKNOWN_CHILD",
+            Self::DuplicateChild { .. } => "E_DUPLICATE_CHILD",
+            Self::Spawn { .. } => "E_SPAWN_FAILED",
+        }
+    }
+}
+
+/// Shared, mutable bookkeeping for a single managed child, updated by the
+/// per-child monitor task and read by `monitor`/`health` snapshots.
+#[derive(Debug)]
+struct ChildBook {
+    /// OS pid of the currently-running incarnation (0 when not running).
+    pid: u32,
+    /// Current liveness state.
+    state: ChildState,
+    /// Total restarts observed for this child.
+    restart_count: u32,
+}
+
+/// One supervised child in a [`ChildRegistry`].
+///
+/// Owns the immutable spec, the platform containment handle, and the shared
+/// [`ChildBook`] the monitor task mutates. The live [`Child`] handle itself is
+/// moved into the detached monitor task on each spawn so a concurrent `restart`
+/// can replace it without contending for the OS wait.
+struct ManagedChild {
+    spec: ChildSpec,
+    job: Arc<JobObject>,
+    book: Arc<Mutex<ChildBook>>,
+}
+
+/// A registry of supervised children keyed by logical `child_id`.
+///
+/// Generalizes the single-[`ChildSpec`] [`Supervisor`] into the multi-child
+/// surface the IPC command channel drives (T11253): `Spawn`/`Restart`/`Monitor`/
+/// `Health` map onto registry operations. Every unexpected child exit and every
+/// restart is broadcast as a [`LifecycleEvent`] over the supplied event sender,
+/// which the IPC server forwards to all connected clients via the
+/// [`crate::ipc_transport::Fanout`] codec.
+///
+/// Cloning a registry yields another handle to the same underlying state, so the
+/// accept loop and per-client tasks can share one registry cheaply.
+#[derive(Clone)]
+pub struct ChildRegistry {
+    children: Arc<Mutex<HashMap<String, ManagedChild>>>,
+    events: UnboundedSender<LifecycleEvent>,
+    started_at: std::time::Instant,
+}
+
+impl ChildRegistry {
+    /// Create an empty registry that publishes lifecycle events on `events`.
+    #[must_use]
+    pub fn new(events: UnboundedSender<LifecycleEvent>) -> Self {
+        Self {
+            children: Arc::new(Mutex::new(HashMap::new())),
+            events,
+            started_at: std::time::Instant::now(),
+        }
+    }
+
+    /// Number of children currently tracked (running or restarting).
+    pub async fn len(&self) -> usize {
+        self.children.lock().await.len()
+    }
+
+    /// Whether the registry currently tracks no children.
+    pub async fn is_empty(&self) -> bool {
+        self.children.lock().await.is_empty()
+    }
+
+    /// Spawn a new child from a wire [`SpawnRequest`] and begin supervising it.
+    ///
+    /// Registers the child, launches the OS process, attaches a detached monitor
+    /// task that emits a [`LifecycleEventKind::ChildExited`] event when the
+    /// process exits, and returns the assigned pid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError::DuplicateChild`] if `child_id` is already
+    /// registered, or [`RegistryError::Spawn`] if the OS process cannot start.
+    pub async fn spawn(&self, req: &SpawnRequest) -> Result<SpawnResult, RegistryError> {
+        let child_id = req.child_id.clone();
+        {
+            let children = self.children.lock().await;
+            if children.contains_key(&child_id) {
+                return Err(RegistryError::DuplicateChild { child_id });
+            }
+        }
+
+        let spec = ChildSpec::from(req);
+        let job = Arc::new(JobObject::new().map_err(|e| RegistryError::Spawn {
+            child_id: child_id.clone(),
+            source: anyhow::Error::new(e),
+        })?);
+        let book = Arc::new(Mutex::new(ChildBook {
+            pid: 0,
+            state: ChildState::Running,
+            restart_count: 0,
+        }));
+
+        let child = Self::spawn_process(&spec, &job).map_err(|source| RegistryError::Spawn {
+            child_id: child_id.clone(),
+            source,
+        })?;
+        let pid = child.id().unwrap_or(0);
+        book.lock().await.pid = pid;
+
+        let managed = ManagedChild {
+            spec: spec.clone(),
+            job: Arc::clone(&job),
+            book: Arc::clone(&book),
+        };
+        self.children.lock().await.insert(child_id.clone(), managed);
+
+        self.spawn_monitor(child_id.clone(), child, Arc::clone(&book));
+        tracing::info!(child_id = %child_id, pid, "registry spawned child");
+        Ok(SpawnResult { child_id, pid })
+    }
+
+    /// Restart a registered child: stop the current incarnation, spawn a fresh
+    /// one, bump the restart counter, and broadcast a
+    /// [`LifecycleEventKind::ChildRestarted`] event.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError::UnknownChild`] if `child_id` is not registered,
+    /// or [`RegistryError::Spawn`] if the replacement process cannot start.
+    pub async fn restart(&self, child_id: &str) -> Result<RestartResult, RegistryError> {
+        let (spec, job, book) = {
+            let children = self.children.lock().await;
+            let managed = children
+                .get(child_id)
+                .ok_or_else(|| RegistryError::UnknownChild {
+                    child_id: child_id.to_string(),
+                })?;
+            (
+                managed.spec.clone(),
+                Arc::clone(&managed.job),
+                Arc::clone(&managed.book),
+            )
+        };
+
+        // Terminate the running incarnation (best-effort) so the replacement has
+        // a clean slate. The old monitor task observes the exit and would emit a
+        // child_exited event; mark the book Restarting first so that exit is not
+        // misread as an unexpected crash by snapshots taken mid-restart.
+        let old_pid = {
+            let mut guard = book.lock().await;
+            guard.state = ChildState::Restarting;
+            guard.pid
+        };
+        if old_pid != 0 {
+            let _ = process::request_terminate(old_pid);
+            let _ = process::force_kill(old_pid);
+        }
+
+        let child = Self::spawn_process(&spec, &job).map_err(|source| RegistryError::Spawn {
+            child_id: child_id.to_string(),
+            source,
+        })?;
+        let pid = child.id().unwrap_or(0);
+
+        let restart_count = {
+            let mut guard = book.lock().await;
+            guard.restart_count = guard.restart_count.saturating_add(1);
+            guard.pid = pid;
+            guard.state = ChildState::Running;
+            guard.restart_count
+        };
+
+        self.spawn_monitor(child_id.to_string(), child, Arc::clone(&book));
+
+        let _ = self.events.send(LifecycleEvent {
+            event: LifecycleEventKind::ChildRestarted,
+            child_id: child_id.to_string(),
+            exit_code: None,
+            signal: None,
+            restart_delay_ms: None,
+        });
+        tracing::info!(child_id = %child_id, pid, restart_count, "registry restarted child");
+        Ok(RestartResult {
+            child_id: child_id.to_string(),
+            pid,
+            restart_count,
+        })
+    }
+
+    /// Produce a monitor snapshot for one child (when `child_id` is `Some`) or
+    /// for all children (when `None`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError::UnknownChild`] when a specific `child_id` is
+    /// requested but not registered.
+    pub async fn monitor(
+        &self,
+        child_id: Option<&str>,
+    ) -> Result<MonitorResult, RegistryError> {
+        let children = self.children.lock().await;
+        match child_id {
+            Some(id) => {
+                let managed = children
+                    .get(id)
+                    .ok_or_else(|| RegistryError::UnknownChild {
+                        child_id: id.to_string(),
+                    })?;
+                Ok(MonitorResult {
+                    children: vec![status_of(id, managed).await],
+                })
+            }
+            None => {
+                let mut rows = Vec::with_capacity(children.len());
+                for (id, managed) in children.iter() {
+                    rows.push(status_of(id, managed).await);
+                }
+                Ok(MonitorResult { children: rows })
+            }
+        }
+    }
+
+    /// Number of children currently tracked, for the health snapshot.
+    pub async fn child_count(&self) -> u32 {
+        u32::try_from(self.children.lock().await.len()).unwrap_or(u32::MAX)
+    }
+
+    /// Seconds since this registry was constructed (supervisor uptime).
+    #[must_use]
+    pub fn uptime_secs(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+
+    /// Build the platform-configured [`Command`] and spawn it, assigning the
+    /// child to the containment [`JobObject`] (Windows) where applicable.
+    fn spawn_process(spec: &ChildSpec, job: &JobObject) -> anyhow::Result<Child> {
+        let mut cmd = Command::new(&spec.program);
+        cmd.args(&spec.args);
+        for (k, v) in &spec.env {
+            cmd.env(k, v);
+        }
+        if let Some(cwd) = &spec.cwd {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+        cmd.kill_on_drop(true);
+        #[cfg(unix)]
+        {
+            cmd.process_group(0);
+        }
+        let child = cmd
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to spawn {}: {e}", spec.program))?;
+        if let Some(pid) = child.id()
+            && pid != 0
+        {
+            job.assign(pid)?;
+        }
+        Ok(child)
+    }
+
+    /// Attach a detached task that waits for `child` to exit, records the exit on
+    /// the shared [`ChildBook`], and broadcasts a `child_exited`
+    /// [`LifecycleEvent`].
+    ///
+    /// The task ends after a single exit; a restart spawns a fresh monitor for
+    /// the replacement incarnation, so each task supervises exactly one OS
+    /// process lifetime.
+    fn spawn_monitor(&self, child_id: String, mut child: Child, book: Arc<Mutex<ChildBook>>) {
+        let events = self.events.clone();
+        tokio::spawn(async move {
+            let status = child.wait().await;
+            let code = status.ok().and_then(|s| s.code());
+            // If a restart already moved the book to Restarting/Running for a new
+            // incarnation, do not clobber it; only mark Stopped when this task is
+            // still the owner of the recorded pid.
+            {
+                let mut guard = book.lock().await;
+                if matches!(guard.state, ChildState::Running) {
+                    guard.state = ChildState::Stopped;
+                    guard.pid = 0;
+                }
+            }
+            let _ = events.send(LifecycleEvent {
+                event: LifecycleEventKind::ChildExited,
+                child_id: child_id.clone(),
+                exit_code: code,
+                signal: None,
+                restart_delay_ms: None,
+            });
+            tracing::info!(child_id = %child_id, code = ?code, "registry child exited");
+        });
+    }
+}
+
+/// Snapshot a single managed child into its wire [`ChildStatus`].
+async fn status_of(child_id: &str, managed: &ManagedChild) -> ChildStatus {
+    let guard = managed.book.lock().await;
+    ChildStatus {
+        child_id: child_id.to_string(),
+        pid: guard.pid,
+        state: guard.state,
+        restart_count: guard.restart_count,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,5 +777,194 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
         assert!(!process::is_alive(pid), "child should be dead after stop()");
+    }
+
+    // ── ChildRegistry (R2) ──────────────────────────────────────────────────
+
+    use crate::ipc::{EnvPair, LifecycleEventKind};
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    fn spawn_req_sleep(child_id: &str, secs: u64) -> SpawnRequest {
+        if cfg!(windows) {
+            SpawnRequest {
+                child_id: child_id.into(),
+                program: "cmd".into(),
+                args: vec!["/C".into(), format!("ping 127.0.0.1 -n {} >NUL", secs + 1)],
+                env: vec![],
+                cwd: None,
+            }
+        } else {
+            SpawnRequest {
+                child_id: child_id.into(),
+                program: "/bin/sh".into(),
+                args: vec!["-c".into(), format!("sleep {secs}")],
+                env: vec![],
+                cwd: None,
+            }
+        }
+    }
+
+    fn spawn_req_true(child_id: &str) -> SpawnRequest {
+        if cfg!(windows) {
+            SpawnRequest {
+                child_id: child_id.into(),
+                program: "cmd".into(),
+                args: vec!["/C".into(), "exit 0".into()],
+                env: vec![],
+                cwd: None,
+            }
+        } else {
+            SpawnRequest {
+                child_id: child_id.into(),
+                program: "/bin/true".into(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            }
+        }
+    }
+
+    /// Drain a single lifecycle event from the channel with a timeout so a
+    /// missing broadcast fails fast instead of hanging the test.
+    async fn next_event(rx: &mut UnboundedReceiver<LifecycleEvent>) -> LifecycleEvent {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out waiting for a lifecycle event")
+            .expect("event channel closed unexpectedly")
+    }
+
+    #[test]
+    fn spawn_request_lowers_into_child_spec() {
+        let req = SpawnRequest {
+            child_id: "w".into(),
+            program: "/bin/echo".into(),
+            args: vec!["hi".into()],
+            env: vec![EnvPair {
+                key: "K".into(),
+                value: "V".into(),
+            }],
+            cwd: Some("/tmp".into()),
+        };
+        let spec = ChildSpec::from(&req);
+        assert_eq!(spec.child_id, "w");
+        assert_eq!(spec.program, "/bin/echo");
+        assert_eq!(spec.args, vec!["hi".to_string()]);
+        assert_eq!(spec.env, vec![("K".to_string(), "V".to_string())]);
+        assert_eq!(spec.cwd, Some("/tmp".to_string()));
+    }
+
+    #[tokio::test]
+    async fn registry_spawn_registers_and_reports_pid() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let result = registry
+            .spawn(&spawn_req_sleep("w1", 30))
+            .await
+            .expect("spawn");
+        assert_eq!(result.child_id, "w1");
+        assert!(result.pid > 0);
+        assert_eq!(registry.len().await, 1);
+        assert!(!registry.is_empty().await);
+        assert!(process::is_alive(result.pid));
+        // Clean up the long-lived child.
+        let _ = process::force_kill(result.pid);
+    }
+
+    #[tokio::test]
+    async fn registry_duplicate_spawn_is_rejected() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let first = registry.spawn(&spawn_req_sleep("dup", 30)).await.expect("spawn");
+        let err = registry
+            .spawn(&spawn_req_sleep("dup", 30))
+            .await
+            .expect_err("duplicate child id must be rejected");
+        assert_eq!(err.code(), "E_DUPLICATE_CHILD");
+        let _ = process::force_kill(first.pid);
+    }
+
+    #[tokio::test]
+    async fn registry_exit_broadcasts_child_exited_event() {
+        let (tx, mut rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        registry.spawn(&spawn_req_true("quick")).await.expect("spawn");
+        // /bin/true exits immediately — expect a child_exited event.
+        let event = next_event(&mut rx).await;
+        assert_eq!(event.event, LifecycleEventKind::ChildExited);
+        assert_eq!(event.child_id, "quick");
+    }
+
+    #[tokio::test]
+    async fn registry_restart_bumps_count_and_broadcasts_event() {
+        let (tx, mut rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let first = registry
+            .spawn(&spawn_req_sleep("svc", 30))
+            .await
+            .expect("spawn");
+        let restarted = registry.restart("svc").await.expect("restart");
+        assert_eq!(restarted.child_id, "svc");
+        assert_eq!(restarted.restart_count, 1);
+        assert_ne!(restarted.pid, first.pid, "restart must yield a fresh pid");
+
+        // The channel carries a child_exited (from the killed first incarnation)
+        // and a child_restarted; assert child_restarted is observed.
+        let mut saw_restarted = false;
+        for _ in 0..4 {
+            let event = next_event(&mut rx).await;
+            if event.event == LifecycleEventKind::ChildRestarted {
+                assert_eq!(event.child_id, "svc");
+                saw_restarted = true;
+                break;
+            }
+        }
+        assert!(saw_restarted, "restart must broadcast a child_restarted event");
+        let _ = process::force_kill(restarted.pid);
+    }
+
+    #[tokio::test]
+    async fn registry_restart_unknown_child_errors() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let err = registry
+            .restart("nope")
+            .await
+            .expect_err("unknown child restart must error");
+        assert_eq!(err.code(), "E_UNKNOWN_CHILD");
+    }
+
+    #[tokio::test]
+    async fn registry_monitor_all_and_one() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let a = registry.spawn(&spawn_req_sleep("a", 30)).await.expect("spawn a");
+        let b = registry.spawn(&spawn_req_sleep("b", 30)).await.expect("spawn b");
+
+        let all = registry.monitor(None).await.expect("monitor all");
+        assert_eq!(all.children.len(), 2);
+
+        let one = registry.monitor(Some("a")).await.expect("monitor a");
+        assert_eq!(one.children.len(), 1);
+        assert_eq!(one.children[0].child_id, "a");
+        assert_eq!(one.children[0].state, ChildState::Running);
+
+        let missing = registry
+            .monitor(Some("zzz"))
+            .await
+            .expect_err("monitor of unknown child errors");
+        assert_eq!(missing.code(), "E_UNKNOWN_CHILD");
+
+        let _ = process::force_kill(a.pid);
+        let _ = process::force_kill(b.pid);
+    }
+
+    #[tokio::test]
+    async fn registry_health_counts_children() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        assert_eq!(registry.child_count().await, 0);
+        let w = registry.spawn(&spawn_req_sleep("h", 30)).await.expect("spawn");
+        assert_eq!(registry.child_count().await, 1);
+        let _ = process::force_kill(w.pid);
     }
 }

--- a/crates/cleo-supervisor/tests/ipc_e2e_smoke.rs
+++ b/crates/cleo-supervisor/tests/ipc_e2e_smoke.rs
@@ -11,7 +11,7 @@
 //!   1. Bind the supervisor IPC `UnixListener` at a temp socket path and run the
 //!      accept loop ([`cleo_supervisor::ipc_server::serve`]).
 //!   2. Connect a client `UnixStream`.
-//!   3. Send a `Spawn` request for a trivial child (`/bin/true`) as one NDJSON
+//!   3. Send a `Spawn` request for a trivial child (`true`) as one NDJSON
 //!      [`IpcEnvelope`] line.
 //!   4. Observe the correlated `Spawned` response AND the unsolicited
 //!      `child_exited` [`LifecycleEvent`] broadcast over the same channel.
@@ -35,12 +35,23 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::sync::mpsc::unbounded_channel;
 
+/// Path to the always-available `true` binary on the host. macOS ships it at
+/// `/usr/bin/true` (no `/bin/true`), Linux at `/bin/true`; probe the canonical
+/// macOS path first and fall back to the Linux path.
+fn true_cmd() -> &'static str {
+    if std::path::Path::new("/usr/bin/true").exists() {
+        "/usr/bin/true"
+    } else {
+        "/bin/true"
+    }
+}
+
 /// A trivial, always-available child that exits immediately so the smoke test
 /// observes a `child_exited` event deterministically and fast.
 fn trivial_spawn(child_id: &str) -> SpawnRequest {
     SpawnRequest {
         child_id: child_id.into(),
-        program: "/bin/true".into(),
+        program: true_cmd().into(),
         args: vec![],
         env: vec![],
         cwd: None,
@@ -97,7 +108,7 @@ async fn bind_accept_spawn_observe_lifecycle_event() {
     let (read, mut write) = stream.into_split();
     let mut lines = BufReader::new(read).lines();
 
-    // ── Send a Spawn request for /bin/true ──────────────────────────────────
+    // ── Send a Spawn request for the trivial `true` child ───────────────────
     let request = IpcEnvelope::request(
         "req-spawn-1",
         IpcRequest::Spawn(trivial_spawn("smoke-child")),

--- a/crates/cleo-supervisor/tests/ipc_e2e_smoke.rs
+++ b/crates/cleo-supervisor/tests/ipc_e2e_smoke.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/cleo-supervisor in the CleoCode monorepo.
+
+//! End-to-end IPC smoke test (T11626 AC4 / R2).
+//!
+//! Proves the R1-deferred R2 loop is finished by exercising the real transport
+//! end to end on Unix:
+//!
+//!   1. Bind the supervisor IPC `UnixListener` at a temp socket path and run the
+//!      accept loop ([`cleo_supervisor::ipc_server::serve`]).
+//!   2. Connect a client `UnixStream`.
+//!   3. Send a `Spawn` request for a trivial child (`/bin/true`) as one NDJSON
+//!      [`IpcEnvelope`] line.
+//!   4. Observe the correlated `Spawned` response AND the unsolicited
+//!      `child_exited` [`LifecycleEvent`] broadcast over the same channel.
+//!
+//! The whole flow runs over a real Unix-domain socket — no in-memory shim — so a
+//! green run is direct evidence the bind + accept + dispatch + fan-out path is
+//! wired. Windows uses a named-pipe transport not yet implemented in this crate,
+//! so the test is `cfg(unix)`-gated.
+
+#![cfg(unix)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::time::Duration;
+
+use cleo_supervisor::ipc::{
+    IpcEnvelope, IpcPayload, IpcRequest, IpcResponse, LifecycleEventKind, SpawnRequest,
+};
+use cleo_supervisor::ipc_server;
+use cleo_supervisor::supervisor::ChildRegistry;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::mpsc::unbounded_channel;
+
+/// A trivial, always-available child that exits immediately so the smoke test
+/// observes a `child_exited` event deterministically and fast.
+fn trivial_spawn(child_id: &str) -> SpawnRequest {
+    SpawnRequest {
+        child_id: child_id.into(),
+        program: "/bin/true".into(),
+        args: vec![],
+        env: vec![],
+        cwd: None,
+    }
+}
+
+/// Read the next response-direction envelope from the client connection,
+/// failing the test if the stream closes or stalls.
+async fn read_response<R>(lines: &mut tokio::io::Lines<BufReader<R>>) -> IpcEnvelope
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let next = tokio::time::timeout(Duration::from_secs(5), lines.next_line())
+        .await
+        .expect("timed out waiting for an IPC line")
+        .expect("read error on client stream")
+        .expect("server closed the connection before responding");
+    IpcEnvelope::from_ndjson(&next).expect("server sent an unparseable envelope")
+}
+
+/// AC4: bind the socket, accept a client, Spawn a child, observe its
+/// [`LifecycleEvent`](cleo_supervisor::ipc::LifecycleEvent).
+#[tokio::test]
+async fn bind_accept_spawn_observe_lifecycle_event() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("cleo-supervisor.sock");
+
+    // ── Stand up the supervisor IPC accept loop ─────────────────────────────
+    let (event_tx, event_rx) = unbounded_channel();
+    let registry = ChildRegistry::new(event_tx);
+    let serve_socket = socket_path.clone();
+    let server = tokio::spawn(async move {
+        // The accept loop runs until the test drops everything; an early error
+        // would surface here. We ignore the Result because the test tears the
+        // task down with `abort()` rather than a clean shutdown signal.
+        let _ = ipc_server::serve(&serve_socket, registry, event_rx).await;
+    });
+
+    // Wait for the socket file to appear (bind completed) before connecting.
+    let mut bound = false;
+    for _ in 0..200 {
+        if socket_path.exists() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(bound, "supervisor never bound the IPC socket");
+
+    // ── Connect a client and split into reader + writer ─────────────────────
+    let stream = UnixStream::connect(&socket_path)
+        .await
+        .expect("client connect");
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+
+    // ── Send a Spawn request for /bin/true ──────────────────────────────────
+    let request = IpcEnvelope::request(
+        "req-spawn-1",
+        IpcRequest::Spawn(trivial_spawn("smoke-child")),
+    );
+    let mut line = request.to_ndjson().expect("serialize request");
+    line.push('\n');
+    write
+        .write_all(line.as_bytes())
+        .await
+        .expect("write spawn request");
+    write.flush().await.expect("flush");
+
+    // ── Observe the Spawned response AND the child_exited LifecycleEvent ─────
+    let mut saw_spawned = false;
+    let mut saw_exit_event = false;
+    let mut observed_pid = 0u32;
+
+    // The two messages can arrive in either order (the broadcast event races the
+    // direct response), so drain a few envelopes until both are seen.
+    for _ in 0..6 {
+        if saw_spawned && saw_exit_event {
+            break;
+        }
+        let env = read_response(&mut lines).await;
+        let IpcPayload::Response { response } = env.payload else {
+            panic!("expected a response-direction envelope, got a request");
+        };
+        match response {
+            IpcResponse::Spawned(result) => {
+                assert_eq!(result.child_id, "smoke-child");
+                assert!(result.pid > 0, "spawned child must report a real pid");
+                observed_pid = result.pid;
+                saw_spawned = true;
+            }
+            IpcResponse::Event(event) => {
+                assert_eq!(event.event, LifecycleEventKind::ChildExited);
+                assert_eq!(event.child_id, "smoke-child");
+                saw_exit_event = true;
+            }
+            other => panic!("unexpected response while draining: {other:?}"),
+        }
+    }
+
+    assert!(saw_spawned, "never received the Spawned response");
+    assert!(
+        saw_exit_event,
+        "never received the child_exited LifecycleEvent broadcast"
+    );
+    assert!(observed_pid > 0, "spawn must have yielded a pid");
+
+    // ── Tear down ───────────────────────────────────────────────────────────
+    server.abort();
+}


### PR DESCRIPTION
## Summary

R2 of the supervisor restructure (EP-SUPERVISOR-ARBITER · parent T11625): finishes the R1-deferred IPC accept loop in `cleo-supervisor`, generalizes the single-child supervisor into a multi-child `ChildRegistry`, and broadcasts lifecycle events to all connected clients over the frozen IPC v1.0 wire — proven end-to-end by a real-socket smoke test.

## What changed

- **`main.rs` — accept loop wired into runtime.** After pidfile + logging, `run()` binds the IPC `UnixListener` and runs the accept loop (`serve_until_shutdown`) concurrently with the signal loop via `tokio::select!`, removing the stale socket on shutdown.
- **`supervisor.rs` — `ChildRegistry`.** The single-`ChildSpec` `Supervisor` is generalized into a `ChildRegistry` (`HashMap<child_id, ManagedChild>`). `Spawn`/`Restart`/`Monitor`/`Health` map onto registry ops. Each spawn attaches a detached monitor task; child exit broadcasts a `child_exited` and restart a `child_restarted` `LifecycleEvent` over an mpsc channel. `RegistryError` carries stable `E_*` codes.
  - Also fixes two review findings on the now-live multi-child path: (1) a **zombie-reaping race** — the global `waitpid(-1, WNOHANG)` SIGCHLD reaper was stealing `tokio::process::Child` children before tokio's driver could reap them (ECHILD → lost exit codes / false stop failures); reaping is now owned exclusively by tokio's `Child::wait()`. (2) a **stale-monitor clobber** — a monitor blocked on a killed incarnation could overwrite a freshly-restarted child's state; fixed with a monotonic per-incarnation generation token so a stale monitor's exit is a no-op.
- **`ipc_server.rs` (new).** `bind_listener` + accept loop + per-client NDJSON request parser + dispatch + an event pump that broadcasts `LifecycleEvent`s to all clients via the existing `Fanout` codec. `SharedWriter` wraps each client's write half so one half serves both direct responses and broadcasts. Windows `serve()` returns `Unsupported` (named-pipe transport not yet implemented here).
- **`paths.rs`.** Adds `socket_path()` / `SOCKET_NAME` under the CLEO home.
- **`tests/ipc_e2e_smoke.rs` (new).** Binds a real Unix socket, accepts a client, spawns `/bin/true`, and observes both the `Spawned` response and the `child_exited` `LifecycleEvent` over the wire.

## Acceptance criteria mapping

| AC | Requirement | Where |
|----|-------------|-------|
| AC1 | `main.rs run()` binds a `UnixListener` and runs an accept loop feeding `ipc_transport::Fanout` | `main.rs` (`tokio::select!` accept + signal loops), `ipc_server.rs` (`bind_listener` / `serve_until_shutdown`) |
| AC2 | Generalize `supervisor.rs` from one `ChildSpec` to a `ChildRegistry`; `Spawn`/`Restart`/`Monitor`/`Health` map onto registry ops | `supervisor.rs` `ChildRegistry` + dispatch in `ipc_server.rs` |
| AC3 | `child_exited`/`child_restarted` `LifecycleEvent`s broadcast over the existing `Fanout` codec; **no edit to frozen `ipc.rs` v1.0** | `supervisor.rs` mpsc lifecycle channel → `ipc_server.rs` event pump → `Fanout`; `ipc.rs` untouched (proof below) |
| AC4 | e2e smoke binds the socket, accepts a client, spawns a child, observes its `LifecycleEvent` | `tests/ipc_e2e_smoke.rs::bind_accept_spawn_observe_lifecycle_event` |

## Frozen `ipc.rs` v1.0 untouched — proof

The frozen v1.0 message set is used **additively only**; no variant was edited or removed. Verified empty diff:

```
$ git diff main...HEAD -- crates/cleo-supervisor/src/ipc.rs
(empty)
```

## Test results

`cargo test -p cleo-supervisor` — all green:

```
src/lib.rs unittests ........... 41 passed; 0 failed (incl. registry_*, stop_*, pidfile_*, logging_*)
src/main.rs unittests ...........  3 passed; 0 failed
tests/idle_rss.rs ...............  1 passed; 0 failed; 1 ignored (60s settle — CI matrix only)
tests/ipc_e2e_smoke.rs ..........  1 passed; 0 failed  (AC4: bind_accept_spawn_observe_lifecycle_event)
tests/lifecycle_smoke.rs ........  2 passed; 0 failed
Doc-tests ........................ 0 passed; 0 failed
```

Total: 48 passed, 0 failed, 1 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
