### PR TITLE
feat(T11764): cleo go drives playbook runtime BY DEFAULT + IvtrHandler redirect + ivtr-loop walk deleted (T11896)

### DIFF
--- a/packages/cleo/src/dispatch/domains/__tests__/ivtr.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/ivtr.test.ts
@@ -2,10 +2,16 @@
  * Integration tests for the IvtrHandler dispatch domain.
  *
  * Validates LAFS envelope shape, routing, and error cases.
- * Core state machine logic is tested in ivtr-loop.test.ts.
+ *
+ * After the T11764 state-machine collapse (T11896) the IVTR phase walk lives on
+ * the cantbook runtime — the manual `start`/`next`/`release`/`loop-back` mutate
+ * ops are DEPRECATED and now return a typed `E_DEPRECATED_USE_PLAYBOOK`
+ * migration envelope (ADR-086). The `status` query still reads the retained
+ * `ivtr_state` column via `getIvtrState`.
  *
  * @epic T810
  * @task T811
+ * @task T11896 — mutate ops redirected onto the cantbook runtime
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -35,14 +41,10 @@ vi.mock('../../lib/engine.js', () => ({
   orchestrateCheck: vi.fn(),
 }));
 
+// The handler now imports only the read path + logging/paths from core/internal
+// (the walk functions were deleted in T11896 — the mutate ops are deprecated).
 vi.mock('@cleocode/core/internal', () => ({
-  startIvtr: vi.fn(),
-  advanceIvtr: vi.fn(),
-  loopBackIvtr: vi.fn(),
-  releaseIvtr: vi.fn(),
   getIvtrState: vi.fn(),
-  resolvePhasePrompt: vi.fn(),
-  getTask: vi.fn(),
   getProjectRoot: vi.fn(() => '/mock/project'),
   getLogger: vi.fn(() => ({
     info: vi.fn(),
@@ -56,30 +58,13 @@ vi.mock('@cleocode/core/internal', () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import {
-  advanceIvtr,
-  getIvtrState,
-  getTask,
-  loopBackIvtr,
-  releaseIvtr,
-  resolvePhasePrompt,
-  startIvtr,
-} from '@cleocode/core/internal';
+import { getIvtrState } from '@cleocode/core/internal';
 
-import { IvtrHandler } from '../ivtr.js';
+import { E_DEPRECATED_USE_PLAYBOOK, IvtrHandler } from '../ivtr.js';
 
 // ---------------------------------------------------------------------------
 // Shared test data
 // ---------------------------------------------------------------------------
-
-const mockTask = {
-  id: 'T999',
-  title: 'Test Task',
-  description: 'Do the thing',
-  status: 'in_progress' as const,
-  priority: 'medium' as const,
-  depends: [],
-};
 
 const mockState = {
   taskId: 'T999',
@@ -165,184 +150,66 @@ describe('IvtrHandler', () => {
   });
 
   // -----------------------------------------------------------------------
-  // mutate: start
+  // mutate ops — DEPRECATED (T11896 · cantbook-runtime collapse)
+  //
+  // start/next/release/loop-back no longer drive the hand-rolled phase walk.
+  // Each returns the typed E_DEPRECATED_USE_PLAYBOOK migration envelope with an
+  // ADR-086 hint (fix + details.migration + alternatives). No core walk
+  // function is invoked — the behaviour is intentionally removed, not weakened.
   // -----------------------------------------------------------------------
 
-  describe('mutate("start")', () => {
-    it('returns E_INVALID_INPUT when taskId is missing', async () => {
-      const result = await handler.mutate('start', {});
+  describe.each([
+    'start',
+    'next',
+    'release',
+    'loop-back',
+  ] as const)('mutate("%s") is deprecated', (op) => {
+    it(`returns ${E_DEPRECATED_USE_PLAYBOOK} with a migration hint`, async () => {
+      const result = await handler.mutate(op, { taskId: 'T999' });
+
       expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('E_INVALID_INPUT');
+      expect(result.error?.code).toBe(E_DEPRECATED_USE_PLAYBOOK);
+      // The message routes the caller onto the cantbook runtime.
+      expect(result.error?.message).toContain('cleo go');
+      expect(result.error?.message).toContain('cleo playbook run ivtr');
     });
 
-    it('returns E_NOT_FOUND when task does not exist', async () => {
-      vi.mocked(getTask).mockResolvedValue(null);
+    it('carries the ADR-086 fix + details.migration + alternatives payload', async () => {
+      const result = await handler.mutate(op, { taskId: 'T999' });
 
-      const result = await handler.mutate('start', { taskId: 'T999' });
-      expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('E_NOT_FOUND');
+      // Copy-paste fix (the manual single-run command, woven with taskId).
+      expect(result.error?.fix).toContain('cleo playbook run ivtr');
+      expect(result.error?.fix).toContain('T999');
+
+      // Structured migration details (machine-routable per ADR-086).
+      const migration = (result.error?.details as Record<string, unknown> | undefined)?.[
+        'migration'
+      ] as Record<string, unknown> | undefined;
+      expect(migration?.['deprecatedBy']).toBe('T11764-state-machine-collapse');
+      expect(migration?.['deprecatedOp']).toBe(op);
+      expect(migration?.['taskId']).toBe('T999');
+      expect(migration?.['autonomous']).toBe('cleo go');
+
+      // Alternatives forwarded onto the dispatch error.
+      const alternatives = result.error?.alternatives;
+      expect(Array.isArray(alternatives)).toBe(true);
+      expect(alternatives?.map((a) => a.command)).toContain('cleo go');
     });
 
-    it('returns resolved prompt on successful start', async () => {
-      vi.mocked(getTask).mockResolvedValue(mockTask);
-      vi.mocked(startIvtr).mockResolvedValue(mockState);
-      vi.mocked(resolvePhasePrompt).mockReturnValue('# IVTR Agent Prompt — implement');
-
-      const result = await handler.mutate('start', { taskId: 'T999' });
-      expect(result.success).toBe(true);
-
-      const data = result.data as Record<string, unknown>;
-      expect(data['taskId']).toBe('T999');
-      expect(data['currentPhase']).toBe('implement');
-      expect(data['resolvedPrompt']).toContain('implement');
-
-      expect(startIvtr).toHaveBeenCalledWith(
-        'T999',
-        expect.objectContaining({ cwd: '/mock/project' }),
-      );
-    });
-
-    it('conforms to LAFS envelope shape', async () => {
-      vi.mocked(getTask).mockResolvedValue(mockTask);
-      vi.mocked(startIvtr).mockResolvedValue(mockState);
-      vi.mocked(resolvePhasePrompt).mockReturnValue('prompt');
-
-      const result = await handler.mutate('start', { taskId: 'T999' });
+    it('conforms to the LAFS mutate envelope shape', async () => {
+      const result = await handler.mutate(op, { taskId: 'T999' });
 
       expect(result).toHaveProperty('success');
       expect(result).toHaveProperty('meta');
-      expect(result.meta).toHaveProperty('operation');
-      expect(result.meta).toHaveProperty('domain');
       expect(result.meta.domain).toBe('ivtr');
       expect(result.meta.gateway).toBe('mutate');
     });
-  });
 
-  // -----------------------------------------------------------------------
-  // mutate: next
-  // -----------------------------------------------------------------------
-
-  describe('mutate("next")', () => {
-    it('advances phase and returns new prompt', async () => {
-      const advancedState = {
-        ...mockState,
-        currentPhase: 'validate' as const,
-        phaseHistory: [
-          {
-            ...mockState.phaseHistory[0]!,
-            passed: true,
-            completedAt: '2026-04-16T01:00:00.000Z',
-          },
-          {
-            phase: 'validate' as const,
-            agentIdentity: null,
-            startedAt: '2026-04-16T01:00:00.000Z',
-            completedAt: null,
-            passed: null,
-            evidenceRefs: [],
-          },
-        ],
-      };
-
-      vi.mocked(getTask).mockResolvedValue(mockTask);
-      vi.mocked(advanceIvtr).mockResolvedValue(advancedState);
-      vi.mocked(resolvePhasePrompt).mockReturnValue('# Validate prompt');
-
-      const result = await handler.mutate('next', {
-        taskId: 'T999',
-        evidence: 'sha-abc,sha-def',
-      });
-
-      expect(result.success).toBe(true);
-
-      const data = result.data as Record<string, unknown>;
-      expect(data['currentPhase']).toBe('validate');
-      expect(data['resolvedPrompt']).toBe('# Validate prompt');
-      expect(advanceIvtr).toHaveBeenCalledWith('T999', ['sha-abc', 'sha-def'], expect.any(Object));
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // mutate: release
-  // -----------------------------------------------------------------------
-
-  describe('mutate("release")', () => {
-    it('returns success when gate passes', async () => {
-      vi.mocked(releaseIvtr).mockResolvedValue({ released: true });
-
-      const result = await handler.mutate('release', { taskId: 'T999' });
-      expect(result.success).toBe(true);
-
-      const data = result.data as Record<string, unknown>;
-      expect(data['released']).toBe(true);
-    });
-
-    it('returns error envelope when gate fails', async () => {
-      vi.mocked(releaseIvtr).mockResolvedValue({
-        released: false,
-        failures: ["Phase 'test' has no passing entry"],
-      });
-
-      const result = await handler.mutate('release', { taskId: 'T999' });
-      expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('E_IVTR_GATE_FAILED');
-      expect(result.error?.message).toContain("Phase 'test'");
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // mutate: loop-back
-  // -----------------------------------------------------------------------
-
-  describe('mutate("loop-back")', () => {
-    it('returns E_INVALID_INPUT when phase is missing or invalid', async () => {
-      const result = await handler.mutate('loop-back', {
-        taskId: 'T999',
-        reason: 'broke',
-      });
-      expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('E_INVALID_INPUT');
-      expect(result.error?.message).toContain('--phase must be one of');
-    });
-
-    it('returns E_INVALID_INPUT when reason is missing', async () => {
-      const result = await handler.mutate('loop-back', {
-        taskId: 'T999',
-        phase: 'implement',
-      });
-      expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('E_INVALID_INPUT');
-      expect(result.error?.message).toContain('--reason is required');
-    });
-
-    it('rewinds phase and returns prompt on success', async () => {
-      const rewoundState = { ...mockState, currentPhase: 'implement' as const };
-
-      vi.mocked(getTask).mockResolvedValue(mockTask);
-      vi.mocked(loopBackIvtr).mockResolvedValue(rewoundState);
-      vi.mocked(resolvePhasePrompt).mockReturnValue('# Implement again');
-
-      const result = await handler.mutate('loop-back', {
-        taskId: 'T999',
-        phase: 'implement',
-        reason: 'Tests failed',
-        evidence: 'fail-sha',
-      });
-
-      expect(result.success).toBe(true);
-
-      const data = result.data as Record<string, unknown>;
-      expect(data['loopedBackTo']).toBe('implement');
-      expect(data['reason']).toBe('Tests failed');
-      expect(data['resolvedPrompt']).toBe('# Implement again');
-
-      expect(loopBackIvtr).toHaveBeenCalledWith(
-        'T999',
-        'implement',
-        'Tests failed',
-        ['fail-sha'],
-        expect.any(Object),
-      );
+    it('does NOT invoke any core IVTR walk function', async () => {
+      await handler.mutate(op, { taskId: 'T999' });
+      // getIvtrState is the only retained core read — the deprecated mutate
+      // path never touches it (or any deleted walk function).
+      expect(getIvtrState).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cleo/src/dispatch/domains/__tests__/release.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/release.test.ts
@@ -70,7 +70,7 @@ const gateFailedResult = {
     code: 'E_IVTR_INCOMPLETE',
     message: `IVTR gate FAILED for epic ${EPIC_ID}. 1 task(s) not yet released: ${TASK_ID}.`,
     exitCode: 83,
-    fix: `cleo orchestrate ivtr ${TASK_ID} --release`,
+    fix: `cleo playbook run ivtr --context '{"taskId":"${TASK_ID}"}'`,
     details: {
       blocked: [TASK_ID],
       unchecked: [],
@@ -239,7 +239,7 @@ describe('ReleaseHandler', () => {
       const result = await handler.query('gate', { epicId: EPIC_ID });
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('E_IVTR_INCOMPLETE');
-      expect(result.error?.fix).toBe(`cleo orchestrate ivtr ${TASK_ID} --release`);
+      expect(result.error?.fix).toBe(`cleo playbook run ivtr --context '{"taskId":"${TASK_ID}"}'`);
     });
 
     it('passes force=true when params.force is true', async () => {

--- a/packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/tasks.test.ts
@@ -793,7 +793,7 @@ describe('TasksHandler', () => {
             currentPhase: 'validate',
             failedPhases: ["Phase 'implement' has no passing entry"],
           },
-          fix: "Advance the IVTR loop to 'released' via 'cleo orchestrate ivtr T001 --next'",
+          fix: "Drive the IVTR loop to 'released' via the cantbook runtime (T11764): 'cleo go' (autonomous, default) or 'cleo playbook run ivtr --context '{\"taskId\":\"T001\"}'' (single manual run). Evidence-based bypass: CLEO_OWNER_OVERRIDE=1 on 'cleo verify' (audited, see ADR-051).",
         },
       });
 

--- a/packages/cleo/src/dispatch/domains/ivtr.ts
+++ b/packages/cleo/src/dispatch/domains/ivtr.ts
@@ -7,14 +7,22 @@
  *
  * QUERY:
  *   status     — return current phase + evidence list + phase history
+ *                (reads the retained `ivtr_state` column via `getIvtrState`)
  *
- * MUTATE:
- *   start      — begin Implement phase (returns resolved prompt)
- *   next       — advance from current phase to next (validates evidence; returns prompt)
- *   release    — FINAL gate: requires I+V+T evidence, marks task done
- *   loop-back  — rewind to specified phase with failure evidence attached
+ * MUTATE (DEPRECATED — T11896 · T11764 state-machine collapse):
+ *   start / next / release / loop-back — the hand-rolled per-step phase walk
+ *   (`startIvtr`/`advanceIvtr`/`releaseIvtr`/`loopBackIvtr`) has been collapsed
+ *   into the cantbook runtime (the survivor state machine). There is no per-step
+ *   primitive on the runtime to map these 1:1 onto — `executePlaybook` /
+ *   `resumePlaybook` drive an ENTIRE run, not a single phase advance — so each
+ *   mutate op now returns a typed {@link E_DEPRECATED_USE_PLAYBOOK} error with
+ *   an ADR-086 migration-hint envelope (`fix` + `details.migration` +
+ *   `alternatives`) instead of silently breaking. The autonomous IVTR loop is
+ *   `cleo go` (T11896 — defaults to `executePlaybook(ivtr.cantbook)`); a manual
+ *   run is `cleo playbook run ivtr --context '{"taskId":"T###"}'`.
  *
- * All state is persisted via the `ivtr_state` JSON column on `tasks`.
+ * The `status` query stays intact — it backs `cleo show --ivtr-history` and the
+ * strict `E_IVTR_INCOMPLETE` completion gate keeps reading the same column.
  *
  * Type-safe dispatch via `TypedDomainHandler<IvtrOps>` per ADR-058.
  * Param extraction inferred via `OpsFromCore<typeof ivtrCoreOps>`.
@@ -23,25 +31,13 @@
  * @epic T810
  * @task T811
  * @task T1539 — OpsFromCore migration per ADR-058
+ * @task T11896 — mutate ops redirected onto the cantbook runtime (collapse)
  */
 
 import type { EngineResult } from '@cleocode/core';
 import type { IvtrPhase, IvtrPhaseEntry } from '@cleocode/core/internal';
-import {
-  advanceIvtr,
-  autoRunGatesAndRecord,
-  E_IVTR_MAX_RETRIES,
-  extractTypedGates,
-  getIvtrState,
-  getLogger,
-  getProjectRoot,
-  getTask,
-  loopBackIvtr,
-  releaseIvtr,
-  resolvePhasePrompt,
-  startIvtr,
-} from '@cleocode/core/internal';
-import { engineError, engineSuccess, releaseIvtrAutoSuggest } from '@cleocode/runtime/gateway';
+import { getIvtrState, getLogger, getProjectRoot } from '@cleocode/core/internal';
+import { engineSuccess } from '@cleocode/runtime/gateway';
 import {
   defineTypedHandler,
   lafsError,
@@ -54,6 +50,20 @@ import { handleErrorResult, unsupportedOp } from './_base.js';
 import { dispatchMeta } from './_meta.js';
 
 const log = getLogger('domain:ivtr');
+
+/**
+ * Error code returned by every deprecated IVTR mutate op (`start`/`next`/
+ * `release`/`loop-back`) after the T11764 state-machine collapse.
+ *
+ * The hand-rolled per-step phase walk was folded into the cantbook runtime
+ * (the survivor state machine). Because the runtime exposes whole-run
+ * primitives (`executePlaybook`/`resumePlaybook`) rather than per-phase steps,
+ * the manual ops have no 1:1 redirect target and instead surface this typed
+ * error with an ADR-086 migration-hint envelope. Read ops are unaffected.
+ *
+ * @task T11896
+ */
+export const E_DEPRECATED_USE_PLAYBOOK = 'E_DEPRECATED_USE_PLAYBOOK' as const;
 
 // ---------------------------------------------------------------------------
 // Local param types for OpsFromCore wrapper functions
@@ -88,26 +98,107 @@ interface IvtrLoopBackParams {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers (extracted from handler cases for reuse)
+// Deprecation envelope (T11896 · collapse)
 // ---------------------------------------------------------------------------
 
-/** Validate that a string is a legal IvtrPhase (excluding 'released'). */
-function isLoopBackTarget(phase: string): phase is Exclude<IvtrPhase, 'released'> {
-  return phase === 'implement' || phase === 'validate' || phase === 'test';
+/**
+ * Structured `details` payload attached to the {@link E_DEPRECATED_USE_PLAYBOOK}
+ * envelope so machine consumers (and `cleo show --human`) can route on the
+ * migration metadata rather than parsing prose. Conforms to the ADR-086
+ * `DispatchError.details` contract.
+ *
+ * @task T11896
+ */
+interface IvtrMigrationDetails {
+  /** Always `'T11764-state-machine-collapse'` — the supersession source. */
+  deprecatedBy: 'T11764-state-machine-collapse';
+  /** The IVTR mutate op the caller invoked (`start`/`next`/`release`/`loop-back`). */
+  deprecatedOp: string;
+  /** Task the caller was driving, when supplied. */
+  taskId?: string;
+  /** The survivor state machine the loop now runs on. */
+  survivor: 'cantbook-runtime (ivtr.cantbook)';
+  /** Autonomous replacement command (default path). */
+  autonomous: string;
+  /** Manual single-run replacement command. */
+  manual: string;
 }
 
-/** Extract an evidence array from raw value (accepts string[] or comma-separated string). */
-function extractEvidenceFromRaw(raw: unknown): string[] {
-  if (Array.isArray(raw)) return raw.map(String);
-  if (typeof raw === 'string' && raw.length > 0) return raw.split(',').map((s) => s.trim());
-  return [];
+/**
+ * Build the typed {@link E_DEPRECATED_USE_PLAYBOOK} LAFS error envelope for a
+ * deprecated IVTR mutate op.
+ *
+ * Carries an ADR-086 migration-hint payload: a copy-paste `fix`, a structured
+ * `details.migration` object, and `alternatives` so no behaviour is orphaned
+ * silently — the caller is told exactly which command replaces the manual walk.
+ *
+ * @param op - The deprecated mutate op name (`start`/`next`/`release`/`loop-back`).
+ * @param taskId - Task the caller was driving (for the migration command), or
+ *   `undefined` when the caller omitted it.
+ * @returns A `LafsError` envelope with `code`, `message`, `fix`, and `details`.
+ * @task T11896
+ */
+function deprecatedMutateEnvelope(op: string, taskId: string | undefined) {
+  const id = taskId ?? 'T####';
+  const manual = `cleo playbook run ivtr --context '{"taskId":"${id}"}'`;
+  const autonomous = 'cleo go';
+  const migration: IvtrMigrationDetails = {
+    deprecatedBy: 'T11764-state-machine-collapse',
+    deprecatedOp: op,
+    survivor: 'cantbook-runtime (ivtr.cantbook)',
+    autonomous,
+    manual,
+    ...(taskId !== undefined ? { taskId } : {}),
+  };
+  return lafsError(
+    E_DEPRECATED_USE_PLAYBOOK,
+    `'cleo orchestrate ivtr --${op}' is deprecated. The hand-rolled IVTR phase ` +
+      `walk was collapsed into the cantbook runtime (T11764). Drive IVTR through ` +
+      `the playbook runtime instead: '${autonomous}' (autonomous, default) or ` +
+      `'${manual}' (single manual run).`,
+    op,
+    manual,
+    {
+      migration: migration as unknown as Record<string, unknown>,
+      alternatives: [
+        { action: 'Autonomous IVTR loop (default)', command: autonomous },
+        { action: 'Manual single IVTR run', command: manual },
+      ],
+    },
+  );
+}
+
+/** A single ADR-086 `DispatchError.alternatives` entry. */
+interface AlternativeAction {
+  action: string;
+  command: string;
+}
+
+/**
+ * Type guard for an {@link AlternativeAction} list — used to narrow the
+ * `details.alternatives` value lifted off the deprecation envelope before it is
+ * forwarded onto the typed `DispatchError.alternatives` field (zero `any`).
+ *
+ * @task T11896
+ */
+function isAlternativesList(value: unknown): value is AlternativeAction[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (v): v is AlternativeAction =>
+        typeof v === 'object' &&
+        v !== null &&
+        typeof (v as { action?: unknown }).action === 'string' &&
+        typeof (v as { command?: unknown }).command === 'string',
+    )
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Core op wrappers — single-param functions for OpsFromCore inference
 //
-// All stateful logic lives in these wrappers (matching the pipeline.ts pattern).
-// The typed handler cases become single-line wrapCoreResult calls.
+// `status` reads the retained `ivtr_state` column; the four mutate ops are
+// DEPRECATED stubs (T11896) whose typed handler returns the migration envelope.
 // ---------------------------------------------------------------------------
 
 interface IvtrStatusResult {
@@ -131,7 +222,10 @@ async function ivtrStatusOp(params: IvtrStatusParams): Promise<EngineResult<Ivtr
       started: false,
       currentPhase: null,
       phaseHistory: [] as IvtrPhaseEntry[],
-      message: `Task ${params.taskId} has no active IVTR loop. Run --start to begin.`,
+      message:
+        `Task ${params.taskId} has no IVTR state. The IVTR loop now runs on the ` +
+        `cantbook runtime (T11764) — drive it with 'cleo go' (autonomous) or ` +
+        `'cleo playbook run ivtr --context '{"taskId":"${params.taskId}"}''.`,
     });
   }
 
@@ -154,226 +248,59 @@ async function ivtrStatusOp(params: IvtrStatusParams): Promise<EngineResult<Ivtr
   });
 }
 
-async function ivtrStartOp(params: IvtrStartParams) {
-  const cwd = getProjectRoot();
-  const task = await getTask(params.taskId, cwd);
-  if (!task) {
-    return engineError('E_NOT_FOUND', `Task ${params.taskId} not found`);
-  }
+/**
+ * Result shape shared by the four deprecated mutate stubs.
+ *
+ * The stubs exist purely to carry the `OpsFromCore` param typing for the typed
+ * handler — the actual deprecation envelope is built in {@link _ivtrTypedHandler}
+ * via {@link deprecatedMutateEnvelope}, so the stub bodies are never invoked on
+ * the success path. They return a frozen {@link E_DEPRECATED_USE_PLAYBOOK}
+ * failure so a stray direct call (e.g. a test) still fails closed rather than
+ * resolving an empty success.
+ *
+ * @task T11896
+ */
+type IvtrDeprecatedResult = EngineResult<never>;
 
-  const state = await startIvtr(params.taskId, { cwd, agentIdentity: params.agentIdentity });
-  const prompt = resolvePhasePrompt(
-    params.taskId,
-    state,
-    task.title,
-    task.description ?? '(no description)',
-  );
+/** Frozen failure result returned by the four deprecated mutate stubs. */
+const DEPRECATED_OP_RESULT: IvtrDeprecatedResult = {
+  success: false,
+  error: { code: E_DEPRECATED_USE_PLAYBOOK, message: 'IVTR mutate ops are deprecated (T11764).' },
+};
 
-  return engineSuccess({
-    taskId: params.taskId,
-    currentPhase: state.currentPhase,
-    startedAt: state.startedAt,
-    resolvedPrompt: prompt,
-    message: `IVTR loop started. Implement phase is now active for task ${params.taskId}.`,
-  });
+/**
+ * `start` op — DEPRECATED. The IVTR loop now runs on the cantbook runtime
+ * (T11764). Param typing is retained for `OpsFromCore` inference; the handler
+ * returns the {@link E_DEPRECATED_USE_PLAYBOOK} migration envelope.
+ *
+ * @task T11896
+ */
+function ivtrStartOp(_params: IvtrStartParams): Promise<IvtrDeprecatedResult> {
+  return Promise.resolve(DEPRECATED_OP_RESULT);
 }
 
-async function ivtrNextOp(params: IvtrNextParams) {
-  const cwd = getProjectRoot();
-  const task = await getTask(params.taskId, cwd);
-  if (!task) {
-    return engineError('E_NOT_FOUND', `Task ${params.taskId} not found`);
-  }
-
-  const evidence = extractEvidenceFromRaw(params.evidence);
-  const autoRunTests = params.autoRunTests === true;
-
-  const state = await advanceIvtr(params.taskId, evidence, {
-    cwd,
-    agentIdentity: params.agentIdentity,
-  });
-
-  // --auto-run-tests: when the new phase is 'test', invoke runGates atomically.
-  let autoRunResult: Awaited<ReturnType<typeof autoRunGatesAndRecord>> | undefined;
-  if (autoRunTests && state.currentPhase === 'test') {
-    const acceptanceItems = (task.acceptance ?? []) as (string | object)[];
-    const typedGateEntries = extractTypedGates(
-      acceptanceItems as Parameters<typeof extractTypedGates>[0],
-    );
-    const gates = typedGateEntries.map((e) => e.gate);
-    autoRunResult = await autoRunGatesAndRecord(params.taskId, gates, params.agentIdentity, cwd);
-  }
-
-  const acceptanceItems = (task.acceptance ?? []) as (string | object)[];
-  const typedGates =
-    state.currentPhase === 'test'
-      ? extractTypedGates(acceptanceItems as Parameters<typeof extractTypedGates>[0]).map(
-          (e) => e.gate,
-        )
-      : undefined;
-
-  const prompt = resolvePhasePrompt(
-    params.taskId,
-    state,
-    task.title,
-    task.description ?? '(no description)',
-    typedGates,
-    [],
-  );
-
-  return engineSuccess({
-    taskId: params.taskId,
-    previousPhase: state.phaseHistory[state.phaseHistory.length - 2]?.phase ?? null,
-    currentPhase: state.currentPhase,
-    evidenceRecorded: evidence.length,
-    resolvedPrompt: prompt,
-    ...(autoRunResult
-      ? {
-          autoRunTests: {
-            attachmentSha256: autoRunResult.attachmentSha256,
-            testsPassed: autoRunResult.testsPassed,
-            testsFailed: autoRunResult.testsFailed,
-            exitCode: autoRunResult.exitCode,
-            evidenceRecord: autoRunResult.evidenceRecord,
-          },
-        }
-      : {}),
-    message: `Phase advanced to '${state.currentPhase}' for task ${params.taskId}.${autoRunResult ? ` Auto-run gates: ${autoRunResult.testsPassed} passed, ${autoRunResult.testsFailed} failed.` : ''}`,
-  });
+/**
+ * `next` op — DEPRECATED (see {@link ivtrStartOp}).
+ * @task T11896
+ */
+function ivtrNextOp(_params: IvtrNextParams): Promise<IvtrDeprecatedResult> {
+  return Promise.resolve(DEPRECATED_OP_RESULT);
 }
 
-async function ivtrReleaseOp(params: IvtrReleaseParams) {
-  const cwd = getProjectRoot();
-  const result = await releaseIvtr(params.taskId, { cwd });
-
-  if (!result.released) {
-    return {
-      success: false,
-      error: {
-        code: 'E_IVTR_GATE_FAILED',
-        message: `Release gate failed for task ${params.taskId}: ${result.failures?.join('; ')}`,
-        details: { failures: result.failures },
-      },
-    };
-  }
-
-  // T820 RELEASE-07: Check sibling task release status for auto-suggestion.
-  let autoSuggest: {
-    epicId: string | null;
-    epicFullyReleased: boolean;
-    suggestedCommand: string | null;
-    message: string;
-  } | null = null;
-
-  try {
-    const suggestResult = await releaseIvtrAutoSuggest(params.taskId, cwd);
-    if (suggestResult.success && suggestResult.data) {
-      const d = suggestResult.data as {
-        epicId: string | null;
-        epicFullyReleased: boolean;
-        suggestedCommand: string | null;
-        message: string;
-      };
-      autoSuggest = {
-        epicId: d.epicId,
-        epicFullyReleased: d.epicFullyReleased,
-        suggestedCommand: d.suggestedCommand,
-        message: d.message,
-      };
-    }
-  } catch {
-    // Auto-suggest is best-effort; never block the release on its failure.
-  }
-
-  return {
-    success: true,
-    data: {
-      taskId: params.taskId,
-      released: true,
-      message: `Task ${params.taskId} has been released. All IVTR phases passed. Status set to done.`,
-      ...(autoSuggest ? { autoSuggest } : {}),
-    },
-  };
+/**
+ * `release` op — DEPRECATED (see {@link ivtrStartOp}).
+ * @task T11896
+ */
+function ivtrReleaseOp(_params: IvtrReleaseParams): Promise<IvtrDeprecatedResult> {
+  return Promise.resolve(DEPRECATED_OP_RESULT);
 }
 
-async function ivtrLoopBackOp(params: IvtrLoopBackParams) {
-  const cwd = getProjectRoot();
-
-  if (!isLoopBackTarget(params.phase)) {
-    return {
-      success: false,
-      error: {
-        code: 'E_INVALID_INPUT',
-        message: `--phase must be one of: implement, validate, test. Got: '${params.phase}'`,
-      },
-    };
-  }
-  if (!params.reason) {
-    return {
-      success: false,
-      error: { code: 'E_INVALID_INPUT', message: '--reason is required for loop-back' },
-    };
-  }
-
-  const task = await getTask(params.taskId, cwd);
-  if (!task) {
-    return engineError('E_NOT_FOUND', `Task ${params.taskId} not found`);
-  }
-
-  const evidence = extractEvidenceFromRaw(params.evidence);
-
-  let state: Awaited<ReturnType<typeof loopBackIvtr>>;
-  try {
-    state = await loopBackIvtr(params.taskId, params.phase, params.reason, evidence, {
-      cwd,
-      agentIdentity: params.agentIdentity,
-    });
-  } catch (loopBackErr) {
-    const msg = loopBackErr instanceof Error ? loopBackErr.message : String(loopBackErr);
-    if (msg.startsWith(E_IVTR_MAX_RETRIES)) {
-      log.warn({ taskId: params.taskId, phase: params.phase }, 'IVTR max retries reached');
-      return {
-        success: false,
-        error: {
-          code: E_IVTR_MAX_RETRIES,
-          message: msg,
-          details: {
-            taskId: params.taskId,
-            phase: params.phase,
-            hitlEscalation: true,
-            escalationNote:
-              'Maximum loop-backs reached. A human must inspect the loop-back history and resolve the root cause before the IVTR loop can continue.',
-          },
-        },
-      };
-    }
-    throw loopBackErr;
-  }
-
-  const prompt = resolvePhasePrompt(
-    params.taskId,
-    state,
-    task.title,
-    task.description ?? '(no description)',
-  );
-
-  return {
-    success: true,
-    data: {
-      taskId: params.taskId,
-      loopedBackTo: params.phase,
-      reason: params.reason,
-      currentPhase: state.currentPhase,
-      loopBackCount: state.loopBackCount ?? {
-        implement: 0,
-        validate: 0,
-        test: 0,
-        released: 0,
-      },
-      resolvedPrompt: prompt,
-      message: `IVTR loop-back recorded. Phase rewound to '${params.phase}' for task ${params.taskId}.`,
-    },
-  };
+/**
+ * `loop-back` op — DEPRECATED (see {@link ivtrStartOp}).
+ * @task T11896
+ */
+function ivtrLoopBackOp(_params: IvtrLoopBackParams): Promise<IvtrDeprecatedResult> {
+  return Promise.resolve(DEPRECATED_OP_RESULT);
 }
 
 // ---------------------------------------------------------------------------
@@ -423,37 +350,15 @@ const _ivtrTypedHandler = defineTypedHandler<IvtrOps>('ivtr', {
       : lafsError(result.error?.code ?? 'E_INTERNAL', result.error?.message ?? '', 'status');
   },
 
-  start: async (params) => {
-    if (!params.taskId) return lafsError('E_INVALID_INPUT', 'taskId is required', 'start');
-    const result = await ivtrCoreOps.start(params);
-    return result.success
-      ? lafsSuccess(result.data, 'start')
-      : lafsError(result.error?.code ?? 'E_INTERNAL', result.error?.message ?? '', 'start');
-  },
-
-  next: async (params) => {
-    if (!params.taskId) return lafsError('E_INVALID_INPUT', 'taskId is required', 'next');
-    const result = await ivtrCoreOps.next(params);
-    return result.success
-      ? lafsSuccess(result.data, 'next')
-      : lafsError(result.error?.code ?? 'E_INTERNAL', result.error?.message ?? '', 'next');
-  },
-
-  release: async (params) => {
-    if (!params.taskId) return lafsError('E_INVALID_INPUT', 'taskId is required', 'release');
-    const result = await ivtrCoreOps.release(params);
-    return result.success
-      ? lafsSuccess(result.data, 'release')
-      : lafsError(result.error?.code ?? 'E_INTERNAL', result.error?.message ?? '', 'release');
-  },
-
-  'loop-back': async (params) => {
-    if (!params.taskId) return lafsError('E_INVALID_INPUT', 'taskId is required', 'loop-back');
-    const result = await ivtrCoreOps['loop-back'](params);
-    return result.success
-      ? lafsSuccess(result.data, 'loop-back')
-      : lafsError(result.error?.code ?? 'E_INTERNAL', result.error?.message ?? '', 'loop-back');
-  },
+  // ── DEPRECATED mutate ops (T11896 · T11764 collapse) ────────────────────
+  // The per-step phase walk has no 1:1 mapping onto the whole-run cantbook
+  // primitives (`executePlaybook`/`resumePlaybook`), so each op returns the
+  // typed E_DEPRECATED_USE_PLAYBOOK migration envelope (ADR-086) rather than
+  // silently breaking. `params.taskId` is woven into the migration command.
+  start: async (params) => deprecatedMutateEnvelope('start', params.taskId),
+  next: async (params) => deprecatedMutateEnvelope('next', params.taskId),
+  release: async (params) => deprecatedMutateEnvelope('release', params.taskId),
+  'loop-back': async (params) => deprecatedMutateEnvelope('loop-back', params.taskId),
 });
 
 // ---------------------------------------------------------------------------
@@ -532,13 +437,14 @@ export class IvtrHandler implements DomainHandler {
   // -----------------------------------------------------------------------
 
   /**
-   * Handle state-modifying IVTR mutations.
+   * Handle state-modifying IVTR mutations — all DEPRECATED (T11896).
    *
-   * Supported operations:
-   * - `start`     — begin Implement phase, return resolved prompt
-   * - `next`      — advance from current phase to next, return prompt for next phase
-   * - `release`   — run final gate, mark task done
-   * - `loop-back` — rewind to specified phase with failure evidence
+   * `start`/`next`/`release`/`loop-back` are no longer driven by the hand-rolled
+   * phase walk; each returns the typed {@link E_DEPRECATED_USE_PLAYBOOK}
+   * migration envelope (carrying `fix`, `details.migration`, and `alternatives`
+   * per ADR-086) so the caller is routed onto the cantbook runtime. The full
+   * migration-hint payload is forwarded onto the `DispatchResponse.error` —
+   * nothing is orphaned silently.
    */
   async mutate(operation: string, params?: Record<string, unknown>): Promise<DispatchResponse> {
     const startTime = Date.now();
@@ -550,33 +456,39 @@ export class IvtrHandler implements DomainHandler {
     }
 
     try {
-      // Validate taskId before dispatching — gives correct E_INVALID_INPUT error code.
-      if (!params?.['taskId']) {
-        return {
-          meta: dispatchMeta('mutate', 'ivtr', operation, startTime),
-          success: false,
-          error: { code: 'E_INVALID_INPUT', message: 'taskId is required' },
-        };
-      }
-
+      // NOTE (T11896): unlike the pre-collapse handler, taskId is NOT required
+      // up front — the deprecation migration envelope is returned regardless so
+      // even a malformed `cleo orchestrate ivtr --next` surfaces the migration
+      // hint rather than a generic E_INVALID_INPUT.
       const envelope = await typedDispatch(
         _ivtrTypedHandler,
         operation as keyof IvtrOps & string,
         params ?? {},
       );
 
+      if (envelope.success) {
+        return {
+          meta: dispatchMeta('mutate', 'ivtr', operation, startTime),
+          success: true,
+          data: envelope.data as unknown,
+        };
+      }
+
+      // Forward the full ADR-086 migration-hint payload (fix + details +
+      // alternatives) onto the dispatch error so the CLI renderer surfaces it.
+      const err = envelope.error;
+      const error: NonNullable<DispatchResponse['error']> = {
+        code: err?.code !== undefined ? String(err.code) : 'E_INTERNAL',
+        message: err?.message ?? 'Unknown error',
+      };
+      if (err?.fix !== undefined) error.fix = err.fix;
+      if (err?.details !== undefined) error.details = err.details;
+      const alternatives = err?.details?.['alternatives'];
+      if (isAlternativesList(alternatives)) error.alternatives = alternatives;
       return {
         meta: dispatchMeta('mutate', 'ivtr', operation, startTime),
-        success: envelope.success,
-        ...(envelope.success
-          ? { data: envelope.data as unknown }
-          : {
-              error: {
-                code:
-                  envelope.error?.code !== undefined ? String(envelope.error.code) : 'E_INTERNAL',
-                message: envelope.error?.message ?? 'Unknown error',
-              },
-            }),
+        success: false,
+        error,
       };
     } catch (err) {
       log.error({ err, operation }, 'IvtrHandler mutate error');

--- a/packages/core/src/go/__tests__/driver.test.ts
+++ b/packages/core/src/go/__tests__/driver.test.ts
@@ -9,8 +9,10 @@
  *
  * The test stubs out the imported engines (sagaNext, orchestrateReady,
  * armGoalLoop) so no DB or filesystem is touched. The IVTR seam (T11805) is now
- * an *injected* runner — `cleoGo` no longer imports `startIvtr` — so the fan-out
- * scenarios pass a mock {@link go.IvtrRunner} via `params.ivtrRunner`.
+ * an *injected* runner — the default cantbook path (T11896) — so the fan-out
+ * scenarios pass a mock {@link go.IvtrRunner} via `params.ivtrRunner`. The
+ * kill-switch (`CLEO_GO_VIA_PLAYBOOK=0`) fallback seeds via the retained
+ * `seedIvtrForPlaybook` (byte-identical to the deleted `startIvtr`).
  *
  * @task T11494 — E2-CLEO-GO
  * @task T11805 — IVTR seam: injected `executePlaybook(ivtr.cantbook)` runner
@@ -29,7 +31,7 @@ const mockSagaNext = vi.fn();
 const mockOrchestrateReady = vi.fn();
 const mockIvtrRunner = vi.fn();
 const mockArmGoalLoop = vi.fn();
-const mockStartIvtr = vi.fn();
+const mockSeedIvtr = vi.fn();
 
 /** Injected IVTR runner under test (T11805). */
 const ivtrRunner: IvtrRunner = (...args) => mockIvtrRunner(...args);
@@ -50,10 +52,11 @@ vi.mock('../../paths.js', () => ({
   getProjectRoot: (_p?: string) => _p ?? '/test/root',
 }));
 
-// T11805 — the driver now imports `startIvtr` for the flag-OFF fallback path
-// (Risk #1 mitigation). Stub it so the fallback never touches a real DB.
+// T11896 — the kill-switch fallback now seeds `ivtr_state` via the retained
+// `seedIvtrForPlaybook` (byte-identical to the deleted `startIvtr`). Stub it so
+// the fallback path never touches a real DB.
 vi.mock('../../lifecycle/ivtr-loop.js', () => ({
-  startIvtr: (...args: unknown[]) => mockStartIvtr(...args),
+  seedIvtrForPlaybook: (...args: unknown[]) => mockSeedIvtr(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -106,7 +109,7 @@ describe('cleoGo driver (T11494)', () => {
     vi.clearAllMocks();
     mockIvtrRunner.mockResolvedValue({ taskId: 'T999', runId: 'pbr_999' });
     mockArmGoalLoop.mockResolvedValue({ id: 'g-armed-1', status: 'active' });
-    mockStartIvtr.mockResolvedValue({ taskId: 'T999', currentPhase: 'implement' });
+    mockSeedIvtr.mockResolvedValue({ taskId: 'T999', currentPhase: 'implement' });
     // The cantbook seam defaults ON (T11896) — leaving the env unset already
     // exercises the seam path. We clear it here so the default-ON behaviour is
     // what the fan-out tests assert; the dedicated kill-switch test below sets
@@ -295,7 +298,7 @@ describe('cleoGo driver (T11494)', () => {
       });
     });
 
-    it('falls back to startIvtr when no runner is injected (no silent skip)', async () => {
+    it('falls back to the legacy seed when no runner is injected (no silent skip)', async () => {
       mockSagaNext.mockResolvedValue({
         success: true,
         data: makeSagaNextResult({
@@ -319,27 +322,27 @@ describe('cleoGo driver (T11494)', () => {
         makeReadyResult([{ id: 'T102', pipelineStage: 'implementation', parentId: 'T101' }]),
       );
 
-      // Flag ON but no runner → fallback to startIvtr (no silent skip).
+      // Flag ON but no runner → fallback to the legacy seed (no silent skip).
       const result = await cleoGo({ sagaId: 'T100' });
       expect(result.success).toBe(true);
       const outcome = result.data?.outcome;
       expect(outcome?.action).toBe('ivtrFanOut');
       if (outcome?.action === 'ivtrFanOut') {
-        // Fallback path seeds via startIvtr — the task IS surfaced.
+        // Fallback path seeds via seedIvtrForPlaybook — the task IS surfaced.
         expect(outcome.tasks).toEqual(['T102']);
         expect(outcome.runIds).toEqual([]);
       }
-      expect(mockStartIvtr).toHaveBeenCalledTimes(1);
-      expect(mockStartIvtr.mock.calls[0]?.[0]).toBe('T102');
+      expect(mockSeedIvtr).toHaveBeenCalledTimes(1);
+      expect(mockSeedIvtr.mock.calls[0]?.[0]).toBe('T102');
       expect(mockIvtrRunner).not.toHaveBeenCalled();
       expect(result.data?.diagnostics.some((d) => d.includes('runner not provided'))).toBe(true);
     });
 
     // ---- Risk #1 mitigation: feature flag gates the cantbook seam ----------
 
-    it('kill-switch CLEO_GO_VIA_PLAYBOOK=0: falls back to startIvtr even when a runner IS injected', async () => {
+    it('kill-switch CLEO_GO_VIA_PLAYBOOK=0: falls back to the legacy seed even when a runner IS injected', async () => {
       // T11896 — the seam defaults ON; the explicit `=0` kill-switch restores
-      // the legacy startIvtr seed for one deprecation cycle.
+      // the legacy seedIvtrForPlaybook seed for one deprecation cycle.
       process.env[CLEO_GO_VIA_PLAYBOOK_ENV] = '0';
       mockSagaNext.mockResolvedValue({
         success: true,
@@ -377,11 +380,11 @@ describe('cleoGo driver (T11494)', () => {
       }
       // The injected cantbook runner is NOT called when the flag is OFF.
       expect(mockIvtrRunner).not.toHaveBeenCalled();
-      expect(mockStartIvtr).toHaveBeenCalledTimes(2);
+      expect(mockSeedIvtr).toHaveBeenCalledTimes(2);
       expect(result.data?.diagnostics.some((d) => d.includes('seam disabled'))).toBe(true);
     });
 
-    it('flag ON: drives the injected cantbook runner instead of startIvtr', async () => {
+    it('flag ON: drives the injected cantbook runner instead of the legacy seed', async () => {
       process.env[CLEO_GO_VIA_PLAYBOOK_ENV] = 'true';
       mockSagaNext.mockResolvedValue({
         success: true,
@@ -419,7 +422,7 @@ describe('cleoGo driver (T11494)', () => {
         expect(outcome.runIds).toEqual(['pbr_102']);
       }
       expect(mockIvtrRunner).toHaveBeenCalledTimes(1);
-      expect(mockStartIvtr).not.toHaveBeenCalled();
+      expect(mockSeedIvtr).not.toHaveBeenCalled();
     });
 
     it('gracefully handles IVTR start failures and reports in diagnostics', async () => {

--- a/packages/core/src/go/__tests__/driver.test.ts
+++ b/packages/core/src/go/__tests__/driver.test.ts
@@ -107,10 +107,11 @@ describe('cleoGo driver (T11494)', () => {
     mockIvtrRunner.mockResolvedValue({ taskId: 'T999', runId: 'pbr_999' });
     mockArmGoalLoop.mockResolvedValue({ id: 'g-armed-1', status: 'active' });
     mockStartIvtr.mockResolvedValue({ taskId: 'T999', currentPhase: 'implement' });
-    // The cantbook seam is flag-gated and defaults OFF. Most fan-out tests
-    // exercise the seam path, so enable it by default; the dedicated
-    // fallback-path tests below clear it explicitly.
-    process.env[CLEO_GO_VIA_PLAYBOOK_ENV] = '1';
+    // The cantbook seam defaults ON (T11896) — leaving the env unset already
+    // exercises the seam path. We clear it here so the default-ON behaviour is
+    // what the fan-out tests assert; the dedicated kill-switch test below sets
+    // `CLEO_GO_VIA_PLAYBOOK=0` explicitly to exercise the legacy fallback.
+    delete process.env[CLEO_GO_VIA_PLAYBOOK_ENV];
   });
 
   afterEach(() => {
@@ -336,8 +337,10 @@ describe('cleoGo driver (T11494)', () => {
 
     // ---- Risk #1 mitigation: feature flag gates the cantbook seam ----------
 
-    it('flag OFF (default): falls back to startIvtr even when a runner IS injected', async () => {
-      delete process.env[CLEO_GO_VIA_PLAYBOOK_ENV];
+    it('kill-switch CLEO_GO_VIA_PLAYBOOK=0: falls back to startIvtr even when a runner IS injected', async () => {
+      // T11896 — the seam defaults ON; the explicit `=0` kill-switch restores
+      // the legacy startIvtr seed for one deprecation cycle.
+      process.env[CLEO_GO_VIA_PLAYBOOK_ENV] = '0';
       mockSagaNext.mockResolvedValue({
         success: true,
         data: makeSagaNextResult({

--- a/packages/core/src/go/driver.ts
+++ b/packages/core/src/go/driver.ts
@@ -22,23 +22,26 @@
  *   → return ONE LAFS-compatible EngineResult envelope
  * ```
  *
- * ## IVTR seam (T11805 · E-ORCH-STATE-MACHINE-COLLAPSE / T11764)
+ * ## IVTR seam (T11805 · T11896 · E-ORCH-STATE-MACHINE-COLLAPSE / T11764)
  *
- * The implementation+ branch is flag-gated by {@link CLEO_GO_VIA_PLAYBOOK_ENV}
- * (defaulting **OFF** — Risk #1 mitigation, `cleo go` is the shipped autopilot
- * hot path):
+ * The implementation+ branch is gated by {@link CLEO_GO_VIA_PLAYBOOK_ENV}, which
+ * now defaults **ON** (T11896): the cantbook runtime is the shipped survivor
+ * state machine and `cleo go` drives IVTR through it. The flag is retained for
+ * **one deprecation cycle** as an opt-OUT kill-switch — set
+ * `CLEO_GO_VIA_PLAYBOOK=0` (or `false`/`no`/`off`) to restore the legacy
+ * `startIvtr` seed for a single release if a cantbook-path regression surfaces.
  *
- * - **Flag OFF (default)** — seed each ready task via the legacy `startIvtr`
- *   phase walk (byte-identical to the pre-T11805 behaviour); the seam is a
- *   no-op. This keeps a regression in the cantbook path from ever blocking
- *   autopilot and is retained as the fallback for one release.
- * - **Flag ON** — fan out an injected {@link IvtrRunner} — supplied by the CLI
- *   `cleo go` handler — that drives each task through
+ * - **Flag ON (default)** — fan out an injected {@link IvtrRunner} — supplied
+ *   by the CLI `cleo go` handler — that drives each task through
  *   `executePlaybook(ivtr.cantbook)` (the cantbook runtime, the survivor state
  *   machine) AND mirrors the run's terminal status back into `ivtr_state`
  *   (`finalizeIvtrFromPlaybook`) so the strict `E_IVTR_INCOMPLETE` completion
  *   gate reflects the cantbook run. The runtime's
  *   `on_failure.inject_into: implement` edge reproduces the IVTR loop-back walk.
+ * - **Flag OFF (opt-out kill-switch)** OR **no runner injected** — seed each
+ *   ready task via the legacy `startIvtr` phase walk (byte-identical to the
+ *   pre-T11805 behaviour); the seam is a no-op. This fallback is retained for
+ *   one release so a regression in the cantbook path can never strand autopilot.
  *
  * The driver stays in `@cleocode/core` and must NOT import `@cleocode/playbooks`
  * (that would invert the package dependency), so the runtime call is injected
@@ -67,30 +70,37 @@ import { getProjectRoot } from '../paths.js';
 import { sagaNext } from '../sagas/next.js';
 
 /**
- * Feature-flag env var gating the cantbook IVTR seam (T11805 · collapse-plan
- * Risk Register §7 row #1).
+ * Feature-flag env var gating the cantbook IVTR seam (T11805 · T11896 ·
+ * collapse-plan Risk Register §7 row #1).
  *
- * `cleo go` is the shipped SG-AUTOPILOT hot path, so the seam lands behind a
- * flag that defaults **OFF**. When unset/`'0'`/`'false'`, the
- * implementation-stage branch falls back to the legacy {@link startIvtr} phase
- * seed (byte-identical to the pre-T11805 behaviour) so a regression in the
- * cantbook path never blocks autopilot. Set `CLEO_GO_VIA_PLAYBOOK=1` to drive
- * the injected {@link IvtrRunner} (`executePlaybook(ivtr.cantbook)`). The
- * fallback is retained for one release per the collapse-plan mitigation.
+ * As of T11896 the cantbook runtime is the **shipped default** — the flag now
+ * defaults **ON** and is retained for one deprecation cycle purely as an
+ * opt-OUT kill-switch. When unset (or any truthy value) the implementation-stage
+ * branch drives the injected {@link IvtrRunner}
+ * (`executePlaybook(ivtr.cantbook)`). Set `CLEO_GO_VIA_PLAYBOOK=0` (or
+ * `false`/`no`/`off`) to restore the legacy {@link startIvtr} phase seed
+ * (byte-identical to the pre-T11805 behaviour) for a single release if a
+ * cantbook-path regression surfaces. The kill-switch is removed in a follow-up
+ * once the cantbook path has baked.
  */
 export const CLEO_GO_VIA_PLAYBOOK_ENV = 'CLEO_GO_VIA_PLAYBOOK' as const;
 
 /**
  * Resolve whether the cantbook IVTR seam is enabled for this `cleo go` turn.
  *
- * @returns `true` only when {@link CLEO_GO_VIA_PLAYBOOK_ENV} is an explicit
- *   truthy value (`'1'` | `'true'`, case-insensitive). Default OFF.
+ * Defaults **ON** (T11896): the seam is disabled only by an explicit opt-OUT
+ * kill-switch value of {@link CLEO_GO_VIA_PLAYBOOK_ENV} (`'0'` | `'false'` |
+ * `'no'` | `'off'`, case-insensitive). Unset — and every other value — keeps
+ * the cantbook runtime engaged.
+ *
+ * @returns `false` only when the env var is an explicit falsy kill-switch
+ *   value; `true` otherwise (including when unset).
  */
 function isPlaybookSeamEnabled(): boolean {
   const raw = process.env[CLEO_GO_VIA_PLAYBOOK_ENV];
-  if (raw === undefined) return false;
+  if (raw === undefined) return true;
   const v = raw.trim().toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
 }
 
 // ---------------------------------------------------------------------------
@@ -177,12 +187,12 @@ export interface CleoGoParams {
   /** Override project root (useful in tests). */
   projectRoot?: string;
   /**
-   * Drives each ready task through `executePlaybook(ivtr.cantbook)` when the
-   * cantbook seam is enabled via {@link CLEO_GO_VIA_PLAYBOOK_ENV} (T11805).
+   * Drives each ready task through `executePlaybook(ivtr.cantbook)` — the
+   * shipped default path (T11896) gated by {@link CLEO_GO_VIA_PLAYBOOK_ENV}.
    * Injected by the CLI handler so the core driver never imports the playbooks
-   * runtime. When the flag is OFF (default) or this is omitted, the driver
-   * falls back to the legacy `startIvtr` seed for the implementation+ branch
-   * (no behaviour is silently skipped).
+   * runtime. When the kill-switch is set (`CLEO_GO_VIA_PLAYBOOK=0`) or this is
+   * omitted, the driver falls back to the legacy `startIvtr` seed for the
+   * implementation+ branch (no behaviour is silently skipped).
    */
   ivtrRunner?: IvtrRunner;
   /**
@@ -414,28 +424,28 @@ export async function cleoGo(params: CleoGoParams = {}): Promise<EngineResult<Cl
 
   // 7. Implementation+ → fan-out the IVTR loop over the ready frontier.
   //
-  //    Two paths, gated by the CLEO_GO_VIA_PLAYBOOK feature flag (Risk #1
-  //    mitigation — the seam lands behind a flag defaulting OFF, keeping the
-  //    legacy `startIvtr` seed as the fallback for one release):
+  //    Two paths, gated by the CLEO_GO_VIA_PLAYBOOK feature flag (T11896 — the
+  //    cantbook runtime is now the shipped default; the flag is retained for one
+  //    cycle as an opt-OUT kill-switch):
   //
-  //    - Flag OFF (default) OR no runner injected → seed each ready task via
-  //      the hand-rolled `startIvtr` phase walk (byte-identical to the
-  //      pre-T11805 behaviour). This is the shipped autopilot hot path.
-  //    - Flag ON AND a runner injected → drive each ready task through
+  //    - Flag ON (default) AND a runner injected → drive each ready task through
   //      `executePlaybook(ivtr.cantbook)` via the injected runner, which also
   //      mirrors the terminal status back into `ivtr_state`. The runner is
   //      injected by the CLI handler so the core driver never imports
-  //      `@cleocode/playbooks`.
+  //      `@cleocode/playbooks`. This is the shipped autopilot hot path.
+  //    - Flag OFF (kill-switch `CLEO_GO_VIA_PLAYBOOK=0`) OR no runner injected →
+  //      seed each ready task via the hand-rolled `startIvtr` phase walk
+  //      (byte-identical to the pre-T11805 behaviour), retained for one release.
   const ivtrStarted: string[] = [];
   const ivtrRunIds: string[] = [];
 
   const seamEnabled = isPlaybookSeamEnabled();
 
   if (!seamEnabled || !params.ivtrRunner) {
-    // Fallback path: legacy `startIvtr` seed (flag OFF or no runner injected).
+    // Fallback path: legacy `startIvtr` seed (kill-switch set or no runner).
     if (params.ivtrRunner && !seamEnabled) {
       diagnostics.push(
-        `IVTR cantbook seam disabled (${CLEO_GO_VIA_PLAYBOOK_ENV} not set) — using legacy startIvtr seed`,
+        `IVTR cantbook seam disabled (${CLEO_GO_VIA_PLAYBOOK_ENV}=0 kill-switch) — using legacy startIvtr seed`,
       );
     } else if (!params.ivtrRunner) {
       diagnostics.push('IVTR runner not provided — using legacy startIvtr seed');

--- a/packages/core/src/go/driver.ts
+++ b/packages/core/src/go/driver.ts
@@ -29,7 +29,8 @@
  * state machine and `cleo go` drives IVTR through it. The flag is retained for
  * **one deprecation cycle** as an opt-OUT kill-switch — set
  * `CLEO_GO_VIA_PLAYBOOK=0` (or `false`/`no`/`off`) to restore the legacy
- * `startIvtr` seed for a single release if a cantbook-path regression surfaces.
+ * `ivtr_state` seed (`seedIvtrForPlaybook`, byte-identical to the retired
+ * `startIvtr`) for a single release if a cantbook-path regression surfaces.
  *
  * - **Flag ON (default)** — fan out an injected {@link IvtrRunner} — supplied
  *   by the CLI `cleo go` handler — that drives each task through
@@ -39,9 +40,9 @@
  *   gate reflects the cantbook run. The runtime's
  *   `on_failure.inject_into: implement` edge reproduces the IVTR loop-back walk.
  * - **Flag OFF (opt-out kill-switch)** OR **no runner injected** — seed each
- *   ready task via the legacy `startIvtr` phase walk (byte-identical to the
- *   pre-T11805 behaviour); the seam is a no-op. This fallback is retained for
- *   one release so a regression in the cantbook path can never strand autopilot.
+ *   ready task's `ivtr_state` via `seedIvtrForPlaybook` (byte-identical to the
+ *   retired `startIvtr` seed); the seam is a no-op. This fallback is retained
+ *   for one release so a cantbook-path regression can never strand autopilot.
  *
  * The driver stays in `@cleocode/core` and must NOT import `@cleocode/playbooks`
  * (that would invert the package dependency), so the runtime call is injected
@@ -64,7 +65,7 @@
 import type { TaskViewPipelineStage } from '@cleocode/contracts';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { armGoalLoop } from '../goal/arm.js';
-import { startIvtr } from '../lifecycle/ivtr-loop.js';
+import { seedIvtrForPlaybook } from '../lifecycle/ivtr-loop.js';
 import { orchestrateReady } from '../orchestrate/query-ops.js';
 import { getProjectRoot } from '../paths.js';
 import { sagaNext } from '../sagas/next.js';
@@ -78,8 +79,8 @@ import { sagaNext } from '../sagas/next.js';
  * opt-OUT kill-switch. When unset (or any truthy value) the implementation-stage
  * branch drives the injected {@link IvtrRunner}
  * (`executePlaybook(ivtr.cantbook)`). Set `CLEO_GO_VIA_PLAYBOOK=0` (or
- * `false`/`no`/`off`) to restore the legacy {@link startIvtr} phase seed
- * (byte-identical to the pre-T11805 behaviour) for a single release if a
+ * `false`/`no`/`off`) to restore the legacy `seedIvtrForPlaybook` seed
+ * (byte-identical to the retired `startIvtr`) for a single release if a
  * cantbook-path regression surfaces. The kill-switch is removed in a follow-up
  * once the cantbook path has baked.
  */
@@ -191,8 +192,8 @@ export interface CleoGoParams {
    * shipped default path (T11896) gated by {@link CLEO_GO_VIA_PLAYBOOK_ENV}.
    * Injected by the CLI handler so the core driver never imports the playbooks
    * runtime. When the kill-switch is set (`CLEO_GO_VIA_PLAYBOOK=0`) or this is
-   * omitted, the driver falls back to the legacy `startIvtr` seed for the
-   * implementation+ branch (no behaviour is silently skipped).
+   * omitted, the driver falls back to the legacy `seedIvtrForPlaybook` seed for
+   * the implementation+ branch (no behaviour is silently skipped).
    */
   ivtrRunner?: IvtrRunner;
   /**
@@ -434,30 +435,34 @@ export async function cleoGo(params: CleoGoParams = {}): Promise<EngineResult<Cl
   //      injected by the CLI handler so the core driver never imports
   //      `@cleocode/playbooks`. This is the shipped autopilot hot path.
   //    - Flag OFF (kill-switch `CLEO_GO_VIA_PLAYBOOK=0`) OR no runner injected →
-  //      seed each ready task via the hand-rolled `startIvtr` phase walk
-  //      (byte-identical to the pre-T11805 behaviour), retained for one release.
+  //      seed each ready task's `ivtr_state` via `seedIvtrForPlaybook`
+  //      (byte-identical to the retired `startIvtr` seed), retained one release.
   const ivtrStarted: string[] = [];
   const ivtrRunIds: string[] = [];
 
   const seamEnabled = isPlaybookSeamEnabled();
 
   if (!seamEnabled || !params.ivtrRunner) {
-    // Fallback path: legacy `startIvtr` seed (kill-switch set or no runner).
+    // Fallback path: legacy `ivtr_state` seed (kill-switch set or no runner).
     if (params.ivtrRunner && !seamEnabled) {
       diagnostics.push(
-        `IVTR cantbook seam disabled (${CLEO_GO_VIA_PLAYBOOK_ENV}=0 kill-switch) — using legacy startIvtr seed`,
+        `IVTR cantbook seam disabled (${CLEO_GO_VIA_PLAYBOOK_ENV}=0 kill-switch) — using legacy fallback seed`,
       );
     } else if (!params.ivtrRunner) {
-      diagnostics.push('IVTR runner not provided — using legacy startIvtr seed');
+      diagnostics.push('IVTR runner not provided — using legacy fallback seed');
     }
 
     for (const taskId of readyFrontier) {
       try {
-        await startIvtr(taskId, { cwd: root });
+        // The legacy seed is now `seedIvtrForPlaybook` — byte-identical to the
+        // retired `startIvtr` (both share `buildInitialIvtrState`), so the
+        // kill-switch fallback produces the same `ivtr_state` row while the
+        // hand-rolled `startIvtr` walk function is deleted (T11896 AC3).
+        await seedIvtrForPlaybook(taskId, { cwd: root });
         ivtrStarted.push(taskId);
-        diagnostics.push(`IVTR started for ${taskId} (startIvtr seed)`);
+        diagnostics.push(`IVTR seeded for ${taskId} (legacy fallback seed)`);
       } catch (err: unknown) {
-        diagnostics.push(`IVTR start failed for ${taskId}: ${(err as Error).message}`);
+        diagnostics.push(`IVTR seed failed for ${taskId}: ${(err as Error).message}`);
       }
     }
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -561,26 +561,20 @@ export {
   skipStageWithReason,
   TIER_0_SKILLS,
 } from './lifecycle/index.js';
-// IVTR orchestration harness (T811 + T813 + T814)
+// IVTR `ivtr_state` read + cantbook-mirror surface (T811 + T11805; the
+// hand-rolled phase-walk functions were deleted in T11896 — the loop now runs
+// on the cantbook runtime).
 export type {
-  AutoRunGatesResult,
   IvtrPhase,
   IvtrPhaseEntry,
   IvtrState,
 } from './lifecycle/ivtr-loop.js';
 export {
-  advanceIvtr,
-  autoRunGatesAndRecord,
-  E_IVTR_MAX_RETRIES,
   finalizeIvtrFromPlaybook,
   getIvtrState,
   type IvtrPlaybookTerminalStatus,
-  loopBackIvtr,
   MAX_LOOP_BACKS_PER_PHASE,
-  releaseIvtr,
-  resolvePhasePrompt,
   seedIvtrForPlaybook,
-  startIvtr,
 } from './lifecycle/ivtr-loop.js';
 export { STAGE_DEFINITIONS } from './lifecycle/stages.js';
 // Lifecycle — verify explain (T1013 / T1541 / ADR-051 / ADR-057)

--- a/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts
+++ b/packages/core/src/lifecycle/__tests__/ivtr-loop.test.ts
@@ -1,35 +1,29 @@
 /**
- * Tests for IVTR orchestration loop state machine.
+ * Tests for the IVTR `ivtr_state` read + cantbook-mirror surface.
  *
- * Covers:
- * - Happy path: start → implement → validate → test → release
- * - Loop-back: test fails → rewind to implement → continue
- * - Max retries: third loop-back to same phase rejects with E_IVTR_MAX_RETRIES
- * - Prompt enrichment: loop-back context injected into Implement prompt
- * - Edge cases: double-start idempotency, advance past released
+ * The hand-rolled phase-walk functions (`startIvtr`/`advanceIvtr`/
+ * `loopBackIvtr`/`releaseIvtr`) and the per-phase prompt/auto-gate helpers were
+ * deleted in T11896 when the IVTR loop was collapsed onto the cantbook runtime.
+ * This file now covers the RETAINED surface:
+ *
+ * - `seedIvtrForPlaybook` — the `cleo go` seam seeds `ivtr_state` at implement.
+ * - `finalizeIvtrFromPlaybook` — mirrors the cantbook run's terminal status
+ *   back into `ivtr_state` so the strict `E_IVTR_INCOMPLETE` gate stays
+ *   load-bearing (a `completed` run drives the column to `released`).
+ * - `getIvtrState` — the read path backing the completion gate +
+ *   `cleo show --ivtr-history`.
  *
  * @epic T810
  * @task T811
- * @task T814
+ * @task T11805 — cantbook seam (seed + finalize mirror)
+ * @task T11896 — phase-walk functions deleted; this is the read/mirror surface
  */
 
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  advanceIvtr,
-  E_IVTR_MAX_RETRIES,
-  finalizeIvtrFromPlaybook,
-  getIvtrState,
-  type ImplEvidenceSummary,
-  loopBackIvtr,
-  MAX_LOOP_BACKS_PER_PHASE,
-  releaseIvtr,
-  resolvePhasePrompt,
-  seedIvtrForPlaybook,
-  startIvtr,
-} from '../ivtr-loop.js';
+import { finalizeIvtrFromPlaybook, getIvtrState, seedIvtrForPlaybook } from '../ivtr-loop.js';
 
 // ---------------------------------------------------------------------------
 // Test setup
@@ -74,39 +68,19 @@ afterEach(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Happy path: start → implement → validate → test → release
+// seedIvtrForPlaybook — the cantbook seam seeds ivtr_state at implement
 // ---------------------------------------------------------------------------
 
-describe('IVTR happy path', () => {
-  it('startIvtr creates state with implement phase', async () => {
-    const state = await startIvtr('T999', { cwd: testDir });
-
-    expect(state.taskId).toBe('T999');
-    expect(state.currentPhase).toBe('implement');
-    expect(state.phaseHistory).toHaveLength(1);
-    expect(state.phaseHistory[0]?.phase).toBe('implement');
-    expect(state.phaseHistory[0]?.passed).toBeNull();
-    expect(state.phaseHistory[0]?.completedAt).toBeNull();
-    expect(state.startedAt).toBeDefined();
-  });
-
-  it('startIvtr is idempotent — second call returns existing state', async () => {
-    const first = await startIvtr('T999', { cwd: testDir });
-    const second = await startIvtr('T999', { cwd: testDir });
-
-    expect(second.startedAt).toBe(first.startedAt);
-    expect(second.phaseHistory).toHaveLength(1);
-  });
-
-  it('getIvtrState returns null before start', async () => {
+describe('seedIvtrForPlaybook (T11805 cantbook seam)', () => {
+  it('getIvtrState returns null before any seed', async () => {
     const state = await getIvtrState('T999', { cwd: testDir });
     expect(state).toBeNull();
   });
 
-  // T11805 — the `cleo go` seam seeds ivtr_state via seedIvtrForPlaybook (NOT
-  // startIvtr) so the strict E_IVTR_INCOMPLETE completion gate stays
-  // load-bearing for cantbook-driven runs (collapse-plan §3 item 4).
-  it('seedIvtrForPlaybook produces the same implement-phase state as startIvtr', async () => {
+  // T11805 — the `cleo go` seam seeds ivtr_state via seedIvtrForPlaybook so the
+  // strict E_IVTR_INCOMPLETE completion gate stays load-bearing for
+  // cantbook-driven runs (collapse-plan §3 item 4).
+  it('seeds a fresh schema-v2 implement-phase state', async () => {
     const seeded = await seedIvtrForPlaybook('T999', { cwd: testDir });
 
     expect(seeded.taskId).toBe('T999');
@@ -130,813 +104,126 @@ describe('IVTR happy path', () => {
     expect(readBack?.currentPhase).toBe('implement');
   });
 
-  it('seedIvtrForPlaybook is idempotent — second call returns existing state', async () => {
+  it('is idempotent — second call returns existing state', async () => {
     const first = await seedIvtrForPlaybook('T999', { cwd: testDir });
     const second = await seedIvtrForPlaybook('T999', { cwd: testDir });
 
     expect(second.startedAt).toBe(first.startedAt);
     expect(second.phaseHistory).toHaveLength(1);
   });
+});
 
-  // T11805 — terminal-mirror: the `cleo go` cantbook seam mirrors the playbook
-  // run's TERMINAL status back into ivtr_state so the strict E_IVTR_INCOMPLETE
-  // gate reflects an autonomous run (collapse-plan §3 item 4 + Risk #2).
-  describe('finalizeIvtrFromPlaybook (T11805 terminal mirror)', () => {
-    it("on 'completed' advances seeded implement state to released with passing phase history", async () => {
-      // Seam seeds at implement (passed: null) — this is the frozen state the
-      // bug left behind. finalize must drive it to released.
-      const seeded = await seedIvtrForPlaybook('T999', { cwd: testDir });
-      expect(seeded.currentPhase).toBe('implement');
-      expect(seeded.phaseHistory[0]?.passed).toBeNull();
+// ---------------------------------------------------------------------------
+// finalizeIvtrFromPlaybook — terminal-status mirror back into ivtr_state
+// ---------------------------------------------------------------------------
 
-      const result = await finalizeIvtrFromPlaybook('T999', 'completed', {
-        cwd: testDir,
-        runId: 'pbr_999',
-        finalContext: { taskId: 'T999', testsPassed: true, __lastError: 'should-be-stripped' },
-      });
+// T11805 — terminal-mirror: the `cleo go` cantbook seam mirrors the playbook
+// run's TERMINAL status back into ivtr_state so the strict E_IVTR_INCOMPLETE
+// gate reflects an autonomous run (collapse-plan §3 item 4 + Risk #2).
+describe('finalizeIvtrFromPlaybook (T11805 terminal mirror)', () => {
+  it("on 'completed' advances seeded implement state to released with passing phase history", async () => {
+    // Seam seeds at implement (passed: null) — this is the frozen state the
+    // bug left behind. finalize must drive it to released.
+    const seeded = await seedIvtrForPlaybook('T999', { cwd: testDir });
+    expect(seeded.currentPhase).toBe('implement');
+    expect(seeded.phaseHistory[0]?.passed).toBeNull();
 
-      expect(result.state?.currentPhase).toBe('released');
-      // implement/validate/audit/test all have a passing entry → gate passes.
-      for (const phase of ['implement', 'validate', 'audit', 'test'] as const) {
-        const hasPassed = result.state?.phaseHistory.some(
-          (e) => e.phase === phase && e.passed === true,
-        );
-        expect(hasPassed).toBe(true);
-      }
-      // No in-progress entry remains (gate's active-entry check passes).
-      expect(result.state?.phaseHistory.every((e) => e.completedAt !== null)).toBe(true);
-
-      // Persisted: read back as released.
-      const readBack = await getIvtrState('T999', { cwd: testDir });
-      expect(readBack?.currentPhase).toBe('released');
+    const result = await finalizeIvtrFromPlaybook('T999', 'completed', {
+      cwd: testDir,
+      runId: 'pbr_999',
+      finalContext: { taskId: 'T999', testsPassed: true, __lastError: 'should-be-stripped' },
     });
 
-    it("on 'completed' reproduces the attachment-store evidence write (sha256 recorded)", async () => {
-      await seedIvtrForPlaybook('T999', { cwd: testDir });
-      const result = await finalizeIvtrFromPlaybook('T999', 'completed', {
-        cwd: testDir,
-        runId: 'pbr_evidence',
-        finalContext: { taskId: 'T999', diff: 'abc' },
-      });
+    expect(result.state?.currentPhase).toBe('released');
+    // implement/validate/audit/test all have a passing entry → gate passes.
+    for (const phase of ['implement', 'validate', 'audit', 'test'] as const) {
+      const hasPassed = result.state?.phaseHistory.some(
+        (e) => e.phase === phase && e.passed === true,
+      );
+      expect(hasPassed).toBe(true);
+    }
+    // No in-progress entry remains (gate's active-entry check passes).
+    expect(result.state?.phaseHistory.every((e) => e.completedAt !== null)).toBe(true);
 
-      // A provenance evidence ref (sha256) is produced and recorded.
-      expect(result.evidenceRef).toMatch(/^[0-9a-f]{64}$/);
-      const allRefs = result.state?.phaseHistory.flatMap((e) => e.evidenceRefs) ?? [];
-      expect(allRefs).toContain(result.evidenceRef);
-    });
-
-    it("on 'failed' marks the active phase failed and leaves currentPhase un-advanced (gate blocks)", async () => {
-      await seedIvtrForPlaybook('T999', { cwd: testDir });
-      const result = await finalizeIvtrFromPlaybook('T999', 'failed', {
-        cwd: testDir,
-        runId: 'pbr_fail',
-        error: 'implement node exceeded retries',
-      });
-
-      expect(result.state?.currentPhase).toBe('implement'); // NOT released
-      const implEntry = result.state?.phaseHistory.find((e) => e.phase === 'implement');
-      expect(implEntry?.passed).toBe(false);
-      expect(implEntry?.reason).toMatch(/Playbook failed/);
-
-      // The strict gate (currentPhase !== 'released') would still block complete.
-      const readBack = await getIvtrState('T999', { cwd: testDir });
-      expect(readBack?.currentPhase).not.toBe('released');
-    });
-
-    it("on 'exceeded_iteration_cap' marks failed and does not release", async () => {
-      await seedIvtrForPlaybook('T999', { cwd: testDir });
-      const result = await finalizeIvtrFromPlaybook('T999', 'exceeded_iteration_cap', {
-        cwd: testDir,
-      });
-      expect(result.state?.currentPhase).toBe('implement');
-      const implEntry = result.state?.phaseHistory.find((e) => e.phase === 'implement');
-      expect(implEntry?.passed).toBe(false);
-    });
-
-    it("on 'pending_approval' is a no-op (run awaits HITL; later resume finalizes)", async () => {
-      await seedIvtrForPlaybook('T999', { cwd: testDir });
-      const result = await finalizeIvtrFromPlaybook('T999', 'pending_approval', { cwd: testDir });
-      expect(result.state?.currentPhase).toBe('implement');
-      // Seed entry stays in-progress (passed: null) — nothing was finalized.
-      expect(result.state?.phaseHistory[0]?.passed).toBeNull();
-    });
-
-    it('returns null state when no ivtr_state was seeded (defensive no-op)', async () => {
-      const result = await finalizeIvtrFromPlaybook('T999', 'completed', { cwd: testDir });
-      expect(result.state).toBeNull();
-    });
-
-    it('is idempotent when already released', async () => {
-      await seedIvtrForPlaybook('T999', { cwd: testDir });
-      await finalizeIvtrFromPlaybook('T999', 'completed', { cwd: testDir, runId: 'r1' });
-      const second = await finalizeIvtrFromPlaybook('T999', 'completed', {
-        cwd: testDir,
-        runId: 'r2',
-      });
-      expect(second.state?.currentPhase).toBe('released');
-    });
-
-    it('end-to-end: seed → finalize(completed) yields a state the strict gate accepts', async () => {
-      // Mirror the gate's own check (complete.ts:1400): ivtrState !== null &&
-      // currentPhase !== 'released' → reject. After finalize, this must pass.
-      await seedIvtrForPlaybook('T999', { cwd: testDir });
-      await finalizeIvtrFromPlaybook('T999', 'completed', { cwd: testDir, runId: 'pbr_gate' });
-
-      const state = await getIvtrState('T999', { cwd: testDir });
-      expect(state).not.toBeNull();
-      const gateWouldBlock = state !== null && state.currentPhase !== 'released';
-      expect(gateWouldBlock).toBe(false);
-    });
+    // Persisted: read back as released.
+    const readBack = await getIvtrState('T999', { cwd: testDir });
+    expect(readBack?.currentPhase).toBe('released');
   });
 
-  it('advanceIvtr transitions implement → validate', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const evidence = ['abc123'];
-    const state = await advanceIvtr('T999', evidence, { cwd: testDir });
+  it("on 'completed' reproduces the attachment-store evidence write (sha256 recorded)", async () => {
+    await seedIvtrForPlaybook('T999', { cwd: testDir });
+    const result = await finalizeIvtrFromPlaybook('T999', 'completed', {
+      cwd: testDir,
+      runId: 'pbr_evidence',
+      finalContext: { taskId: 'T999', diff: 'abc' },
+    });
 
-    expect(state.currentPhase).toBe('validate');
-    expect(state.phaseHistory).toHaveLength(2);
-
-    const implEntry = state.phaseHistory[0]!;
-    expect(implEntry.phase).toBe('implement');
-    expect(implEntry.passed).toBe(true);
-    expect(implEntry.evidenceRefs).toContain('abc123');
-    expect(implEntry.completedAt).toBeDefined();
-
-    const valEntry = state.phaseHistory[1]!;
-    expect(valEntry.phase).toBe('validate');
-    expect(valEntry.passed).toBeNull();
-    expect(valEntry.completedAt).toBeNull();
+    // A provenance evidence ref (sha256) is produced and recorded.
+    expect(result.evidenceRef).toMatch(/^[0-9a-f]{64}$/);
+    const allRefs = result.state?.phaseHistory.flatMap((e) => e.evidenceRefs) ?? [];
+    expect(allRefs).toContain(result.evidenceRef);
   });
 
-  it('advanceIvtr transitions validate → audit (T9216: audit phase added)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['impl-sha'], { cwd: testDir });
-    const state = await advanceIvtr('T999', ['val-sha'], { cwd: testDir });
+  it("on 'failed' marks the active phase failed and leaves currentPhase un-advanced (gate blocks)", async () => {
+    await seedIvtrForPlaybook('T999', { cwd: testDir });
+    const result = await finalizeIvtrFromPlaybook('T999', 'failed', {
+      cwd: testDir,
+      runId: 'pbr_fail',
+      error: 'implement node exceeded retries',
+    });
 
-    expect(state.currentPhase).toBe('audit');
-    expect(state.phaseHistory).toHaveLength(3);
-    expect(state.phaseHistory[2]?.phase).toBe('audit');
+    expect(result.state?.currentPhase).toBe('implement'); // NOT released
+    const implEntry = result.state?.phaseHistory.find((e) => e.phase === 'implement');
+    expect(implEntry?.passed).toBe(false);
+    expect(implEntry?.reason).toMatch(/Playbook failed/);
+
+    // The strict gate (currentPhase !== 'released') would still block complete.
+    const readBack = await getIvtrState('T999', { cwd: testDir });
+    expect(readBack?.currentPhase).not.toBe('released');
   });
 
-  it('full happy path: implement → validate → audit → test → release (T9216)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['impl-sha'], { cwd: testDir });
-    await advanceIvtr('T999', ['val-sha'], { cwd: testDir });
-    await advanceIvtr('T999', ['audit-sha'], { cwd: testDir }); // T9216: audit phase
-    await advanceIvtr('T999', ['test-sha'], { cwd: testDir });
+  it("on 'exceeded_iteration_cap' marks failed and does not release", async () => {
+    await seedIvtrForPlaybook('T999', { cwd: testDir });
+    const result = await finalizeIvtrFromPlaybook('T999', 'exceeded_iteration_cap', {
+      cwd: testDir,
+    });
+    expect(result.state?.currentPhase).toBe('implement');
+    const implEntry = result.state?.phaseHistory.find((e) => e.phase === 'implement');
+    expect(implEntry?.passed).toBe(false);
+  });
 
-    const result = await releaseIvtr('T999', { cwd: testDir });
-    expect(result.released).toBe(true);
-    expect(result.failures).toBeUndefined();
+  it("on 'pending_approval' is a no-op (run awaits HITL; later resume finalizes)", async () => {
+    await seedIvtrForPlaybook('T999', { cwd: testDir });
+    const result = await finalizeIvtrFromPlaybook('T999', 'pending_approval', { cwd: testDir });
+    expect(result.state?.currentPhase).toBe('implement');
+    // Seed entry stays in-progress (passed: null) — nothing was finalized.
+    expect(result.state?.phaseHistory[0]?.passed).toBeNull();
+  });
+
+  it('returns null state when no ivtr_state was seeded (defensive no-op)', async () => {
+    const result = await finalizeIvtrFromPlaybook('T999', 'completed', { cwd: testDir });
+    expect(result.state).toBeNull();
+  });
+
+  it('is idempotent when already released', async () => {
+    await seedIvtrForPlaybook('T999', { cwd: testDir });
+    await finalizeIvtrFromPlaybook('T999', 'completed', { cwd: testDir, runId: 'r1' });
+    const second = await finalizeIvtrFromPlaybook('T999', 'completed', {
+      cwd: testDir,
+      runId: 'r2',
+    });
+    expect(second.state?.currentPhase).toBe('released');
+  });
+
+  it('end-to-end: seed → finalize(completed) yields a state the strict gate accepts', async () => {
+    // Mirror the gate's own check (complete.ts:1400): ivtrState !== null &&
+    // currentPhase !== 'released' → reject. After finalize, this must pass.
+    await seedIvtrForPlaybook('T999', { cwd: testDir });
+    await finalizeIvtrFromPlaybook('T999', 'completed', { cwd: testDir, runId: 'pbr_gate' });
 
     const state = await getIvtrState('T999', { cwd: testDir });
-    expect(state?.currentPhase).toBe('released');
-  });
-
-  it('releaseIvtr is idempotent when already released', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i'], { cwd: testDir });
-    await advanceIvtr('T999', ['v'], { cwd: testDir });
-    await advanceIvtr('T999', ['a'], { cwd: testDir }); // T9216: audit phase
-    await advanceIvtr('T999', ['t'], { cwd: testDir });
-    await releaseIvtr('T999', { cwd: testDir });
-
-    const second = await releaseIvtr('T999', { cwd: testDir });
-    expect(second.released).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Loop-back: phase failure → rewind
-// ---------------------------------------------------------------------------
-
-describe('IVTR loop-back', () => {
-  it('loopBackIvtr from audit to implement records failure (T9216)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['impl-sha'], { cwd: testDir });
-    await advanceIvtr('T999', ['val-sha'], { cwd: testDir });
-    // Now in audit phase (T9216)
-
-    const state = await loopBackIvtr(
-      'T999',
-      'implement',
-      'Audit failed: evidence atom re-validation E_EVIDENCE_STALE',
-      [],
-      { cwd: testDir },
-    );
-
-    expect(state.currentPhase).toBe('implement');
-    // History: implement(pass) + validate(pass) + audit(fail) + implement(new)
-    expect(state.phaseHistory).toHaveLength(4);
-
-    const failedAudit = state.phaseHistory[2]!;
-    expect(failedAudit.phase).toBe('audit');
-    expect(failedAudit.passed).toBe(false);
-    expect(failedAudit.reason).toBe('Audit failed: evidence atom re-validation E_EVIDENCE_STALE');
-
-    const newImpl = state.phaseHistory[3]!;
-    expect(newImpl.phase).toBe('implement');
-    expect(newImpl.passed).toBeNull();
-    expect(newImpl.reason).toMatch(/Loop-back from audit/);
-  });
-
-  it('after loop-back, advance resumes from implement again', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i1'], { cwd: testDir });
-    await advanceIvtr('T999', ['v1'], { cwd: testDir });
-    await loopBackIvtr('T999', 'implement', 'fix needed', [], { cwd: testDir });
-
-    // Advance implement → validate → audit → test (T9216: audit phase added)
-    await advanceIvtr('T999', ['i2'], { cwd: testDir });
-    await advanceIvtr('T999', ['v2'], { cwd: testDir });
-    await advanceIvtr('T999', ['a2'], { cwd: testDir }); // T9216: audit
-    await advanceIvtr('T999', ['t2'], { cwd: testDir });
-
-    const result = await releaseIvtr('T999', { cwd: testDir });
-    expect(result.released).toBe(true);
-  });
-
-  it('loopBackIvtr rejects target of released', async () => {
-    await startIvtr('T999', { cwd: testDir });
-
-    await expect(
-      loopBackIvtr('T999', 'released' as never, 'bad', [], { cwd: testDir }),
-    ).rejects.toThrow("Cannot loop back to 'released'");
-  });
-
-  it('loopBackIvtr rejects when no IVTR state exists', async () => {
-    await expect(loopBackIvtr('T999', 'implement', 'bad', [], { cwd: testDir })).rejects.toThrow(
-      'No IVTR state',
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Release gate failures
-// ---------------------------------------------------------------------------
-
-describe('releaseIvtr gate failures', () => {
-  it('fails when implement phase has no passing entry', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const result = await releaseIvtr('T999', { cwd: testDir });
-
-    expect(result.released).toBe(false);
-    expect(result.failures).toContain("Phase 'implement' has no passing entry");
-    expect(result.failures).toContain("Phase 'validate' has no passing entry");
-    expect(result.failures).toContain("Phase 'audit' has no passing entry"); // T9216
-    expect(result.failures).toContain("Phase 'test' has no passing entry");
-  });
-
-  it('fails when only implement has passed', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i'], { cwd: testDir });
-    const result = await releaseIvtr('T999', { cwd: testDir });
-
-    expect(result.released).toBe(false);
-    expect(result.failures).not.toContain("Phase 'implement' has no passing entry");
-    expect(result.failures).toContain("Phase 'validate' has no passing entry");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Edge cases
-// ---------------------------------------------------------------------------
-
-describe('IVTR edge cases', () => {
-  it('advanceIvtr throws when no state exists', async () => {
-    await expect(advanceIvtr('T999', [], { cwd: testDir })).rejects.toThrow('No IVTR state');
-  });
-
-  it('advanceIvtr throws when already released', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i'], { cwd: testDir });
-    await advanceIvtr('T999', ['v'], { cwd: testDir });
-    await advanceIvtr('T999', ['a'], { cwd: testDir }); // T9216: audit phase
-    await advanceIvtr('T999', ['t'], { cwd: testDir });
-    await releaseIvtr('T999', { cwd: testDir });
-
-    await expect(advanceIvtr('T999', [], { cwd: testDir })).rejects.toThrow('already released');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// resolvePhasePrompt
-// ---------------------------------------------------------------------------
-
-describe('resolvePhasePrompt', () => {
-  it('generates implement prompt with correct phase header', async () => {
-    const state = await startIvtr('T999', { cwd: testDir });
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Do the thing');
-
-    expect(prompt).toContain('Phase: **IMPLEMENT**');
-    expect(prompt).toContain('T999: My Task');
-    expect(prompt).toContain('Do the thing');
-    expect(prompt).toContain('Implementation agent');
-    expect(prompt).toContain('Prior Phase Evidence\n(none — first phase)');
-  });
-
-  it('generates validate prompt with prior evidence (raw sha256 fallback)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', ['sha-abc'], { cwd: testDir });
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Do the thing');
-
-    expect(prompt).toContain('Phase: **VALIDATE**');
-    // impl-diff sha256 surfaces in the evidence bundle fallback
-    expect(prompt).toContain('sha-abc');
-    // T812: Validate agent (not "Validation agent")
-    expect(prompt).toContain('Validate agent');
-    // T812: spec↔code alignment check instruction
-    expect(prompt).toContain('spec↔code alignment');
-    // T812: validate-spec-check kind
-    expect(prompt).toContain('validate-spec-check');
-    // T812: REJECT criteria
-    expect(prompt).toContain('REJECT criteria');
-  });
-
-  it('injects Blast-Radius Test Scope into validate prompt when infrastructure files changed (T9842)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', ['sha-impl'], { cwd: testDir });
-    const evidenceBundle: ImplEvidenceSummary[] = [
-      {
-        attachmentSha256: 'a'.repeat(64),
-        kind: 'impl-diff',
-        filesChanged: [
-          // Mirrors the T9814 precedent: a transaction primitive in core/store.
-          'packages/core/src/store/sqlite-data-accessor.ts',
-        ],
-        linesAdded: 12,
-        linesRemoved: 4,
-        durationMs: 1500,
-      },
-    ];
-    const prompt = resolvePhasePrompt(
-      'T999',
-      state,
-      'My Task',
-      'Refactor DataAccessor.transaction()',
-      undefined,
-      evidenceBundle,
-    );
-
-    // The synthetic infrastructure change with targeted-test-only Lead review
-    // would be caught by the updated protocol (AC3).
-    expect(prompt).toContain('Blast-Radius Test Scope');
-    expect(prompt).toContain('T9842');
-    // T9814 precedent must be cited in the Lead-spawn prompt (AC4).
-    expect(prompt).toContain('T9814');
-    expect(prompt).toContain('agent-resolver');
-    // Lead is instructed to run the full per-package vitest, not targeted-only.
-    expect(prompt).toContain('pnpm --filter @cleocode/core run test');
-    // New REJECT criterion is wired up.
-    expect(prompt).toContain('Infra-test-scope violation');
-    expect(prompt).toContain('infra-test-scope-violation');
-  });
-
-  it('does NOT inject Blast-Radius Test Scope when impl-diff is non-infrastructure (T9842)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', ['sha-impl'], { cwd: testDir });
-    const evidenceBundle: ImplEvidenceSummary[] = [
-      {
-        attachmentSha256: 'b'.repeat(64),
-        kind: 'impl-diff',
-        filesChanged: [
-          'packages/cleo/src/cli/commands/show.ts',
-          'docs/release/branch-protection-setup.md',
-        ],
-      },
-    ];
-    const prompt = resolvePhasePrompt(
-      'T999',
-      state,
-      'My Task',
-      'CLI show polish',
-      undefined,
-      evidenceBundle,
-    );
-
-    expect(prompt).not.toContain('Blast-Radius Test Scope');
-    expect(prompt).not.toContain('infra-test-scope-violation');
-  });
-
-  it('aggregates filesChanged across multiple impl evidence entries (T9842)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', ['sha-impl'], { cwd: testDir });
-    const evidenceBundle: ImplEvidenceSummary[] = [
-      {
-        attachmentSha256: 'a'.repeat(64),
-        kind: 'impl-diff',
-        filesChanged: ['packages/cleo/src/cli/commands/show.ts'],
-      },
-      {
-        attachmentSha256: 'c'.repeat(64),
-        kind: 'impl-diff',
-        filesChanged: ['packages/contracts/src/envelope.ts'],
-      },
-    ];
-    const prompt = resolvePhasePrompt(
-      'T999',
-      state,
-      'My Task',
-      'Mixed change',
-      undefined,
-      evidenceBundle,
-    );
-
-    expect(prompt).toContain('Blast-Radius Test Scope');
-    expect(prompt).toContain('pnpm --filter @cleocode/contracts run test');
-  });
-
-  it('generates audit prompt after validate (T9216: audit phase added)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['sha-i'], { cwd: testDir });
-    const state = await advanceIvtr('T999', ['sha-v'], { cwd: testDir });
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Do the thing');
-
-    expect(prompt).toContain('Phase: **AUDIT**');
-    // Audit phase: references ADR-051 evidence-atom re-validation (T9337)
-    expect(prompt).toContain('Auditor agent');
-    expect(prompt).toContain('cleo verify');
-    expect(prompt).toContain('ADR-051');
-  });
-
-  it('generates test prompt with prior evidence', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['sha-i'], { cwd: testDir });
-    await advanceIvtr('T999', ['sha-v'], { cwd: testDir }); // → audit (T9216)
-    const state = await advanceIvtr('T999', ['sha-a'], { cwd: testDir }); // audit → test
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Do the thing');
-
-    expect(prompt).toContain('Phase: **TEST**');
-    expect(prompt).toContain('Testing agent');
-    // T813 test-phase prompt: uses `cleo verify <id> --run` as canonical driver
-    // when typed gates are present; `pnpm run test` appears inside a gate's
-    // command field when provided. Accept either marker.
-    expect(prompt).toMatch(/cleo verify.*--run|pnpm run test/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Max retries: loop-back count enforcement (T814)
-// ---------------------------------------------------------------------------
-
-describe('IVTR loop-back max retries', () => {
-  it('first loop-back (count=1) succeeds — loopBackCount increments', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['impl-sha'], { cwd: testDir }); // → validate
-    await advanceIvtr('T999', ['val-sha'], { cwd: testDir }); // → audit (T9216)
-
-    const state = await loopBackIvtr('T999', 'implement', 'Audit failed round 1', [], {
-      cwd: testDir,
-    });
-
-    expect(state.loopBackCount.implement).toBe(1);
-    expect(state.currentPhase).toBe('implement');
-  });
-
-  it('second loop-back (count=2) succeeds — loopBackCount reaches MAX', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i1'], { cwd: testDir });
-    await advanceIvtr('T999', ['v1'], { cwd: testDir }); // → audit (T9216)
-    await loopBackIvtr('T999', 'implement', 'Round 1 failure', [], { cwd: testDir });
-
-    // Resume: advance back through validate → audit (T9216)
-    await advanceIvtr('T999', ['i2'], { cwd: testDir });
-    await advanceIvtr('T999', ['v2'], { cwd: testDir }); // → audit
-
-    const state = await loopBackIvtr('T999', 'implement', 'Round 2 failure', [], {
-      cwd: testDir,
-    });
-
-    expect(state.loopBackCount.implement).toBe(2);
-    expect(state.currentPhase).toBe('implement');
-  });
-
-  it('third loop-back (count=3) rejects with E_IVTR_MAX_RETRIES', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    // Pass 1: implement → validate → audit → loop-back 1 (T9216: from audit)
-    await advanceIvtr('T999', ['i1'], { cwd: testDir });
-    await advanceIvtr('T999', ['v1'], { cwd: testDir }); // → audit
-    await loopBackIvtr('T999', 'implement', 'Failure 1', [], { cwd: testDir });
-
-    // Pass 2: implement → validate → audit → loop-back 2
-    await advanceIvtr('T999', ['i2'], { cwd: testDir });
-    await advanceIvtr('T999', ['v2'], { cwd: testDir }); // → audit
-    await loopBackIvtr('T999', 'implement', 'Failure 2', [], { cwd: testDir });
-
-    // Pass 3: implement → validate → audit → loop-back 3 (should FAIL)
-    await advanceIvtr('T999', ['i3'], { cwd: testDir });
-    await advanceIvtr('T999', ['v3'], { cwd: testDir }); // → audit
-
-    await expect(
-      loopBackIvtr('T999', 'implement', 'Failure 3', [], { cwd: testDir }),
-    ).rejects.toThrow(E_IVTR_MAX_RETRIES);
-  });
-
-  it('state is NOT mutated when max retries throws', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i1'], { cwd: testDir });
-    await advanceIvtr('T999', ['v1'], { cwd: testDir }); // → audit (T9216)
-    await loopBackIvtr('T999', 'implement', 'Failure 1', [], { cwd: testDir });
-
-    await advanceIvtr('T999', ['i2'], { cwd: testDir });
-    await advanceIvtr('T999', ['v2'], { cwd: testDir }); // → audit
-    await loopBackIvtr('T999', 'implement', 'Failure 2', [], { cwd: testDir });
-
-    await advanceIvtr('T999', ['i3'], { cwd: testDir });
-    await advanceIvtr('T999', ['v3'], { cwd: testDir }); // → audit
-
-    // Attempt the rejected 3rd loop-back
-    await expect(
-      loopBackIvtr('T999', 'implement', 'Failure 3', [], { cwd: testDir }),
-    ).rejects.toThrow(E_IVTR_MAX_RETRIES);
-
-    // Phase must still be 'audit' (T9216: the in-progress phase before the rejected loop-back)
-    const state = await getIvtrState('T999', { cwd: testDir });
-    expect(state?.currentPhase).toBe('audit');
-    expect(state?.loopBackCount.implement).toBe(MAX_LOOP_BACKS_PER_PHASE);
-  });
-
-  it('loopBackCount initialises to 0 on startIvtr', async () => {
-    const state = await startIvtr('T999', { cwd: testDir });
-    expect(state.loopBackCount).toEqual({
-      implement: 0,
-      validate: 0,
-      audit: 0,
-      test: 0,
-      released: 0,
-    }); // T9216: audit added
-  });
-
-  it('backward-compat: legacy state without loopBackCount still works', async () => {
-    // Start the IVTR loop and manually strip loopBackCount from the persisted JSON
-    // to simulate a pre-T814 state row already in the DB.
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i'], { cwd: testDir });
-    await advanceIvtr('T999', ['v'], { cwd: testDir });
-
-    // Inject a legacy state (no loopBackCount) directly.
-    const { getDb } = await import('../../store/sqlite.js');
-    const { eq } = await import('drizzle-orm');
-    const { tasks } = await import('../../store/tasks-schema.js');
-    const db = await getDb(testDir);
-    const rawRows = await db
-      .select({ ivtrState: tasks.ivtrState })
-      .from(tasks)
-      .where(eq(tasks.id, 'T999'))
-      .all();
-    const parsed = JSON.parse(rawRows[0]!.ivtrState!) as Record<string, unknown>;
-    delete parsed['loopBackCount'];
-    await db
-      .update(tasks)
-      .set({ ivtrState: JSON.stringify(parsed) })
-      .where(eq(tasks.id, 'T999'))
-      .run();
-
-    // Now loop-back should succeed — loopBackCount initialised to 0 on-the-fly.
-    const state = await loopBackIvtr('T999', 'implement', 'Legacy compat failure', [], {
-      cwd: testDir,
-    });
-    expect(state.loopBackCount.implement).toBe(1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Prompt enrichment: loop-back context section (T814)
-// ---------------------------------------------------------------------------
-
-describe('resolvePhasePrompt loop-back context injection', () => {
-  it('no loop-back section when implement is first-attempt (no failures)', async () => {
-    const state = await startIvtr('T999', { cwd: testDir });
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec here');
-
-    expect(prompt).not.toContain('LOOP-BACK CONTEXT');
-    expect(prompt).not.toContain('CRITICAL INSTRUCTION');
-    expect(prompt).toContain('Phase: **IMPLEMENT**');
-  });
-
-  it('loop-back section included after validate failure triggers implement re-spawn', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['impl-sha'], { cwd: testDir }); // → validate
-
-    // Validate fails → loop-back to implement
-    const state = await loopBackIvtr(
-      'T999',
-      'implement',
-      'Missing acceptance criterion X',
-      ['validate-failure-sha'],
-      { cwd: testDir },
-    );
-
-    expect(state.currentPhase).toBe('implement');
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec here');
-
-    expect(prompt).toContain('LOOP-BACK CONTEXT');
-    expect(prompt).toContain('VALIDATE');
-    expect(prompt).toContain('Missing acceptance criterion X');
-    expect(prompt).toContain('validate-failure-sha');
-    expect(prompt).toContain('CRITICAL INSTRUCTION');
-    expect(prompt).toContain('Fix the ROOT CAUSE');
-    expect(prompt).toContain('Loop-back History');
-  });
-
-  it('loop-back section included after audit failure triggers implement re-spawn (T9216)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i1'], { cwd: testDir });
-    await advanceIvtr('T999', ['v1'], { cwd: testDir }); // → audit (T9216)
-
-    // Audit fails → loop-back to implement
-    const state = await loopBackIvtr(
-      'T999',
-      'implement',
-      'Verifier exit 1: AC check failed',
-      ['audit-output-sha'],
-      { cwd: testDir },
-    );
-
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec here');
-
-    expect(prompt).toContain('LOOP-BACK CONTEXT');
-    expect(prompt).toContain('AUDIT');
-    expect(prompt).toContain('Verifier exit 1: AC check failed');
-    expect(prompt).toContain('audit-output-sha');
-    expect(prompt).toContain('Loop-back History (all prior failures for this task)');
-    // History must list the failed audit entry
-    expect(prompt).toContain('1. Phase: AUDIT');
-  });
-
-  it('multi-failure: loop-back history lists ALL prior failures (T9216: from audit)', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i1'], { cwd: testDir });
-    await advanceIvtr('T999', ['v1'], { cwd: testDir }); // → audit (T9216)
-
-    // First loop-back from audit
-    await loopBackIvtr('T999', 'implement', 'First audit failure', ['sha-fail-1'], {
-      cwd: testDir,
-    });
-
-    // Advance again and fail a second time
-    await advanceIvtr('T999', ['i2'], { cwd: testDir });
-    await advanceIvtr('T999', ['v2'], { cwd: testDir }); // → audit
-    const state = await loopBackIvtr('T999', 'implement', 'Second audit failure', ['sha-fail-2'], {
-      cwd: testDir,
-    });
-
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec here');
-
-    // Both failures must appear in loop-back history (T9216: phase is now AUDIT)
-    expect(prompt).toContain('1. Phase: AUDIT');
-    expect(prompt).toContain('2. Phase: AUDIT');
-    expect(prompt).toContain('First audit failure');
-    expect(prompt).toContain('Second audit failure');
-  });
-
-  it('no loop-back section on validate prompt even when prior implement passed', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', ['impl-sha'], { cwd: testDir });
-
-    // Must be 'validate' now, no failed entries
-    expect(state.currentPhase).toBe('validate');
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec here');
-
-    expect(prompt).not.toContain('LOOP-BACK CONTEXT');
-    expect(prompt).toContain('Phase: **VALIDATE**');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// T812: Validate-phase prompt enrichment (evidence bundle + REJECT criteria)
-// ---------------------------------------------------------------------------
-
-describe('resolvePhasePrompt validate-phase enrichment (T812)', () => {
-  it('validate prompt contains Validate agent header and validate-spec-check guidance', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    // Advance implement → validate with impl-diff evidence ref
-    const state = await advanceIvtr('T999', ['impl-diff-sha256abc'], { cwd: testDir });
-
-    expect(state.currentPhase).toBe('validate');
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec including REQ-001');
-
-    // Section 1: task spec
-    expect(prompt).toContain('## Task Specification');
-    expect(prompt).toContain('Spec including REQ-001');
-
-    // Section 2: impl evidence bundle fallback (raw sha256 refs)
-    expect(prompt).toContain('Implement-Phase Evidence Bundle');
-    expect(prompt).toContain('impl-diff-sha256abc');
-
-    // Section 3: Validate agent instructions
-    expect(prompt).toContain('Validate agent');
-    expect(prompt).toContain('validate-spec-check');
-    expect(prompt).toContain('reqIdsChecked');
-    expect(prompt).toContain(`cleo orchestrate ivtr T999 --next --evidence`);
-    expect(prompt).toContain(`cleo orchestrate ivtr T999 --loop-back --phase implement`);
-
-    // Section 4: REJECT criteria
-    expect(prompt).toContain('REJECT criteria');
-    expect(prompt).toContain('Spec-code mismatch');
-    expect(prompt).toContain('Missing test');
-    expect(prompt).toContain('Undocumented deviation');
-    expect(prompt).toContain('Quality gate not run');
-  });
-
-  it('validate prompt with enriched evidence bundle renders table', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', ['abc123deadbeef00'.repeat(4)], { cwd: testDir });
-
-    const bundle: ImplEvidenceSummary[] = [
-      {
-        attachmentSha256: 'a'.repeat(64),
-        kind: 'impl-diff',
-        filesChanged: ['src/foo.ts', 'src/bar.ts'],
-        linesAdded: 42,
-        linesRemoved: 5,
-        durationMs: 1200,
-      },
-    ];
-
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec', undefined, bundle);
-
-    // Table header
-    expect(prompt).toContain(
-      '| sha256 (prefix) | kind | filesChanged | linesAdded/Removed | duration |',
-    );
-    // Table row with the enriched data
-    expect(prompt).toContain('impl-diff');
-    expect(prompt).toContain('src/foo.ts, src/bar.ts');
-    expect(prompt).toContain('+42');
-    expect(prompt).toContain('-5');
-    expect(prompt).toContain('1200ms');
-    // Retrieve hint
-    expect(prompt).toContain('cleo docs show <sha256>');
-  });
-
-  it('validate prompt shows REJECT criteria even without evidence bundle', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    const state = await advanceIvtr('T999', [], { cwd: testDir });
-
-    const prompt = resolvePhasePrompt('T999', state, 'My Task', 'Spec');
-
-    expect(prompt).toContain('REJECT criteria');
-    expect(prompt).toContain('Spec-code mismatch');
-    expect(prompt).toContain('Missing test');
-    expect(prompt).toContain('Quality gate not run');
-    expect(prompt).toContain('Undocumented deviation');
-  });
-
-  it('validate prompt includes HITL escalation note after 2 loop-backs to validate', async () => {
-    await startIvtr('T999', { cwd: testDir });
-    await advanceIvtr('T999', ['i1'], { cwd: testDir }); // → validate
-
-    // Loop-back from validate to implement (count=1)
-    await loopBackIvtr('T999', 'implement', 'val fail 1', [], { cwd: testDir });
-    await advanceIvtr('T999', ['i2'], { cwd: testDir }); // → validate again (count still 0 for validate)
-
-    // Loop-back again from validate (count=1 → now 1 validate loop-back)
-    await loopBackIvtr('T999', 'validate', 'implement-fail-re-validate-1', [], { cwd: testDir });
-    await advanceIvtr('T999', ['v2'], { cwd: testDir }); // → test... wait, validate loop-back re-opens validate
-
-    // Actually: loop-back to validate opens a new validate entry, then we advance that to test
-    // Re-check: the escalation note appears when loopBackCount.validate >= 2
-    // Let's do 2 loop-backs targeting 'validate'
-    await loopBackIvtr('T999', 'validate', 'implement-fail-re-validate-2', [], { cwd: testDir });
-
-    const state2 = await advanceIvtr('T999', ['v3'], { cwd: testDir });
-    // state2 is now test phase (not validate)... the prompt won't show escalation
-    // Actually we need the state at the validate phase to see the warning.
-    // Let's just verify the loopBackCount drives the escalation note.
-    // We'll call resolvePhasePrompt with a synthetic state.
-    const syntheticState = await startIvtr('T998' as never, { cwd: testDir }).catch(() => null);
-    void syntheticState; // unused — use the manual approach below
-
-    // Build a minimal IvtrState manually for the escalation test
-    const fakeState = {
-      taskId: 'T999',
-      currentPhase: 'validate' as const,
-      phaseHistory: [
-        {
-          phase: 'implement' as const,
-          agentIdentity: null,
-          startedAt: new Date().toISOString(),
-          completedAt: new Date().toISOString(),
-          passed: true,
-          evidenceRefs: ['impl-sha'],
-        },
-        {
-          phase: 'validate' as const,
-          agentIdentity: null,
-          startedAt: new Date().toISOString(),
-          completedAt: null,
-          passed: null,
-          evidenceRefs: [],
-        },
-      ],
-      startedAt: new Date().toISOString(),
-      loopBackCount: { implement: 0, validate: 2, audit: 0, test: 0, released: 0 }, // T9216: audit added
-    };
-
-    const promptWithEscalation = resolvePhasePrompt('T999', fakeState, 'My Task', 'Spec');
-    expect(promptWithEscalation).toContain('HITL escalation');
-    expect(promptWithEscalation).toContain('WARNING');
+    expect(state).not.toBeNull();
+    const gateWouldBlock = state !== null && state.currentPhase !== 'released';
+    expect(gateWouldBlock).toBe(false);
   });
 });

--- a/packages/core/src/lifecycle/ivtr-loop.ts
+++ b/packages/core/src/lifecycle/ivtr-loop.ts
@@ -1,20 +1,25 @@
 /**
- * IVTR Orchestration Loop — State Machine
+ * IVTR `ivtr_state` record — read + cantbook-mirror surface.
  *
- * Implements the Implement → Validate → Test → Release phase state machine
- * for per-task multi-agent enforcement. State is persisted as JSON in the
- * `ivtr_state` column on the `tasks` table.
+ * The Implement → Validate → Audit → Test → Release phase loop now runs on the
+ * cantbook runtime (the survivor state machine after the T11764 collapse). The
+ * hand-rolled phase-walk functions (`startIvtr`/`advanceIvtr`/`loopBackIvtr`/
+ * `releaseIvtr`) plus the per-phase prompt/auto-gate helpers were deleted in
+ * T11896 once `cleo go` (default) drives `executePlaybook(ivtr.cantbook)` and
+ * the manual `cleo orchestrate ivtr` mutate ops were deprecated.
  *
- * State machine transitions:
- *
- *   (none) ──startIvtr──► implement
- *   implement ──advanceIvtr──► validate
- *   validate  ──advanceIvtr──► test
- *   test      ──advanceIvtr──► released
- *
- *   implement | validate | test ──loopBackIvtr──► implement | validate | test
- *
- *   released ──releaseIvtr──► marks task status=done
+ * This module now owns the RETAINED `ivtr_state` surface (one deprecation
+ * cycle):
+ *  - {@link IvtrState} / {@link IvtrPhase} / {@link IvtrPhaseEntry} — the JSON
+ *    shape persisted in the `ivtr_state` column on `tasks`.
+ *  - {@link getIvtrState} — the read path backing `cleo show --ivtr-history`
+ *    and the strict `E_IVTR_INCOMPLETE` completion gate (`tasks/complete.ts`).
+ *  - {@link seedIvtrForPlaybook} / {@link finalizeIvtrFromPlaybook} — the
+ *    `cleo go` cantbook seam (T11805): seed the column at `implement` and
+ *    mirror the run's terminal status back so the completion gate stays
+ *    load-bearing.
+ *  - {@link MAX_LOOP_BACKS_PER_PHASE} — read by `classify-readiness.ts`.
+ *  - {@link validateSpawnRequest} — Lead authorship-bypass guard (ADR-070).
  *
  * Evidence refs are sha256 hashes of attachment blobs stored under
  * .cleo/attachments (see ADR T796 attachment store).
@@ -22,18 +27,16 @@
  * @epic T810
  * @task T811
  * @task T813
+ * @task T11805 — cantbook seam (seed + finalize mirror)
+ * @task T11896 — phase-walk functions deleted; this is the read/mirror surface
  */
 
 import { createHash } from 'node:crypto';
-import type { AcceptanceGate, TestOutputRecord } from '@cleocode/contracts';
 import { eq } from 'drizzle-orm';
 import { getLogger } from '../logger.js';
-import { getProjectRoot } from '../paths.js';
 import { createAttachmentStore } from '../store/attachment-store.js';
 import { getDb } from '../store/sqlite.js';
 import * as schema from '../store/tasks-schema.js';
-import { extractTypedGates, runGates } from '../tasks/gate-runner.js';
-import { buildBlastRadiusTestScopeSection, detectInfrastructureTouch } from './infra-touch.js';
 
 const log = getLogger('lifecycle:ivtr');
 
@@ -98,22 +101,6 @@ export interface IvtrState {
 }
 
 // =============================================================================
-// PHASE ORDER
-// =============================================================================
-
-/** @task T9216 — 'audit' inserted between validate and test */
-const PHASE_ORDER: IvtrPhase[] = ['implement', 'validate', 'audit', 'test', 'released'];
-
-/**
- * Return the next phase after `current`, or null if already at `released`.
- */
-function nextPhase(current: IvtrPhase): IvtrPhase | null {
-  const idx = PHASE_ORDER.indexOf(current);
-  if (idx === -1 || idx >= PHASE_ORDER.length - 1) return null;
-  return PHASE_ORDER[idx + 1] ?? null;
-}
-
-// =============================================================================
 // PERSISTENCE HELPERS
 // =============================================================================
 
@@ -174,38 +161,12 @@ async function writeIvtrState(state: IvtrState, cwd?: string): Promise<void> {
 // =============================================================================
 
 /**
- * Start the IVTR loop for a task.
- *
- * Creates a fresh IvtrState with `currentPhase = 'implement'` and persists
- * it to the task row. Idempotent: calling again on a task that already has
- * IVTR state returns the existing state without mutation.
- *
- * @param taskId - Task ID to start the IVTR loop for.
- * @param options - Optional cwd and agent identity.
- * @returns The current (possibly new) IvtrState.
- */
-export async function startIvtr(
-  taskId: string,
-  options?: { cwd?: string; agentIdentity?: string },
-): Promise<IvtrState> {
-  const existing = await readIvtrStateRaw(taskId, options?.cwd);
-  if (existing) {
-    log.info({ taskId }, 'IVTR already started; returning existing state');
-    return existing;
-  }
-
-  const state = buildInitialIvtrState(taskId, options?.agentIdentity ?? null);
-  await writeIvtrState(state, options?.cwd);
-  log.info({ taskId }, 'IVTR loop started at implement phase');
-  return state;
-}
-
-/**
  * Build the canonical fresh {@link IvtrState} seeded at the `implement` phase.
  *
- * Shared between {@link startIvtr} (the manual/legacy walk) and
- * {@link seedIvtrForPlaybook} (the `cleo go` cantbook seam, T11805) so both
- * paths produce byte-identical initial state.
+ * The historical manual walk (`startIvtr`) was deleted in T11896 when the IVTR
+ * loop was collapsed onto the cantbook runtime; {@link seedIvtrForPlaybook}
+ * (the `cleo go` seam, T11805) is now the sole producer of a fresh IvtrState
+ * and delegates here so the seeded state is byte-identical to the retired walk.
  *
  * @param taskId - Task the IVTR loop is seeded for.
  * @param agentIdentity - Agent identity string for the first phase entry, or
@@ -518,240 +479,17 @@ async function writeIvtrPlaybookProvenance(
 }
 
 /**
- * Advance the IVTR loop from the current phase to the next.
- *
- * Closes the current in-progress phase entry (marks it `passed: true`,
- * records evidence), opens a new entry for the next phase.
- *
- * Throws if:
- * - No IVTR state exists (call startIvtr first).
- * - Already at `released` (use releaseIvtr to finalise).
- *
- * @param taskId   - Task to advance.
- * @param evidence - sha256 hashes of evidence attachments from this phase.
- * @param options  - Optional cwd and agent identity for the next phase entry.
- * @returns Updated IvtrState.
- */
-export async function advanceIvtr(
-  taskId: string,
-  evidence: string[],
-  options?: { cwd?: string; agentIdentity?: string },
-): Promise<IvtrState> {
-  const state = await readIvtrStateRaw(taskId, options?.cwd);
-  if (!state) {
-    throw new Error(`No IVTR state for task ${taskId}. Call startIvtr first.`);
-  }
-  if (state.currentPhase === 'released') {
-    throw new Error(`Task ${taskId} is already released. Use releaseIvtr to finalise.`);
-  }
-
-  const now = new Date().toISOString();
-
-  // Close the current active phase entry.
-  const activeEntry = state.phaseHistory.findLast((e) => e.completedAt === null);
-  if (activeEntry) {
-    activeEntry.completedAt = now;
-    activeEntry.passed = true;
-    activeEntry.evidenceRefs = [...activeEntry.evidenceRefs, ...evidence];
-  }
-
-  const next = nextPhase(state.currentPhase);
-  if (!next) {
-    throw new Error(`Cannot advance beyond released phase for task ${taskId}`);
-  }
-
-  state.currentPhase = next;
-
-  if (next !== 'released') {
-    const nextEntry: IvtrPhaseEntry = {
-      phase: next,
-      agentIdentity: options?.agentIdentity ?? null,
-      startedAt: now,
-      completedAt: null,
-      passed: null,
-      evidenceRefs: [],
-    };
-    state.phaseHistory.push(nextEntry);
-  }
-
-  await writeIvtrState(state, options?.cwd);
-  log.info(
-    { taskId, from: state.currentPhase === next ? 'unknown' : next, to: next },
-    'IVTR advanced',
-  );
-  return state;
-}
-
-/**
  * Maximum number of loop-backs allowed per phase before HITL escalation.
  *
- * After `MAX_LOOP_BACKS_PER_PHASE` loop-backs to the same phase, the next
- * attempt is rejected with `E_IVTR_MAX_RETRIES` so that a human can
- * intervene rather than the loop spinning indefinitely.
+ * The hand-rolled loop-back walk (`loopBackIvtr`) that enforced this cap was
+ * deleted in T11896 (the IVTR loop now runs on the cantbook runtime). The
+ * constant is RETAINED because {@link classifyReadiness} still reads it to
+ * detect tasks whose `ivtr_state.loopBackCount` has reached the monotonic
+ * per-target cap (the audit's "Gap A" parity check) and must escalate to HITL.
+ *
+ * @see packages/core/src/orchestration/classify-readiness.ts
  */
 export const MAX_LOOP_BACKS_PER_PHASE = 2;
-
-/**
- * Error code emitted when a phase has exceeded its maximum loop-back count.
- *
- * Callers (domain handlers, orchestrators) should surface this to the operator
- * as a HITL escalation prompt — the task cannot self-heal and needs review.
- */
-export const E_IVTR_MAX_RETRIES = 'E_IVTR_MAX_RETRIES';
-
-/**
- * Loop back to an earlier phase due to failure.
- *
- * Closes the current active phase entry as failed, appends a failure note
- * to the history, then opens a new entry for the target phase.
- *
- * Increments the `loopBackCount` for the target phase. After
- * `MAX_LOOP_BACKS_PER_PHASE` loop-backs to the same phase, subsequent
- * calls throw an error with code `E_IVTR_MAX_RETRIES`.
- *
- * @param taskId  - Task to loop back.
- * @param toPhase - Phase to rewind to. Must be 'implement', 'validate', or 'test'.
- * @param reason  - Human-readable explanation of the failure.
- * @param evidence - sha256 hashes of failure evidence attachments.
- * @param options  - Optional cwd and agent identity.
- * @returns Updated IvtrState.
- * @throws Error with message starting with `E_IVTR_MAX_RETRIES` when the
- *         per-phase loop-back limit is exceeded.
- */
-export async function loopBackIvtr(
-  taskId: string,
-  toPhase: IvtrPhase,
-  reason: string,
-  evidence: string[],
-  options?: { cwd?: string; agentIdentity?: string },
-): Promise<IvtrState> {
-  if (toPhase === 'released') {
-    throw new Error(`Cannot loop back to 'released'. Use releaseIvtr to finalise.`);
-  }
-
-  const state = await readIvtrStateRaw(taskId, options?.cwd);
-  if (!state) {
-    throw new Error(`No IVTR state for task ${taskId}. Call startIvtr first.`);
-  }
-  if (state.currentPhase === 'released') {
-    throw new Error(`Task ${taskId} is already released. Cannot loop back.`);
-  }
-
-  // Backward-compat: legacy states may not have loopBackCount or audit field.
-  if (!state.loopBackCount) {
-    state.loopBackCount = { implement: 0, validate: 0, audit: 0, test: 0, released: 0 };
-  }
-  // Defensive: legacy rows predating T9216 won't have loopBackCount.audit.
-  state.loopBackCount.audit = state.loopBackCount.audit ?? 0;
-
-  // Check max BEFORE any mutation so the state stays clean on reject.
-  const currentCount = state.loopBackCount[toPhase] ?? 0;
-  if (currentCount >= MAX_LOOP_BACKS_PER_PHASE) {
-    throw new Error(
-      `${E_IVTR_MAX_RETRIES}: Task ${taskId} has reached the maximum of ${MAX_LOOP_BACKS_PER_PHASE} loop-backs to phase '${toPhase}'. ` +
-        `HITL escalation required — review the loop-back history and resolve the root cause manually before retrying.`,
-    );
-  }
-
-  const now = new Date().toISOString();
-
-  // Close the current active phase entry as failed.
-  const activeEntry = state.phaseHistory.findLast((e) => e.completedAt === null);
-  if (activeEntry) {
-    activeEntry.completedAt = now;
-    activeEntry.passed = false;
-    activeEntry.evidenceRefs = [...activeEntry.evidenceRefs, ...evidence];
-    activeEntry.reason = reason;
-  }
-
-  // Open a new entry for the target phase.
-  const loopEntry: IvtrPhaseEntry = {
-    phase: toPhase,
-    agentIdentity: options?.agentIdentity ?? null,
-    startedAt: now,
-    completedAt: null,
-    passed: null,
-    evidenceRefs: [],
-    reason: `Loop-back from ${state.currentPhase}: ${reason}`,
-  };
-
-  state.currentPhase = toPhase;
-  state.phaseHistory.push(loopEntry);
-  state.loopBackCount[toPhase] = currentCount + 1;
-
-  await writeIvtrState(state, options?.cwd);
-  log.info(
-    { taskId, toPhase, reason, loopBackCount: state.loopBackCount[toPhase] },
-    'IVTR loop-back recorded',
-  );
-  return state;
-}
-
-/**
- * Attempt to release a task after all three phases have passed.
- *
- * Validates that implement, validate, and test all have at least one passing
- * phase entry. If validation passes, marks the task status = 'done' and
- * sets `currentPhase = 'released'`.
- *
- * @param taskId  - Task to release.
- * @param options - Optional cwd.
- * @returns `{ released: true }` on success, or `{ released: false, failures }` listing missing phases.
- */
-export async function releaseIvtr(
-  taskId: string,
-  options?: { cwd?: string },
-): Promise<{ released: boolean; failures?: string[] }> {
-  const state = await readIvtrStateRaw(taskId, options?.cwd);
-  if (!state) {
-    return { released: false, failures: [`No IVTR state for task ${taskId}`] };
-  }
-  if (state.currentPhase === 'released') {
-    return { released: true };
-  }
-
-  const failures: string[] = [];
-  // T9216: 'audit' added as required phase
-  const required: Array<Exclude<IvtrPhase, 'released'>> = [
-    'implement',
-    'validate',
-    'audit',
-    'test',
-  ];
-
-  for (const phase of required) {
-    const passed = state.phaseHistory.some((e) => e.phase === phase && e.passed === true);
-    if (!passed) {
-      failures.push(`Phase '${phase}' has no passing entry`);
-    }
-  }
-
-  if (failures.length > 0) {
-    return { released: false, failures };
-  }
-
-  // Close the active test entry if still open.
-  const now = new Date().toISOString();
-  const activeEntry = state.phaseHistory.findLast((e) => e.completedAt === null);
-  if (activeEntry) {
-    activeEntry.completedAt = now;
-    activeEntry.passed = true;
-  }
-
-  state.currentPhase = 'released';
-  await writeIvtrState(state, options?.cwd);
-
-  // Mark the task done.
-  const db = await getDb(options?.cwd);
-  await db
-    .update(schema.tasks)
-    .set({ status: 'done', completedAt: now, updatedAt: now })
-    .where(eq(schema.tasks.id, taskId))
-    .all();
-
-  log.info({ taskId }, 'IVTR released --- task marked done');
-  return { released: true };
-}
 
 /**
  * Retrieve the current IVTR state for a task, or null if the loop has not
@@ -766,448 +504,6 @@ export async function getIvtrState(
   options?: { cwd?: string },
 ): Promise<IvtrState | null> {
   return readIvtrStateRaw(taskId, options?.cwd);
-}
-
-// =============================================================================
-// PROMPT RESOLUTION HELPERS (phase-specific agent instructions)
-// =============================================================================
-
-/**
- * A condensed summary of a single implement-phase evidence attachment.
- *
- * Callers who have access to the full `ImplDiffRecord` from
- * `@cleocode/contracts` SHOULD populate all optional fields. Callers that
- * only have access to the sha256 ref from `IvtrPhaseEntry.evidenceRefs` MAY
- * leave them undefined — the prompt will fall back to listing the sha256 alone.
- *
- * @see `ImplDiffRecord` in `@cleocode/contracts` for the full shape.
- */
-export interface ImplEvidenceSummary {
-  /** SHA-256 hex digest of the attachment blob (64 chars). */
-  attachmentSha256: string;
-  /** Evidence kind discriminant (e.g. `'impl-diff'`, `'lint-report'`). */
-  kind: string;
-  /** Relative paths of every file the diff touches. */
-  filesChanged?: string[];
-  /** Net lines added across all changed files. */
-  linesAdded?: number;
-  /** Net lines removed across all changed files. */
-  linesRemoved?: number;
-  /** Wall-clock duration of the implement action in milliseconds. */
-  durationMs?: number;
-}
-
-/**
- * Build the validate-phase evidence bundle section (T812 §2).
- *
- * Renders a structured Markdown table when enriched summaries are provided,
- * or falls back to listing raw sha256 refs from the passed phase entries.
- *
- * @param implEntries    - Implement phase entries with `passed === true`.
- * @param evidenceBundle - Optional enriched summaries from the attachment store.
- */
-function buildValidateEvidenceBundle(
-  implEntries: IvtrPhaseEntry[],
-  evidenceBundle: ImplEvidenceSummary[],
-): string {
-  if (evidenceBundle.length > 0) {
-    const rows = evidenceBundle.map((e) => {
-      const files =
-        e.filesChanged && e.filesChanged.length > 0 ? e.filesChanged.join(', ') : '(unknown)';
-      const added = e.linesAdded !== undefined ? `+${e.linesAdded}` : '?';
-      const removed = e.linesRemoved !== undefined ? `-${e.linesRemoved}` : '?';
-      const duration = e.durationMs !== undefined ? `${e.durationMs}ms` : '?';
-      return `| \`${e.attachmentSha256.slice(0, 16)}...\` | ${e.kind} | ${files} | ${added}/${removed} | ${duration} |`;
-    });
-
-    return `## Implement-Phase Evidence Bundle
-
-| sha256 (prefix) | kind | filesChanged | linesAdded/Removed | duration |
-|---|---|---|---|---|
-${rows.join('\n')}
-
-> Retrieve full diff: \`cleo docs show <sha256>\``;
-  }
-
-  // Fallback: list raw refs from phase history.
-  const allRefs = implEntries.flatMap((e) => e.evidenceRefs);
-  if (allRefs.length === 0) {
-    return '## Implement-Phase Evidence Bundle\n(none recorded — impl agent may not have produced attachments)';
-  }
-
-  return `## Implement-Phase Evidence Bundle (sha256 refs)
-${allRefs.map((r) => `- \`${r}\``).join('\n')}
-
-> Retrieve diff content: \`cleo docs show <sha256>\``;
-}
-
-/**
- * Build the validate-phase instruction block + REJECT criteria (T812 §§3–4).
- *
- * @param taskId         - Task ID for CLI command references.
- * @param state          - Current IvtrState (currentPhase === 'validate').
- * @param evidenceBundle - Pre-fetched implement evidence summaries (may be empty).
- */
-function buildValidatePhaseInstruction(
-  taskId: string,
-  state: IvtrState,
-  evidenceBundle: ImplEvidenceSummary[],
-): string {
-  const loopCount = state.loopBackCount?.validate ?? 0;
-  const escalationNote =
-    loopCount >= 2
-      ? '\n> WARNING: This is loop-back attempt 3+. HITL escalation is required if this validate phase fails again.\n'
-      : '';
-
-  const implRefHint =
-    evidenceBundle.length > 0
-      ? evidenceBundle
-          .map(
-            (e) =>
-              `- \`${e.attachmentSha256.slice(0, 16)}...\` (${e.kind}${e.filesChanged ? ', ' + e.filesChanged.length + ' file(s)' : ''})`,
-          )
-          .join('\n')
-      : '(enumerate REQ-IDs from the task specification above and cross-reference the impl-diff sha256 refs in the evidence bundle)';
-
-  // T9842 — Blast-radius infrastructure-touch detection. Aggregate every
-  // `filesChanged` array from the impl-phase evidence bundle and feed it to
-  // the detector. When the impl touched an infrastructure path, the rendered
-  // section instructs the Lead to run full per-package tests rather than the
-  // targeted subset called out in the task spec.
-  const allFilesChanged = evidenceBundle.flatMap((e) => e.filesChanged ?? []);
-  const infraTouch = detectInfrastructureTouch(allFilesChanged);
-  const blastRadiusSection = buildBlastRadiusTestScopeSection(infraTouch);
-  const blastRadiusBlock = blastRadiusSection ? `\n\n${blastRadiusSection}\n` : '';
-  const blastRadiusRejectLine = infraTouch.affected
-    ? '\n- **Infra-test-scope violation (T9842)**: infrastructure paths were touched (see the Blast-Radius Test Scope section above) but no full per-package vitest run was attached. Loop-back reason: `infra-test-scope-violation`.'
-    : '';
-
-  return `## Phase: Validate
-You are the Validate agent for task ${taskId}. Read the impl diff + evidence listed in the Implement-Phase Evidence Bundle above. Check spec↔code alignment per each acceptance criterion and REQ-ID.${escalationNote}
-
-### Your responsibilities
-
-1. Read the task spec and each evidence attachment in the Implement-Phase Evidence Bundle above.
-2. Retrieve each diff blob: \`cleo docs show <sha256>\`
-3. For every acceptance criterion and REQ-ID in the task spec, verify it is traceable to a concrete code change in the impl diff.
-4. Produce a \`ValidateSpecCheckRecord\` (\`kind: 'validate-spec-check'\`) and write it to a JSON file:
-   \`\`\`json
-   {
-     "kind": "validate-spec-check",
-     "phase": "validate",
-     "agentIdentity": "<your-agent-id>",
-     "attachmentSha256": "<sha256-of-this-report>",
-     "reqIdsChecked": ["<REQ-ID-1>", "<REQ-ID-2>"],
-     "passed": true,
-     "details": "<per-REQ-ID verdict, one sentence each>",
-     "ranAt": "<ISO-8601-timestamp>",
-     "durationMs": 0
-   }
-   \`\`\`
-5. Attach the report: \`cleo docs add <file> --task ${taskId}\`
-6. Pass the returned sha256 to \`--next\`:
-   - **PASS**: \`cleo orchestrate ivtr ${taskId} --next --evidence <sha256>\`
-   - **FAIL**: \`cleo orchestrate ivtr ${taskId} --loop-back --phase implement --reason "<details>"\`
-
-### Impl-diff attachment refs to review
-
-${implRefHint}${blastRadiusBlock}
-### REJECT criteria — trigger loop-back if ANY of the following are true
-
-- **Spec-code mismatch**: an acceptance criterion or REQ-ID has no traceable code change in the impl diff.
-- **Missing test**: an acceptance criterion that requires test coverage has no corresponding test added or updated in the diff.
-- **Undocumented deviation**: the implementation deviates from the task spec without a documented reason (comment, ADR reference, or inline note in the diff).
-- **Quality gate not run**: the impl-phase evidence does not include proof that \`pnpm biome check\` and \`pnpm run build\` both passed (lint-report or command-output attachment with exit code 0).${blastRadiusRejectLine}`;
-}
-
-/**
- * Build a resolved prompt string for the current phase's assigned agent.
- *
- * When advancing to the `validate` phase the prompt is enriched with four
- * additional sections required by T812:
- *
- * 1. **Original task spec** — always included.
- * 2. **Implement-phase evidence bundle** — all `IvtrPhaseEntry` records where
- *    `phase === 'implement'` and `passed === true`, rendered with attachment
- *    metadata (sha256, kind, filesChanged, linesAdded/Removed, duration).
- *    Callers pass the optional `evidenceBundle` to supply pre-fetched metadata
- *    from the attachment store; the function falls back to raw sha256 refs if
- *    the bundle is empty.
- * 3. **Validate-agent instructions** — how to produce a `ValidateSpecCheckRecord`
- *    (`kind: 'validate-spec-check'`) and attach it via `cleo docs add`.
- * 4. **Explicit REJECT criteria** — conditions under which the validate agent
- *    MUST trigger a loop-back to implement.
- *
- * When the target phase is `implement` and prior failures exist, a loop-back
- * context section is injected with the triggering reason and history.
- *
- * For the `test` phase, the prompt instructs the agent to run
- * `cleo verify <id> --run` and produce a `TestOutputRecord`.
- *
- * @param taskId          - Task ID (used to label the prompt).
- * @param state           - Current IvtrState (after the transition to the target phase).
- * @param taskTitle       - Short task title (from cleo show).
- * @param taskDesc        - Full task description / spec including REQ-IDs.
- * @param acceptanceGates - Optional typed AcceptanceGate objects (used by the test phase).
- * @param evidenceBundle  - Optional pre-fetched implement-phase evidence summaries
- *                          (used by the validate phase; ignored for other phases).
- * @returns Prompt string for the phase's assigned agent.
- */
-export function resolvePhasePrompt(
-  taskId: string,
-  state: IvtrState,
-  taskTitle: string,
-  taskDesc: string,
-  acceptanceGates?: AcceptanceGate[],
-  evidenceBundle: ImplEvidenceSummary[] = [],
-): string {
-  // ── Validate phase: structured 4-section prompt (T812) ───────────────────
-  if (state.currentPhase === 'validate') {
-    const implEntries = state.phaseHistory.filter(
-      (e) => e.phase === 'implement' && e.passed === true,
-    );
-    const bundleSection = buildValidateEvidenceBundle(implEntries, evidenceBundle);
-    const instructionSection = buildValidatePhaseInstruction(taskId, state, evidenceBundle);
-
-    return `# IVTR Agent Prompt — ${taskId}: ${taskTitle}
-Phase: **VALIDATE**
-
-## Task Specification
-${taskDesc}
-
-${bundleSection}
-
-${instructionSection}
-`;
-  }
-
-  // ── Generic evidence refs section (implement / test / released) ───────────
-  const priorEvidence = state.phaseHistory
-    .filter((e) => e.passed === true)
-    .flatMap((e) => e.evidenceRefs);
-
-  const evidenceSection =
-    priorEvidence.length > 0
-      ? `## Prior Phase Evidence (sha256 attachment refs)\n${priorEvidence.map((r) => `- ${r}`).join('\n')}`
-      : '## Prior Phase Evidence\n(none — first phase)';
-
-  // Build loop-back context section when re-spawning Implement after a failure (T814).
-  const failedEntries = state.phaseHistory.filter((e) => e.passed === false);
-  let loopBackSection = '';
-  if (state.currentPhase === 'implement' && failedEntries.length > 0) {
-    const triggeringFailure = failedEntries[failedEntries.length - 1]!;
-    const failureEvidenceLines =
-      triggeringFailure.evidenceRefs.length > 0
-        ? triggeringFailure.evidenceRefs.map((r) => `- ${r}`).join('\n')
-        : '(no attachment refs --- check the reason text above for details)';
-    const historyLines = failedEntries
-      .map(
-        (e, idx) =>
-          `${idx + 1}. Phase: ${e.phase.toUpperCase()} | Reason: ${e.reason ?? '(none)'} | CompletedAt: ${e.completedAt ?? 'unknown'}`,
-      )
-      .join('\n');
-    loopBackSection = `
-## LOOP-BACK CONTEXT --- READ THIS CAREFULLY
-
-**Previous attempt failed at phase: ${triggeringFailure.phase.toUpperCase()}**
-**Failure reason**: ${triggeringFailure.reason ?? '(none)'}
-
-### Failure Evidence (sha256 refs from the failing phase)
-${failureEvidenceLines}
-
-### Loop-back History (all prior failures for this task)
-${historyLines}
-
-**CRITICAL INSTRUCTION**: Previous attempt(s) failed. Read the failure evidence above.
-Fix the ROOT CAUSE --- do NOT retry the same approach.
-If the test phase failed, check what tests broke and WHY.
-If the validate phase failed, check which acceptance criteria were not met and ensure they are addressed.
-`;
-  }
-
-  // Build the typed gates section for the test phase prompt.
-  const gatesSection =
-    acceptanceGates && acceptanceGates.length > 0
-      ? `\n## Typed AcceptanceGates (programmatic --- run via cleo verify --run)\n${acceptanceGates
-          .map((g, i) => {
-            const label =
-              'command' in g
-                ? (g as { command: string }).command
-                : 'url' in g
-                  ? (g as { url: string }).url
-                  : g.kind;
-            return `${i + 1}. [${g.kind}] ${g.req ?? '(no req)'} --- ${label}`;
-          })
-          .join('\n')}`
-      : '';
-
-  const phaseInstructions: Record<IvtrPhase, string> = {
-    implement: `## Phase: Implement
-You are the Implementation agent for task ${taskId}.
-
-Your responsibilities:
-1. Read the task spec below in full.
-2. Write, modify, or extend code to satisfy the acceptance criteria.
-3. Run quality gates: pnpm biome check --write . then pnpm run build.
-4. Produce a git diff or file list as evidence.
-5. Report your sha256 attachment refs as evidence when you call cleo orchestrate ivtr ${taskId} --next.`,
-
-    validate: '', // handled above — this branch is unreachable when currentPhase === 'validate'
-
-    audit: `## Phase: Audit
-You are the independent Auditor agent for task ${taskId}.
-
-Your responsibilities:
-1. Run cleo verify ${taskId} --explain to re-validate every ADR-051 evidence atom (commit reachable, file sha256, test-run hash, tool exit code) against the live git/fs/toolchain.
-2. Read the captured evidence atoms from prior phases — do NOT trust the agent's prose claims, only the re-validated atom set.
-3. If every required gate is backed by a passing atom: call cleo orchestrate ivtr ${taskId} --next.
-4. If any atom fails re-validation (E_EVIDENCE_STALE, E_EVIDENCE_TESTS_FAILED, E_EVIDENCE_TOOL_FAILED) or any required gate is unbacked: call cleo orchestrate ivtr ${taskId} --loop-back --phase implement --reason "<atom diagnostic>".
-The Pre-Complete Gate Ritual (ADR-051) is the only enforcement surface — atoms re-validate against external state, so the Implementer cannot fake them.`,
-
-    test: `## Phase: Test
-You are the Testing agent for task ${taskId}.
-
-Your responsibilities:
-1. Read the task spec and all prior-phase evidence refs listed above (impl + validate).
-2. Run cleo verify ${taskId} --run to execute all programmatic AcceptanceGates.
-3. Attach the full gate-run output via cleo docs add --labels test-output.
-4. Compute or capture the sha256 of the attached output.
-5. Pass the sha256 + gate-pass-count + gate-fail-count back in your --next call as:
-   EvidenceRecord{kind:'test-output', command:'cleo verify ${taskId} --run', exitCode, testsPassed, testsFailed}
-6. If all gates pass, call cleo orchestrate ivtr ${taskId} --next --evidence <sha256>.
-7. If any gate fails, call cleo orchestrate ivtr ${taskId} --loop-back --phase implement --reason "<failure summary>".
-${gatesSection}`,
-
-    released: `## Phase: Released
-Task ${taskId} has been released. No further agent action required.`,
-  };
-
-  return `# IVTR Agent Prompt --- ${taskId}: ${taskTitle}
-Phase: **${state.currentPhase.toUpperCase()}**
-
-## Task Specification
-${taskDesc}
-
-${evidenceSection}
-${loopBackSection}
-${phaseInstructions[state.currentPhase]}
-`;
-}
-// =============================================================================
-// AUTO-RUN GATES (T813)
-// =============================================================================
-
-/**
- * Result returned by autoRunGatesAndRecord.
- */
-export interface AutoRunGatesResult {
-  /** sha256 of the stored attachment containing the full gate-run output. */
-  attachmentSha256: string;
-  /** Number of gates that passed. */
-  testsPassed: number;
-  /** Number of gates that failed or errored. */
-  testsFailed: number;
-  /** The composite exit code: 0 if all gates passed, 1 otherwise. */
-  exitCode: number;
-  /** The synthesised EvidenceRecord (kind: 'test-output'). */
-  evidenceRecord: TestOutputRecord;
-}
-
-/**
- * Execute all typed AcceptanceGates for a task atomically during an IVTR
- * --next transition with --auto-run-tests set.
- *
- * Steps performed in a single atomic operation:
- * 1. Accept the typed gates array (strings already filtered by caller).
- * 2. Run each gate via runGates().
- * 3. Serialise the results to JSON and store via AttachmentStore.
- * 4. Synthesise a TestOutputRecord carrying the sha256, pass/fail counts,
- *    and exit code.
- * 5. Append the sha256 to the active phaseHistory entry's evidenceRefs and
- *    persist the updated IvtrState.
- *
- * @param taskId          - Task ID being tested.
- * @param acceptanceItems - Mixed acceptance array from the task record (strings
- *                          are silently ignored; only typed gates are executed).
- * @param agentIdentity   - Optional agent identity string for provenance.
- * @param cwd             - Optional working directory.
- * @returns AutoRunGatesResult with the attachment sha256 and counts.
- */
-export async function autoRunGatesAndRecord(
-  taskId: string,
-  acceptanceItems: (string | AcceptanceGate)[],
-  agentIdentity?: string,
-  cwd?: string,
-): Promise<AutoRunGatesResult> {
-  const projectRoot = getProjectRoot(cwd);
-  const ranAt = new Date().toISOString();
-  const startMs = Date.now();
-
-  // 1. Filter to typed gates only (strings are silently skipped).
-  const typedGateEntries = extractTypedGates(acceptanceItems);
-  const gates = typedGateEntries.map((e) => e.gate);
-
-  // 2. Execute gates.
-  const results = await runGates(gates, { projectRoot, skipManual: true });
-
-  const testsPassed = results.filter((r) => r.result === 'pass').length;
-  const testsFailed = results.filter((r) => r.result === 'fail' || r.result === 'error').length;
-  const exitCode = testsFailed > 0 ? 1 : 0;
-  const durationMs = Date.now() - startMs;
-
-  // 3. Serialise gate results as JSON and store as an attachment.
-  const outputJson = JSON.stringify({ taskId, gates: results, testsPassed, testsFailed }, null, 2);
-  const attachmentSha256 = createHash('sha256').update(outputJson).digest('hex');
-
-  const store = createAttachmentStore();
-  // BlobAttachment requires storageKey; the store writes the actual content-addressed
-  // path itself. Omit<Attachment,'sha256'> on a discriminated union does not distribute
-  // 'storageKey' as a shared known property, so we use an explicit cast here.
-  type AttachmentInput = Parameters<typeof store.put>[1];
-  await store.put(
-    outputJson,
-    {
-      kind: 'blob',
-      storageKey: '',
-      mime: 'application/json',
-      size: Buffer.byteLength(outputJson),
-    } as AttachmentInput,
-    'task',
-    taskId,
-    agentIdentity ?? 'ivtr-auto-run',
-    cwd,
-  );
-
-  // 4. Build the TestOutputRecord.
-  const evidenceRecord: TestOutputRecord = {
-    kind: 'test-output',
-    phase: 'test',
-    agentIdentity: agentIdentity ?? 'ivtr-auto-run',
-    attachmentSha256,
-    command: `cleo verify ${taskId} --run`,
-    exitCode,
-    testsPassed,
-    testsFailed,
-    ranAt,
-    durationMs,
-  };
-
-  // 5. Append sha256 to the active phase entry's evidenceRefs and persist.
-  const state = await readIvtrStateRaw(taskId, cwd);
-  if (state) {
-    const activeEntry = state.phaseHistory.findLast((e) => e.completedAt === null);
-    if (activeEntry) {
-      activeEntry.evidenceRefs = [...activeEntry.evidenceRefs, attachmentSha256];
-    }
-    await writeIvtrState(state, cwd);
-  }
-
-  log.info(
-    { taskId, testsPassed, testsFailed, exitCode, attachmentSha256 },
-    'IVTR auto-run gates complete',
-  );
-
-  return { attachmentSha256, testsPassed, testsFailed, exitCode, evidenceRecord };
 }
 
 // =============================================================================

--- a/packages/core/src/release/engine-ops.ts
+++ b/packages/core/src/release/engine-ops.ts
@@ -497,11 +497,11 @@ export async function releaseGateCheck(
         ? `IVTR gate passed for epic ${epicId}. ${released.length} task(s) released, ${unchecked.length} unchecked (non-blocking).`
         : `IVTR gate passed for epic ${epicId}. All ${released.length} task(s) are in released phase.`
       : `IVTR gate FAILED for epic ${epicId}. ${blocked.length} task(s) not yet released: ${blocked.join(', ')}.` +
-        ` Run \`cleo orchestrate ivtr <taskId> --release\` for each blocking task, or pass --force to bypass.`;
+        ` Drive each blocking task to 'released' via the cantbook runtime (T11764) — \`cleo go\` (autonomous) or \`cleo playbook run ivtr --context '{"taskId":"<taskId>"}'\` (manual) — or pass --force to bypass.`;
 
     if (!passed) {
       return engineError('E_IVTR_INCOMPLETE', summary, {
-        fix: `cleo orchestrate ivtr ${blocked[0]} --release`,
+        fix: `cleo playbook run ivtr --context '{"taskId":"${blocked[0]}"}'`,
         details: { blocked, unchecked, epicId, tasks },
       });
     }

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -1425,7 +1425,7 @@ export async function completeTaskStrict(
           `Task ${taskId} IVTR loop is not complete — currentPhase='${ivtrState.currentPhase}', not 'released'`,
           {
             details: { taskId, currentPhase: ivtrState.currentPhase, failedPhases },
-            fix: `Advance the IVTR loop to 'released' via 'cleo orchestrate ivtr ${taskId} --next'. Evidence-based bypass: CLEO_OWNER_OVERRIDE=1 on 'cleo verify' (audited, see ADR-051).`,
+            fix: `Drive the IVTR loop to 'released' via the cantbook runtime (T11764): 'cleo go' (autonomous, default) or 'cleo playbook run ivtr --context '{"taskId":"${taskId}"}'' (single manual run). Evidence-based bypass: CLEO_OWNER_OVERRIDE=1 on 'cleo verify' (audited, see ADR-051).`,
           },
         );
       }


### PR DESCRIPTION
## T11896 — `cleo go` drives the playbook runtime BY DEFAULT (state-machine collapse, epic ACs 2 + 4)

Completes the IVTR state-machine collapse (T11764) honestly: the hand-rolled IVTR phase walk is **deleted**, and both `cleo go` and the `cleo ivtr` mutate verbs now route onto the **cantbook runtime** (the survivor state machine).

### What changed
- **`cleo go` seam default flipped ON (opt-OUT kill-switch).** `CLEO_GO_VIA_PLAYBOOK` now defaults to enabled; only an explicit falsy value (`0`/`false`/`no`/`off`) restores the legacy fallback. `driver.ts` runs the IVTR loop via `executePlaybook(ivtr.cantbook)` and seeds/mirrors `tasks.ivtr_state` through the retained `seedIvtrForPlaybook` / `finalizeIvtrFromPlaybook` bridge.
- **`IvtrHandler` mutate ops redirected onto the cantbook runtime.** The per-step phase walk has no 1:1 primitive on the runtime, so the deprecated mutate verbs return `E_DEPRECATED_USE_PLAYBOOK` with a per-op redirect mapping pointing callers at `cleo go` (autonomous, default) or `cleo playbook run ivtr` (single manual run).
- **Dead IVTR phase-walk functions deleted from `ivtr-loop.ts`:** `startIvtr`, `advanceIvtr`, `loopBackIvtr`, `releaseIvtr`, `resolvePhasePrompt`, `autoRunGatesAndRecord`, `E_IVTR_MAX_RETRIES`, `AutoRunGatesResult` — ripgrep-verified zero live callers; barrel re-exports in `internal.ts` trimmed accordingly.
- **Stale IVTR-gate remediation hints repointed** onto the cantbook runtime across `complete.ts` and the dispatch layer (`E_IVTR_INCOMPLETE` fix text now names `cleo go` / `cleo playbook run ivtr` + the audited `CLEO_OWNER_OVERRIDE` bypass).

### Retained (deprecation-cycle pieces — deliberately NOT deleted)
- `tasks.ivtr_state` column + `getIvtrState` read path (backs `cleo show --ivtr-history`)
- `complete.ts` `E_IVTR_INCOMPLETE` strict-completion gate
- `MAX_LOOP_BACKS_PER_PHASE`, `seedIvtrForPlaybook`, `finalizeIvtrFromPlaybook`

### Verification
- `pnpm biome check` clean · `pnpm run build` success · `cleo check arch` 5/5 gates pass
- Core `go` + `ivtr-loop` suites: 83/83 pass; `@cleocode/playbooks`: 133/133 pass
- `ivtr` / `release` / `tasks` dispatch suites pass under the full root-config run (the only harness that reproduces CI's mock resolution in this worktree)
- Diff scoped to 11 T11896 files (+501 / −2124); no behavior-parity test expectations were weakened — the single `tasks.test.ts` change updates one remediation-hint string to match the new production hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
