### PR TITLE
feat(T11629): supervisor passes stamped session env verbatim on Spawn (fork-tree parent)

### DIFF
--- a/crates/cleo-supervisor/src/supervisor.rs
+++ b/crates/cleo-supervisor/src/supervisor.rs
@@ -50,6 +50,21 @@ use crate::process;
 /// child's value of this key through to the child VERBATIM (never rewriting it)
 /// so the worker resolves exactly ONE session via `resolveSessionIdFromEnv`
 /// with zero DB scan (T11629, DHQ-047 class).
+///
+/// # Inheritance hazard (T11629 review fix)
+///
+/// A spawned [`Child`] inherits the supervisor's WHOLE environment, including
+/// the supervisor's own `CLEO_SESSION_ID` (its root session). If a worker
+/// [`SpawnRequest`] omits its own `CLEO_SESSION_ID`, the child would otherwise
+/// SILENTLY inherit the supervisor's root session as its OWN session — and
+/// because the supervisor also stamps [`PARENT_SESSION_ID_ENV_KEY`] = root, the
+/// worker would resolve `parent == child == root`: exactly the DHQ-047
+/// session-bleed class this work dissolves. To close that latent hazard the
+/// supervisor ACTIVELY NEUTRALISES the inherited value to the empty string when
+/// the request carries no explicit session id AND the supervisor itself has a
+/// root session (see [`ChildRegistry::stamp_fork_tree_session_env`]). An empty
+/// value is treated as ABSENT by the TS `resolveSessionIdFromEnv`, so the worker
+/// falls through to its own DB-resolved identity instead of inheriting the root.
 pub const SESSION_ID_ENV_KEY: &str = "CLEO_SESSION_ID";
 
 /// Canonical environment key carrying the active CLEO agent id (T11343).
@@ -549,10 +564,15 @@ impl ChildRegistry {
         self.root_session_id.as_deref()
     }
 
-    /// Stamp the fork-tree parent session ([`PARENT_SESSION_ID_ENV_KEY`]) into a
-    /// child's environment override list (T11629).
+    /// Resolve the fork-tree session environment a child must see, stamping the
+    /// parent edge AND closing the inherited-session bleed hazard (T11629).
     ///
-    /// Semantics:
+    /// A spawned [`Child`] inherits the supervisor's whole environment, so the
+    /// supervisor's own `CLEO_SESSION_ID` (root session) leaks into every child
+    /// unless explicitly overridden. This method mutates the child's env override
+    /// list to enforce BOTH halves of the fork-tree contract:
+    ///
+    /// ## Parent edge ([`PARENT_SESSION_ID_ENV_KEY`])
     ///
     ///   * If the request ALREADY carries an explicit `CLEO_PARENT_SESSION_ID`
     ///     override, it is left untouched — the caller's declared fork-tree
@@ -562,18 +582,35 @@ impl ChildRegistry {
     ///     to the supervisor root that spawned it.
     ///   * When the supervisor has no root session id, nothing is stamped.
     ///
-    /// This NEVER mutates the verbatim pass-through keys (`CLEO_SESSION_ID` /
-    /// `CLEO_AGENT_ID`): those flow through unchanged so the worker resolves
-    /// exactly one session with no DB scan.
-    fn stamp_parent_session(&self, env: &mut Vec<(String, String)>) {
-        let already_present = env
-            .iter()
-            .any(|(k, _)| k == PARENT_SESSION_ID_ENV_KEY);
-        if already_present {
-            return;
-        }
-        if let Some(root) = &self.root_session_id {
+    /// ## Child session anti-bleed (review fix)
+    ///
+    /// The verbatim pass-through key `CLEO_SESSION_ID` is NEVER rewritten when the
+    /// request supplies it — an explicit worker session flows through byte-for-
+    /// byte. But when the request OMITS `CLEO_SESSION_ID` and the supervisor HAS a
+    /// root session, the child would otherwise inherit the supervisor's root as
+    /// its OWN session (yielding `parent == child == root` — the DHQ-047 bleed).
+    /// To prevent that the supervisor appends `CLEO_SESSION_ID=""` (empty), which
+    /// `resolveSessionIdFromEnv` treats as ABSENT, so the worker resolves its own
+    /// DB-backed identity instead of silently adopting the supervisor's session.
+    ///
+    /// `CLEO_AGENT_ID` is left to flow through unchanged either way: agent
+    /// identity is not the bleed vector and an inherited agent id is benign.
+    fn stamp_fork_tree_session_env(&self, env: &mut Vec<(String, String)>) {
+        // --- Parent edge ---
+        let parent_present = env.iter().any(|(k, _)| k == PARENT_SESSION_ID_ENV_KEY);
+        if !parent_present
+            && let Some(root) = &self.root_session_id
+        {
             env.push((PARENT_SESSION_ID_ENV_KEY.to_string(), root.clone()));
+        }
+
+        // --- Child session anti-bleed ---
+        // Only neutralise the inherited root when (a) the supervisor actually has
+        // a root session that WOULD leak, and (b) the request did not declare its
+        // own session. An explicit worker `CLEO_SESSION_ID` is honoured verbatim.
+        let session_present = env.iter().any(|(k, _)| k == SESSION_ID_ENV_KEY);
+        if !session_present && self.root_session_id.is_some() {
+            env.push((SESSION_ID_ENV_KEY.to_string(), String::new()));
         }
     }
 
@@ -607,11 +644,13 @@ impl ChildRegistry {
         }
 
         let mut spec = ChildSpec::from(req);
-        // Stamp the fork-tree parent (the supervisor's root session) before the
-        // spec is stored, so it is reapplied verbatim on every restart too
-        // (T11629). The pass-through env keys (CLEO_SESSION_ID / CLEO_AGENT_ID)
-        // are NOT touched here — they flow through ChildSpec::from unmodified.
-        self.stamp_parent_session(&mut spec.env);
+        // Resolve the fork-tree session env before the spec is stored, so it is
+        // reapplied verbatim on every restart too (T11629). This stamps the
+        // parent edge AND, when the request omits its own session, neutralises
+        // the supervisor's inherited CLEO_SESSION_ID so the worker cannot bleed
+        // the root as its own identity. An explicit worker CLEO_SESSION_ID /
+        // CLEO_AGENT_ID flows through ChildSpec::from unmodified.
+        self.stamp_fork_tree_session_env(&mut spec.env);
         let job = Arc::new(JobObject::new().map_err(|e| RegistryError::Spawn {
             child_id: child_id.clone(),
             source: anyhow::Error::new(e),
@@ -1317,6 +1356,60 @@ mod tests {
         );
     }
 
+    /// Review-fix regression END-TO-END (T11629, DHQ-047 class): the supervisor
+    /// HAS a root session and the worker request OMITS its own `CLEO_SESSION_ID`.
+    /// The spawned child must NOT silently inherit the supervisor's root session
+    /// as its own — the observed `CLEO_SESSION_ID` must be EMPTY (neutralised),
+    /// distinct from the `CLEO_PARENT_SESSION_ID` (which is the root). This is the
+    /// exact interaction the prior verbatim test side-stepped with
+    /// `with_root_session(tx, None)`.
+    ///
+    /// The neutralising stamp (`CLEO_SESSION_ID=""`) is applied as an explicit env
+    /// override on the child [`Command`]; an explicit override always wins over
+    /// the inherited value, so the child observes the empty string regardless of
+    /// what `CLEO_SESSION_ID` the supervisor process itself carries. The test
+    /// therefore does not (and must not — the crate forbids `unsafe`) mutate this
+    /// process's global environment; the pure-transform companion test
+    /// `stamp_fork_tree_session_env_neutralises_inherited_root_when_request_omits_session`
+    /// proves the override is appended, and this test proves it reaches the child.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn registry_does_not_bleed_root_session_into_child_omitting_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("env.txt");
+        let (tx, _rx) = unbounded_channel();
+        let root = "ses_20260607150503_7962a8";
+
+        let registry = ChildRegistry::with_root_session(tx, Some(root.into()));
+        // Request carries NO CLEO_SESSION_ID (only an agent id), mirroring a
+        // fork-tree worker spawn that forgot to declare its own session.
+        let req = spawn_req_dump_env(
+            "no-session",
+            &out,
+            vec![EnvPair {
+                key: "CLEO_AGENT_ID".into(),
+                value: "agent-z".into(),
+            }],
+        );
+        registry.spawn(&req).await.expect("spawn");
+
+        let (session, agent, parent) = read_dumped_env(&out).await;
+
+        assert_eq!(
+            session, "",
+            "child must NOT inherit the supervisor root as its own session (DHQ-047 bleed)"
+        );
+        assert_ne!(
+            session, root,
+            "neutralised child session must differ from the supervisor root"
+        );
+        assert_eq!(agent, "agent-z", "explicit agent id still flows through");
+        assert_eq!(
+            parent, root,
+            "the root is the fork-tree PARENT, not the child's own session"
+        );
+    }
+
     /// AC(b) override: an explicit `CLEO_PARENT_SESSION_ID` on the request takes
     /// precedence — the supervisor does NOT clobber a caller-declared fork-tree
     /// parent with its own root.
@@ -1346,20 +1439,21 @@ mod tests {
         );
     }
 
-    /// `stamp_parent_session` is a pure transform on the env override list: it
-    /// appends the parent only when absent, leaves the pass-through keys
-    /// untouched, and no-ops without a root session.
+    /// `stamp_fork_tree_session_env` is a pure transform on the env override
+    /// list: it appends the parent only when absent, honours an explicit worker
+    /// session verbatim, and no-ops the parent stamp without a root session.
     #[test]
-    fn stamp_parent_session_is_idempotent_and_non_destructive() {
+    fn stamp_fork_tree_session_env_is_idempotent_and_non_destructive() {
         let (tx, _rx) = unbounded_channel();
 
-        // With a root session: appends the parent, preserves existing keys.
+        // With a root session AND an explicit worker session: appends the parent,
+        // preserves existing keys, and does NOT neutralise the explicit session.
         let with_root = ChildRegistry::with_root_session(tx.clone(), Some("ses_root".into()));
         let mut env = vec![
             ("CLEO_SESSION_ID".to_string(), "ses_child".to_string()),
             ("CLEO_AGENT_ID".to_string(), "agent-x".to_string()),
         ];
-        with_root.stamp_parent_session(&mut env);
+        with_root.stamp_fork_tree_session_env(&mut env);
         assert_eq!(
             env,
             vec![
@@ -1369,27 +1463,61 @@ mod tests {
             ]
         );
 
-        // Explicit parent already present: left untouched (no duplicate).
-        let mut env2 = vec![(
-            "CLEO_PARENT_SESSION_ID".to_string(),
-            "ses_explicit".to_string(),
-        )];
-        with_root.stamp_parent_session(&mut env2);
+        // Explicit parent already present: left untouched (no duplicate). The
+        // request also carries its own session, so no neutralising stamp.
+        let mut env2 = vec![
+            ("CLEO_SESSION_ID".to_string(), "ses_child".to_string()),
+            (
+                "CLEO_PARENT_SESSION_ID".to_string(),
+                "ses_explicit".to_string(),
+            ),
+        ];
+        with_root.stamp_fork_tree_session_env(&mut env2);
         assert_eq!(
             env2,
-            vec![(
-                "CLEO_PARENT_SESSION_ID".to_string(),
-                "ses_explicit".to_string()
-            )]
+            vec![
+                ("CLEO_SESSION_ID".to_string(), "ses_child".to_string()),
+                (
+                    "CLEO_PARENT_SESSION_ID".to_string(),
+                    "ses_explicit".to_string()
+                ),
+            ]
         );
 
-        // No root session: no stamp.
+        // No root session: no parent stamp AND no neutralising stamp (nothing
+        // would leak, so the inherited session — if any — is the caller's own).
         let no_root = ChildRegistry::with_root_session(tx, None);
-        let mut env3 = vec![("CLEO_SESSION_ID".to_string(), "ses_child".to_string())];
-        no_root.stamp_parent_session(&mut env3);
+        let mut env3 = vec![("CLEO_AGENT_ID".to_string(), "agent-x".to_string())];
+        no_root.stamp_fork_tree_session_env(&mut env3);
         assert_eq!(
             env3,
-            vec![("CLEO_SESSION_ID".to_string(), "ses_child".to_string())]
+            vec![("CLEO_AGENT_ID".to_string(), "agent-x".to_string())]
+        );
+    }
+
+    /// Review-fix regression (T11629, DHQ-047 class): when the supervisor HAS a
+    /// root session and the worker request OMITS its own `CLEO_SESSION_ID`, the
+    /// supervisor MUST neutralise the inherited root to an empty string so the
+    /// child cannot silently resolve `parent == child == root`. The pure
+    /// transform exercises the env mutation without spawning a process.
+    #[test]
+    fn stamp_fork_tree_session_env_neutralises_inherited_root_when_request_omits_session() {
+        let (tx, _rx) = unbounded_channel();
+        let with_root = ChildRegistry::with_root_session(tx, Some("ses_root".into()));
+
+        // Request omits CLEO_SESSION_ID entirely (only an agent id present).
+        let mut env = vec![("CLEO_AGENT_ID".to_string(), "agent-y".to_string())];
+        with_root.stamp_fork_tree_session_env(&mut env);
+        assert_eq!(
+            env,
+            vec![
+                ("CLEO_AGENT_ID".to_string(), "agent-y".to_string()),
+                // Parent edge stamped to the root...
+                ("CLEO_PARENT_SESSION_ID".to_string(), "ses_root".to_string()),
+                // ...and the inherited root session NEUTRALISED to empty so the
+                // worker does not adopt the supervisor's session as its own.
+                ("CLEO_SESSION_ID".to_string(), String::new()),
+            ]
         );
     }
 

--- a/crates/cleo-supervisor/src/supervisor.rs
+++ b/crates/cleo-supervisor/src/supervisor.rs
@@ -42,6 +42,51 @@ use crate::ipc::{
 use crate::jobobject::JobObject;
 use crate::process;
 
+/// Canonical environment key carrying the active CLEO session id (T11347).
+///
+/// Mirror of `CANONICAL_SESSION_ENV_KEY` in
+/// `packages/core/src/sessions/session-id.ts`. The supervisor reads its OWN
+/// value of this key at startup to learn its root session id, and passes a
+/// child's value of this key through to the child VERBATIM (never rewriting it)
+/// so the worker resolves exactly ONE session via `resolveSessionIdFromEnv`
+/// with zero DB scan (T11629, DHQ-047 class).
+pub const SESSION_ID_ENV_KEY: &str = "CLEO_SESSION_ID";
+
+/// Canonical environment key carrying the active CLEO agent id (T11343).
+///
+/// Mirror of the `CLEO_AGENT_ID` key read by `resolveAgentIdFromEnv` in
+/// `packages/core/src/sessions/session-id.ts`. Passed through to spawned
+/// children VERBATIM alongside [`SESSION_ID_ENV_KEY`].
+pub const AGENT_ID_ENV_KEY: &str = "CLEO_AGENT_ID";
+
+/// Canonical environment key carrying the fork-tree PARENT session id (T11629).
+///
+/// The supervisor stamps this key into every child it spawns, set to the
+/// supervisor's OWN root session id (the value of [`SESSION_ID_ENV_KEY`] in the
+/// supervisor's environment at startup). The Node side reads it via
+/// `resolveParentSessionIdFromEnv` to build the session fork tree, attributing
+/// each worker session to the supervisor root that spawned it.
+///
+/// An explicit `CLEO_PARENT_SESSION_ID` already present on a [`SpawnRequest`]
+/// takes precedence — the caller may override the fork-tree parent (e.g. a
+/// nested orchestrator). The supervisor only stamps the default when the
+/// request did not supply one.
+pub const PARENT_SESSION_ID_ENV_KEY: &str = "CLEO_PARENT_SESSION_ID";
+
+/// Read the supervisor's own root session id from its process environment
+/// ([`SESSION_ID_ENV_KEY`]) (T11629).
+///
+/// An empty value is treated as absent (mirrors the TS
+/// `resolveSessionIdFromEnv`, which skips empty-string env vars), so a
+/// supervisor launched with `CLEO_SESSION_ID=""` stamps no fork-tree parent.
+#[must_use]
+fn read_root_session_from_env() -> Option<String> {
+    match std::env::var(SESSION_ID_ENV_KEY) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}
+
 /// Default grace window between SIGTERM and SIGKILL when stopping a child.
 ///
 /// Matches the 10-second grace period the TS `StudioSupervisor.stop()` uses.
@@ -459,16 +504,76 @@ pub struct ChildRegistry {
     children: Arc<Mutex<HashMap<String, ManagedChild>>>,
     events: UnboundedSender<LifecycleEvent>,
     started_at: std::time::Instant,
+    /// The supervisor's OWN root session id, captured at construction from the
+    /// [`SESSION_ID_ENV_KEY`] env var. Stamped as [`PARENT_SESSION_ID_ENV_KEY`]
+    /// (the fork-tree parent) onto every spawned child unless the request
+    /// already carries an explicit parent. `None` when the supervisor was
+    /// launched without a session id in its environment (T11629).
+    root_session_id: Option<String>,
 }
 
 impl ChildRegistry {
     /// Create an empty registry that publishes lifecycle events on `events`.
+    ///
+    /// Captures the supervisor's root session id from the process environment
+    /// ([`SESSION_ID_ENV_KEY`]) so it can be stamped as the fork-tree parent on
+    /// every child this registry spawns (T11629).
     #[must_use]
     pub fn new(events: UnboundedSender<LifecycleEvent>) -> Self {
+        Self::with_root_session(events, read_root_session_from_env())
+    }
+
+    /// Create an empty registry with an explicit root session id, bypassing the
+    /// process-environment read.
+    ///
+    /// This is the seam tests use to assert the stamped fork-tree parent
+    /// deterministically without mutating the shared process environment
+    /// (T11629). Production code uses [`ChildRegistry::new`].
+    #[must_use]
+    pub fn with_root_session(
+        events: UnboundedSender<LifecycleEvent>,
+        root_session_id: Option<String>,
+    ) -> Self {
         Self {
             children: Arc::new(Mutex::new(HashMap::new())),
             events,
             started_at: std::time::Instant::now(),
+            root_session_id,
+        }
+    }
+
+    /// The supervisor's root session id (the fork-tree parent stamped onto
+    /// children), if one was present in the environment at construction.
+    #[must_use]
+    pub fn root_session_id(&self) -> Option<&str> {
+        self.root_session_id.as_deref()
+    }
+
+    /// Stamp the fork-tree parent session ([`PARENT_SESSION_ID_ENV_KEY`]) into a
+    /// child's environment override list (T11629).
+    ///
+    /// Semantics:
+    ///
+    ///   * If the request ALREADY carries an explicit `CLEO_PARENT_SESSION_ID`
+    ///     override, it is left untouched — the caller's declared fork-tree
+    ///     parent wins (e.g. a nested orchestrator chains its own root through).
+    ///   * Otherwise, when the supervisor has a root session id, append
+    ///     `CLEO_PARENT_SESSION_ID=<root>` so the worker's session is attributed
+    ///     to the supervisor root that spawned it.
+    ///   * When the supervisor has no root session id, nothing is stamped.
+    ///
+    /// This NEVER mutates the verbatim pass-through keys (`CLEO_SESSION_ID` /
+    /// `CLEO_AGENT_ID`): those flow through unchanged so the worker resolves
+    /// exactly one session with no DB scan.
+    fn stamp_parent_session(&self, env: &mut Vec<(String, String)>) {
+        let already_present = env
+            .iter()
+            .any(|(k, _)| k == PARENT_SESSION_ID_ENV_KEY);
+        if already_present {
+            return;
+        }
+        if let Some(root) = &self.root_session_id {
+            env.push((PARENT_SESSION_ID_ENV_KEY.to_string(), root.clone()));
         }
     }
 
@@ -501,7 +606,12 @@ impl ChildRegistry {
             }
         }
 
-        let spec = ChildSpec::from(req);
+        let mut spec = ChildSpec::from(req);
+        // Stamp the fork-tree parent (the supervisor's root session) before the
+        // spec is stored, so it is reapplied verbatim on every restart too
+        // (T11629). The pass-through env keys (CLEO_SESSION_ID / CLEO_AGENT_ID)
+        // are NOT touched here — they flow through ChildSpec::from unmodified.
+        self.stamp_parent_session(&mut spec.env);
         let job = Arc::new(JobObject::new().map_err(|e| RegistryError::Spawn {
             child_id: child_id.clone(),
             source: anyhow::Error::new(e),
@@ -1085,5 +1195,243 @@ mod tests {
         let w = registry.spawn(&spawn_req_sleep("h", 30)).await.expect("spawn");
         assert_eq!(registry.child_count().await, 1);
         let _ = process::force_kill(w.pid);
+    }
+
+    // ── Session-env stamping + verbatim passthrough (T11629) ────────────────
+
+    /// Build a spawn request whose child dumps the three session env vars it
+    /// actually sees (one per line, in order: session, agent, parent) into
+    /// `out_path`, then exits. Reading the file back proves what env the
+    /// supervisor handed the child VERBATIM.
+    #[cfg(unix)]
+    fn spawn_req_dump_env(
+        child_id: &str,
+        out_path: &std::path::Path,
+        env: Vec<EnvPair>,
+    ) -> SpawnRequest {
+        let script = format!(
+            "printf '%s\\n%s\\n%s\\n' \"$CLEO_SESSION_ID\" \"$CLEO_AGENT_ID\" \"$CLEO_PARENT_SESSION_ID\" > {}",
+            out_path.display()
+        );
+        SpawnRequest {
+            child_id: child_id.into(),
+            program: "/bin/sh".into(),
+            args: vec!["-c".into(), script],
+            env,
+            cwd: None,
+        }
+    }
+
+    /// Wait (bounded) for the child's env-dump file to materialise, then return
+    /// its three lines: (session, agent, parent).
+    #[cfg(unix)]
+    async fn read_dumped_env(out_path: &std::path::Path) -> (String, String, String) {
+        for _ in 0..200 {
+            if let Ok(contents) = std::fs::read_to_string(out_path) {
+                let mut lines = contents.lines();
+                let session = lines.next().unwrap_or_default().to_string();
+                let agent = lines.next().unwrap_or_default().to_string();
+                let parent = lines.next().unwrap_or_default().to_string();
+                return (session, agent, parent);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("child never wrote its env dump file at {}", out_path.display());
+    }
+
+    /// AC(a): the supervisor passes the stamped `CLEO_SESSION_ID` /
+    /// `CLEO_AGENT_ID` env block through to the spawned child VERBATIM — no
+    /// filtering, no rewrite. The child observes the EXACT values the request
+    /// carried.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn registry_passes_session_env_to_child_verbatim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("env.txt");
+        let (tx, _rx) = unbounded_channel();
+        // Registry with NO root session, so the parent stamp does not interfere
+        // with the verbatim-passthrough assertion.
+        let registry = ChildRegistry::with_root_session(tx, None);
+
+        let want_session = "ses_20260607150503_7962a8";
+        let want_agent = "agent-t11629";
+        let req = spawn_req_dump_env(
+            "verbatim",
+            &out,
+            vec![
+                EnvPair {
+                    key: "CLEO_SESSION_ID".into(),
+                    value: want_session.into(),
+                },
+                EnvPair {
+                    key: "CLEO_AGENT_ID".into(),
+                    value: want_agent.into(),
+                },
+            ],
+        );
+        registry.spawn(&req).await.expect("spawn");
+
+        let (session, agent, parent) = read_dumped_env(&out).await;
+        assert_eq!(
+            session, want_session,
+            "CLEO_SESSION_ID must reach the child byte-for-byte"
+        );
+        assert_eq!(
+            agent, want_agent,
+            "CLEO_AGENT_ID must reach the child byte-for-byte"
+        );
+        // No root session on the registry and no explicit parent on the request,
+        // so the child sees an empty parent.
+        assert_eq!(parent, "", "no parent should be stamped without a root session");
+    }
+
+    /// AC(b): the supervisor's OWN root session id is stamped onto the child as
+    /// `CLEO_PARENT_SESSION_ID` (the fork-tree parent), while the child's own
+    /// `CLEO_SESSION_ID` still passes through verbatim.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn registry_stamps_root_session_as_parent_on_child() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("env.txt");
+        let (tx, _rx) = unbounded_channel();
+        let root = "ses_20260607150503_7962a8";
+        let registry = ChildRegistry::with_root_session(tx, Some(root.into()));
+        assert_eq!(registry.root_session_id(), Some(root));
+
+        let want_session = "ses_20260607151111_abcdef";
+        let req = spawn_req_dump_env(
+            "forked",
+            &out,
+            vec![EnvPair {
+                key: "CLEO_SESSION_ID".into(),
+                value: want_session.into(),
+            }],
+        );
+        registry.spawn(&req).await.expect("spawn");
+
+        let (session, _agent, parent) = read_dumped_env(&out).await;
+        assert_eq!(session, want_session, "worker session passes through verbatim");
+        assert_eq!(
+            parent, root,
+            "supervisor root session must become the child's CLEO_PARENT_SESSION_ID"
+        );
+    }
+
+    /// AC(b) override: an explicit `CLEO_PARENT_SESSION_ID` on the request takes
+    /// precedence — the supervisor does NOT clobber a caller-declared fork-tree
+    /// parent with its own root.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn registry_explicit_parent_session_overrides_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("env.txt");
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::with_root_session(tx, Some("ses_root_aaaa".into()));
+
+        let explicit_parent = "ses_explicit_bbbb";
+        let req = spawn_req_dump_env(
+            "explicit",
+            &out,
+            vec![EnvPair {
+                key: "CLEO_PARENT_SESSION_ID".into(),
+                value: explicit_parent.into(),
+            }],
+        );
+        registry.spawn(&req).await.expect("spawn");
+
+        let (_session, _agent, parent) = read_dumped_env(&out).await;
+        assert_eq!(
+            parent, explicit_parent,
+            "an explicit request parent must win over the supervisor root"
+        );
+    }
+
+    /// `stamp_parent_session` is a pure transform on the env override list: it
+    /// appends the parent only when absent, leaves the pass-through keys
+    /// untouched, and no-ops without a root session.
+    #[test]
+    fn stamp_parent_session_is_idempotent_and_non_destructive() {
+        let (tx, _rx) = unbounded_channel();
+
+        // With a root session: appends the parent, preserves existing keys.
+        let with_root = ChildRegistry::with_root_session(tx.clone(), Some("ses_root".into()));
+        let mut env = vec![
+            ("CLEO_SESSION_ID".to_string(), "ses_child".to_string()),
+            ("CLEO_AGENT_ID".to_string(), "agent-x".to_string()),
+        ];
+        with_root.stamp_parent_session(&mut env);
+        assert_eq!(
+            env,
+            vec![
+                ("CLEO_SESSION_ID".to_string(), "ses_child".to_string()),
+                ("CLEO_AGENT_ID".to_string(), "agent-x".to_string()),
+                ("CLEO_PARENT_SESSION_ID".to_string(), "ses_root".to_string()),
+            ]
+        );
+
+        // Explicit parent already present: left untouched (no duplicate).
+        let mut env2 = vec![(
+            "CLEO_PARENT_SESSION_ID".to_string(),
+            "ses_explicit".to_string(),
+        )];
+        with_root.stamp_parent_session(&mut env2);
+        assert_eq!(
+            env2,
+            vec![(
+                "CLEO_PARENT_SESSION_ID".to_string(),
+                "ses_explicit".to_string()
+            )]
+        );
+
+        // No root session: no stamp.
+        let no_root = ChildRegistry::with_root_session(tx, None);
+        let mut env3 = vec![("CLEO_SESSION_ID".to_string(), "ses_child".to_string())];
+        no_root.stamp_parent_session(&mut env3);
+        assert_eq!(
+            env3,
+            vec![("CLEO_SESSION_ID".to_string(), "ses_child".to_string())]
+        );
+    }
+
+    /// The fork-tree parent stamp survives a restart: the replacement
+    /// incarnation is spawned from the SAME stored spec (stamped once at the
+    /// initial spawn), so the parent env is reapplied verbatim.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn registry_parent_stamp_persists_across_restart() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("env.txt");
+        let (tx, _rx) = unbounded_channel();
+        let root = "ses_root_restart";
+        let registry = ChildRegistry::with_root_session(tx, Some(root.into()));
+
+        // A long-lived child so the first incarnation is still around to restart.
+        let script = format!(
+            "printf '%s\\n%s\\n%s\\n' \"$CLEO_SESSION_ID\" \"$CLEO_AGENT_ID\" \"$CLEO_PARENT_SESSION_ID\" > {}; sleep 30",
+            out.display()
+        );
+        let req = SpawnRequest {
+            child_id: "restartable".into(),
+            program: "/bin/sh".into(),
+            args: vec!["-c".into(), script],
+            env: vec![EnvPair {
+                key: "CLEO_SESSION_ID".into(),
+                value: "ses_worker".into(),
+            }],
+            cwd: None,
+        };
+        registry.spawn(&req).await.expect("spawn");
+        let (_s1, _a1, parent1) = read_dumped_env(&out).await;
+        assert_eq!(parent1, root);
+
+        // Restart and re-read the (overwritten) dump file.
+        std::fs::remove_file(&out).ok();
+        let restarted = registry.restart("restartable").await.expect("restart");
+        let (_s2, _a2, parent2) = read_dumped_env(&out).await;
+        assert_eq!(
+            parent2, root,
+            "restarted incarnation must still carry the fork-tree parent"
+        );
+        let _ = process::force_kill(restarted.pid);
     }
 }

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1222,10 +1222,13 @@ export {
   switchSession,
 } from './sessions/index.js';
 // Canonical env-first session/agent identity resolution (T11344 · T11343 · Epic T11284)
+// T11629 — fork-tree PARENT session resolution (supervisor-stamped)
 export {
   CANONICAL_SESSION_ENV_KEY,
   generateSessionId,
+  PARENT_SESSION_ENV_KEY,
   resolveAgentIdFromEnv,
+  resolveParentSessionIdFromEnv,
   resolveSessionIdFromEnv,
   SESSION_ENV_KEY_PRECEDENCE,
 } from './sessions/session-id.js';

--- a/packages/core/src/sessions/__tests__/per-agent-session.test.ts
+++ b/packages/core/src/sessions/__tests__/per-agent-session.test.ts
@@ -128,6 +128,50 @@ describe('resolveSessionIdFromEnv', () => {
 });
 
 // ---------------------------------------------------------------------------
+// resolveParentSessionIdFromEnv — fork-tree parent (supervisor-stamped, T11629)
+// ---------------------------------------------------------------------------
+
+describe('resolveParentSessionIdFromEnv (T11629)', () => {
+  afterEach(() => {
+    delete process.env['CLEO_PARENT_SESSION_ID'];
+    delete process.env['CLEO_SESSION_ID'];
+  });
+
+  it('returns null when CLEO_PARENT_SESSION_ID is unset (root process)', async () => {
+    const { resolveParentSessionIdFromEnv } = await import('../session-id.js');
+    expect(resolveParentSessionIdFromEnv()).toBeNull();
+  });
+
+  it('returns null when CLEO_PARENT_SESSION_ID is empty (treated as absent)', async () => {
+    process.env['CLEO_PARENT_SESSION_ID'] = '';
+    const { resolveParentSessionIdFromEnv } = await import('../session-id.js');
+    expect(resolveParentSessionIdFromEnv()).toBeNull();
+  });
+
+  it('returns the supervisor-stamped fork-tree parent session id', async () => {
+    process.env['CLEO_PARENT_SESSION_ID'] = 'ses_root_supervisor';
+    const { resolveParentSessionIdFromEnv } = await import('../session-id.js');
+    expect(resolveParentSessionIdFromEnv()).toBe('ses_root_supervisor');
+  });
+
+  it('is independent of the process own session id (child vs parent edge)', async () => {
+    // The fork-tree CHILD (this process) and its PARENT are distinct edges.
+    process.env['CLEO_SESSION_ID'] = 'ses_worker_child';
+    process.env['CLEO_PARENT_SESSION_ID'] = 'ses_root_parent';
+    const { resolveParentSessionIdFromEnv, resolveSessionIdFromEnv } = await import(
+      '../session-id.js'
+    );
+    expect(resolveSessionIdFromEnv()).toBe('ses_worker_child');
+    expect(resolveParentSessionIdFromEnv()).toBe('ses_root_parent');
+  });
+
+  it('exposes CLEO_PARENT_SESSION_ID as the canonical PARENT_SESSION_ENV_KEY', async () => {
+    const { PARENT_SESSION_ENV_KEY } = await import('../session-id.js');
+    expect(PARENT_SESSION_ENV_KEY).toBe('CLEO_PARENT_SESSION_ID');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // sessionStart — per-agent conflict scoping
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -614,9 +614,12 @@ export { getContextDrift } from './session-drift.js';
 export type { SessionHistoryEntry, SessionHistoryParams } from './session-history.js';
 export { getSessionHistory } from './session-history.js';
 // T9975 / T11344 — env-precedence session + agent resolution
+// T11629 — fork-tree PARENT session resolution (supervisor-stamped)
 export {
   CANONICAL_SESSION_ENV_KEY,
+  PARENT_SESSION_ENV_KEY,
   resolveAgentIdFromEnv,
+  resolveParentSessionIdFromEnv,
   resolveSessionIdFromEnv,
   SESSION_ENV_KEY_PRECEDENCE,
 } from './session-id.js';

--- a/packages/core/src/sessions/session-id.ts
+++ b/packages/core/src/sessions/session-id.ts
@@ -162,6 +162,45 @@ export function resolveAgentIdFromEnv(): string | null {
   return value !== undefined && value !== '' ? value : null;
 }
 
+/**
+ * Canonical environment key carrying the fork-tree PARENT session id (T11629).
+ *
+ * The native supervisor (`crates/cleo-supervisor`) stamps this key onto every
+ * worker it spawns, set to the supervisor's OWN root session id (the value of
+ * {@link CANONICAL_SESSION_ENV_KEY} in the supervisor's environment). It is the
+ * fork-tree edge: a worker's own session ({@link CANONICAL_SESSION_ENV_KEY})
+ * resolved by {@link resolveSessionIdFromEnv} is the CHILD; the value of this
+ * key is its PARENT. Reading both lets the session subsystem reconstruct the
+ * orchestrator→worker fork tree without a DB scan.
+ *
+ * The Rust constant of the same name lives in
+ * `crates/cleo-supervisor/src/supervisor.rs` (`PARENT_SESSION_ID_ENV_KEY`).
+ *
+ * @task T11629
+ */
+export const PARENT_SESSION_ENV_KEY = 'CLEO_PARENT_SESSION_ID' as const;
+
+/**
+ * Resolve the fork-tree PARENT session id from the environment (T11629).
+ *
+ * Returns the {@link PARENT_SESSION_ENV_KEY} (`CLEO_PARENT_SESSION_ID`) value
+ * stamped by the supervisor when it spawned this process, or `null` when
+ * unset/empty (e.g. a top-level/root process with no supervisor parent). The
+ * companion of {@link resolveSessionIdFromEnv}: that resolves THIS process's own
+ * session (the fork-tree child); this resolves the session that spawned it (the
+ * fork-tree parent).
+ *
+ * Like the other env resolvers this NEVER reads the database — it is synchronous
+ * and safe in hot paths. Empty-string values are treated as absent.
+ *
+ * @returns The parent session id string when set, otherwise `null`.
+ * @task T11629
+ */
+export function resolveParentSessionIdFromEnv(): string | null {
+  const value = process.env[PARENT_SESSION_ENV_KEY];
+  return value !== undefined && value !== '' ? value : null;
+}
+
 function parseCompactTimestamp(ts: string): Date | null {
   if (ts.length !== 14) return null;
   const year = ts.substring(0, 4);


### PR DESCRIPTION
## T11629 — supervisor passes stamped session env verbatim on Spawn (fork-tree parent)

Closes the **acquisition-side session bleed** (DHQ-047 class) at the native supervisor boundary: when the supervisor spawns a worker, the worker must resolve **exactly one** session via `resolveSessionIdFromEnv` with **zero DB scan**, and its session must be attributed to the supervisor root that forked it.

### Acceptance criteria → evidence

| AC | What it requires | Where it lands | Proof |
|----|------------------|----------------|-------|
| **(a)** Supervisor passes the stamped `CLEO_SESSION_ID` / `CLEO_AGENT_ID` env block to the spawned child **verbatim** (no filtering, no rewrite). | `IpcRequest::Spawn` → `ChildRegistry::spawn` → `ChildSpec::from(&SpawnRequest)` → `Command::env` flows the request `env` through unchanged. | `registry_passes_session_env_to_child_verbatim` — child dumps its observed `$CLEO_SESSION_ID` / `$CLEO_AGENT_ID`; both match byte-for-byte. |
| **(b)** Supervisor stamps its own root session as the child's fork-tree **parent** (`CLEO_PARENT_SESSION_ID`), explicit request parent wins. | `ChildRegistry` captures `CLEO_SESSION_ID` at construction (`read_root_session_from_env`); `stamp_fork_tree_session_env` appends `CLEO_PARENT_SESSION_ID=<root>` only when absent; persists in the stored `ChildSpec` across restarts. | `registry_stamps_root_session_as_parent_on_child`, `registry_explicit_parent_session_overrides_root`, `registry_parent_stamp_persists_across_restart`. |
| **Review-fix (DHQ-047)** Worker that **omits** its own session must NOT inherit the supervisor root as its own (`parent == child == root` bleed). | `stamp_fork_tree_session_env` neutralises the inherited root: appends `CLEO_SESSION_ID=""` when the request omits it and a root exists; TS `resolveSessionIdFromEnv` treats `""` as absent → worker resolves its own DB identity. | `registry_does_not_bleed_root_session_into_child_omitting_session` (end-to-end) + `stamp_fork_tree_session_env_neutralises_inherited_root_when_request_omits_session` (pure transform). |
| **Node consumer** `resolveParentSessionIdFromEnv` reads the stamped parent. | `packages/core/src/sessions/session-id.ts` adds `PARENT_SESSION_ENV_KEY` + `resolveParentSessionIdFromEnv`, re-exported via `sessions/index.ts` + `internal.ts`. | 5 new TS tests in `per-agent-session.test.ts`. |

### Frozen IPC proof (rule 3)

`crates/cleo-supervisor/src/ipc.rs` is **UNTOUCHED**. `SpawnRequest.env: Vec<EnvPair>` already exists in the byte-frozen v1.0 message set (`ipc.rs:150`) — it is consumed verbatim, no wire change.

```
$ git diff origin/main..HEAD --stat -- crates/cleo-supervisor/src/ipc.rs
(empty — not modified)
```

### Coordinate-not-duplicate (RISK-6)

The Node side **extends** `session-id.ts` — `resolveParentSessionIdFromEnv` is added alongside the existing canonical `resolveSessionIdFromEnv` / `resolveAgentIdFromEnv` (env-first, never reads the DB), it does **not** re-implement the env-precedence resolver.

### Test evidence

- `cargo test -p cleo-supervisor` (rustc 1.94.0): **48 passed, 0 failed** — including all 5 new fork-tree tests + 2 pure-transform regressions.
- `pnpm biome check`: clean (3526 files, no fixes).
- `pnpm run build`: success (all waves).
- `pnpm --filter @cleocode/core test` (full suite): **11321 passed**. The 15 failures are pre-existing, environment-induced (`worktree-napi` native addon unavailable → `"integrateWorktree not available in test fallback"` / `git not found`) in `worktree-*` + `audit/reconstruct` tests — **none in the T11629-touched files**; the new `per-agent-session` session tests all pass.

### Scope

```
crates/cleo-supervisor/src/supervisor.rs            | 478 +++++-
packages/core/src/internal.ts                       |   3 +
packages/core/src/sessions/__tests__/per-agent-session.test.ts | 44 +
packages/core/src/sessions/index.ts                 |   3 +
packages/core/src/sessions/session-id.ts            |  39 +
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
