### PR TITLE
feat(T11627): ST-5 supervisor lease fast path — v1.1 router + LeaseAcquire + lease-ipc-client (T11894)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ version = "2026.5.105"
 dependencies = [
  "anyhow",
  "nix",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -533,6 +534,18 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -745,6 +758,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -760,6 +776,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1148,6 +1173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1740,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2309,6 +2365,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/cleo-supervisor/Cargo.toml
+++ b/crates/cleo-supervisor/Cargo.toml
@@ -40,6 +40,16 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+# Synchronous SQLite driver for the writer-lease claim transaction (T11894 / ST-5).
+# The supervisor `LeaseAcquire` handler runs the SAME `BEGIN IMMEDIATE` claim txn
+# against the SAME persisted `_writer_leases` row that the Node engine arbitrates
+# in `local` mode (packages/core/src/store/writer-lease.ts `tryClaimOnce`) — one
+# shared arbitration primitive, one row format. `rusqlite` gives byte-identical
+# synchronous semantics to Node's `node:sqlite`; the bundled feature compiles
+# SQLite in so the standalone binary carries no external libsqlite3 requirement.
+# Claims run on a blocking thread (`tokio::task::spawn_blocking`) so the sync API
+# never blocks the tokio reactor.
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true }

--- a/crates/cleo-supervisor/src/ipc_server.rs
+++ b/crates/cleo-supervisor/src/ipc_server.rs
@@ -37,6 +37,10 @@ use crate::ipc::{
     IPC_PROTOCOL_VERSION,
 };
 use crate::ipc_transport::Fanout;
+use crate::lease_handler::{LeaseArbiter, request_kind};
+use crate::lease_ipc::{
+    LEASE_IPC_PROTOCOL_VERSION, LeaseEnvelope, LeasePayload, LeaseResponse,
+};
 use crate::process;
 use crate::supervisor::{ChildRegistry, RegistryError};
 
@@ -159,6 +163,40 @@ fn error_response(err: &RegistryError) -> IpcResponse {
     })
 }
 
+/// A version-only peek at an inbound NDJSON line.
+///
+/// Both the frozen v1.0 [`IpcEnvelope`] and the parallel v1.1 [`LeaseEnvelope`]
+/// carry `protocol_version` as their first-class field, so the accept-loop
+/// version router reads ONLY that field to decide which union to parse the line
+/// through — without committing to (or failing on) either union's inner shape.
+#[derive(serde::Deserialize)]
+struct VersionPeek {
+    /// The wire protocol version (`"1.0.0"` → v1.0 dispatch, `"1.1.0"` → lease).
+    protocol_version: String,
+}
+
+/// Dispatch a parsed v1.1 [`crate::lease_ipc::LeaseRequest`] through the lease
+/// arbiter (ST-5), returning the correlated [`LeaseResponse`].
+///
+/// The arbiter runs the SAME `BEGIN IMMEDIATE` claim transaction the Node engine
+/// runs in `local` mode against the SAME persisted `_writer_leases` row — the
+/// supervisor is just a second caller of one shared primitive. The synchronous
+/// `rusqlite` claim runs on a blocking thread so it never blocks the reactor.
+async fn dispatch_lease(arbiter: &LeaseArbiter, request: crate::lease_ipc::LeaseRequest) -> LeaseResponse {
+    let kind = request_kind(&request);
+    let arbiter = arbiter.clone();
+    let response = tokio::task::spawn_blocking(move || arbiter.handle(request))
+        .await
+        .unwrap_or_else(|join_err| {
+            LeaseResponse::Error(crate::ipc::ErrorResult {
+                code: "E_LEASE_CLAIM_FAILED".to_string(),
+                message: format!("lease claim task panicked: {join_err}"),
+            })
+        });
+    tracing::trace!(verb = kind, "dispatched lease request");
+    response
+}
+
 /// Drive the per-client read loop: parse one [`IpcEnvelope`] request per NDJSON
 /// line, dispatch it, and write the correlated response back over `writer`.
 ///
@@ -166,8 +204,12 @@ fn error_response(err: &RegistryError) -> IpcResponse {
 /// that is not recoverable. Parse errors on a single line are answered with an
 /// `IpcResponse::Error` and the loop continues, so one malformed line does not
 /// drop an otherwise-healthy client.
-async fn client_read_loop<R, W>(read: R, writer: SharedWriter<W>, registry: ChildRegistry)
-where
+async fn client_read_loop<R, W>(
+    read: R,
+    writer: SharedWriter<W>,
+    registry: ChildRegistry,
+    lease: Option<LeaseArbiter>,
+) where
     R: tokio::io::AsyncRead + Unpin + Send,
     W: AsyncWrite + Unpin + Send,
 {
@@ -185,6 +227,54 @@ where
         if line.trim().is_empty() {
             continue;
         }
+
+        // ── Version router (ST-5) ───────────────────────────────────────────
+        // Peek ONLY the protocol_version, then route the line through the
+        // matching union. The v1.0 path below is byte-identical to the frozen
+        // behaviour; the v1.1 path is additive and never touches v1.0 framing.
+        let version = match serde_json::from_str::<VersionPeek>(&line) {
+            Ok(peek) => peek.protocol_version,
+            Err(e) => {
+                // Not even a versioned envelope — answer on the v1.0 framing
+                // (unchanged from the frozen behaviour) and continue.
+                let reply = IpcEnvelope::response(
+                    "unparseable",
+                    IpcResponse::Error(crate::ipc::ErrorResult {
+                        code: "E_BAD_REQUEST".to_string(),
+                        message: format!("could not parse IPC envelope: {e}"),
+                    }),
+                );
+                if write_envelope(&mut writer, &reply).await.is_err() {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        if version == LEASE_IPC_PROTOCOL_VERSION {
+            // ── v1.1 → LeaseRequest dispatch ────────────────────────────────
+            if handle_lease_line(&line, lease.as_ref(), &mut writer).await.is_err() {
+                break;
+            }
+            continue;
+        }
+        if version != IPC_PROTOCOL_VERSION {
+            // Unknown version — reject with a lease-protocol bad-version error on
+            // the lease framing so a v1.1-aware client can correlate it.
+            let reply = LeaseEnvelope::response(
+                "bad-version",
+                LeaseResponse::Error(crate::ipc::ErrorResult {
+                    code: "E_LEASE_BAD_VERSION".to_string(),
+                    message: format!("unsupported protocol_version: {version}"),
+                }),
+            );
+            if write_lease_envelope(&mut writer, &reply).await.is_err() {
+                break;
+            }
+            continue;
+        }
+
+        // ── v1.0 → IpcRequest dispatch (UNCHANGED — frozen behaviour) ───────
         match IpcEnvelope::from_ndjson(&line) {
             Ok(env) => match env.payload {
                 IpcPayload::Request { request } => {
@@ -216,10 +306,74 @@ where
     }
 }
 
+/// Parse + dispatch a v1.1 lease line, writing the correlated lease response.
+///
+/// Returns `Err(())` only when the write half is broken (the caller drops the
+/// client); a malformed lease frame or an absent arbiter is answered with a
+/// lease-framed error and is NOT fatal to the connection.
+async fn handle_lease_line<W>(
+    line: &str,
+    lease: Option<&LeaseArbiter>,
+    writer: &mut SharedWriter<W>,
+) -> Result<(), ()>
+where
+    W: AsyncWrite + Unpin + Send,
+{
+    let env = match LeaseEnvelope::from_ndjson(line) {
+        Ok(env) => env,
+        Err(e) => {
+            let reply = LeaseEnvelope::response(
+                "unparseable",
+                LeaseResponse::Error(crate::ipc::ErrorResult {
+                    code: "E_LEASE_BAD_REQUEST".to_string(),
+                    message: format!("could not parse lease envelope: {e}"),
+                }),
+            );
+            return write_lease_envelope(writer, &reply).await.map_err(|_| ());
+        }
+    };
+    let LeasePayload::Request { request } = env.payload else {
+        // Clients do not send responses; ignore defensively (non-fatal).
+        tracing::debug!("ignoring unexpected response-direction lease envelope from client");
+        return Ok(());
+    };
+    let response = match lease {
+        Some(arbiter) => dispatch_lease(arbiter, request).await,
+        // No arbiter wired (the daemon-on fast path is opt-in): a v1.1 client
+        // gets a clear unavailable error rather than a silent drop.
+        None => LeaseResponse::Error(crate::ipc::ErrorResult {
+            code: "E_LEASE_UNAVAILABLE".to_string(),
+            message: "supervisor lease arbiter is not enabled".to_string(),
+        }),
+    };
+    let reply = LeaseEnvelope::response(env.id, response);
+    write_lease_envelope(writer, &reply).await.map_err(|_| ())
+}
+
 /// Serialize and write one envelope as an NDJSON line + flush.
 async fn write_envelope<W>(
     writer: &mut SharedWriter<W>,
     envelope: &IpcEnvelope,
+) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin + Send,
+{
+    let mut line = envelope
+        .to_ndjson()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await
+}
+
+/// Serialize and write one v1.1 [`LeaseEnvelope`] as an NDJSON line + flush.
+///
+/// Identical framing to [`write_envelope`] (single NDJSON line + flush) — the
+/// v1.1 wire bytes match the v1.0 framing; only the version string and inner
+/// union differ.
+async fn write_lease_envelope<W>(
+    writer: &mut SharedWriter<W>,
+    envelope: &LeaseEnvelope,
 ) -> std::io::Result<()>
 where
     W: AsyncWrite + Unpin + Send,
@@ -271,6 +425,7 @@ mod unix_serve {
         listener: UnixListener,
         registry: ChildRegistry,
         events: UnboundedReceiver<LifecycleEvent>,
+        lease: Option<LeaseArbiter>,
     ) -> std::io::Result<()> {
         let fanout: Fanout<SharedWriter<tokio::net::unix::OwnedWriteHalf>> = Fanout::new();
         tokio::spawn(event_pump(events, fanout.clone()));
@@ -280,7 +435,12 @@ mod unix_serve {
             let (read, write) = stream.into_split();
             let shared = SharedWriter::new(write);
             fanout.add_client(shared.clone()).await;
-            tokio::spawn(client_read_loop(read, shared, registry.clone()));
+            tokio::spawn(client_read_loop(
+                read,
+                shared,
+                registry.clone(),
+                lease.clone(),
+            ));
         }
     }
 }
@@ -303,6 +463,30 @@ pub async fn serve(
     registry: ChildRegistry,
     events: UnboundedReceiver<LifecycleEvent>,
 ) -> std::io::Result<()> {
+    // v1.0-only accept loop: no lease arbiter wired, so v1.1 frames are answered
+    // with E_LEASE_UNAVAILABLE. v1.0 dispatch is byte-identical to the frozen
+    // behaviour. The daemon-on fast path uses `serve_with_lease`.
+    serve_with_lease(socket_path, registry, events, None).await
+}
+
+/// Bind the supervisor IPC listener and run the accept loop with an OPTIONAL
+/// v1.1 lease arbiter wired into the version router (ST-5 — the daemon-on fast
+/// path).
+///
+/// When `lease` is `Some`, `"1.1.0"` frames are dispatched through the arbiter's
+/// `BEGIN IMMEDIATE` claim transaction; `"1.0.0"` frames route to the unchanged
+/// v1.0 dispatch. When `lease` is `None` this is byte-identical to [`serve`].
+///
+/// # Errors
+///
+/// Returns an I/O error if the socket cannot be bound or the accept loop fails.
+#[cfg(unix)]
+pub async fn serve_with_lease(
+    socket_path: &std::path::Path,
+    registry: ChildRegistry,
+    events: UnboundedReceiver<LifecycleEvent>,
+    lease: Option<LeaseArbiter>,
+) -> std::io::Result<()> {
     use tokio::net::UnixListener;
 
     if let Some(parent) = socket_path.parent() {
@@ -318,7 +502,7 @@ pub async fn serve(
     }
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(socket = %socket_path.display(), "supervisor IPC listening");
-    unix_serve::run(listener, registry, events).await
+    unix_serve::run(listener, registry, events, lease).await
 }
 
 /// Windows IPC is not yet implemented in this crate (named-pipe server lands
@@ -333,6 +517,25 @@ pub async fn serve(
     _socket_path: &std::path::Path,
     _registry: ChildRegistry,
     _events: UnboundedReceiver<LifecycleEvent>,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "named-pipe IPC transport is not yet implemented for Windows in cleo-supervisor",
+    ))
+}
+
+/// Windows variant of [`serve_with_lease`]. The named-pipe transport is not yet
+/// implemented in this crate, so this returns an error (matching [`serve`]).
+///
+/// # Errors
+///
+/// Always returns `ErrorKind::Unsupported` on Windows.
+#[cfg(not(unix))]
+pub async fn serve_with_lease(
+    _socket_path: &std::path::Path,
+    _registry: ChildRegistry,
+    _events: UnboundedReceiver<LifecycleEvent>,
+    _lease: Option<LeaseArbiter>,
 ) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,

--- a/crates/cleo-supervisor/src/lease_handler.rs
+++ b/crates/cleo-supervisor/src/lease_handler.rs
@@ -1,0 +1,828 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/cleo-supervisor in the CleoCode monorepo.
+
+//! Supervisor-side `lease-ipc` v1.1 arbitration handler (T11627 ST-5 — the
+//! daemon-on fast path).
+//!
+//! The Node engine (`packages/core/src/store/writer-lease.ts`) arbitrates the
+//! writer lease over a persisted `_writer_leases` row via a `BEGIN IMMEDIATE`
+//! claim transaction in `local` mode (daemon disabled). This module is the
+//! **upgrade-only** supervisor fast path: when the daemon is re-enabled
+//! (`CLEO_WRITER_LEASE_MODE=supervisor`), the supervisor runs the SAME
+//! `BEGIN IMMEDIATE` claim transaction against the SAME row — one shared
+//! arbitration primitive, one row format. IPC is a coordination optimization
+//! over the persisted source-of-truth, never a second source.
+//!
+//! ## What lands here (ST-5)
+//!
+//!   * [`LeaseArbiter::handle`] — the [`crate::lease_ipc::LeaseRequest`]
+//!     dispatcher invoked by the accept-loop version router for `"1.1.0"` frames.
+//!   * `lease_acquire` / `lease_release` / `lease_renew` — the v1 core verbs,
+//!     each a synchronous `rusqlite` transaction against the scope's `cleo.db`
+//!     that mirrors the Node `tryClaimOnce` / release / heartbeat SQL byte for
+//!     byte (same table names, same columns, same epoch-CAS, same partial-unique
+//!     `active = 1` invariant).
+//!   * `rate_check` / `tool_grant` — declared in the frozen v1.1 union so the
+//!     protocol never needs a second version bump, but the handlers are
+//!     DEFERRED: they return `E_LEASE_UNIMPLEMENTED` until a follow-up task.
+//!   * [`LeaseArbiter::reclaim_or_kill`] — the kill path: a holder past
+//!     `3 × renew-interval` (i.e. its TTL) whose pid is dead is reclaimed and a
+//!     [`crate::lease_ipc::ChildKilled`] (`child_killed_unresponsive`) event is
+//!     produced. **Only the supervisor kills** — `local` mode (the Node engine)
+//!     never kills, it only reclaims a dead pid on the next acquire (spec §7).
+//!
+//! ## DB access model
+//!
+//! `rusqlite` is a SYNCHRONOUS driver; the supervisor runs on a tokio reactor.
+//! Each claim opens a short-lived connection, applies the same
+//! `busy_timeout=30000` backstop the Node engine and `specs/sqlite-pragmas.json`
+//! pin, runs the `BEGIN IMMEDIATE` transaction, and closes. Callers invoke the
+//! handler on a blocking thread (`tokio::task::spawn_blocking`) so the sync API
+//! never blocks the reactor — see [`crate::ipc_server`].
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::lease_ipc::{
+    ChildKilled, DbScope, LeaseAcquireReq, LeaseGranted, LeaseLane, LeaseRenewReq, LeaseReleaseReq,
+    LeaseRequest, LeaseResponse,
+};
+
+/// Error code returned for a request kind that is declared in the frozen v1.1
+/// union but whose handler is deferred (`rate_check` / `tool_grant`).
+pub const E_LEASE_UNIMPLEMENTED: &str = "E_LEASE_UNIMPLEMENTED";
+
+/// Error code returned when the arbiter cannot resolve / open the scope's
+/// `cleo.db` to run the claim transaction.
+pub const E_LEASE_DB_UNAVAILABLE: &str = "E_LEASE_DB_UNAVAILABLE";
+
+/// Error code returned when the claim transaction fails unexpectedly.
+pub const E_LEASE_CLAIM_FAILED: &str = "E_LEASE_CLAIM_FAILED";
+
+/// Reason string stamped on the `child_killed_unresponsive` event when a holder
+/// is killed for blowing its TTL with a dead pid.
+pub const KILL_REASON_UNRESPONSIVE: &str = "unresponsive past ttl (3x renew interval) and pid dead";
+
+/// Table name for the persisted lease row. MUST equal `WRITER_LEASES_TABLE` in
+/// `packages/core/src/store/writer-lease-schema.ts` — the supervisor and Node
+/// arbitrate the SAME row.
+const WRITER_LEASES_TABLE: &str = "_writer_leases";
+
+/// Table name for the FIFO+priority waiter queue. MUST equal `WRITER_QUEUE_TABLE`
+/// in `writer-lease-schema.ts`.
+const WRITER_QUEUE_TABLE: &str = "_writer_queue";
+
+/// `busy_timeout` backstop (ms) on the `BEGIN IMMEDIATE` lock — byte-equal to the
+/// Node engine's `DEFAULT_TTL_MS` / `specs/sqlite-pragmas.json` pin so a contended
+/// claim degrades to today's bounded wait rather than a hang.
+const BUSY_TIMEOUT_MS: u64 = 30_000;
+
+/// Resolves a [`DbScope`] to the absolute on-disk `cleo.db` path the lease row
+/// lives in.
+///
+/// Injectable so tests arbitrate against an isolated temp fixture with no
+/// supervisor home and no canonical-path side effects.
+pub type ScopeDbResolver = Arc<dyn Fn(DbScope) -> anyhow::Result<PathBuf> + Send + Sync>;
+
+/// The serde `kind` string for a [`LeaseRequest`] variant — used by the accept
+/// loop to record which verb it routed without re-serializing.
+#[must_use]
+pub fn request_kind(req: &LeaseRequest) -> &'static str {
+    match req {
+        LeaseRequest::LeaseAcquire(_) => "lease_acquire",
+        LeaseRequest::LeaseRelease(_) => "lease_release",
+        LeaseRequest::LeaseRenew(_) => "lease_renew",
+        LeaseRequest::RateCheck(_) => "rate_check",
+        LeaseRequest::ToolGrant(_) => "tool_grant",
+    }
+}
+
+/// Current wall-clock in epoch milliseconds (matches Node's `Date.now()`).
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+/// The serde `snake_case` string for a [`DbScope`] — the value persisted in the
+/// `scope` column (matches Node's `'project' | 'global'`).
+fn scope_str(scope: DbScope) -> &'static str {
+    match scope {
+        DbScope::Project => "project",
+        DbScope::Global => "global",
+    }
+}
+
+/// The serde `snake_case` string for a [`LeaseLane`] — the value persisted in the
+/// `lane` column (matches Node's `'tasks' | 'brain' | 'bulk'`).
+fn lane_str(lane: LeaseLane) -> &'static str {
+    match lane {
+        LeaseLane::Tasks => "tasks",
+        LeaseLane::Brain => "brain",
+        LeaseLane::Bulk => "bulk",
+    }
+}
+
+/// No-throw pid-liveness probe. Mirrors the Node engine's `isPidAlive`
+/// (`process.kill(pid, 0)`): a process that exists (even if not ours) is alive;
+/// `ESRCH` means dead.
+#[cfg(unix)]
+fn is_pid_alive(pid: i32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    match kill(Pid::from_raw(pid), None) {
+        Ok(()) => true,
+        // EPERM => the process exists but is not ours (alive). ESRCH => dead.
+        Err(Errno::EPERM) => true,
+        Err(_) => false,
+    }
+}
+
+/// On non-Unix targets the lease fast path is not exercised in production (the
+/// daemon ships Unix-first); treat every pid as alive so reclaim never fires.
+#[cfg(not(unix))]
+fn is_pid_alive(_pid: i32) -> bool {
+    true
+}
+
+/// The outcome of a claim transaction: either a grant (with the assigned epoch)
+/// or a "contended by a live holder" miss (the caller is queued).
+enum ClaimOutcome {
+    /// The lease was granted; carries the assigned epoch.
+    Granted { epoch: u64 },
+    /// A live holder owns the row; the caller was enqueued for FIFO ordering.
+    Queued { ticket: i64, ahead: u32 },
+}
+
+/// The active-row snapshot read inside the claim transaction.
+struct ActiveRow {
+    id: i64,
+    holder_id: String,
+    holder_pid: i32,
+    epoch: u64,
+    heartbeat_at: u64,
+    ttl_ms: u64,
+}
+
+/// The supervisor-side writer-lease arbiter.
+///
+/// Holds the scope→db-path resolver and arbitrates `lease-ipc` v1.1 requests
+/// against the persisted `_writer_leases` row using the SAME `BEGIN IMMEDIATE`
+/// primitive the Node engine uses in `local` mode.
+#[derive(Clone)]
+pub struct LeaseArbiter {
+    resolver: ScopeDbResolver,
+}
+
+impl LeaseArbiter {
+    /// Build an arbiter from a scope→db-path resolver.
+    #[must_use]
+    pub fn new(resolver: ScopeDbResolver) -> Self {
+        Self { resolver }
+    }
+
+    /// Dispatch a single parsed [`LeaseRequest`], returning the correlated
+    /// [`LeaseResponse`] to send back to the requesting client.
+    ///
+    /// SYNCHRONOUS: runs the `rusqlite` claim transaction inline. Callers MUST
+    /// invoke this on a blocking thread (`tokio::task::spawn_blocking`) so the
+    /// sync `SQLite` API never blocks the tokio reactor.
+    ///
+    /// - `lease_acquire` → `BEGIN IMMEDIATE` claim → `lease_granted` /
+    ///   `lease_queued`.
+    /// - `lease_release` → epoch-guarded free-row → `lease_granted` echo of the
+    ///   released grant (idempotent; a stale epoch no-ops).
+    /// - `lease_renew`   → epoch-guarded heartbeat advance → `lease_granted`.
+    /// - `rate_check` / `tool_grant` → DEFERRED: `error` with
+    ///   [`E_LEASE_UNIMPLEMENTED`].
+    #[must_use]
+    pub fn handle(&self, request: LeaseRequest) -> LeaseResponse {
+        match request {
+            LeaseRequest::LeaseAcquire(req) => self.handle_acquire(&req),
+            LeaseRequest::LeaseRelease(req) => self.handle_release(&req),
+            LeaseRequest::LeaseRenew(req) => self.handle_renew(&req),
+            // Declared in the frozen v1.1 union so the protocol never needs a
+            // second version bump; handlers deferred to a follow-up task.
+            LeaseRequest::RateCheck(_) => Self::unimplemented("rate_check"),
+            LeaseRequest::ToolGrant(_) => Self::unimplemented("tool_grant"),
+        }
+    }
+
+    /// The deferred-handler error response (`E_LEASE_UNIMPLEMENTED`).
+    fn unimplemented(verb: &str) -> LeaseResponse {
+        LeaseResponse::Error(crate::ipc::ErrorResult {
+            code: E_LEASE_UNIMPLEMENTED.to_string(),
+            message: format!("lease-ipc verb '{verb}' is declared but its handler is deferred"),
+        })
+    }
+
+    /// Resolve + open the scope's `cleo.db`, applying the `busy_timeout` backstop.
+    fn open_scope_db(&self, scope: DbScope) -> Result<rusqlite::Connection, LeaseResponse> {
+        let path = (self.resolver)(scope).map_err(|e| {
+            LeaseResponse::LeaseDenied(crate::lease_ipc::LeaseDenied {
+                scope,
+                code: E_LEASE_DB_UNAVAILABLE.to_string(),
+                message: format!("cannot resolve cleo.db for scope: {e}"),
+            })
+        })?;
+        Self::open_at(scope, &path)
+    }
+
+    /// Open a connection at an explicit path with the shared pragmas.
+    fn open_at(scope: DbScope, path: &Path) -> Result<rusqlite::Connection, LeaseResponse> {
+        let conn = rusqlite::Connection::open(path).map_err(|e| {
+            LeaseResponse::LeaseDenied(crate::lease_ipc::LeaseDenied {
+                scope,
+                code: E_LEASE_DB_UNAVAILABLE.to_string(),
+                message: format!("cannot open cleo.db at {}: {e}", path.display()),
+            })
+        })?;
+        // Same busy_timeout backstop the Node engine relies on so a contended
+        // BEGIN IMMEDIATE degrades to a bounded wait, never a hang.
+        let _ = conn.busy_timeout(std::time::Duration::from_millis(BUSY_TIMEOUT_MS));
+        Ok(conn)
+    }
+
+    /// `lease_acquire` — the `BEGIN IMMEDIATE` claim against the active row.
+    fn handle_acquire(&self, req: &LeaseAcquireReq) -> LeaseResponse {
+        let conn = match self.open_scope_db(req.scope) {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        match self.claim(&conn, req) {
+            Ok(ClaimOutcome::Granted { epoch }) => LeaseResponse::LeaseGranted(LeaseGranted {
+                scope: req.scope,
+                lane: req.lane,
+                holder_id: req.holder_id.clone(),
+                epoch,
+                ttl_ms: req.ttl_ms,
+                expires_at_ms: now_ms().saturating_add(req.ttl_ms),
+            }),
+            Ok(ClaimOutcome::Queued { ticket, ahead }) => {
+                LeaseResponse::LeaseQueued(crate::lease_ipc::LeaseQueued {
+                    scope: req.scope,
+                    lane: req.lane,
+                    ticket,
+                    ahead,
+                })
+            }
+            Err(e) => LeaseResponse::LeaseDenied(crate::lease_ipc::LeaseDenied {
+                scope: req.scope,
+                code: E_LEASE_CLAIM_FAILED.to_string(),
+                message: format!("claim transaction failed: {e}"),
+            }),
+        }
+    }
+
+    /// The `BEGIN IMMEDIATE` claim transaction — byte-for-byte the Node
+    /// `tryClaimOnce` logic, plus a kill-on-reclaim hook so the supervisor (and
+    /// ONLY the supervisor) kills a dead-pid TTL-blown holder.
+    fn claim(
+        &self,
+        conn: &rusqlite::Connection,
+        req: &LeaseAcquireReq,
+    ) -> rusqlite::Result<ClaimOutcome> {
+        let now = now_ms();
+        let scope = scope_str(req.scope);
+        let lane = lane_str(req.lane);
+        conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
+
+        let result = (|| -> rusqlite::Result<ClaimOutcome> {
+            let active = Self::read_active(conn, scope, lane)?;
+            match active {
+                None => {
+                    // No active holder — take a fresh row with the next epoch.
+                    let next_epoch: u64 = conn.query_row(
+                        &format!(
+                            "SELECT COALESCE(MAX(epoch), 0) + 1 FROM {WRITER_LEASES_TABLE} \
+                             WHERE scope = ?1 AND lane = ?2"
+                        ),
+                        rusqlite::params![scope, lane],
+                        |r| r.get(0),
+                    )?;
+                    conn.execute(
+                        &format!(
+                            "INSERT INTO {WRITER_LEASES_TABLE} \
+                             (scope, lane, holder_id, holder_pid, epoch, acquired_at, heartbeat_at, ttl_ms, reentrancy_depth, active) \
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, 1)"
+                        ),
+                        rusqlite::params![
+                            scope,
+                            lane,
+                            req.holder_id,
+                            i64::from(std::process::id().min(i32::MAX as u32) as i32),
+                            next_epoch,
+                            now,
+                            now,
+                            req.ttl_ms,
+                        ],
+                    )?;
+                    Ok(ClaimOutcome::Granted { epoch: next_epoch })
+                }
+                Some(row) if row.holder_id == req.holder_id => {
+                    // Same holder re-entry — bump durable depth, re-assert epoch.
+                    conn.execute(
+                        &format!(
+                            "UPDATE {WRITER_LEASES_TABLE} \
+                             SET reentrancy_depth = reentrancy_depth + 1, heartbeat_at = ?1 WHERE id = ?2"
+                        ),
+                        rusqlite::params![now, row.id],
+                    )?;
+                    Ok(ClaimOutcome::Granted { epoch: row.epoch })
+                }
+                Some(row) => {
+                    // A different holder owns the row. Reclaim IFF stale (TTL
+                    // expired AND pid dead). SQLite serializes this inside BEGIN
+                    // IMMEDIATE so two reclaimers cannot both win.
+                    let stale = now.saturating_sub(row.heartbeat_at) > row.ttl_ms
+                        && !is_pid_alive(row.holder_pid);
+                    if stale {
+                        let reclaimed_epoch = row.epoch + 1;
+                        conn.execute(
+                            &format!(
+                                "UPDATE {WRITER_LEASES_TABLE} \
+                                 SET holder_id = ?1, holder_pid = ?2, epoch = ?3, acquired_at = ?4, \
+                                     heartbeat_at = ?5, ttl_ms = ?6, reentrancy_depth = 1 \
+                                 WHERE id = ?7 AND epoch = ?8"
+                            ),
+                            rusqlite::params![
+                                req.holder_id,
+                                i64::from(std::process::id().min(i32::MAX as u32) as i32),
+                                reclaimed_epoch,
+                                now,
+                                now,
+                                req.ttl_ms,
+                                row.id,
+                                row.epoch,
+                            ],
+                        )?;
+                        Ok(ClaimOutcome::Granted {
+                            epoch: reclaimed_epoch,
+                        })
+                    } else {
+                        // Live holder — enqueue this waiter (idempotent) and report
+                        // queue position. busy_timeout already backstopped the lock.
+                        let (ticket, ahead) =
+                            Self::enqueue_waiter(conn, scope, lane, req, now)?;
+                        Ok(ClaimOutcome::Queued { ticket, ahead })
+                    }
+                }
+            }
+        })();
+
+        match result {
+            Ok(outcome) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    /// Read the single active row for `(scope, lane)` (partial-unique `active=1`).
+    fn read_active(
+        conn: &rusqlite::Connection,
+        scope: &str,
+        lane: &str,
+    ) -> rusqlite::Result<Option<ActiveRow>> {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT id, holder_id, holder_pid, epoch, heartbeat_at, ttl_ms \
+             FROM {WRITER_LEASES_TABLE} WHERE scope = ?1 AND lane = ?2 AND active = 1"
+        ))?;
+        let mut rows = stmt.query(rusqlite::params![scope, lane])?;
+        if let Some(r) = rows.next()? {
+            Ok(Some(ActiveRow {
+                id: r.get(0)?,
+                holder_id: r.get(1)?,
+                holder_pid: r.get(2)?,
+                epoch: r.get(3)?,
+                heartbeat_at: r.get(4)?,
+                ttl_ms: r.get(5)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Enqueue a waiter row (idempotent per holder) and return `(ticket, ahead)`.
+    fn enqueue_waiter(
+        conn: &rusqlite::Connection,
+        scope: &str,
+        lane: &str,
+        req: &LeaseAcquireReq,
+        now: u64,
+    ) -> rusqlite::Result<(i64, u32)> {
+        let existing: Option<i64> = conn
+            .query_row(
+                &format!(
+                    "SELECT ticket FROM {WRITER_QUEUE_TABLE} \
+                     WHERE scope = ?1 AND lane = ?2 AND holder_id = ?3"
+                ),
+                rusqlite::params![scope, lane, req.holder_id],
+                |r| r.get(0),
+            )
+            .ok();
+        let ticket = match existing {
+            Some(t) => t,
+            None => {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO {WRITER_QUEUE_TABLE} \
+                         (scope, lane, holder_id, priority, enqueued_at, deadline_at) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
+                    ),
+                    rusqlite::params![
+                        scope,
+                        lane,
+                        req.holder_id,
+                        i64::from(req.priority),
+                        now,
+                        now + req.ttl_ms,
+                    ],
+                )?;
+                conn.last_insert_rowid()
+            }
+        };
+        // Count waiters ahead of us by grant order (priority ASC, ticket ASC).
+        let ahead: u32 = conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {WRITER_QUEUE_TABLE} q \
+                 WHERE q.scope = ?1 AND q.lane = ?2 \
+                   AND (q.priority < ?3 OR (q.priority = ?3 AND q.ticket < ?4))"
+            ),
+            rusqlite::params![scope, lane, i64::from(req.priority), ticket],
+            |r| r.get::<_, i64>(0).map(|n| u32::try_from(n).unwrap_or(u32::MAX)),
+        )?;
+        Ok((ticket, ahead))
+    }
+
+    /// `lease_release` — free the active row under the epoch guard. Idempotent: a
+    /// stale epoch (the lease was already reclaimed) updates 0 rows and the echo
+    /// still succeeds. Returns a `lease_granted` echo of the released grant.
+    fn handle_release(&self, req: &LeaseReleaseReq) -> LeaseResponse {
+        let conn = match self.open_scope_db(req.scope) {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        let scope = scope_str(req.scope);
+        let lane = lane_str(req.lane);
+        let res = conn.execute(
+            &format!(
+                "UPDATE {WRITER_LEASES_TABLE} SET active = 0, reentrancy_depth = 0 \
+                 WHERE scope = ?1 AND lane = ?2 AND holder_id = ?3 AND epoch = ?4 AND active = 1"
+            ),
+            rusqlite::params![scope, lane, req.holder_id, req.epoch],
+        );
+        match res {
+            Ok(_) => LeaseResponse::LeaseGranted(LeaseGranted {
+                scope: req.scope,
+                lane: req.lane,
+                holder_id: req.holder_id.clone(),
+                epoch: req.epoch,
+                ttl_ms: 0,
+                expires_at_ms: now_ms(),
+            }),
+            Err(e) => LeaseResponse::LeaseDenied(crate::lease_ipc::LeaseDenied {
+                scope: req.scope,
+                code: E_LEASE_CLAIM_FAILED.to_string(),
+                message: format!("release failed: {e}"),
+            }),
+        }
+    }
+
+    /// `lease_renew` — advance `heartbeat_at` under the epoch guard. A reclaimed
+    /// holder's renew updates 0 rows (no-op via the epoch guard). Returns a
+    /// `lease_granted` carrying the refreshed expiry.
+    fn handle_renew(&self, req: &LeaseRenewReq) -> LeaseResponse {
+        let conn = match self.open_scope_db(req.scope) {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        let scope = scope_str(req.scope);
+        let lane = lane_str(req.lane);
+        let now = now_ms();
+        // Read the row's ttl_ms first so the granted expiry is accurate.
+        let ttl_ms: u64 = conn
+            .query_row(
+                &format!(
+                    "SELECT ttl_ms FROM {WRITER_LEASES_TABLE} \
+                     WHERE scope = ?1 AND lane = ?2 AND holder_id = ?3 AND epoch = ?4 AND active = 1"
+                ),
+                rusqlite::params![scope, lane, req.holder_id, req.epoch],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        let res = conn.execute(
+            &format!(
+                "UPDATE {WRITER_LEASES_TABLE} SET heartbeat_at = ?1 \
+                 WHERE scope = ?2 AND lane = ?3 AND holder_id = ?4 AND epoch = ?5 AND active = 1"
+            ),
+            rusqlite::params![now, scope, lane, req.holder_id, req.epoch],
+        );
+        match res {
+            Ok(_) => LeaseResponse::LeaseGranted(LeaseGranted {
+                scope: req.scope,
+                lane: req.lane,
+                holder_id: req.holder_id.clone(),
+                epoch: req.epoch,
+                ttl_ms,
+                expires_at_ms: now.saturating_add(ttl_ms),
+            }),
+            Err(e) => LeaseResponse::LeaseDenied(crate::lease_ipc::LeaseDenied {
+                scope: req.scope,
+                code: E_LEASE_CLAIM_FAILED.to_string(),
+                message: format!("renew failed: {e}"),
+            }),
+        }
+    }
+
+    /// Scan the active rows for a stale, dead-pid holder and reclaim it, emitting
+    /// a `child_killed_unresponsive` event — the supervisor-ONLY kill path
+    /// (spec §7). A holder is killable IFF it has blown its TTL
+    /// (`now - heartbeat_at > ttl_ms`, i.e. it missed ≥ 3 renew intervals since
+    /// the renew interval is `ttl/3`) AND its pid is dead. `local` mode (the Node
+    /// engine) never calls this — it only reclaims on the next acquire.
+    ///
+    /// Returns one [`ChildKilled`] event per holder reclaimed in this sweep.
+    #[must_use]
+    pub fn reclaim_or_kill(&self, scope: DbScope) -> Vec<ChildKilled> {
+        let conn = match self.open_scope_db(scope) {
+            Ok(c) => c,
+            // A missing/unopenable scope DB has nothing to reclaim.
+            Err(_) => return Vec::new(),
+        };
+        let now = now_ms();
+        let mut killed = Vec::new();
+        // Snapshot candidates first (read), then reclaim each under its own
+        // BEGIN IMMEDIATE so two reclaimers cannot both win a given row.
+        let candidates = Self::read_kill_candidates(&conn, scope_str(scope), now);
+        for (id, holder_id, holder_pid, epoch, lane) in candidates {
+            if is_pid_alive(holder_pid) {
+                // Slow-but-live holder — never kill (risk #4 mitigation).
+                continue;
+            }
+            // Reclaim the row (active = 0) under the epoch guard. Loser of a race
+            // sees the bumped epoch and reclaims nothing.
+            let affected = conn
+                .execute(
+                    &format!(
+                        "UPDATE {WRITER_LEASES_TABLE} SET active = 0, reentrancy_depth = 0, epoch = epoch + 1 \
+                         WHERE id = ?1 AND epoch = ?2 AND active = 1 AND ?3 - heartbeat_at > ttl_ms"
+                    ),
+                    rusqlite::params![id, epoch, now],
+                )
+                .unwrap_or(0);
+            if affected > 0 {
+                killed.push(ChildKilled {
+                    child_id: holder_id.clone(),
+                    holder_id,
+                    scope,
+                    reason: format!("{KILL_REASON_UNRESPONSIVE} (lane={lane})"),
+                });
+            }
+        }
+        killed
+    }
+
+    /// Read active rows whose TTL has expired (candidates for the kill sweep).
+    /// pid-liveness is re-checked by the caller before reclaiming.
+    fn read_kill_candidates(
+        conn: &rusqlite::Connection,
+        scope: &str,
+        now: u64,
+    ) -> Vec<(i64, String, i32, u64, String)> {
+        let mut out = Vec::new();
+        let Ok(mut stmt) = conn.prepare(&format!(
+            "SELECT id, holder_id, holder_pid, epoch, lane FROM {WRITER_LEASES_TABLE} \
+             WHERE scope = ?1 AND active = 1 AND ?2 - heartbeat_at > ttl_ms"
+        )) else {
+            return out;
+        };
+        let Ok(mut rows) = stmt.query(rusqlite::params![scope, now]) else {
+            return out;
+        };
+        while let Ok(Some(r)) = rows.next() {
+            let Ok(id) = r.get::<_, i64>(0) else { continue };
+            let Ok(holder_id) = r.get::<_, String>(1) else {
+                continue;
+            };
+            let Ok(holder_pid) = r.get::<_, i32>(2) else {
+                continue;
+            };
+            let Ok(epoch) = r.get::<_, u64>(3) else {
+                continue;
+            };
+            let Ok(lane) = r.get::<_, String>(4) else {
+                continue;
+            };
+            out.push((id, holder_id, holder_pid, epoch, lane));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lease_ipc::{LeaseAcquireReq, LeaseRenewReq, LeaseReleaseReq, LeaseRequest};
+    use std::sync::Arc;
+
+    /// The lease-table bootstrap DDL — byte-equivalent (modulo `IF NOT EXISTS`) to
+    /// the Node `COLD_OPEN_LEASE_BOOTSTRAP_DDL` so the supervisor claims against
+    /// the SAME schema the Node engine creates.
+    const BOOTSTRAP_DDL: &str = "\
+        CREATE TABLE IF NOT EXISTS _writer_leases (\
+          id INTEGER PRIMARY KEY, scope TEXT NOT NULL, lane TEXT NOT NULL, \
+          holder_id TEXT NOT NULL, holder_pid INTEGER NOT NULL, epoch INTEGER NOT NULL, \
+          acquired_at INTEGER NOT NULL, heartbeat_at INTEGER NOT NULL, ttl_ms INTEGER NOT NULL, \
+          reentrancy_depth INTEGER NOT NULL DEFAULT 1, active INTEGER NOT NULL DEFAULT 1);\
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_writer_leases_active ON _writer_leases (scope, lane) WHERE active = 1;\
+        CREATE TABLE IF NOT EXISTS _writer_queue (\
+          ticket INTEGER PRIMARY KEY AUTOINCREMENT, scope TEXT NOT NULL, lane TEXT NOT NULL, \
+          holder_id TEXT NOT NULL, priority INTEGER NOT NULL DEFAULT 100, \
+          enqueued_at INTEGER NOT NULL, deadline_at INTEGER NOT NULL);\
+        CREATE INDEX IF NOT EXISTS ix_writer_queue_order ON _writer_queue (scope, lane, priority ASC, ticket ASC);";
+
+    /// Build an arbiter bound to a single temp `cleo.db` for every scope, with the
+    /// lease tables bootstrapped — an isolated fixture with no supervisor home.
+    fn fixture() -> (LeaseArbiter, tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("cleo.db");
+        let conn = rusqlite::Connection::open(&db_path).expect("open");
+        conn.execute_batch(BOOTSTRAP_DDL).expect("bootstrap");
+        let path = db_path.clone();
+        let resolver: ScopeDbResolver = Arc::new(move |_scope| Ok(path.clone()));
+        (LeaseArbiter::new(resolver), dir, db_path)
+    }
+
+    fn acquire(holder: &str, ttl_ms: u64) -> LeaseRequest {
+        LeaseRequest::LeaseAcquire(LeaseAcquireReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: holder.into(),
+            priority: 0,
+            ttl_ms,
+            reentrant: true,
+        })
+    }
+
+    #[test]
+    fn acquire_grants_when_no_active_holder() {
+        let (arb, _dir, _p) = fixture();
+        let resp = arb.handle(acquire("h1", 30_000));
+        match resp {
+            LeaseResponse::LeaseGranted(g) => {
+                assert_eq!(g.holder_id, "h1");
+                assert_eq!(g.epoch, 1);
+                assert_eq!(g.ttl_ms, 30_000);
+            }
+            other => panic!("expected LeaseGranted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn second_holder_is_queued_while_first_is_live() {
+        let (arb, _dir, _p) = fixture();
+        // h1 acquires with a long TTL and a LIVE pid (this test process).
+        assert!(matches!(
+            arb.handle(acquire("h1", 60_000)),
+            LeaseResponse::LeaseGranted(_)
+        ));
+        // h2 contends — h1 is not stale (fresh heartbeat) so h2 is queued.
+        match arb.handle(acquire("h2", 60_000)) {
+            LeaseResponse::LeaseQueued(q) => {
+                assert_eq!(q.ahead, 0);
+                assert!(q.ticket >= 1);
+            }
+            other => panic!("expected LeaseQueued, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn same_holder_reacquire_reenters_and_keeps_epoch() {
+        let (arb, _dir, _p) = fixture();
+        let first = arb.handle(acquire("h1", 60_000));
+        let LeaseResponse::LeaseGranted(g1) = first else {
+            panic!("expected grant");
+        };
+        let second = arb.handle(acquire("h1", 60_000));
+        let LeaseResponse::LeaseGranted(g2) = second else {
+            panic!("expected re-entry grant");
+        };
+        assert_eq!(g1.epoch, g2.epoch, "re-entry keeps the same epoch");
+    }
+
+    #[test]
+    fn release_frees_the_row_so_next_acquire_grants() {
+        let (arb, _dir, _p) = fixture();
+        let LeaseResponse::LeaseGranted(g) = arb.handle(acquire("h1", 60_000)) else {
+            panic!("expected grant");
+        };
+        let rel = arb.handle(LeaseRequest::LeaseRelease(LeaseReleaseReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "h1".into(),
+            epoch: g.epoch,
+        }));
+        assert!(matches!(rel, LeaseResponse::LeaseGranted(_)));
+        // Now a different holder can take it (fresh row, next epoch).
+        match arb.handle(acquire("h2", 60_000)) {
+            LeaseResponse::LeaseGranted(g2) => assert!(g2.epoch > g.epoch),
+            other => panic!("expected grant after release, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn renew_advances_heartbeat_under_epoch_guard() {
+        let (arb, _dir, _p) = fixture();
+        let LeaseResponse::LeaseGranted(g) = arb.handle(acquire("h1", 30_000)) else {
+            panic!("expected grant");
+        };
+        let renew = arb.handle(LeaseRequest::LeaseRenew(LeaseRenewReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "h1".into(),
+            epoch: g.epoch,
+        }));
+        match renew {
+            LeaseResponse::LeaseGranted(g2) => {
+                assert_eq!(g2.epoch, g.epoch);
+                assert_eq!(g2.ttl_ms, 30_000);
+            }
+            other => panic!("expected renew grant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_check_and_tool_grant_are_unimplemented() {
+        let (arb, _dir, _p) = fixture();
+        let rate = arb.handle(LeaseRequest::RateCheck(crate::lease_ipc::RateCheckReq {
+            scope: DbScope::Global,
+            lane: LeaseLane::Bulk,
+            est_bytes: 4096,
+        }));
+        match rate {
+            LeaseResponse::Error(e) => assert_eq!(e.code, E_LEASE_UNIMPLEMENTED),
+            other => panic!("expected unimplemented error, got {other:?}"),
+        }
+        let tool = arb.handle(LeaseRequest::ToolGrant(crate::lease_ipc::ToolGrantReq {
+            tool: "browser".into(),
+            holder_id: "h1".into(),
+        }));
+        match tool {
+            LeaseResponse::Error(e) => assert_eq!(e.code, E_LEASE_UNIMPLEMENTED),
+            other => panic!("expected unimplemented error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stale_dead_pid_holder_is_reclaimed_and_killed() {
+        let (arb, _dir, db_path) = fixture();
+        // Plant an active row with an already-expired TTL and a pid that is dead
+        // (1 is init/PID-namespace-root which is not killable by us, so use a pid
+        // that is certainly dead: a very high pid value).
+        let dead_pid: i32 = 2_147_483_000; // never a live pid
+        let conn = rusqlite::Connection::open(&db_path).expect("open");
+        conn.execute(
+            "INSERT INTO _writer_leases \
+             (scope, lane, holder_id, holder_pid, epoch, acquired_at, heartbeat_at, ttl_ms, reentrancy_depth, active) \
+             VALUES ('project', 'tasks', 'dead-holder', ?1, 5, 0, 0, 1000, 1, 1)",
+            rusqlite::params![dead_pid],
+        )
+        .expect("seed stale row");
+        let killed = arb.reclaim_or_kill(DbScope::Project);
+        assert_eq!(killed.len(), 1, "the stale dead-pid holder must be reclaimed");
+        assert_eq!(killed[0].holder_id, "dead-holder");
+        assert!(killed[0].reason.contains("unresponsive"));
+        // The next acquire should now grant (the stale row was reclaimed).
+        match arb.handle(acquire("h-new", 30_000)) {
+            LeaseResponse::LeaseGranted(_) => {}
+            other => panic!("expected grant after reclaim, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn live_holder_is_never_killed_even_past_ttl() {
+        let (arb, _dir, db_path) = fixture();
+        // Plant an active row that is past TTL but whose pid is THIS process (live).
+        let live_pid = i32::try_from(std::process::id()).unwrap_or(1);
+        let conn = rusqlite::Connection::open(&db_path).expect("open");
+        conn.execute(
+            "INSERT INTO _writer_leases \
+             (scope, lane, holder_id, holder_pid, epoch, acquired_at, heartbeat_at, ttl_ms, reentrancy_depth, active) \
+             VALUES ('project', 'tasks', 'live-holder', ?1, 5, 0, 0, 1000, 1, 1)",
+            rusqlite::params![live_pid],
+        )
+        .expect("seed past-ttl-but-live row");
+        let killed = arb.reclaim_or_kill(DbScope::Project);
+        assert!(killed.is_empty(), "a live holder must never be killed (risk #4)");
+    }
+}

--- a/crates/cleo-supervisor/src/lib.rs
+++ b/crates/cleo-supervisor/src/lib.rs
@@ -33,6 +33,7 @@ pub mod ipc;
 pub mod ipc_server;
 pub mod ipc_transport;
 pub mod jobobject;
+pub mod lease_handler;
 pub mod lease_ipc;
 pub mod logging;
 pub mod paths;

--- a/crates/cleo-supervisor/tests/lease_ipc_e2e.rs
+++ b/crates/cleo-supervisor/tests/lease_ipc_e2e.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/cleo-supervisor in the CleoCode monorepo.
+
+//! End-to-end `lease-ipc` v1.1 fast-path test (T11894 / ST-5).
+//!
+//! Proves the supervisor fast path over the REAL Unix-domain socket:
+//!
+//!   1. Bind the supervisor IPC `UnixListener` with a v1.1 [`LeaseArbiter`] wired
+//!      into the accept-loop version router
+//!      ([`cleo_supervisor::ipc_server::serve_with_lease`]).
+//!   2. A v1.1 client sends `lease_acquire` and observes a `lease_granted`
+//!      response, then `lease_release` and re-`lease_acquire` to prove the row
+//!      was freed — all through the socket, against the SAME persisted
+//!      `_writer_leases` row the Node engine arbitrates.
+//!   3. **In the SAME accept loop**, a v1.0 client sends a `Health` request and
+//!      observes the unchanged `Health` response — proving the version router
+//!      leaves v1.0 clients completely unaffected (the freeze invariant).
+//!   4. A `rate_check` v1.1 request returns the deferred `E_LEASE_UNIMPLEMENTED`
+//!      error.
+//!
+//! The whole flow runs over a real Unix socket — no in-memory shim — so a green
+//! run is direct evidence the version-routing accept loop + lease claim path is
+//! wired without disturbing the frozen v1.0 contract. Windows uses a named-pipe
+//! transport not yet implemented in this crate, so the test is `cfg(unix)`-gated.
+
+#![cfg(unix)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cleo_supervisor::ipc::{IpcEnvelope, IpcPayload, IpcRequest, IpcResponse};
+use cleo_supervisor::ipc_server;
+use cleo_supervisor::lease_handler::{LeaseArbiter, ScopeDbResolver};
+use cleo_supervisor::lease_ipc::{
+    DbScope, LeaseAcquireReq, LeaseEnvelope, LeaseLane, LeasePayload, LeaseReleaseReq, LeaseRequest,
+    LeaseResponse,
+};
+use cleo_supervisor::supervisor::ChildRegistry;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::mpsc::unbounded_channel;
+
+/// Bootstrap DDL byte-equivalent to the Node `COLD_OPEN_LEASE_BOOTSTRAP_DDL` so
+/// the supervisor claims against the SAME schema the Node engine creates.
+const BOOTSTRAP_DDL: &str = "\
+    CREATE TABLE IF NOT EXISTS _writer_leases (\
+      id INTEGER PRIMARY KEY, scope TEXT NOT NULL, lane TEXT NOT NULL, \
+      holder_id TEXT NOT NULL, holder_pid INTEGER NOT NULL, epoch INTEGER NOT NULL, \
+      acquired_at INTEGER NOT NULL, heartbeat_at INTEGER NOT NULL, ttl_ms INTEGER NOT NULL, \
+      reentrancy_depth INTEGER NOT NULL DEFAULT 1, active INTEGER NOT NULL DEFAULT 1);\
+    CREATE UNIQUE INDEX IF NOT EXISTS ux_writer_leases_active ON _writer_leases (scope, lane) WHERE active = 1;\
+    CREATE TABLE IF NOT EXISTS _writer_queue (\
+      ticket INTEGER PRIMARY KEY AUTOINCREMENT, scope TEXT NOT NULL, lane TEXT NOT NULL, \
+      holder_id TEXT NOT NULL, priority INTEGER NOT NULL DEFAULT 100, \
+      enqueued_at INTEGER NOT NULL, deadline_at INTEGER NOT NULL);\
+    CREATE INDEX IF NOT EXISTS ix_writer_queue_order ON _writer_queue (scope, lane, priority ASC, ticket ASC);";
+
+/// Read the next NDJSON line from the client connection, failing the test if the
+/// stream closes or stalls.
+async fn read_line<R>(lines: &mut tokio::io::Lines<BufReader<R>>) -> String
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    tokio::time::timeout(Duration::from_secs(5), lines.next_line())
+        .await
+        .expect("timed out waiting for an IPC line")
+        .expect("read error on client stream")
+        .expect("server closed the connection before responding")
+}
+
+/// Write one NDJSON line + flush to the client write half.
+async fn write_line(write: &mut tokio::net::unix::OwnedWriteHalf, line: &str) {
+    let mut buf = line.to_string();
+    buf.push('\n');
+    write.write_all(buf.as_bytes()).await.expect("write line");
+    write.flush().await.expect("flush");
+}
+
+/// AC1+AC2+AC5+T15: bind with a lease arbiter, prove v1.1 acquire/release works
+/// over the socket, v1.0 Health is unaffected, and `rate_check` is unimplemented.
+#[tokio::test]
+async fn v1_1_acquire_release_over_socket_v1_0_unaffected() {
+    // ── Isolated fixture cleo.db with the lease tables bootstrapped ──────────
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("cleo.db");
+    {
+        let conn = rusqlite::Connection::open(&db_path).expect("open");
+        conn.execute_batch(BOOTSTRAP_DDL).expect("bootstrap lease tables");
+    }
+    let resolved = db_path.clone();
+    let resolver: ScopeDbResolver = Arc::new(move |_scope| Ok(resolved.clone()));
+    let arbiter = LeaseArbiter::new(resolver);
+
+    let socket_path = dir.path().join("cleo-supervisor.sock");
+
+    // ── Stand up the supervisor IPC accept loop WITH the lease arbiter ───────
+    let (event_tx, event_rx) = unbounded_channel();
+    let registry = ChildRegistry::new(event_tx);
+    let serve_socket = socket_path.clone();
+    let server = tokio::spawn(async move {
+        let _ = ipc_server::serve_with_lease(&serve_socket, registry, event_rx, Some(arbiter)).await;
+    });
+
+    // Wait for the socket to appear (bind completed).
+    let mut bound = false;
+    for _ in 0..200 {
+        if socket_path.exists() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(bound, "supervisor never bound the IPC socket");
+
+    // ── v1.1 client: acquire → granted ──────────────────────────────────────
+    let stream = UnixStream::connect(&socket_path).await.expect("v1.1 connect");
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+
+    let acquire = LeaseEnvelope::request(
+        "lease-acq-1",
+        LeaseRequest::LeaseAcquire(LeaseAcquireReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "pid-1:tasks".into(),
+            priority: 0,
+            ttl_ms: 60_000,
+            reentrant: true,
+        }),
+    );
+    write_line(&mut write, &acquire.to_ndjson().expect("ser acquire")).await;
+
+    let granted_line = read_line(&mut lines).await;
+    let granted = LeaseEnvelope::from_ndjson(&granted_line).expect("parse granted envelope");
+    assert_eq!(granted.protocol_version, "1.1.0", "v1.1 response framing");
+    assert_eq!(granted.id, "lease-acq-1", "correlation id echoed");
+    let granted_epoch = match granted.payload {
+        LeasePayload::Response {
+            response: LeaseResponse::LeaseGranted(g),
+        } => {
+            assert_eq!(g.holder_id, "pid-1:tasks");
+            assert_eq!(g.ttl_ms, 60_000);
+            g.epoch
+        }
+        other => panic!("expected lease_granted, got {other:?}"),
+    };
+
+    // ── v1.0 client (DIFFERENT connection, SAME accept loop): Health unaffected ─
+    let v10_stream = UnixStream::connect(&socket_path).await.expect("v1.0 connect");
+    let (v10_read, mut v10_write) = v10_stream.into_split();
+    let mut v10_lines = BufReader::new(v10_read).lines();
+    let health = IpcEnvelope::request("health-1", IpcRequest::Health(cleo_supervisor::ipc::HealthRequest {}));
+    write_line(&mut v10_write, &health.to_ndjson().expect("ser health")).await;
+    let health_line = read_line(&mut v10_lines).await;
+    let health_env = IpcEnvelope::from_ndjson(&health_line).expect("parse v1.0 health envelope");
+    assert_eq!(health_env.protocol_version, "1.0.0", "v1.0 framing untouched");
+    match health_env.payload {
+        IpcPayload::Response {
+            response: IpcResponse::Health(h),
+        } => {
+            assert_eq!(h.protocol_version, "1.0.0");
+            assert!(h.pid > 0);
+        }
+        other => panic!("expected v1.0 Health response, got {other:?}"),
+    }
+
+    // ── v1.1 client: a SECOND holder is queued while the first holds it ──────
+    let acquire2 = LeaseEnvelope::request(
+        "lease-acq-2",
+        LeaseRequest::LeaseAcquire(LeaseAcquireReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "pid-2:tasks".into(),
+            priority: 0,
+            ttl_ms: 60_000,
+            reentrant: true,
+        }),
+    );
+    write_line(&mut write, &acquire2.to_ndjson().expect("ser acquire2")).await;
+    let queued_line = read_line(&mut lines).await;
+    let queued = LeaseEnvelope::from_ndjson(&queued_line).expect("parse queued envelope");
+    match queued.payload {
+        LeasePayload::Response {
+            response: LeaseResponse::LeaseQueued(q),
+        } => assert_eq!(q.ahead, 0, "second holder is queued behind the live first holder"),
+        other => panic!("expected lease_queued, got {other:?}"),
+    }
+
+    // ── v1.1 client: release the first grant → the row is freed ──────────────
+    let release = LeaseEnvelope::request(
+        "lease-rel-1",
+        LeaseRequest::LeaseRelease(LeaseReleaseReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "pid-1:tasks".into(),
+            epoch: granted_epoch,
+        }),
+    );
+    write_line(&mut write, &release.to_ndjson().expect("ser release")).await;
+    let released_line = read_line(&mut lines).await;
+    let released = LeaseEnvelope::from_ndjson(&released_line).expect("parse release envelope");
+    assert!(matches!(
+        released.payload,
+        LeasePayload::Response {
+            response: LeaseResponse::LeaseGranted(_)
+        }
+    ));
+
+    // ── v1.1 client: re-acquire by a new holder now grants (row was freed) ───
+    let reacquire = LeaseEnvelope::request(
+        "lease-acq-3",
+        LeaseRequest::LeaseAcquire(LeaseAcquireReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "pid-3:tasks".into(),
+            priority: 0,
+            ttl_ms: 60_000,
+            reentrant: true,
+        }),
+    );
+    write_line(&mut write, &reacquire.to_ndjson().expect("ser reacquire")).await;
+    let regrant_line = read_line(&mut lines).await;
+    let regrant = LeaseEnvelope::from_ndjson(&regrant_line).expect("parse regrant envelope");
+    match regrant.payload {
+        LeasePayload::Response {
+            response: LeaseResponse::LeaseGranted(g),
+        } => assert!(g.epoch > granted_epoch, "a fresh grant bumps the epoch"),
+        other => panic!("expected lease_granted after release, got {other:?}"),
+    }
+
+    // ── v1.1 client: rate_check is the deferred E_LEASE_UNIMPLEMENTED ─────────
+    let rate = LeaseEnvelope::request(
+        "rate-1",
+        LeaseRequest::RateCheck(cleo_supervisor::lease_ipc::RateCheckReq {
+            scope: DbScope::Global,
+            lane: LeaseLane::Bulk,
+            est_bytes: 1024,
+        }),
+    );
+    write_line(&mut write, &rate.to_ndjson().expect("ser rate")).await;
+    let rate_line = read_line(&mut lines).await;
+    let rate_env = LeaseEnvelope::from_ndjson(&rate_line).expect("parse rate envelope");
+    match rate_env.payload {
+        LeasePayload::Response {
+            response: LeaseResponse::Error(e),
+        } => assert_eq!(e.code, "E_LEASE_UNIMPLEMENTED"),
+        other => panic!("expected E_LEASE_UNIMPLEMENTED, got {other:?}"),
+    }
+
+    server.abort();
+}
+
+/// A v1.1 frame on a loop with NO lease arbiter wired (the default `serve`)
+/// returns `E_LEASE_UNAVAILABLE` — never a silent drop, and v1.0 stays frozen.
+#[tokio::test]
+async fn v1_1_without_arbiter_returns_unavailable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("cleo-supervisor.sock");
+    let (event_tx, event_rx) = unbounded_channel();
+    let registry = ChildRegistry::new(event_tx);
+    let serve_socket = socket_path.clone();
+    let server = tokio::spawn(async move {
+        // Plain `serve` — no lease arbiter (the production-default v1.0-only loop).
+        let _ = ipc_server::serve(&serve_socket, registry, event_rx).await;
+    });
+
+    let mut bound = false;
+    for _ in 0..200 {
+        if socket_path.exists() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(bound, "supervisor never bound the IPC socket");
+
+    let stream = UnixStream::connect(&socket_path).await.expect("connect");
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+    let acquire = LeaseEnvelope::request(
+        "no-arb-1",
+        LeaseRequest::LeaseAcquire(LeaseAcquireReq {
+            scope: DbScope::Project,
+            lane: LeaseLane::Tasks,
+            holder_id: "pid-9:tasks".into(),
+            priority: 0,
+            ttl_ms: 30_000,
+            reentrant: true,
+        }),
+    );
+    write_line(&mut write, &acquire.to_ndjson().expect("ser acquire")).await;
+    let line = read_line(&mut lines).await;
+    let env = LeaseEnvelope::from_ndjson(&line).expect("parse envelope");
+    match env.payload {
+        LeasePayload::Response {
+            response: LeaseResponse::Error(e),
+        } => assert_eq!(e.code, "E_LEASE_UNAVAILABLE"),
+        other => panic!("expected E_LEASE_UNAVAILABLE, got {other:?}"),
+    }
+
+    server.abort();
+}

--- a/packages/runtime/src/daemon/__tests__/lease-ipc-client.test.ts
+++ b/packages/runtime/src/daemon/__tests__/lease-ipc-client.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the PARALLEL `lease-ipc` v1.1 NDJSON codec (T11894 / ST-5).
+ *
+ * Mirrors the v1.0 `SupervisorIpcClient` codec tests (registry.test.ts) — the
+ * v1.1 client encodes versioned, correlated request lines and rejects malformed
+ * inbound frames with a typed {@link MalformedLeaseIpcFrameError} rather than
+ * silently dropping them.
+ *
+ * @task T11894
+ */
+
+import { LEASE_IPC_PROTOCOL_VERSION } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { createLeaseIpcClient, MalformedLeaseIpcFrameError } from '../lease-ipc-client.js';
+
+describe('LeaseIpcClient NDJSON codec (T11894 ST-5)', () => {
+  it('encodes a lease_acquire request as a versioned, correlated NDJSON line', () => {
+    const client = createLeaseIpcClient();
+    const { id, line } = client.encodeRequest({
+      kind: 'lease_acquire',
+      scope: 'project',
+      lane: 'tasks',
+      holder_id: 'pid-42:tasks',
+      priority: 0,
+      ttl_ms: 30_000,
+      reentrant: true,
+    });
+
+    expect(line.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(line.trimEnd());
+    expect(parsed.protocol_version).toBe(LEASE_IPC_PROTOCOL_VERSION);
+    expect(parsed.protocol_version).toBe('1.1.0');
+    expect(parsed.direction).toBe('request');
+    expect(parsed.id).toBe(id);
+    expect(parsed.request.kind).toBe('lease_acquire');
+    expect(parsed.request.scope).toBe('project');
+    expect(parsed.request.lane).toBe('tasks');
+    expect(parsed.request.holder_id).toBe('pid-42:tasks');
+    expect(parsed.request.reentrant).toBe(true);
+  });
+
+  it('stamps a fresh correlation id per request', () => {
+    const client = createLeaseIpcClient();
+    const a = client.encodeRequest({
+      kind: 'lease_release',
+      scope: 'project',
+      lane: 'tasks',
+      holder_id: 'h',
+      epoch: 1,
+    });
+    const b = client.encodeRequest({
+      kind: 'lease_release',
+      scope: 'project',
+      lane: 'tasks',
+      holder_id: 'h',
+      epoch: 1,
+    });
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('decodes a well-formed lease_granted response envelope', () => {
+    const client = createLeaseIpcClient();
+    const wire = JSON.stringify({
+      protocol_version: '1.1.0',
+      id: 'abc',
+      direction: 'response',
+      response: {
+        kind: 'lease_granted',
+        scope: 'project',
+        lane: 'tasks',
+        holder_id: 'pid-42:tasks',
+        epoch: 7,
+        ttl_ms: 30_000,
+        expires_at_ms: 1_000_030_000,
+      },
+    });
+    const env = client.decodeResponseLine(wire);
+    expect(env.direction).toBe('response');
+    expect(env.response.kind).toBe('lease_granted');
+    if (env.response.kind === 'lease_granted') {
+      expect(env.response.epoch).toBe(7);
+    }
+  });
+
+  it('decodes an unsolicited child_killed_unresponsive event', () => {
+    const client = createLeaseIpcClient();
+    const wire = JSON.stringify({
+      protocol_version: '1.1.0',
+      id: 'evt-1',
+      direction: 'response',
+      response: {
+        kind: 'child_killed_unresponsive',
+        child_id: 'worker-1',
+        holder_id: 'pid-42:tasks',
+        scope: 'project',
+        reason: 'unresponsive past ttl',
+      },
+    });
+    const env = client.decodeResponseLine(wire);
+    expect(env.response.kind).toBe('child_killed_unresponsive');
+  });
+
+  it('decodes a deferred-handler E_LEASE_UNIMPLEMENTED error', () => {
+    const client = createLeaseIpcClient();
+    const wire = JSON.stringify({
+      protocol_version: '1.1.0',
+      id: 'rate-1',
+      direction: 'response',
+      response: { kind: 'error', code: 'E_LEASE_UNIMPLEMENTED', message: 'deferred handler' },
+    });
+    const env = client.decodeResponseLine(wire);
+    expect(env.response.kind).toBe('error');
+    if (env.response.kind === 'error') {
+      expect(env.response.code).toBe('E_LEASE_UNIMPLEMENTED');
+    }
+  });
+
+  it('rejects a non-JSON line with a typed MalformedLeaseIpcFrameError (never silently dropped)', () => {
+    const client = createLeaseIpcClient();
+    expect(() => client.decodeResponseLine('{not json')).toThrow(MalformedLeaseIpcFrameError);
+  });
+
+  it('rejects a schema-violating frame with a typed MalformedLeaseIpcFrameError', () => {
+    const client = createLeaseIpcClient();
+    const bad = JSON.stringify({
+      protocol_version: '1.1.0',
+      id: 'abc',
+      direction: 'response',
+      response: { kind: 'bogus' },
+    });
+    let caught: unknown;
+    try {
+      client.decodeResponseLine(bad);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MalformedLeaseIpcFrameError);
+    expect((caught as MalformedLeaseIpcFrameError).line).toBe(bad);
+  });
+});

--- a/packages/runtime/src/daemon/index.ts
+++ b/packages/runtime/src/daemon/index.ts
@@ -40,6 +40,8 @@ export type {
 } from '@cleocode/contracts';
 
 export { defineSubsystem } from './define-subsystem.js';
+export type { LeaseIpcClient } from './lease-ipc-client.js';
+export { createLeaseIpcClient, MalformedLeaseIpcFrameError } from './lease-ipc-client.js';
 export type { SubsystemLogFields, SubsystemLogger } from './logger.js';
 export { createSubsystemLogger } from './logger.js';
 export { SubsystemRegistry } from './registry.js';

--- a/packages/runtime/src/daemon/lease-ipc-client.ts
+++ b/packages/runtime/src/daemon/lease-ipc-client.ts
@@ -1,0 +1,163 @@
+/**
+ * Typed NDJSON client for the PARALLEL `lease-ipc` v1.1 contract (T11627 ST-5).
+ *
+ * Mirrors {@link ./supervisor-client.ts | supervisor-client.ts} conventions
+ * exactly — a transport-agnostic codec that **owns no socket**. It encodes
+ * outbound {@link LeaseIpcRequestEnvelope}s to newline-delimited JSON (NDJSON)
+ * lines and decodes inbound lines through the v1.1 Zod schemas. **Every inbound
+ * line is parsed** — a malformed or schema-violating frame is rejected with a
+ * typed {@link MalformedLeaseIpcFrameError} and never silently dropped.
+ *
+ * The wire format is byte-identical framing to the frozen `supervisor-ipc` v1.0
+ * envelope; only the version string ({@link LEASE_IPC_PROTOCOL_VERSION} =
+ * `1.1.0`) and the inner union differ. A single supervisor accept loop routes
+ * `1.0.0` frames to the v1.0 union and `1.1.0` frames to this lease union.
+ *
+ * The Rust `cleo-supervisor` is the arbiter (server); a CLEO process running in
+ * `CLEO_WRITER_LEASE_MODE=supervisor` is a client that sends lease requests and
+ * receives lease responses + unsolicited events (`lease_revoked`,
+ * `child_killed_unresponsive`), one NDJSON envelope per line.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11625
+ * @task T11894 — supervisor fast path: TS lease-ipc-client (ST-5)
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ * @see ./supervisor-client.ts — the v1.0 codec this mirrors
+ */
+
+import {
+  LEASE_IPC_PROTOCOL_VERSION,
+  type LeaseIpcRequest,
+  type LeaseIpcRequestEnvelope,
+  LeaseIpcRequestEnvelopeSchema,
+  type LeaseIpcResponseEnvelope,
+  LeaseIpcResponseEnvelopeSchema,
+} from '@cleocode/contracts';
+
+/**
+ * A typed error raised when an inbound NDJSON line cannot be decoded into a
+ * valid {@link LeaseIpcResponseEnvelope}.
+ *
+ * Carries the offending raw `line` and the underlying `cause` (a JSON
+ * `SyntaxError` or a Zod validation error) so callers can log + correlate.
+ * Invalid frames are surfaced as this error — never silently dropped. This is
+ * the v1.1 sibling of {@link MalformedIpcFrameError}.
+ *
+ * @public
+ */
+export class MalformedLeaseIpcFrameError extends Error {
+  /** The raw NDJSON line that failed to decode. */
+  readonly line: string;
+
+  /**
+   * @param line  - The offending raw NDJSON line.
+   * @param cause - The underlying JSON or Zod error.
+   */
+  constructor(line: string, cause: unknown) {
+    super(`Malformed lease-ipc frame: ${cause instanceof Error ? cause.message : cause}`);
+    this.name = 'MalformedLeaseIpcFrameError';
+    this.line = line;
+    this.cause = cause;
+  }
+}
+
+/**
+ * A transport-agnostic codec for the PARALLEL `lease-ipc` v1.1 wire format.
+ *
+ * Construct via {@link createLeaseIpcClient}. The client is stateful only in its
+ * monotonic correlation-id counter; it owns no socket. Callers feed it raw lines
+ * from whatever transport (Unix socket, named pipe, test pair) they own.
+ */
+export interface LeaseIpcClient {
+  /**
+   * Encode a request body into a complete, newline-terminated NDJSON envelope
+   * line ready to write to the transport.
+   *
+   * Stamps the parallel protocol version ({@link LEASE_IPC_PROTOCOL_VERSION}) and
+   * a fresh correlation `id`, validates the result against
+   * {@link LeaseIpcRequestEnvelopeSchema}, and returns the serialized line
+   * (including the trailing `\n`).
+   *
+   * @param request - The request body (validated by the envelope schema).
+   * @returns `{ id, line }` — the correlation id and the NDJSON line to send.
+   */
+  encodeRequest: (request: LeaseIpcRequest) => { id: string; line: string };
+
+  /**
+   * Decode a single inbound NDJSON line into a typed response envelope.
+   *
+   * Parses the line as JSON, then validates it against
+   * {@link LeaseIpcResponseEnvelopeSchema}. A malformed or schema-violating line
+   * throws {@link MalformedLeaseIpcFrameError} — it is never silently dropped.
+   *
+   * @param line - A single NDJSON line (without the trailing newline).
+   * @returns The decoded {@link LeaseIpcResponseEnvelope}.
+   * @throws {MalformedLeaseIpcFrameError} When the line is not a valid response frame.
+   */
+  decodeResponseLine: (line: string) => LeaseIpcResponseEnvelope;
+}
+
+/**
+ * Generate a process-unique correlation id for a lease IPC request envelope.
+ *
+ * @param seq - The client's monotonic sequence number.
+ * @returns A correlation id of the form `l<seq>-<random>`.
+ */
+function nextCorrelationId(seq: number): string {
+  return `l${seq}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Create a typed NDJSON codec for the PARALLEL `lease-ipc` v1.1 contract.
+ *
+ * @returns A {@link LeaseIpcClient}.
+ *
+ * @example
+ * ```ts
+ * const client = createLeaseIpcClient();
+ * const { id, line } = client.encodeRequest({
+ *   kind: 'lease_acquire', scope: 'project', lane: 'tasks',
+ *   holder_id: 'pid-42:tasks', priority: 0, ttl_ms: 30_000, reentrant: true,
+ * });
+ * socket.write(line);
+ * socket.on('line', (raw) => {
+ *   const env = client.decodeResponseLine(raw); // throws on a bad frame
+ *   if (env.response.kind === 'lease_granted') { /* ... *\/ }
+ * });
+ * ```
+ */
+export function createLeaseIpcClient(): LeaseIpcClient {
+  let seq = 0;
+
+  return {
+    encodeRequest(request: LeaseIpcRequest): { id: string; line: string } {
+      seq += 1;
+      const id = nextCorrelationId(seq);
+      const envelope: LeaseIpcRequestEnvelope = {
+        protocol_version: LEASE_IPC_PROTOCOL_VERSION,
+        id,
+        direction: 'request',
+        request,
+      };
+      // Validate before serialization so we never emit an off-contract frame.
+      const parsed = LeaseIpcRequestEnvelopeSchema.parse(envelope);
+      return { id, line: `${JSON.stringify(parsed)}\n` };
+    },
+
+    decodeResponseLine(line: string): LeaseIpcResponseEnvelope {
+      let json: unknown;
+      try {
+        json = JSON.parse(line);
+      } catch (cause) {
+        throw new MalformedLeaseIpcFrameError(line, cause);
+      }
+      const result = LeaseIpcResponseEnvelopeSchema.safeParse(json);
+      if (!result.success) {
+        throw new MalformedLeaseIpcFrameError(line, result.error);
+      }
+      return result.data;
+    },
+  };
+}


### PR DESCRIPTION
## T11627 ST-5 — supervisor lease fast path (daemon-on, upgrade-only)

Lands the supervisor-side writer-lease arbitration so the re-enabled daemon
(`CLEO_WRITER_LEASE_MODE=supervisor`) shares **ONE `BEGIN IMMEDIATE` claim
primitive + one persisted row format** with the Node `local`-mode engine
(`packages/core/src/store/writer-lease.ts` `tryClaimOnce`). IPC is a coordination
optimization over the persisted source-of-truth, never a second source.

Builds on the v1.1 protocol surface merged in **PR #998** (`lease_ipc.rs` +
`@cleocode/contracts` `lease-ipc`) — that file is **extended at the call sites,
not edited**.

### AC mapping

| AC | What lands | Where |
|----|------------|-------|
| **AC1 — v1.1 accept-loop router** | Peek `protocol_version` only, then route `1.0.0` → frozen `IpcRequest` dispatch · `1.1.0` → `LeaseRequest` dispatch · else → `E_LEASE_BAD_VERSION` on lease framing | `ipc_server.rs` (`VersionPeek`, `client_read_loop`, `handle_lease_line`) |
| **AC2 — `LeaseAcquire` handler** | `lease_acquire` = synchronous `rusqlite` `BEGIN IMMEDIATE` claim against the SAME `_writer_leases` row (epoch-CAS, partial-unique `active=1`, FIFO+priority `_writer_queue` enqueue on a live-holder miss) | `lease_handler.rs` (`LeaseArbiter::handle` → `handle_acquire` → `claim`) |
| **AC3 — release / renew / reclaim** | `lease_release` (epoch-guarded free, idempotent) · `lease_renew` (epoch-guarded heartbeat advance) · `reclaim_or_kill` (supervisor-ONLY kill of a past-TTL **and** pid-dead holder → `child_killed_unresponsive`; a slow-but-live holder is never killed) | `lease_handler.rs` |
| **AC4 — deferred verbs declared, not implemented** | `rate_check` / `tool_grant` are declared in the frozen v1.1 union (no second version bump ever needed) but return `E_LEASE_UNIMPLEMENTED` | `lease_handler.rs` |
| **AC5 — TS `lease-ipc-client`** | Transport-agnostic NDJSON codec mirroring `supervisor-client.ts` (owns no socket; stamps `1.1.0`; throws `MalformedLeaseIpcFrameError` on a bad frame — never silently dropped) | `packages/runtime/src/daemon/lease-ipc-client.ts` |
| **AC6 — opt-in, frozen-safe wiring** | New `serve_with_lease()` threads an OPTIONAL `LeaseArbiter`; `serve()` keeps its signature and answers v1.1 frames with `E_LEASE_UNAVAILABLE` when no arbiter is wired | `ipc_server.rs` |

### Frozen-v1.0 proof

- **`crates/cleo-supervisor/src/ipc.rs` diff vs `origin/main` = `0` lines** (byte-frozen v1.0 contract).
- `lease_ipc.rs` (the v1.1 surface from #998) diff vs `origin/main` = `0` lines — extended, not edited.
- The v1.0 dispatch arm in `client_read_loop` is byte-identical to the frozen behaviour; the version router is a pure additive branch in front of it.
- **`tests/lease_ipc_e2e.rs` → `v1_1_acquire_release_over_socket_v1_0_unaffected`**: drives a v1.1 client (acquire → release → re-acquire) **and** a v1.0 `Health` client through the SAME accept loop over a REAL Unix socket; the v1.0 `Health` response is unchanged — direct evidence the router leaves v1.0 untouched.
- `v1_1_without_arbiter_returns_unavailable` proves the opt-in default.

### Node / Rust transaction parity

The Rust `claim()` is a byte-for-byte mirror of the Node `tryClaimOnce`:

| Step | Node (`writer-lease.ts`) | Rust (`lease_handler.rs`) |
|------|--------------------------|---------------------------|
| Tables | `_writer_leases` / `_writer_queue` (`WRITER_LEASES_TABLE` / `WRITER_QUEUE_TABLE`) | same literals |
| Claim txn | `BEGIN IMMEDIATE TRANSACTION` | same |
| Fresh epoch | `COALESCE(MAX(epoch),0)+1` | same |
| Re-entry | `reentrancy_depth = reentrancy_depth + 1, heartbeat_at = ?` | same |
| Reclaim guard | `now - heartbeat_at > ttl_ms && !isPidAlive(pid)` → `epoch + 1` (CAS on `id` + `epoch`) | same |
| Release / renew | epoch-CAS `WHERE … epoch = ? AND active = 1` | same |
| pid liveness | `process.kill(pid, 0)` (`EPERM` = alive) | `nix::kill(pid, None)` (`EPERM` = alive) |
| `busy_timeout` | `30_000` backstop | `30_000` backstop |

`rusqlite` (bundled, `publish = false`) gives byte-identical synchronous semantics to `node:sqlite`; claims run on `tokio::task::spawn_blocking` so the sync driver never blocks the reactor. Spec §7: **only the supervisor kills** — `local` mode reclaims a dead pid on the next acquire and never kills.

### Gates (all green)

- `cargo test -p cleo-supervisor` (toolchain 1.94.0): 64 unit + 3 bin + `lease_ipc_e2e` (2) + `ipc_e2e_smoke` + lifecycle — **0 failures**.
- `pnpm biome check .` — clean (3539 files).
- `pnpm run build` — success (all 9 waves, incl. `@cleocode/runtime` DTS).
- `@cleocode/runtime` tests (cgroup-wrapped, `--maxWorkers=2`): **127 passed / 13 files** (incl. new `lease-ipc-client.test.ts`).
- Crate publish guard: `crates/cleo-supervisor/Cargo.toml` carries `publish = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
