### PR TITLE
fix(T11895): raise unit-test shard timeout to 35m (macOS flake root cause)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1190,7 +1190,7 @@ jobs:
     needs: [biome, changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 35
     strategy:
       matrix:
         # Windows shards temporarily disabled pending T9182/T9181 follow-up — pre-existing


### PR DESCRIPTION
## Problem

The `unit-tests:` job in `.github/workflows/ci.yml` had `timeout-minutes: 20`, but green macOS shards consistently take 18-19 minutes — essentially zero headroom. This caused systematic timeout flakes where the runner killed shards mid-stream even though tests were passing.

## Evidence

- **Run 27098125894** (green): macOS shards took **18m04s** and **19m10s** against `timeout-minutes: 20`.
- **PRs #996 / #997** lost **3 shard runs** to `20mXXs` timeouts while the test output streamed green — the jobs were terminated by the GitHub Actions timeout, not by a test failure.

## Fix

Raise only the `unit-tests:` shard timeout from `20` to `35` minutes, restoring meaningful headroom. One-line diff; the many `timeout-minutes: 2` entries for lint jobs are untouched.

## Gate-7 note

`ci.yml` is **not** Gate-7 templated — the deployed-template-parity gate covers `release-*` workflows only, so this edit does not require a corresponding template change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)