### PR TITLE
feat(T11639): session_manifest global mirror + parentSessionId fork-tree column

### DIFF
--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -121,6 +121,17 @@ export interface Session {
   previousSessionId?: string | null;
   /** ID of the session that follows this one. @defaultValue undefined */
   nextSessionId?: string | null;
+  /**
+   * ID of the fork-tree PARENT session that spawned this one (T11639).
+   *
+   * Sourced from `CLEO_PARENT_SESSION_ID` (stamped by the supervisor — T11629).
+   * Distinct from {@link Session.previousSessionId} (the linear resume chain):
+   * `parentSessionId` is the orchestrator→worker spawn edge. NULL/undefined for a
+   * root session with no spawning parent.
+   *
+   * @defaultValue undefined
+   */
+  parentSessionId?: string | null;
   /** Provider-specific agent identifier string. @defaultValue undefined */
   agentIdentifier?: string | null;
   /** ISO 8601 timestamp of when the handoff was consumed. @defaultValue undefined */

--- a/packages/core/migrations/drizzle-cleo-global/20260607010000_t11639-session-manifest/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260607010000_t11639-session-manifest/migration.sql
@@ -1,0 +1,43 @@
+-- T11639 (EP-SESSION-MANIFEST · epic T11638) — cross-project `session_manifest`
+-- MIRROR table in the consolidated GLOBAL cleo.db (drizzle-cleo-global scope).
+--
+-- The authoritative session row lives per-project in `tasks_sessions` (PROJECT
+-- scope). A best-effort writer mirrors a compact projection into this GLOBAL row so
+-- the fleet has one machine-wide view of every session across every project without
+-- ATTACHing N per-project DBs. NOT authoritative (deliberately NOT named `sessions`):
+-- reconcile-on-start re-reads the project row and overwrites this row so it can never
+-- drift into authority.
+--
+-- `project_id` is a soft FK → `nexus_project_registry.project_id` (same cleo.db),
+-- nullable for sessions started outside any registered project. `parent_session_id`
+-- is a soft self-reference (fork tree, sourced from CLEO_PARENT_SESSION_ID / T11629),
+-- nullable for root sessions. No native FKs: the mirror must tolerate a project row
+-- that lands before/without its registry/parent peer.
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op. Each statement
+-- is separated by a drizzle breakpoint marker so node:sqlite prepare() does not
+-- truncate the multi-statement file to statement one.
+--
+-- @task T11639
+-- @epic T11638
+
+CREATE TABLE IF NOT EXISTS `session_manifest` (
+  `session_id` text PRIMARY KEY NOT NULL,
+  `project_id` text,
+  `parent_session_id` text,
+  `name` text,
+  `status` text,
+  `project_path` text,
+  `started_at` text,
+  `ended_at` text,
+  `mirrored_at` text NOT NULL DEFAULT (datetime('now')),
+  CHECK ("started_at" IS NULL OR "started_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("ended_at" IS NULL OR "ended_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("mirrored_at" IS NULL OR "mirrored_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_session_manifest_project_id` ON `session_manifest` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_session_manifest_parent` ON `session_manifest` (`parent_session_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_session_manifest_status` ON `session_manifest` (`status`);

--- a/packages/core/migrations/drizzle-cleo-project/20260607010000_t11639-session-parent/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260607010000_t11639-session-parent/migration.sql
@@ -1,0 +1,22 @@
+-- T11639 (EP-SESSION-MANIFEST · epic T11638) — add nullable `parent_session_id`
+-- to `tasks_sessions` (consolidated PROJECT cleo.db, drizzle-cleo-project scope).
+--
+-- The fork-tree PARENT session edge: the orchestrator→worker spawn relationship,
+-- sourced from CLEO_PARENT_SESSION_ID (stamped by the supervisor — T11629 / PR #996)
+-- at session start. Distinct from `previous_session_id` (the linear resume chain).
+-- Soft self-reference to `tasks_sessions.id`; nullable so a root session (no spawning
+-- parent) and every existing row stay valid.
+--
+-- No CHECK constraint: `parent_session_id` is a plain free-text soft self-FK (not a
+-- timestamp `_at`, boolean, or enum), so the T11363 consolidation-check injector
+-- contributes nothing for it.
+--
+-- Each statement is separated by a drizzle breakpoint marker so node:sqlite prepare()
+-- does not truncate the multi-statement file to statement one.
+--
+-- @task T11639
+-- @epic T11638
+
+ALTER TABLE `tasks_sessions` ADD COLUMN `parent_session_id` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tasks_sessions_parent` ON `tasks_sessions` (`parent_session_id`);

--- a/packages/core/src/sessions/__tests__/session-manifest-mirror.test.ts
+++ b/packages/core/src/sessions/__tests__/session-manifest-mirror.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the GLOBAL `session_manifest` mirror writers (EP-SESSION-MANIFEST ·
+ * epic T11638 · task T11639).
+ *
+ * Coverage (the four ACs):
+ *   1. ensureGlobalSignaldockDb is idempotent — repeated calls return the SAME
+ *      shared GLOBAL handle and the `session_manifest` table exists (NOT `sessions`).
+ *   2. Mirror write on start + end — mirroring an authoritative session writes/updates
+ *      the manifest row (status/endedAt reflect the close).
+ *   3. Mirror failure does NOT fail the session op — a forced write failure is
+ *      swallowed (the public writer resolves, never throws).
+ *   4. parentSessionId is persisted from CLEO_PARENT_SESSION_ID onto the project row
+ *      AND mirrored into the manifest.
+ *   5. Reconcile-on-start OVERWRITES a stale manifest row from the authoritative
+ *      project row — the manifest can never drift into authority (AC4).
+ *
+ * Every test runs against a TEMP-DIR project `.cleo/cleo.db` and a TEMP-DIR global
+ * `cleo.db` (CLEO_HOME override) — never the real fleet.
+ *
+ * @task T11639
+ * @epic T11638
+ * @saga T11242
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Session } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createSession } from '../../store/session-store.js';
+import { startSession } from '../index.js';
+import {
+  ensureGlobalSignaldockDb,
+  mirrorSessionToManifest,
+  readSessionManifestRow,
+  reconcileSessionManifestOnStart,
+} from '../session-manifest-mirror.js';
+
+let testRoot: string;
+let projectDir: string;
+let globalDir: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `session-manifest-mirror-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  projectDir = join(testRoot, 'project');
+  mkdirSync(join(projectDir, '.cleo'), { recursive: true });
+  // CLEO_HOME must end in 'cleo' so the GLOBAL db path resolves to <CLEO_HOME>/cleo.db.
+  globalDir = join(testRoot, 'cleo');
+  mkdirSync(globalDir, { recursive: true });
+  process.env.CLEO_HOME = globalDir;
+  delete process.env.CLEO_PARENT_SESSION_ID;
+  delete process.env.CLEO_WRITER_LEASE_MODE;
+});
+
+afterEach(async () => {
+  // Reset BOTH dual-scope caches (project + global handles opened by these tests).
+  const { _resetDualScopeDbCache } = await import('../../store/dual-scope-db.js');
+  _resetDualScopeDbCache();
+  const { _resetWriterLeaseStateForTest } = await import('../../store/writer-lease.js');
+  _resetWriterLeaseStateForTest();
+  delete process.env.CLEO_HOME;
+  delete process.env.CLEO_PARENT_SESSION_ID;
+  delete process.env.CLEO_WRITER_LEASE_MODE;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+/** Build a minimal authoritative Session for mirroring. */
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: overrides.id ?? `ses_20260607120000_abc123`,
+    name: overrides.name ?? 'test-session',
+    status: overrides.status ?? 'active',
+    scope: overrides.scope ?? { type: 'global' },
+    startedAt: overrides.startedAt ?? new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('ensureGlobalSignaldockDb (AC1)', () => {
+  it('is idempotent — repeated calls return the same shared GLOBAL handle', async () => {
+    const h1 = await ensureGlobalSignaldockDb();
+    const h2 = await ensureGlobalSignaldockDb();
+    expect(h1).toBe(h2);
+    expect(h1.scope).toBe('global');
+  }, 30_000);
+
+  it('ensures `session_manifest` exists and the table is NOT named `sessions`', async () => {
+    const handle = await ensureGlobalSignaldockDb();
+    // The `as any` cast is required because $client is typed as unknown on the generic db handle.
+    const nativeDb = (handle.db as any).$client as import('node:sqlite').DatabaseSync;
+
+    const manifest = nativeDb
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_manifest'")
+      .get() as { name: string } | undefined;
+    expect(manifest?.name).toBe('session_manifest');
+
+    // AC1: the GLOBAL mirror MUST NOT be named `sessions`.
+    const wrong = nativeDb
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'")
+      .get() as { name: string } | undefined;
+    expect(wrong).toBeUndefined();
+  }, 30_000);
+});
+
+describe('mirrorSessionToManifest (AC3 — start + end)', () => {
+  it('mirrors an active session, then reflects the ended status on a second mirror', async () => {
+    const session = makeSession({ id: 'ses_20260607120001_aaa111', status: 'active' });
+
+    await mirrorSessionToManifest(projectDir, session);
+    const afterStart = await readSessionManifestRow(session.id);
+    expect(afterStart).not.toBeNull();
+    expect(afterStart?.sessionId).toBe(session.id);
+    expect(afterStart?.status).toBe('active');
+    expect(afterStart?.projectPath).toBe(projectDir);
+    expect(afterStart?.endedAt).toBeNull();
+
+    // Mirror the ENDED projection (status + endedAt updated).
+    const endedAt = new Date().toISOString();
+    await mirrorSessionToManifest(projectDir, { ...session, status: 'ended', endedAt });
+    const afterEnd = await readSessionManifestRow(session.id);
+    expect(afterEnd?.status).toBe('ended');
+    expect(afterEnd?.endedAt).toBe(endedAt);
+  }, 30_000);
+});
+
+describe('mirror failure does NOT fail the session op (AC3)', () => {
+  it('swallows a write failure — the public writer resolves, never throws', async () => {
+    // Force the GLOBAL open to throw deterministically: a NUL byte in the resolved
+    // path makes node:fs mkdir/open throw synchronously (ERR_INVALID_ARG_VALUE),
+    // exercising the mirror writer's best-effort catch WITHOUT any DB/lease spin.
+    process.env.CLEO_HOME = join(testRoot, 'cleo\0bad');
+
+    const session = makeSession({ id: 'ses_20260607120002_bbb222' });
+
+    // MUST resolve (not reject) despite the underlying open/write failing.
+    await expect(mirrorSessionToManifest(projectDir, session)).resolves.toBeUndefined();
+    // And reconcile-on-start is equally best-effort under the same failure.
+    await expect(reconcileSessionManifestOnStart(projectDir, session.id)).resolves.toBeUndefined();
+  }, 15_000);
+});
+
+describe('parentSessionId persisted from env (AC2)', () => {
+  it('startSession stamps CLEO_PARENT_SESSION_ID onto the project session row', async () => {
+    const parentId = 'ses_20260607119999_par999';
+    process.env.CLEO_PARENT_SESSION_ID = parentId;
+    // Ensure the env-first resolver does not pick a different own-session id.
+    delete process.env.CLEO_SESSION_ID;
+
+    const session = await startSession(projectDir, { scope: 'global' });
+    expect(session.parentSessionId).toBe(parentId);
+
+    // Persisted on the authoritative project row.
+    const { getSession } = await import('../../store/session-store.js');
+    const persisted = await getSession(session.id, projectDir);
+    expect(persisted?.parentSessionId).toBe(parentId);
+  }, 30_000);
+
+  it('mirrors parentSessionId into the manifest row', async () => {
+    const parentId = 'ses_20260607119998_par998';
+    const session = makeSession({
+      id: 'ses_20260607120003_ccc333',
+      parentSessionId: parentId,
+    });
+    await mirrorSessionToManifest(projectDir, session);
+    const row = await readSessionManifestRow(session.id);
+    expect(row?.parentSessionId).toBe(parentId);
+  }, 30_000);
+});
+
+describe('reconcileSessionManifestOnStart OVERWRITES a stale manifest (AC4)', () => {
+  it('re-reads the authoritative project row and overwrites a drifted manifest row', async () => {
+    const sessionId = 'ses_20260607120004_ddd444';
+
+    // 1. Seed the AUTHORITATIVE project row (status active, name "real").
+    await createSession(
+      makeSession({ id: sessionId, name: 'real-name', status: 'active' }),
+      projectDir,
+    );
+
+    // 2. Plant a STALE/DRIFTED manifest row (wrong name + wrong status) directly.
+    await mirrorSessionToManifest(
+      projectDir,
+      makeSession({ id: sessionId, name: 'STALE-name', status: 'ended' }),
+    );
+    const drifted = await readSessionManifestRow(sessionId);
+    expect(drifted?.name).toBe('STALE-name');
+    expect(drifted?.status).toBe('ended');
+
+    // 3. Reconcile-on-start MUST overwrite the manifest from the authoritative row.
+    await reconcileSessionManifestOnStart(projectDir, sessionId);
+    const reconciled = await readSessionManifestRow(sessionId);
+    expect(reconciled?.name).toBe('real-name');
+    expect(reconciled?.status).toBe('active');
+  }, 30_000);
+
+  it('is a no-op when no authoritative project row exists (nothing to mirror)', async () => {
+    const sessionId = 'ses_20260607120005_eee555';
+    // No project row seeded. Reconcile must not throw and must not invent a row.
+    await expect(reconcileSessionManifestOnStart(projectDir, sessionId)).resolves.toBeUndefined();
+    const row = await readSessionManifestRow(sessionId);
+    expect(row).toBeNull();
+  }, 30_000);
+});

--- a/packages/core/src/sessions/handoff.ts
+++ b/packages/core/src/sessions/handoff.ts
@@ -262,6 +262,18 @@ export async function persistHandoff(
     }
     throw err;
   }
+
+  // T11639: best-effort refresh the GLOBAL session_manifest on handoff (a session-
+  // state event). Re-reads the authoritative project row → re-projects the mirror.
+  // Swallows all errors — a mirror failure NEVER fails handoff persistence (AC3).
+  // Fire-and-forget.
+  import('./session-manifest-mirror.js')
+    .then(({ reconcileSessionManifestOnStart }) =>
+      reconcileSessionManifestOnStart(projectRoot, sessionId),
+    )
+    .catch(() => {
+      /* mirror is best-effort — never block handoff persistence */
+    });
 }
 
 /**

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -23,6 +23,7 @@ import type { DataAccessor } from '../store/data-accessor.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import type { AgentSessionHandle } from './agent-session-adapter.js';
 import { closeAgentSession, openAgentSession } from './agent-session-adapter.js';
+import { resolveParentSessionIdFromEnv } from './session-id.js';
 
 // Auto-register hook handlers
 import '../hooks/handlers/index.js';
@@ -151,6 +152,11 @@ export async function startSession(
     // Provider detection is best-effort
   }
 
+  // Fork-tree PARENT session edge (T11639 · T11629): the supervisor stamps
+  // CLEO_PARENT_SESSION_ID on every worker it spawns (PR #996). Capture it at
+  // start so the session row records the orchestrator→worker spawn edge.
+  const parentSessionId = resolveParentSessionIdFromEnv();
+
   const session: Session = {
     id: generateSessionId(),
     name: params.name ?? `session-${Date.now()}`,
@@ -164,6 +170,7 @@ export async function startSession(
     notes: [],
     tasksCompleted: [],
     tasksCreated: [],
+    parentSessionId: parentSessionId ?? null,
   };
 
   // If grade mode enabled, mark session and set env vars for audit middleware
@@ -176,6 +183,19 @@ export async function startSession(
 
   sessions.push(session);
   await accessor.upsertSingleSession(session);
+
+  // T11639: best-effort mirror this session into the GLOBAL session_manifest, then
+  // reconcile-on-start (re-read the authoritative project row → overwrite the
+  // manifest so it can never drift into authority). Both swallow all errors — a
+  // mirror failure NEVER fails session start (AC3/AC4). Fire-and-forget.
+  import('./session-manifest-mirror.js')
+    .then(async ({ mirrorSessionToManifest, reconcileSessionManifestOnStart }) => {
+      await mirrorSessionToManifest(projectRoot, session);
+      await reconcileSessionManifestOnStart(projectRoot, session.id);
+    })
+    .catch(() => {
+      /* mirror is best-effort — never block session start */
+    });
 
   // T947 Step 2: open a corresponding llmtxt AgentSession for audit
   // receipts. Best-effort — peer-dep absence yields `null` and leaves
@@ -364,6 +384,15 @@ export async function endSession(projectRoot: string, params: SessionEndParams):
   }
 
   await accessor.upsertSingleSession(session);
+
+  // T11639: best-effort mirror the ENDED session into the GLOBAL session_manifest
+  // (status/endedAt now reflect the close). Swallows all errors — NEVER fails
+  // session end (AC3). Fire-and-forget.
+  import('./session-manifest-mirror.js')
+    .then(({ mirrorSessionToManifest }) => mirrorSessionToManifest(projectRoot, session))
+    .catch(() => {
+      /* mirror is best-effort — never block session end */
+    });
 
   // T947 Step 2: close the matching llmtxt AgentSession (if any) and
   // persist the ContributionReceipt to `.cleo/audit/receipts.jsonl`.
@@ -623,6 +652,14 @@ export {
   resolveSessionIdFromEnv,
   SESSION_ENV_KEY_PRECEDENCE,
 } from './session-id.js';
+// T11639 — GLOBAL session_manifest mirror (EP-SESSION-MANIFEST · epic T11638)
+export {
+  ensureGlobalSignaldockDb,
+  mirrorSessionToManifest,
+  readSessionManifestRow,
+  reconcileSessionManifestOnStart,
+  resolveGlobalManifestDbPath,
+} from './session-manifest-mirror.js';
 export type { SessionBridgeData, SessionBridgeResult } from './session-memory-bridge.js';
 export { bridgeSessionToMemory } from './session-memory-bridge.js';
 // Re-export extended session modules (engine-compatible)

--- a/packages/core/src/sessions/session-manifest-mirror.ts
+++ b/packages/core/src/sessions/session-manifest-mirror.ts
@@ -1,0 +1,287 @@
+/**
+ * **session_manifest mirror writers** — best-effort GLOBAL-scope mirror of the
+ * per-project `tasks_sessions` rows (EP-SESSION-MANIFEST · epic T11638 · task T11639).
+ *
+ * ## What this module does
+ *
+ * The authoritative session row lives per-project in `tasks_sessions` (PROJECT
+ * scope `cleo.db`). These writers copy a compact projection of that row into the
+ * `session_manifest` table in the GLOBAL-scope `cleo.db` so the fleet has a single,
+ * machine-wide index of every session across every project — without ATTACHing N
+ * per-project DB files. The manifest is a MIRROR, never the source of truth.
+ *
+ * ## Three invariants (the ACs of T11639)
+ *
+ * 1. **Shared handle, never closed (AC3).** All writes go through the singleton
+ *    GLOBAL `cleo.db` handle returned by {@link openDualScopeDb}('global'). We NEVER
+ *    call `.close()` on it — closing the cached handle would pull the rug from under
+ *    every other global-scope reader/writer in the process.
+ * 2. **Best-effort — never throw into the caller (AC3).** Every public writer here
+ *    swallows ALL errors (log at debug + continue). A failure to mirror MUST NOT
+ *    fail the underlying `cleo session start|end` / handoff op. The mirror is an
+ *    observability convenience, not a correctness dependency.
+ * 3. **MIRROR, never authoritative (AC4).** {@link reconcileSessionManifestOnStart}
+ *    re-reads the AUTHORITATIVE project row and OVERWRITES the manifest row, so a
+ *    stale or partially-written manifest entry can never drift into being treated as
+ *    truth. Consumers needing exact session state read `tasks_sessions`.
+ *
+ * ## Identity (`project_id`)
+ *
+ * The mirror reuses the CANONICAL `nexus_project_registry.project_id` (12-hex) for
+ * the owning project — resolved via the nexus identity helper — never a freshly
+ * minted id. Nullable: a session started outside any resolvable registered project
+ * still mirrors with `project_id` NULL.
+ *
+ * ## Writer lease (operating rule 5)
+ *
+ * Global-scope writes acquire the writer lease ({@link withWriterLease}) for
+ * `(scope='global', lane='tasks')`, pinned to the global `cleo.db` path, so they
+ * serialize with the cold-open and every other chokepoint write — healing T5158.
+ *
+ * @module
+ * @task T11639
+ * @epic T11638
+ * @saga T11242
+ * @see ../store/schema/cleo-global/session-manifest.ts — the table decl
+ * @see ./index.ts — startSession/endSession call sites
+ */
+
+import type { Session } from '@cleocode/contracts';
+import { eq } from 'drizzle-orm';
+import { getLogger } from '../logger.js';
+import {
+  type CleoGlobalDb,
+  type DualScopeDbHandle,
+  openDualScopeDb,
+  resolveDualScopeDbPath,
+} from '../store/dual-scope-db.js';
+import { sessionManifest } from '../store/schema/cleo-global/session-manifest.js';
+import { withWriterLease } from '../store/writer-lease.js';
+
+/**
+ * Lazily-memoized module logger.
+ *
+ * Constructed on first use, never at import time: a top-level `getLogger(...)`
+ * executes the logger factory during module init, which — when this module is
+ * pulled into a test's mocked import graph — can reach a `vi.mock('../logger.js')`
+ * factory before its module-scoped spy `const` is initialized, throwing a TDZ
+ * `ReferenceError`. Deferring keeps import-time side-effect-free (operating rule 4),
+ * matching the pattern in `writer-lease.ts` / `dual-scope-db.ts`.
+ *
+ * @task T11639
+ */
+let _log: ReturnType<typeof getLogger> | null = null;
+function log(): ReturnType<typeof getLogger> {
+  if (_log === null) _log = getLogger('session-manifest-mirror');
+  return _log;
+}
+
+/**
+ * Ensure the GLOBAL `session_manifest` table exists and return the SHARED global
+ * `cleo.db` handle (AC1).
+ *
+ * This is the named "ensure" entry point referenced by EP-SESSION-MANIFEST. It
+ * opens (or re-uses) the singleton GLOBAL-scope handle via {@link openDualScopeDb},
+ * whose migrate step runs the `session_manifest` migration idempotently — so the
+ * table is guaranteed present after this resolves. The returned handle is the SHARED
+ * singleton: callers MUST NOT close it.
+ *
+ * @returns The shared GLOBAL-scope {@link DualScopeDbHandle} (table ensured).
+ * @task T11639
+ */
+export async function ensureGlobalSignaldockDb(): Promise<DualScopeDbHandle<'global'>> {
+  // openDualScopeDb('global') runs the consolidated GLOBAL migrations (which now
+  // include the session_manifest CREATE) under the cold-open lease, then caches +
+  // returns the singleton handle. Idempotent — a re-call returns the same handle.
+  return openDualScopeDb('global');
+}
+
+/**
+ * Build the `session_manifest` mirror row from an authoritative {@link Session}
+ * plus its resolved owning-project metadata.
+ *
+ * Pure projection — no I/O. `mirroredAt` is set to write time here so the row
+ * records WHEN the mirror was last refreshed (independent of session activity).
+ */
+function toManifestRow(
+  session: Session,
+  projectId: string | null,
+  projectPath: string | null,
+): typeof sessionManifest.$inferInsert {
+  return {
+    sessionId: session.id,
+    projectId,
+    parentSessionId: session.parentSessionId ?? null,
+    name: session.name ?? null,
+    status: session.status ?? null,
+    projectPath,
+    startedAt: session.startedAt ?? null,
+    endedAt: session.endedAt ?? null,
+    mirroredAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Resolve the CANONICAL `nexus_project_registry.project_id` (12-hex) for a project
+ * root, best-effort. Returns `null` when the project is not resolvable (e.g. not a
+ * git repo / no canonical id) — the manifest row then carries a NULL `project_id`.
+ *
+ * Lazy `import()` of the nexus identity helper keeps this module's import graph
+ * light and avoids a cycle (the nexus layer transitively imports the store).
+ */
+async function resolveCanonicalProjectId(projectRoot: string): Promise<string | null> {
+  try {
+    const { canonicalProjectId } = await import('../nexus/identity.js');
+    const result = await canonicalProjectId(projectRoot);
+    return result.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write (upsert) a single `session_manifest` mirror row through the GLOBAL handle,
+ * under the writer lease. The PRIVATE core shared by the public best-effort writers.
+ *
+ * Throws on failure — the PUBLIC wrappers ({@link mirrorSessionToManifest} /
+ * {@link reconcileSessionManifestOnStart}) are responsible for swallowing.
+ */
+async function upsertManifestRow(
+  handle: DualScopeDbHandle<'global'>,
+  row: typeof sessionManifest.$inferInsert,
+): Promise<void> {
+  const db: CleoGlobalDb = handle.db;
+  // Operating rule 5: gate the GLOBAL-scope write through the writer lease, pinned
+  // to the global cleo.db path so the lease row lands in THIS file.
+  await withWriterLease(
+    'global',
+    'tasks',
+    async () => {
+      await db
+        .insert(sessionManifest)
+        .values(row)
+        .onConflictDoUpdate({
+          target: sessionManifest.sessionId,
+          // Overwrite every mirrored column on conflict — the manifest is a pure
+          // projection, so the latest write fully replaces the prior projection.
+          set: {
+            projectId: row.projectId,
+            parentSessionId: row.parentSessionId,
+            name: row.name,
+            status: row.status,
+            projectPath: row.projectPath,
+            startedAt: row.startedAt,
+            endedAt: row.endedAt,
+            mirroredAt: row.mirroredAt,
+          },
+        })
+        .run();
+    },
+    { dbPath: handle.dbPath },
+  );
+}
+
+/**
+ * Best-effort mirror of a session into the GLOBAL `session_manifest` (AC3).
+ *
+ * Call on session start / end / handoff. Resolves the owning project's canonical
+ * `project_id`, ensures the table + shared handle, and upserts the mirror row. ANY
+ * failure (DB unopenable, write error, identity-resolution failure) is logged at
+ * debug and SWALLOWED — this NEVER throws into the caller, so a mirror failure
+ * cannot fail the underlying session op.
+ *
+ * @param projectRoot - Absolute path to the project whose session is being mirrored
+ *   (used to resolve the canonical `project_id` and `project_path`).
+ * @param session - The authoritative {@link Session} (post-mutation) to mirror.
+ * @task T11639
+ */
+export async function mirrorSessionToManifest(
+  projectRoot: string,
+  session: Session,
+): Promise<void> {
+  try {
+    const handle = await ensureGlobalSignaldockDb();
+    const projectId = await resolveCanonicalProjectId(projectRoot);
+    const row = toManifestRow(session, projectId, projectRoot);
+    await upsertManifestRow(handle, row);
+  } catch (err) {
+    // Best-effort: a mirror failure MUST NOT fail the session op (AC3).
+    log().debug(
+      { sessionId: session.id, err: err instanceof Error ? err.message : err },
+      'session_manifest mirror write failed (non-fatal); session op unaffected',
+    );
+  }
+}
+
+/**
+ * Reconcile-on-start: re-read the AUTHORITATIVE project session row and OVERWRITE
+ * its manifest mirror so the manifest can never drift into authority (AC4).
+ *
+ * Called at session start (after the project row is persisted). It reads the
+ * canonical `tasks_sessions` row back from the PROJECT scope and re-projects it into
+ * the GLOBAL manifest — guaranteeing the mirror reflects the source of truth even if
+ * a prior mirror write was partial, stale, or raced. Best-effort: ANY failure is
+ * logged at debug and swallowed.
+ *
+ * @param projectRoot - Absolute path to the owning project.
+ * @param sessionId - The session whose manifest row is reconciled.
+ * @task T11639
+ */
+export async function reconcileSessionManifestOnStart(
+  projectRoot: string,
+  sessionId: string,
+): Promise<void> {
+  try {
+    // Re-read the AUTHORITATIVE project row (source of truth) — never trust the
+    // manifest as input. Lazy import breaks the store→sessions cycle.
+    const { getSession } = await import('../store/session-store.js');
+    const authoritative = await getSession(sessionId, projectRoot);
+    if (!authoritative) {
+      // No project row → nothing authoritative to mirror. Leave the manifest as-is.
+      return;
+    }
+    const handle = await ensureGlobalSignaldockDb();
+    const projectId = await resolveCanonicalProjectId(projectRoot);
+    const row = toManifestRow(authoritative, projectId, projectRoot);
+    await upsertManifestRow(handle, row);
+  } catch (err) {
+    log().debug(
+      { sessionId, err: err instanceof Error ? err.message : err },
+      'session_manifest reconcile-on-start failed (non-fatal); session op unaffected',
+    );
+  }
+}
+
+/**
+ * Read a single `session_manifest` mirror row through the SHARED global handle.
+ *
+ * Primarily a test / introspection convenience — production consumers needing exact
+ * session state MUST read the authoritative `tasks_sessions`, not this mirror.
+ *
+ * @param sessionId - The session id to look up in the manifest.
+ * @returns The mirror row, or `null` when absent.
+ * @task T11639
+ */
+export async function readSessionManifestRow(
+  sessionId: string,
+): Promise<typeof sessionManifest.$inferSelect | null> {
+  const handle = await ensureGlobalSignaldockDb();
+  const rows = await handle.db
+    .select()
+    .from(sessionManifest)
+    .where(eq(sessionManifest.sessionId, sessionId))
+    .all();
+  return rows[0] ?? null;
+}
+
+/**
+ * Resolve the absolute on-disk path of the GLOBAL `cleo.db` (the manifest's home).
+ * Thin re-export of the scope→path resolver for callers that want the path without
+ * opening the handle.
+ *
+ * @returns The GLOBAL-scope `cleo.db` absolute path.
+ * @task T11639
+ */
+export function resolveGlobalManifestDbPath(): string {
+  return resolveDualScopeDbPath('global');
+}

--- a/packages/core/src/store/converters.ts
+++ b/packages/core/src/store/converters.ts
@@ -156,6 +156,8 @@ export function rowToSession(row: SessionRow): Session {
     // Session chain fields (T4959)
     previousSessionId: row.previousSessionId ?? null,
     nextSessionId: row.nextSessionId ?? null,
+    // Fork-tree parent edge (T11639)
+    parentSessionId: row.parentSessionId ?? null,
     agentIdentifier: row.agentIdentifier ?? null,
     handoffConsumedAt: row.handoffConsumedAt ?? null,
     handoffConsumedBy: row.handoffConsumedBy ?? null,

--- a/packages/core/src/store/db-helpers.ts
+++ b/packages/core/src/store/db-helpers.ts
@@ -214,6 +214,8 @@ export async function upsertSession(db: DrizzleDb, session: Session): Promise<vo
     // Session chain fields (T4959)
     previousSessionId: session.previousSessionId ?? null,
     nextSessionId: session.nextSessionId ?? null,
+    // Fork-tree parent edge (T11639) — sourced from CLEO_PARENT_SESSION_ID at start.
+    parentSessionId: session.parentSessionId ?? null,
     agentIdentifier: session.agentIdentifier ?? null,
     handoffConsumedAt: session.handoffConsumedAt ?? null,
     handoffConsumedBy: session.handoffConsumedBy ?? null,

--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -95,5 +95,6 @@
 export * from '../cleo-shared/index.js';
 export * from './agent-registry.js';
 export * from './nexus.js';
+export * from './session-manifest.js';
 export * from './skills.js';
 export * from './telemetry.js';

--- a/packages/core/src/store/schema/cleo-global/session-manifest.ts
+++ b/packages/core/src/store/schema/cleo-global/session-manifest.ts
@@ -1,0 +1,109 @@
+/**
+ * Global-scope `cleo.db` — cross-project **session manifest** mirror (1 table).
+ *
+ * EP-SESSION-MANIFEST (epic T11638, task T11639). The `session_manifest` table is
+ * a CROSS-PROJECT MIRROR of the per-project `tasks_sessions` rows: each project's
+ * authoritative session lives in that project's `tasks_sessions` table (PROJECT
+ * scope `cleo.db`), and a best-effort writer copies a compact projection into this
+ * GLOBAL-scope row so the fleet has a single, machine-wide view of every session
+ * across every project — without ATTACHing N per-project DBs.
+ *
+ * ## NOT named `sessions` (AC1)
+ *
+ * The table is deliberately `session_manifest`, NOT `sessions`. The authoritative
+ * project-tier table is `tasks_sessions`; naming the global mirror `sessions` would
+ * invite a future reader to mistake the mirror for the source of truth. The name
+ * encodes its role: a manifest (an index/catalog), never the authority.
+ *
+ * ## MIRROR, never authoritative (AC4)
+ *
+ * Every column here is derived from the project row. The mirror writer is
+ * best-effort (a failure NEVER fails the underlying session op) and reconcile-on-
+ * start re-reads the authoritative project row and OVERWRITES the manifest row, so
+ * a stale or partially-written manifest entry can never drift into being treated as
+ * truth. Consumers needing exact session state MUST read the project's
+ * `tasks_sessions`; this table answers "which sessions exist, where, and how are
+ * they forked" cheaply across projects.
+ *
+ * ## Identity (`project_id`)
+ *
+ * `project_id` is the canonical `nexus_project_registry.project_id` (12-hex) for
+ * the project that owns the session — a soft FK into the global registry table in
+ * THIS same `cleo.db`. It is reused (never minted here) so the manifest joins
+ * cleanly to the registry. Nullable: a session started outside any resolvable
+ * registered project still mirrors, with `project_id` NULL.
+ *
+ * ## Fork tree (`parent_session_id`)
+ *
+ * `parent_session_id` mirrors the project row's own `parent_session_id`
+ * (populated from `CLEO_PARENT_SESSION_ID`, stamped by the supervisor — PR #996 /
+ * T11629). It reconstructs the orchestrator→worker fork tree machine-wide without
+ * a per-project DB scan. Soft self-reference to `session_manifest.session_id`;
+ * NULL for a root session.
+ *
+ * @task T11639
+ * @epic T11638
+ * @saga T11242
+ * @see ../cleo-project/tasks-core.ts — `tasksSessions` (the authoritative source)
+ * @see ./nexus.ts — `nexusProjectRegistry` (the `project_id` SSoT)
+ * @see ../../sessions/session-manifest-mirror.ts — the best-effort mirror writers
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * `session_manifest` — cross-project mirror of per-project `tasks_sessions` rows.
+ *
+ * A best-effort projection: one row per session, keyed on the session id, carrying
+ * just enough to answer fleet-wide "what sessions exist, in which project, and how
+ * are they forked" without opening every project's `cleo.db`. NOT authoritative —
+ * the project's `tasks_sessions` row is the source of truth; this row is overwritten
+ * on reconcile-on-start so it can never drift into authority (AC4).
+ *
+ * @task T11639
+ */
+export const sessionManifest = sqliteTable(
+  'session_manifest',
+  {
+    /** Session id (canonical `ses_...` form). Primary key — one manifest row per session. */
+    sessionId: text('session_id').primaryKey(),
+    /**
+     * Canonical `nexus_project_registry.project_id` (12-hex) of the owning project.
+     * Soft FK into the global registry in THIS `cleo.db`; NULL when the session was
+     * started outside any resolvable registered project.
+     */
+    projectId: text('project_id'),
+    /**
+     * Fork-tree parent session id, mirrored from the project row's own
+     * `parent_session_id` (sourced from `CLEO_PARENT_SESSION_ID`, T11629). Soft
+     * self-reference to `session_manifest.session_id`; NULL for a root session.
+     */
+    parentSessionId: text('parent_session_id'),
+    /** Mirrored session name. */
+    name: text('name'),
+    /** Mirrored session status (`active` | `ended` | `orphaned` | …). */
+    status: text('status'),
+    /** Mirrored absolute project root path (for operator readability / debugging). */
+    projectPath: text('project_path'),
+    /** Mirrored ISO-8601 UTC session-start instant. */
+    startedAt: text('started_at'),
+    /** Mirrored ISO-8601 UTC session-end instant; NULL while active. */
+    endedAt: text('ended_at'),
+    /**
+     * ISO-8601 UTC instant this mirror row was last written by a mirror/reconcile
+     * writer (NOT the session's own activity). Defaults to write time.
+     */
+    mirroredAt: text('mirrored_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_session_manifest_project_id').on(table.projectId),
+    index('idx_session_manifest_parent').on(table.parentSessionId),
+    index('idx_session_manifest_status').on(table.status),
+  ],
+);
+
+/** Row type for `session_manifest` SELECT queries (mirror shape). */
+export type SessionManifestRow = typeof sessionManifest.$inferSelect;
+/** Row type for `session_manifest` INSERT/UPSERT operations (mirror shape). */
+export type NewSessionManifestRow = typeof sessionManifest.$inferInsert;

--- a/packages/core/src/store/schema/cleo-project/tasks-core.ts
+++ b/packages/core/src/store/schema/cleo-project/tasks-core.ts
@@ -422,6 +422,19 @@ export const tasksSessions = sqliteTable(
     nextSessionId: text('next_session_id').references((): AnySQLiteColumn => tasksSessions.id, {
       onDelete: 'set null',
     }),
+    /**
+     * Fork-tree PARENT session pointer (self-FK). Distinct from
+     * `previousSessionId` (the linear resume chain): `parentSessionId` is the
+     * orchestrator→worker spawn edge, sourced from `CLEO_PARENT_SESSION_ID`
+     * (stamped by the supervisor — T11629 / PR #996) at session start. NULL for a
+     * root session with no spawning parent. Nullable, `ON DELETE SET NULL`.
+     *
+     * @task T11639
+     * @epic T11638
+     */
+    parentSessionId: text('parent_session_id').references((): AnySQLiteColumn => tasksSessions.id, {
+      onDelete: 'set null',
+    }),
     /** Agent identifier. */
     agentIdentifier: text('agent_identifier'),
     /** ISO-8601 UTC handoff-consumed instant (canonical TEXT, §4). */
@@ -455,6 +468,7 @@ export const tasksSessions = sqliteTable(
   (table) => [
     index('idx_tasks_sessions_status').on(table.status),
     index('idx_tasks_sessions_previous').on(table.previousSessionId),
+    index('idx_tasks_sessions_parent').on(table.parentSessionId),
     index('idx_tasks_sessions_agent_identifier').on(table.agentIdentifier),
     index('idx_tasks_sessions_started_at').on(table.startedAt),
     index('idx_tasks_sessions_status_started_at').on(table.status, table.startedAt),

--- a/packages/core/src/store/schema/tasks.ts
+++ b/packages/core/src/store/schema/tasks.ts
@@ -525,6 +525,15 @@ export const sessions = sqliteTable(
     nextSessionId: text('next_session_id').references((): AnySQLiteColumn => sessions.id, {
       onDelete: 'set null',
     }),
+    /**
+     * Fork-tree PARENT session pointer (self-FK · T11639). The orchestrator→worker
+     * spawn edge, sourced from `CLEO_PARENT_SESSION_ID` (stamped by the supervisor,
+     * T11629). Distinct from `previousSessionId` (the linear resume chain). NULL for
+     * a root session. Nullable, `ON DELETE SET NULL`.
+     */
+    parentSessionId: text('parent_session_id').references((): AnySQLiteColumn => sessions.id, {
+      onDelete: 'set null',
+    }),
     agentIdentifier: text('agent_identifier'),
     handoffConsumedAt: text('handoff_consumed_at'),
     handoffConsumedBy: text('handoff_consumed_by'),
@@ -550,6 +559,7 @@ export const sessions = sqliteTable(
   (table) => [
     index('idx_sessions_status').on(table.status),
     index('idx_sessions_previous').on(table.previousSessionId),
+    index('idx_sessions_parent').on(table.parentSessionId),
     index('idx_sessions_agent_identifier').on(table.agentIdentifier),
     index('idx_sessions_started_at').on(table.startedAt),
     // T033 composite index: getActiveSession hot path

--- a/packages/core/src/store/session-store.ts
+++ b/packages/core/src/store/session-store.ts
@@ -35,6 +35,8 @@ export async function createSession(session: Session, cwd?: string): Promise<Ses
       tasksCreatedJson: session.tasksCreated ? JSON.stringify(session.tasksCreated) : '[]',
       startedAt: session.startedAt,
       endedAt: session.endedAt,
+      // Fork-tree parent edge (T11639) — sourced from CLEO_PARENT_SESSION_ID at start.
+      parentSessionId: session.parentSessionId ?? null,
     })
     .run();
 
@@ -80,6 +82,8 @@ export async function updateSession(
   if (updates.previousSessionId !== undefined)
     updateRow.previousSessionId = updates.previousSessionId;
   if (updates.nextSessionId !== undefined) updateRow.nextSessionId = updates.nextSessionId;
+  // Fork-tree parent edge (T11639)
+  if (updates.parentSessionId !== undefined) updateRow.parentSessionId = updates.parentSessionId;
   if (updates.agentIdentifier !== undefined) updateRow.agentIdentifier = updates.agentIdentifier;
   if (updates.handoffConsumedAt !== undefined)
     updateRow.handoffConsumedAt = updates.handoffConsumedAt;


### PR DESCRIPTION
## T11639 — `session_manifest` global mirror + `parentSessionId` fork-tree column

EP-SESSION-MANIFEST (epic **T11638**, saga T11242). Unblocks **T11640** (connection-scoped session registry).

Gives the fleet ONE machine-wide view of every session across every project — without ATTACHing N per-project DBs — by best-effort mirroring a compact session projection into a GLOBAL table, plus adds the orchestrator→worker fork-tree edge to the authoritative project session row.

### Mirror-not-authority design note

The authoritative session row remains per-project in `tasks_sessions` (PROJECT-scope `cleo.db`). The new GLOBAL `session_manifest` is a **pure projection**, deliberately:

- **NOT named `sessions`** — the name signals non-authority and prevents a future reader from mistaking it for the source of truth (AC1).
- **Reconcile-on-start overwrites the mirror from the authoritative project row** (AC4) — so the mirror can never drift into authority. On conflict the upsert overwrites *every* mirrored column.
- **No native FKs** — `project_id` (→ `nexus_project_registry.project_id`, same cleo.db) and `parent_session_id` are *soft* references, nullable, so a mirror write tolerates a project/registry/parent peer that lands later or never.
- **Every mirror writer swallows all errors** — a mirror failure (DB unopenable, write error, identity-resolution failure) is logged at debug and NEVER fails the underlying session op (AC3). All mirror calls on start/end/handoff are fire-and-forget.

### Lease usage

The single GLOBAL-scope write path (`mirrorSessionToManifest` → manifest upsert) is gated through the writer lease per Operating Rule 5: `withWriterLease('global', 'tasks', fn, { dbPath: handle.dbPath })` (merged PR #998 / T11890–T11894). The lease is pinned to the resolved global `cleo.db` path recorded at cold-open so the lease row lands in the SAME file the write targets. The shared global handle is opened via `ensureGlobalSignaldockDb` (= `openDualScopeDb('global')`) and never closed.

### AC mapping

| AC | Implementation |
|----|----------------|
| **(a)** GLOBAL `session_manifest` mirror table (NOT `sessions`) ensured in the consolidated global `cleo.db` | New drizzle table `schema/cleo-global/session-manifest.ts` + global migration `20260607010000_t11639-session-manifest` with `--> statement-breakpoint` separators and raw `_at GLOB` CHECKs (consolidated-schema parity). Ensured by `ensureGlobalSignaldockDb` |
| **(b)** `parent_session_id` self-ref on the project sessions table, sourced from `CLEO_PARENT_SESSION_ID` (supervisor — T11629 / PR #996) | `parentSessionId?` added to `Session` contract; new `tasks_sessions.parent_session_id` column (project migration `20260607010000_t11639-session-parent`) + legacy `sessions` schema; wired through converters, `db-helpers.upsertSession`, `session-store`, and captured at `startSession` via `resolveParentSessionIdFromEnv()` |
| **(c)** Best-effort mirror writers on session start / end / handoff via the shared global handle; global writes acquire the writer lease | New module `session-manifest-mirror.ts`. Wired fire-and-forget into `startSession`, `endSession`, and `persistHandoff`. `project_id` = canonical `nexus_project_registry` id. All swallow errors |
| **(d)** Reconcile-on-start re-reads the authoritative project row and overwrites the manifest | `reconcileSessionManifestOnStart` called after the start-mirror and on handoff — overwrites every projected column from the live project row |

### Tests / gates

- 8 new tests (`session-manifest-mirror.test.ts`): schema-ensure idempotent + table NOT named `sessions`; mirror on start/end; mirror failure does not fail op; `parentSessionId` persisted from env; reconcile overwrites a stale row. **8/8 pass.**
- Touched-area suites (`sessions/`, `store/session-store`, `store/converters`, `store/db-helpers`): **358 passed, 2 skipped, 0 failed.**
- biome ✓ · build (core + contracts) ✓ · `lint-no-direct-db-open --strict` zero violations ✓ · `lint-migrations` ✓ · `lint-lafs-schema-parity` ✓ · migration folders sort LAST in both scopes (after `t11891-writer-leases`).
- Import-time side-effect-free (lazy logger); multi-statement migrations use `--> statement-breakpoint`.

> Pre-existing, unrelated: the full `@cleocode/core` run surfaces native-binding fallback failures in `src/spawn/__tests__/worktree-merge.test.ts` (`integrateWorktree not available in test fallback`) — `worktree-napi` is not built in this worktree's `node_modules`. These reproduce in isolation on a clean tree and touch none of the T11639 import graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
