### PR TITLE
feat(T11761): Pi guard surface — deny-first ExecutionEnv + exit-trap containment (S1, T11897)

### DIFF
--- a/packages/core/src/llm/pi/__tests__/pi-errors.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-errors.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for Pi error / exit containment (T11761 · S1 · T11897).
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isPiContainmentError, PiContainmentError, wrapPiCall, wrapPiError } from '../pi-errors.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PiContainmentError', () => {
+  it('carries the string piCode and a numeric CleoError exit code', () => {
+    const err = new PiContainmentError('E_PI_LOOP_FAILED', 'boom');
+    expect(err).toBeInstanceOf(PiContainmentError);
+    expect(err.piCode).toBe('E_PI_LOOP_FAILED');
+    expect(err.name).toBe('PiContainmentError');
+    // numeric ExitCode super-field is present (GENERAL_ERROR = 1 default)
+    expect(typeof err.code).toBe('number');
+    // projects the piCode into LAFS details
+    const lafs = err.toLAFSError();
+    expect(lafs.details).toMatchObject({ fieldDetails: { piCode: 'E_PI_LOOP_FAILED' } });
+  });
+
+  it('isPiContainmentError narrows correctly', () => {
+    expect(isPiContainmentError(new PiContainmentError('E_PI_ABORTED', 'x'))).toBe(true);
+    expect(isPiContainmentError(new Error('x'))).toBe(false);
+    expect(isPiContainmentError(null)).toBe(false);
+  });
+});
+
+describe('wrapPiError', () => {
+  it('passes a PiContainmentError through unchanged', () => {
+    const original = new PiContainmentError('E_PI_PROCESS_EXIT_TRAPPED', 'exit');
+    expect(wrapPiError(original)).toBe(original);
+  });
+
+  it('wraps an arbitrary Error as E_PI_LOOP_FAILED with cause', () => {
+    const cause = new Error('underlying');
+    const wrapped = wrapPiError(cause);
+    expect(wrapped.piCode).toBe('E_PI_LOOP_FAILED');
+    expect(wrapped.cause).toBe(cause);
+  });
+
+  it('wraps a non-Error thrown value', () => {
+    const wrapped = wrapPiError('string failure');
+    expect(wrapped.piCode).toBe('E_PI_LOOP_FAILED');
+    expect(wrapped.message).toContain('string failure');
+  });
+});
+
+describe('wrapPiCall — happy path + result passthrough', () => {
+  it('returns the wrapped fn result and restores process.exit afterwards', async () => {
+    const realExit = process.exit;
+    const result = await wrapPiCall(async () => 42);
+    expect(result).toBe(42);
+    // exit hook restored
+    expect(process.exit).toBe(realExit);
+  });
+
+  it('passes a live AbortSignal into fn', async () => {
+    let received: AbortSignal | undefined;
+    await wrapPiCall(async (sig) => {
+      received = sig;
+      return 'ok';
+    });
+    expect(received).toBeInstanceOf(AbortSignal);
+    expect(received?.aborted).toBe(false);
+  });
+});
+
+describe('wrapPiCall — process.exit trap', () => {
+  it('converts a process.exit() call inside fn into E_PI_PROCESS_EXIT_TRAPPED', async () => {
+    const realExit = process.exit;
+    await expect(
+      wrapPiCall(async () => {
+        // simulate a Pi-internal exit attempt
+        process.exit(1);
+        return 'never';
+      }),
+    ).rejects.toMatchObject({ piCode: 'E_PI_PROCESS_EXIT_TRAPPED' });
+    // daemon survives + hook restored
+    expect(process.exit).toBe(realExit);
+  });
+
+  it('restores process.exit even when fn throws a non-exit error', async () => {
+    const realExit = process.exit;
+    await expect(
+      wrapPiCall(async () => {
+        throw new Error('regular failure');
+      }),
+    ).rejects.toMatchObject({ piCode: 'E_PI_LOOP_FAILED' });
+    expect(process.exit).toBe(realExit);
+  });
+});
+
+describe('wrapPiCall — process.exitCode mutation trap', () => {
+  it('neutralizes a process.exitCode mutation and restores the property', async () => {
+    const before = process.exitCode;
+    await expect(
+      wrapPiCall(async () => {
+        // simulate a Pi-internal exitCode mutation
+        process.exitCode = 137;
+        return 'never';
+      }),
+    ).rejects.toMatchObject({ piCode: 'E_PI_EXIT_CODE_MUTATION_TRAPPED' });
+    // restored: still writable + value unchanged from before the run
+    expect(process.exitCode).toBe(before);
+    // and the property is writable again post-restore (legitimate writes work)
+    process.exitCode = before ?? 0;
+    expect(process.exitCode).toBe(before ?? 0);
+  });
+});
+
+describe('wrapPiCall — abort routing', () => {
+  it('rejects with E_PI_ABORTED when the signal is already aborted (fn never runs)', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fn = vi.fn(async () => 'ran');
+    await expect(wrapPiCall(fn, controller.signal)).rejects.toMatchObject({
+      piCode: 'E_PI_ABORTED',
+    });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('propagates an external abort into the signal handed to fn', async () => {
+    const controller = new AbortController();
+    const seen: boolean[] = [];
+    const promise = wrapPiCall(async (sig) => {
+      // observe the propagation: abort mid-flight then resolve once seen
+      return await new Promise<string>((resolve) => {
+        sig.addEventListener('abort', () => {
+          seen.push(sig.aborted);
+          resolve('aborted-observed');
+        });
+      });
+    }, controller.signal);
+    controller.abort();
+    await expect(promise).resolves.toBe('aborted-observed');
+    expect(seen).toEqual([true]);
+  });
+
+  it('normalizes a thrown AbortError to E_PI_ABORTED', async () => {
+    const controller = new AbortController();
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    await expect(
+      wrapPiCall(async () => {
+        throw abortErr;
+      }, controller.signal),
+    ).rejects.toMatchObject({ piCode: 'E_PI_ABORTED' });
+  });
+});

--- a/packages/core/src/llm/pi/__tests__/pi-errors.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-errors.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isPiContainmentError, PiContainmentError, wrapPiCall, wrapPiError } from '../pi-errors.js';
+import {
+  installDaemonExitGuard,
+  isPiContainmentError,
+  PiContainmentError,
+  wrapPiCall,
+  wrapPiError,
+} from '../pi-errors.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -113,6 +119,58 @@ describe('wrapPiCall — process.exitCode mutation trap', () => {
     // and the property is writable again post-restore (legitimate writes work)
     process.exitCode = before ?? 0;
     expect(process.exitCode).toBe(before ?? 0);
+  });
+});
+
+describe('wrapPiCall — exit trap covers the async/deferred window (T11897)', () => {
+  it('a deferred process.exit() firing while ANOTHER Pi call is still active is trapped', async () => {
+    const realExit = process.exit;
+    let trapped: unknown;
+
+    // Outer long-lived call keeps the ref-counted trap installed.
+    const outer = wrapPiCall(
+      async () =>
+        await new Promise<string>((resolve) => {
+          // Schedule a "detached" exit that fires DURING the outer window.
+          setTimeout(() => {
+            try {
+              // Under the OLD per-call trap this would hit the real exit after the
+              // inner call restored it. Now the outer scope keeps it trapped.
+              (process.exit as (code?: number) => never)(7);
+            } catch (err) {
+              trapped = err;
+            }
+            resolve('outer-done');
+          }, 5);
+        }),
+    );
+
+    // A short inner call settles + releases its hold BEFORE the deferred exit
+    // fires — but the outer call still holds the ref-count.
+    await wrapPiCall(async () => 'inner-done');
+
+    await expect(outer).resolves.toBe('outer-done');
+    expect(isPiContainmentError(trapped)).toBe(true);
+    expect((trapped as PiContainmentError).piCode).toBe('E_PI_PROCESS_EXIT_TRAPPED');
+    // Once all scopes release, the real exit is restored.
+    expect(process.exit).toBe(realExit);
+  });
+
+  it('installDaemonExitGuard pins the trap so a post-call exit is STILL trapped', async () => {
+    const realExit = process.exit;
+    const unpin = installDaemonExitGuard();
+    try {
+      // No wrapPiCall active, yet the trap is pinned for the daemon lifetime.
+      expect(process.exit).not.toBe(realExit);
+      expect(() => (process.exit as (code?: number) => never)(9)).toThrowError(PiContainmentError);
+      // A wrapped call still works and does NOT un-pin on release.
+      await wrapPiCall(async () => 'ok');
+      expect(process.exit).not.toBe(realExit);
+    } finally {
+      unpin();
+    }
+    // After un-pinning (and no active scopes), the real exit is restored.
+    expect(process.exit).toBe(realExit);
   });
 });
 

--- a/packages/core/src/llm/pi/__tests__/pi-execution-env.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-execution-env.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the guarded Pi ExecutionEnv (T11761 · S1 · T11897).
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createToolGuard } from '../../../tools/guard.js';
+import { createGuardedExecutionEnv, GuardedExecutionEnv } from '../pi-execution-env.js';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'cleo-pi-env-'));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** A guard in enforce mode confined to the workspace root. */
+function enforcedEnv() {
+  const guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+  return createGuardedExecutionEnv({ guard, workspaceRoot: root });
+}
+
+describe('pure path arithmetic', () => {
+  it('cwd returns the resolved workspace root', () => {
+    const env = enforcedEnv();
+    expect(env.cwd()).toBe(root);
+  });
+
+  it('joinPath / absolutePath anchor at the workspace root', () => {
+    const env = enforcedEnv();
+    expect(env.joinPath('a', 'b')).toBe(join(root, 'a', 'b'));
+    expect(env.absolutePath('rel.txt')).toBe(join(root, 'rel.txt'));
+  });
+});
+
+describe('file ops inside the workspace (allowed)', () => {
+  it('writes then reads a file via the guard', async () => {
+    const env = enforcedEnv();
+    const target = join(root, 'note.txt');
+    const w = await env.writeFile(target, 'hello');
+    expect(w.ok).toBe(true);
+    const r = await env.readTextFile(target);
+    expect(r).toEqual({ ok: true, value: 'hello' });
+  });
+
+  it('readTextLines splits content into lines', async () => {
+    const env = enforcedEnv();
+    const target = join(root, 'lines.txt');
+    await env.writeFile(target, 'a\nb\nc');
+    const r = await env.readTextLines(target);
+    expect(r).toEqual({ ok: true, value: ['a', 'b', 'c'] });
+  });
+
+  it('appendFile concatenates onto existing content', async () => {
+    const env = enforcedEnv();
+    const target = join(root, 'log.txt');
+    await env.writeFile(target, 'one');
+    await env.appendFile(target, '-two');
+    const r = await env.readTextFile(target);
+    expect(r).toEqual({ ok: true, value: 'one-two' });
+  });
+
+  it('appendFile treats a missing file as empty', async () => {
+    const env = enforcedEnv();
+    const target = join(root, 'fresh.txt');
+    await env.appendFile(target, 'first');
+    const r = await env.readTextFile(target);
+    expect(r).toEqual({ ok: true, value: 'first' });
+  });
+
+  it('exists + fileInfo report file vs directory', async () => {
+    const env = enforcedEnv();
+    const target = join(root, 'present.txt');
+    await env.writeFile(target, 'x');
+    expect(await env.exists(target)).toEqual({ ok: true, value: true });
+    const info = await env.fileInfo(target);
+    expect(info).toEqual({ ok: true, value: { isFile: true, isDirectory: false } });
+  });
+
+  it('exists is false for a missing path; fileInfo errors NOT_FOUND', async () => {
+    const env = enforcedEnv();
+    const missing = join(root, 'nope.txt');
+    expect(await env.exists(missing)).toEqual({ ok: true, value: false });
+    const info = await env.fileInfo(missing);
+    expect(info.ok).toBe(false);
+    expect(info.ok === false && info.error.code).toBe('E_PI_FS_NOT_FOUND');
+  });
+
+  it('canonicalPath returns the confined absolute path', async () => {
+    const env = enforcedEnv();
+    const r = await env.canonicalPath('sub/x.txt');
+    expect(r).toEqual({ ok: true, value: join(root, 'sub', 'x.txt') });
+  });
+});
+
+describe('deny-first workspace boundary (path-escape)', () => {
+  it('rejects a parent-traversal (../) read without touching the fs', async () => {
+    const env = enforcedEnv();
+    const r = await env.readTextFile('../outside.txt');
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+  });
+
+  it('rejects a deep ../../ escape', async () => {
+    const env = enforcedEnv();
+    const r = await env.readTextFile('a/../../../../etc/passwd');
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+  });
+
+  it('rejects an absolute path outside the workspace', async () => {
+    const env = enforcedEnv();
+    const r = await env.writeFile('/etc/cleo-should-not-exist', 'x');
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+  });
+
+  it('denies exists/fileInfo/canonicalPath for escaping paths too', async () => {
+    const env = enforcedEnv();
+    for (const r of [
+      await env.exists('../x'),
+      await env.fileInfo('../x'),
+      await env.canonicalPath('../x'),
+      await env.appendFile('../x', 'y'),
+    ]) {
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+    }
+  });
+});
+
+describe('guard enforce-mode denial → Result.err (never throws)', () => {
+  it('a path that escapes the guard allowlist returns Result.err, not a throw', async () => {
+    // Workspace root permits ../escape past confine, but the guard's own
+    // allowlist is narrower — assert the GuardDeniedError is caught.
+    const parent = mkdtempSync(join(tmpdir(), 'cleo-pi-parent-'));
+    try {
+      const inner = join(parent, 'inner');
+      // workspace root = parent (so ../ stays inside), guard allowlist = inner only
+      const guard = createToolGuard({ allowedRoots: [inner], mode: 'enforce' });
+      const env = createGuardedExecutionEnv({ guard, workspaceRoot: parent });
+      // path is inside workspace (parent) but OUTSIDE guard allowlist (inner)
+      const r = await env.writeFile(join(parent, 'top.txt'), 'x');
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('unsupported v0 capabilities are denied (no fs reach)', () => {
+  it('binary read, listDir, createDir, remove, temp ops all deny', async () => {
+    const env = enforcedEnv();
+    const results = [
+      await env.readBinaryFile(join(root, 'x')),
+      await env.listDir(root),
+      await env.createDir(join(root, 'd')),
+      await env.remove(join(root, 'x')),
+      await env.createTempDir(),
+      await env.createTempFile(),
+    ];
+    for (const r of results) {
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.error.code).toBe('E_PI_FS_UNSUPPORTED');
+    }
+  });
+});
+
+describe('shell exec pass-through to the ToolGuard', () => {
+  it('runs an allowed command and maps the result', async () => {
+    const env = enforcedEnv();
+    const r = await env.exec('echo', { env: { CLEO_TEST: '1' } });
+    expect(r.ok).toBe(true);
+    expect(r.ok === true && typeof r.value.exitCode).toBe('number');
+  });
+
+  it('a denied command surfaces as Result.err (never throws)', async () => {
+    const guard = createToolGuard({
+      allowedRoots: [root],
+      deniedCommands: ['rm'],
+      mode: 'enforce',
+    });
+    const env = createGuardedExecutionEnv({ guard, workspaceRoot: root });
+    const r = await env.exec('rm');
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_EXEC_DENIED');
+  });
+
+  it('an escaping cwd is denied before execution', async () => {
+    const env = enforcedEnv();
+    const r = await env.exec('echo', { cwd: '/etc' });
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_EXEC_DENIED');
+  });
+});
+
+describe('cleanup is a best-effort no-op', () => {
+  it('resolves without throwing', async () => {
+    const env = enforcedEnv();
+    await expect(env.cleanup()).resolves.toBeUndefined();
+  });
+});
+
+describe('factory + class parity', () => {
+  it('createGuardedExecutionEnv yields a GuardedExecutionEnv instance', () => {
+    const guard = createToolGuard({ allowedRoots: [root] });
+    const env = createGuardedExecutionEnv({ guard, workspaceRoot: root });
+    expect(env).toBeInstanceOf(GuardedExecutionEnv);
+  });
+});

--- a/packages/core/src/llm/pi/__tests__/pi-execution-env.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-execution-env.test.ts
@@ -6,7 +6,7 @@
  * @task T11897
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -20,7 +20,13 @@ import {
 let root: string;
 
 beforeEach(() => {
-  root = mkdtempSync(join(tmpdir(), 'cleo-pi-env-'));
+  // `realpathSync` so the root is the REAL on-disk path. On macOS the OS tmpdir
+  // is reached through a symlink (`/var`→`/private/var`, `/tmp`→`/private/tmp`),
+  // so `mkdtempSync` returns a symlinked path; the symlink-resolving boundary
+  // (`#confine`/`canonicalPath`) returns the REAL location, and expectations that
+  // build paths from `root` must therefore anchor on the real root too — else
+  // they diverge by the `/private` prefix on macOS only. (No-op on Linux.)
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'cleo-pi-env-')));
 });
 afterEach(() => {
   rmSync(root, { recursive: true, force: true });
@@ -102,6 +108,82 @@ describe('file ops inside the workspace (allowed)', () => {
     const env = enforcedEnv();
     const r = await env.canonicalPath('sub/x.txt');
     expect(r).toEqual({ ok: true, value: join(root, 'sub', 'x.txt') });
+  });
+});
+
+describe('symlinked workspace root (macOS /tmp→/private/tmp parity)', () => {
+  // On macOS the OS tmpdir (`/var/folders/...`, and `/tmp`) is reached through a
+  // symlink (`/var`→`/private/var`, `/tmp`→`/private/tmp`), so `mkdtempSync` hands
+  // back a path whose realpath has a DIFFERENT prefix. The symlink-resolving
+  // boundary (`#confine`) returns that REAL path; any op that fed the resolved
+  // path back through a second confinement (e.g. `appendFile`'s read-then-write)
+  // would see it as `../`-outside the lexical root and falsely deny it. This
+  // block reproduces that on Linux by making the workspace root itself a symlink
+  // to a sibling dir with a different prefix.
+  let base: string;
+  let symlinkedRoot: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'cleo-pi-symroot-'));
+    const realStore = join(base, 'realstore');
+    mkdirSync(realStore);
+    symlinkedRoot = join(base, 'link');
+    symlinkSync(realStore, symlinkedRoot); // root → realstore (prefix differs, like /var→/private/var)
+  });
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  /** Env whose workspaceRoot is a symlink to a different-prefix real dir. */
+  function symlinkedEnv() {
+    const guard = createToolGuard({ allowedRoots: [symlinkedRoot], mode: 'enforce' });
+    return createGuardedExecutionEnv({ guard, workspaceRoot: symlinkedRoot });
+  }
+
+  it('appendFile concatenates onto existing content under a symlinked root', async () => {
+    const env = symlinkedEnv();
+    const target = join(symlinkedRoot, 'log.txt');
+    expect((await env.writeFile(target, 'one')).ok).toBe(true);
+    expect((await env.appendFile(target, '-two')).ok).toBe(true);
+    expect(await env.readTextFile(target)).toEqual({ ok: true, value: 'one-two' });
+  });
+
+  it('appendFile creates a missing file under a symlinked root', async () => {
+    const env = symlinkedEnv();
+    const fresh = join(symlinkedRoot, 'fresh.txt');
+    expect((await env.appendFile(fresh, 'first')).ok).toBe(true);
+    expect(await env.readTextFile(fresh)).toEqual({ ok: true, value: 'first' });
+  });
+
+  it('canonicalPath resolves to the REAL (symlink-followed) path, not the link path', async () => {
+    // `canonicalPath` is symlink-RESOLVING by contract — under a symlinked root it
+    // returns the real on-disk location (the `/private`-prefixed path on macOS),
+    // NOT the symlinked input. This locks the exact divergence the macOS CI hit.
+    const env = symlinkedEnv();
+    const realRoot = realpathSync(symlinkedRoot);
+    const r = await env.canonicalPath('sub/x.txt');
+    expect(r).toEqual({ ok: true, value: join(realRoot, 'sub', 'x.txt') });
+    // Sanity: the resolved value is genuinely different from the lexical link path.
+    expect(r.ok === true && r.value).not.toBe(join(symlinkedRoot, 'sub', 'x.txt'));
+  });
+
+  it('still DENIES a symlink that escapes the (symlinked) workspace root', async () => {
+    // Symlink-escape protection must survive the symlinked-root fix: a symlink
+    // planted inside the workspace whose real target leaves the root is denied.
+    const env = symlinkedEnv();
+    const outside = join(base, 'outside');
+    mkdirSync(outside);
+    writeFileSync(join(outside, 'secret.txt'), 'TOPSECRET');
+    symlinkSync(outside, join(symlinkedRoot, 'evil')); // dir symlink escaping the root
+
+    for (const r of [
+      await env.readTextFile(join(symlinkedRoot, 'evil', 'secret.txt')),
+      await env.writeFile(join(symlinkedRoot, 'evil', 'pwned.txt'), 'x'),
+      await env.appendFile(join(symlinkedRoot, 'evil', 'pwned2.txt'), 'x'),
+    ]) {
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+    }
   });
 });
 

--- a/packages/core/src/llm/pi/__tests__/pi-execution-env.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-execution-env.test.ts
@@ -11,7 +11,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createToolGuard } from '../../../tools/guard.js';
-import { createGuardedExecutionEnv, GuardedExecutionEnv } from '../pi-execution-env.js';
+import {
+  createGuardedExecutionEnv,
+  GuardedExecutionEnv,
+  PiGuardModeError,
+} from '../pi-execution-env.js';
 
 let root: string;
 
@@ -212,8 +216,32 @@ describe('cleanup is a best-effort no-op', () => {
 
 describe('factory + class parity', () => {
   it('createGuardedExecutionEnv yields a GuardedExecutionEnv instance', () => {
-    const guard = createToolGuard({ allowedRoots: [root] });
+    const guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
     const env = createGuardedExecutionEnv({ guard, workspaceRoot: root });
     expect(env).toBeInstanceOf(GuardedExecutionEnv);
+  });
+});
+
+describe('factory REQUIRES an enforce-mode guard (warn-mode is rejected)', () => {
+  it('throws PiGuardModeError when the guard is in warn mode', () => {
+    // A warn-mode guard's allowlist/denylist are advisory — the Pi adapter must
+    // refuse it rather than run untrusted work behind an advisory boundary.
+    const warnGuard = createToolGuard({ allowedRoots: [root], mode: 'warn' });
+    expect(() => createGuardedExecutionEnv({ guard: warnGuard, workspaceRoot: root })).toThrow(
+      PiGuardModeError,
+    );
+  });
+
+  it('throws when no explicit mode is given (live default is warn)', () => {
+    // The live default posture is `warn` (GUARD_ENFORCE_FLIP_ENABLED=false), so a
+    // guard built without an explicit mode must also be rejected.
+    const defaultGuard = createToolGuard({ allowedRoots: [root] });
+    try {
+      createGuardedExecutionEnv({ guard: defaultGuard, workspaceRoot: root });
+      expect.unreachable('expected PiGuardModeError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PiGuardModeError);
+      expect((err as PiGuardModeError).code).toBe('E_PI_GUARD_NOT_ENFORCING');
+    }
   });
 });

--- a/packages/core/src/llm/pi/__tests__/pi-import-purity.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-import-purity.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Import-time purity guard for the S1 Pi guard surface (T11761 · S1 · T11897).
+ *
+ * AC3: importing the S1 modules must be side-effect free — NO logger
+ * initialization, NO DB access, NO pi-ai provider-registry trigger. This test
+ * imports both modules and asserts neither performed observable global work at
+ * module-evaluation time (the lazy logger is only resolved inside `wrapPiCall`).
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ */
+
+import { describe, expect, it } from 'vitest';
+
+describe('S1 import-time purity', () => {
+  it('importing pi-errors performs no top-level side effect', async () => {
+    const before = process.exit;
+    const mod = await import('../pi-errors.js');
+    // The exports exist and process.exit was NOT trapped merely by importing.
+    expect(typeof mod.wrapPiCall).toBe('function');
+    expect(typeof mod.PiContainmentError).toBe('function');
+    expect(process.exit).toBe(before);
+  });
+
+  it('importing pi-execution-env performs no top-level side effect', async () => {
+    const mod = await import('../pi-execution-env.js');
+    expect(typeof mod.createGuardedExecutionEnv).toBe('function');
+    expect(typeof mod.GuardedExecutionEnv).toBe('function');
+  });
+});

--- a/packages/core/src/llm/pi/__tests__/pi-security-hardening.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-security-hardening.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Security-hardening regression tests for the guarded Pi surface (T11897).
+ *
+ * These tests are the closing-the-escape counterparts to the adversarial probes
+ * that originally REPRODUCED the findings. Each `describe` block pins one of the
+ * fixed classes:
+ *
+ * 1. Symlink escape (read + dir-symlink write) — `#confine` + the guard now
+ *    canonicalize via `fs.realpath` and re-check containment against the REAL
+ *    target, so a symlink planted inside the workspace can no longer leak.
+ * 2. Sandbox escape via Pi-controlled env (LD_PRELOAD / PATH / NODE_OPTIONS) —
+ *    `exec` scrubs Pi's env to a minimal allowlist, pins PATH, drops loader
+ *    hooks, so a workspace-resident impostor on a hijacked PATH is not found and
+ *    no loader hook is forwarded.
+ * 3. Daemon-secret leak — the scrubbed env never inherits `process.env`, so a
+ *    child never sees `ANTHROPIC_API_KEY` / `CLEO_VAULT_*`.
+ * 4. Warn-mode guard rejection — the Pi adapter refuses a non-enforce guard.
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ */
+
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createToolGuard } from '../../../tools/guard.js';
+import { createGuardedExecutionEnv } from '../pi-execution-env.js';
+
+let root: string;
+let outside: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'cleo-pi-sec-root-'));
+  outside = mkdtempSync(join(tmpdir(), 'cleo-pi-sec-outside-'));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+});
+
+/** An enforce-mode env confined to `root` (the real Pi deployment posture). */
+function enforcedEnv() {
+  const guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+  return createGuardedExecutionEnv({ guard, workspaceRoot: root });
+}
+
+describe('symlink escape — READ through a file symlink is denied', () => {
+  it('a symlinked file inside the workspace pointing outside does NOT leak content', async () => {
+    const secret = join(outside, 'secret.txt');
+    writeFileSync(secret, 'TOP-SECRET-OUTSIDE-WORKSPACE');
+    // Plant a symlink INSIDE the workspace pointing to the external secret.
+    const planted = join(root, 'innocent.txt');
+    symlinkSync(secret, planted);
+
+    const env = enforcedEnv();
+    const r = await env.readTextFile('innocent.txt');
+    // BEFORE the fix this returned { ok:true, value:'TOP-SECRET-OUTSIDE-WORKSPACE' }.
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+  });
+});
+
+describe('symlink escape — WRITE through a directory symlink is denied', () => {
+  it('a symlinked directory inside the workspace does NOT let a write land outside', async () => {
+    // root/sub -> outside  (a symlinked directory inside the workspace)
+    const planted = join(root, 'sub');
+    symlinkSync(outside, planted);
+
+    const env = enforcedEnv();
+    const r = await env.writeFile('sub/x.txt', 'should-not-land-outside');
+    // BEFORE the fix the tmp-then-rename landed the file at outside/x.txt.
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+  });
+
+  it('a legitimate nested write inside a REAL subdirectory still succeeds', async () => {
+    mkdirSync(join(root, 'realdir'));
+    const env = enforcedEnv();
+    const w = await env.writeFile('realdir/ok.txt', 'fine');
+    expect(w.ok).toBe(true);
+    const back = await env.readTextFile('realdir/ok.txt');
+    expect(back).toEqual({ ok: true, value: 'fine' });
+  });
+});
+
+describe('symlink escape — exists/fileInfo/canonicalPath also deny a planted symlink', () => {
+  it('a symlink to outside is reported denied across the metadata surface', async () => {
+    const secret = join(outside, 'secret.txt');
+    writeFileSync(secret, 'x');
+    symlinkSync(secret, join(root, 'link.txt'));
+    const env = enforcedEnv();
+    for (const r of [
+      await env.exists('link.txt'),
+      await env.fileInfo('link.txt'),
+      await env.canonicalPath('link.txt'),
+    ]) {
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.error.code).toBe('E_PI_FS_DENIED');
+    }
+  });
+});
+
+describe('sandbox escape via Pi-controlled subprocess env', () => {
+  it('a Pi-hijacked PATH does NOT make a workspace impostor satisfy a command basename', async () => {
+    // Drop a malicious `env` impostor in the writable workspace.
+    const impostor = join(root, 'env');
+    writeFileSync(impostor, '#!/bin/sh\necho ARBITRARY-EXECUTION\n');
+    chmodSync(impostor, 0o755);
+
+    const env = enforcedEnv();
+    // Pi tries to run `env` with PATH hijacked to the workspace (where the
+    // impostor lives) plus a forwarded loader hook.
+    const r = await env.exec('env', {
+      env: { PATH: root, LD_PRELOAD: join(outside, 'evil.so') },
+    });
+    // PATH is pinned to TRUSTED_PATH (the workspace is NOT on it), so the
+    // impostor is never resolved; the real /usr/bin/env runs instead and its
+    // output must NOT contain the impostor's marker.
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.stdout).not.toContain('ARBITRARY-EXECUTION');
+    }
+  });
+
+  it('LD_PRELOAD / NODE_OPTIONS / GIT_SSH_COMMAND are NOT forwarded to the child', async () => {
+    const env = enforcedEnv();
+    const r = await env.exec('env', {
+      env: {
+        LD_PRELOAD: '/tmp/evil.so',
+        NODE_OPTIONS: '--require /tmp/evil.js',
+        GIT_SSH_COMMAND: 'sh -c "touch /tmp/pwned"',
+        SAFE_VAR: 'kept',
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const out = r.value.stdout;
+      expect(out).not.toMatch(/LD_PRELOAD/);
+      expect(out).not.toMatch(/NODE_OPTIONS/);
+      expect(out).not.toMatch(/GIT_SSH_COMMAND/);
+      // a benign caller var DOES pass through
+      expect(out).toMatch(/SAFE_VAR=kept/);
+    }
+  });
+});
+
+describe('daemon-secret leak through the guarded exec seam', () => {
+  const SAVED = { ...process.env };
+  afterEach(() => {
+    // restore env keys we set
+    for (const k of ['ANTHROPIC_API_KEY', 'CLEO_VAULT_SECRET', 'OPENAI_API_KEY']) {
+      if (SAVED[k] === undefined) delete process.env[k];
+      else process.env[k] = SAVED[k];
+    }
+  });
+
+  it('a subprocess does NOT inherit the daemon ANTHROPIC_API_KEY / vault secret', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-SECRET-DAEMON-KEY';
+    process.env.CLEO_VAULT_SECRET = 'vault-material';
+    process.env.OPENAI_API_KEY = 'sk-openai-secret';
+
+    const env = enforcedEnv();
+    const r = await env.exec('env');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const out = r.value.stdout;
+      expect(out).not.toContain('sk-ant-SECRET-DAEMON-KEY');
+      expect(out).not.toContain('vault-material');
+      expect(out).not.toContain('sk-openai-secret');
+      expect(out).not.toMatch(/ANTHROPIC_API_KEY/);
+      expect(out).not.toMatch(/CLEO_VAULT_SECRET/);
+    }
+  });
+});

--- a/packages/core/src/llm/pi/pi-errors.ts
+++ b/packages/core/src/llm/pi/pi-errors.ts
@@ -4,12 +4,22 @@
  * The Pi agent loop runs **in-process** inside the Cleo daemon with ZERO
  * authority. Two library packages are in the safe import set
  * (`@earendil-works/pi-agent-core` + `@earendil-works/pi-ai`) and both are
- * verified exit-clean, but the daemon MUST be structurally immune to a process
- * termination originating from ANY Pi code path — present or future. This module
- * is the containment boundary: it converts a `process.exit()` call or a
- * `process.exitCode` mutation attempted while running Pi code into a typed
- * {@link PiContainmentError} thrown back to the caller, and it restores the real
- * process hooks in a `finally` so the trap never leaks past the wrapped call.
+ * verified exit-clean, but the daemon MUST be protected from a process
+ * termination originating from a Pi code path. This module is the containment
+ * boundary: it converts a `process.exit()` call or a `process.exitCode` mutation
+ * attempted while running Pi code into a typed {@link PiContainmentError} thrown
+ * back to the caller.
+ *
+ * ## Containment scope (honest guarantee)
+ *
+ * The `process.exit` trap is process-global and REF-COUNTED across overlapping
+ * {@link wrapPiCall} scopes, so it covers the synchronous body, every awaited
+ * continuation, AND any deferred/detached exit (`setTimeout`, un-awaited
+ * promise, microtask) that fires while ANY Pi call is still active. The ONLY
+ * residual window is an exit fired AFTER the last active call has settled. To
+ * close that too — a daemon-lifetime guarantee covering ANY present/future Pi
+ * exit, synchronous or detached — the daemon calls {@link installDaemonExitGuard}
+ * once at startup to PIN the trap for its whole lifetime.
  *
  * Scope discipline (S1): NO `pi-ai`/`pi-agent-core` imports, NO DB access, NO
  * LLM calls. Import-time side-effect free — the logger is resolved lazily
@@ -102,93 +112,169 @@ export function wrapPiError(err: unknown): PiContainmentError {
 }
 
 /**
- * The scoped process-exit guard installed for the duration of one wrapped Pi
- * call. The two concerns have DIFFERENT lifecycles (see {@link
- * installProcessExitGuard}):
- * - {@link checkExitCode} is invoked SYNCHRONOUSLY immediately after the wrapped
- *   `fn` settles (before the outer `await` resolves) — this is the instant the
- *   mutated value is still observable.
- * - {@link restoreExit} is invoked in the `finally`.
+ * The scoped process-exit guard for the duration of one wrapped Pi call.
+ *
+ * The `process.exit` TRAP itself is NOT per-call: it is installed
+ * process-globally and REF-COUNTED across overlapping {@link wrapPiCall} scopes
+ * (see {@link acquireExitTrap}/{@link releaseExitTrap}). This closes the async
+ * leak window — while ANY Pi call is active the trap stays installed, so a
+ * DEFERRED or DETACHED `process.exit()` (a `setTimeout`, an un-awaited promise,
+ * a microtask outliving the await) fired during the active window is still
+ * neutralized, not run against the real exit.
+ *
+ * Only {@link checkExitCode} is per-scope: it snapshots `process.exitCode` at
+ * acquire and is invoked SYNCHRONOUSLY the instant `fn` settles, while a mutated
+ * value is still observable.
  */
 interface ProcessExitGuard {
   /**
    * Detect + neutralize a `process.exitCode` mutation. Compares the live value
-   * against the pre-trap snapshot; on a difference, writes the snapshot back via
-   * the native setter (so the daemon's eventual exit is unaffected) and returns
-   * the offending value. Idempotent — a second call returns `undefined`.
+   * against this scope's acquire-time snapshot; on a difference, writes the
+   * snapshot back via the native setter (so the daemon's eventual exit is
+   * unaffected) and returns the offending value. Idempotent — a second call
+   * returns `undefined`.
    */
   checkExitCode(): { mutatedExitCode: typeof process.exitCode } | undefined;
-  /** Reassign the original `process.exit`. MUST run exactly once in a `finally`. */
-  restoreExit(): void;
+  /** Release this scope's hold on the ref-counted trap. MUST run exactly once in a `finally`. */
+  release(): void;
 }
 
 /**
- * Install scoped guards around `process.exit` and `process.exitCode`.
+ * The original `process.exit`, captured at the FIRST trap install and restored
+ * only when the ref-count returns to zero. `null` while no trap is installed.
+ */
+let originalProcessExit: typeof process.exit | null = null;
+
+/** Number of live {@link wrapPiCall} scopes currently holding the exit trap. */
+let exitTrapRefCount = 0;
+
+/** Whether the daemon has pinned the trap for its whole lifetime (never released). */
+let daemonExitTrapPinned = false;
+
+/** The trapped `process.exit` — throws instead of terminating. Built once, reused. */
+const trappedExit = ((code?: number): never => {
+  throw new PiContainmentError(
+    'E_PI_PROCESS_EXIT_TRAPPED',
+    `Pi attempted process.exit(${code ?? ''}) in-process; daemon-fatal exit neutralized`,
+  );
+}) as typeof process.exit;
+
+/**
+ * Install the process-global `process.exit` trap if it is not already installed.
+ * Idempotent — overlapping callers share ONE trap.
+ */
+function ensureExitTrapInstalled(): void {
+  if (originalProcessExit === null) {
+    originalProcessExit = process.exit;
+    process.exit = trappedExit;
+  }
+}
+
+/**
+ * Restore the real `process.exit` when (and only when) no scope holds the trap
+ * and the daemon has not pinned it. A no-op otherwise.
+ */
+function maybeRestoreExitTrap(): void {
+  if (exitTrapRefCount === 0 && !daemonExitTrapPinned && originalProcessExit !== null) {
+    process.exit = originalProcessExit;
+    originalProcessExit = null;
+  }
+}
+
+/**
+ * Pin the `process.exit` trap for the ENTIRE daemon lifetime.
  *
- * - `process.exit` is a plain writable function property, so it is REPLACED with
- *   a function that THROWS a {@link PiContainmentError} instead of terminating;
- *   {@link ProcessExitGuard.restoreExit} reassigns the original in the `finally`.
- * - `process.exitCode` is, on modern Node, a NON-CONFIGURABLE native accessor —
- *   it cannot be redefined to intercept writes (`Object.defineProperty`/`delete`
- *   both throw). It IS writable via its native setter. So the guard uses
- *   **snapshot + synchronous detect-and-restore** ({@link
- *   ProcessExitGuard.checkExitCode}): the caller invokes it the instant `fn`
- *   settles, while the mutated value is still observable, then writes the
- *   snapshot back and surfaces `E_PI_EXIT_CODE_MUTATION_TRAPPED`. (Detecting
- *   later — e.g. in `finally` after the outer `await` — is unreliable under some
- *   test harnesses that reset `exitCode` when `process.exit` is reassigned.)
+ * This is the durable, complete fix for the async-exit leak: once pinned, the
+ * trap is NEVER restored, so a `process.exit()` originating from ANY Pi code path
+ * — synchronous, awaited, deferred (`setTimeout`), detached (fire-and-forget),
+ * present or future — is neutralized for as long as the daemon runs. Call this
+ * once at daemon startup BEFORE any Pi-touching work is dispatched.
  *
- * Re-entrant-safe: a second overlapping wrapped call snapshots the
- * already-trapped `process.exit` and the live `exitCode`; restore is a plain
- * reassignment and compare — no `defineProperty` ever runs.
+ * Idempotent. The returned function un-pins (e.g. for a graceful shutdown that
+ * legitimately needs to exit); after un-pinning, the trap is restored when no
+ * {@link wrapPiCall} scope is active.
+ *
+ * @returns A function that un-pins the daemon-lifetime trap.
+ *
+ * @example
+ * ```ts
+ * // daemon bootstrap, before serving requests:
+ * const unpin = installDaemonExitGuard();
+ * // ... daemon runs; all Pi exits are trapped for the whole lifetime ...
+ * unpin(); // only if a controlled shutdown must reach the real process.exit
+ * ```
+ */
+export function installDaemonExitGuard(): () => void {
+  daemonExitTrapPinned = true;
+  ensureExitTrapInstalled();
+  return () => {
+    daemonExitTrapPinned = false;
+    maybeRestoreExitTrap();
+  };
+}
+
+/**
+ * Acquire the ref-counted process-exit guard for one wrapped Pi call.
+ *
+ * Increments the global ref-count and installs the shared `process.exit` trap on
+ * the 0→1 transition; snapshots `process.exitCode` for this scope. The trap is
+ * released (and, at the last release, restored — unless daemon-pinned) via
+ * {@link ProcessExitGuard.release}.
+ *
+ * `process.exitCode` is, on modern Node, a NON-CONFIGURABLE native accessor — it
+ * cannot be redefined to intercept writes. It IS writable via its native setter,
+ * so the guard uses **snapshot + synchronous detect-and-restore**
+ * ({@link ProcessExitGuard.checkExitCode}).
+ *
+ * Re-entrant-safe: overlapping calls share the single installed trap; each holds
+ * its own `exitCode` snapshot and `release` is an idempotent decrement.
  *
  * @returns A scoped guard handle.
  */
-function installProcessExitGuard(): ProcessExitGuard {
-  const originalExit = process.exit;
+function acquireExitTrap(): ProcessExitGuard {
   // Snapshot the value (NOT the descriptor — the property is non-configurable on
   // modern Node, so we never redefine it; we compare-and-write via its setter).
-  const originalExitCodeValue: typeof process.exitCode = process.exitCode;
+  const snapshotExitCode: typeof process.exitCode = process.exitCode;
   let exitCodeChecked = false;
+  let released = false;
 
-  // `process.exit(code?)` → throw, never terminate. `never` return type is
-  // preserved because the function always throws.
-  const trappedExit = ((code?: number): never => {
-    throw new PiContainmentError(
-      'E_PI_PROCESS_EXIT_TRAPPED',
-      `Pi attempted process.exit(${code ?? ''}) in-process; daemon-fatal exit neutralized`,
-    );
-  }) as typeof process.exit;
-  process.exit = trappedExit;
+  exitTrapRefCount += 1;
+  ensureExitTrapInstalled();
 
   return {
     checkExitCode(): { mutatedExitCode: typeof process.exitCode } | undefined {
       if (exitCodeChecked) return undefined;
       exitCodeChecked = true;
       const current = process.exitCode;
-      if (current !== originalExitCodeValue) {
-        process.exitCode = originalExitCodeValue;
+      if (current !== snapshotExitCode) {
+        process.exitCode = snapshotExitCode;
         return { mutatedExitCode: current };
       }
       return undefined;
     },
-    restoreExit(): void {
-      process.exit = originalExit;
+    release(): void {
+      if (released) return;
+      released = true;
+      exitTrapRefCount -= 1;
+      maybeRestoreExitTrap();
     },
   };
 }
 
 /**
- * Run a Pi-touching async function under full process-exit containment +
- * abort routing.
+ * Run a Pi-touching async function under process-exit containment + abort
+ * routing.
  *
  * Behaviour:
- * - Installs the {@link installProcessExitGuard} trap for the duration of `fn`
- *   and restores the real hooks in a `finally` — a `process.exit()` call becomes
- *   a thrown {@link PiContainmentError} immediately, and a `process.exitCode`
- *   mutation is detected-and-restored at teardown then surfaced as a thrown
- *   `E_PI_EXIT_CODE_MUTATION_TRAPPED` (the value never leaks into the daemon's
- *   eventual exit code). Either way the daemon survives.
+ * - Acquires the REF-COUNTED, process-global {@link acquireExitTrap} for the
+ *   duration of `fn` and releases it in a `finally`. A `process.exit()` call —
+ *   synchronous, awaited, OR deferred/detached but firing while ANY Pi call is
+ *   still active — becomes a thrown {@link PiContainmentError} (the daemon
+ *   survives). A `process.exitCode` mutation is detected-and-restored the instant
+ *   `fn` settles, then surfaced as a thrown `E_PI_EXIT_CODE_MUTATION_TRAPPED`.
+ *   For a guarantee that spans even an exit fired AFTER the last call settles,
+ *   the daemon should additionally pin the trap once at startup via
+ *   {@link installDaemonExitGuard}.
  * - If `signal` is already aborted, rejects with `E_PI_ABORTED` WITHOUT invoking
  *   `fn`. Otherwise the signal is propagated to `fn` (the caller threads it into
  *   Pi's agent loop); an abort that surfaces as a thrown `AbortError`/`DOMException`
@@ -221,7 +307,7 @@ export async function wrapPiCall<T>(
   const onExternalAbort = (): void => controller.abort(signal?.reason);
   if (signal) signal.addEventListener('abort', onExternalAbort, { once: true });
 
-  const guard = installProcessExitGuard();
+  const guard = acquireExitTrap();
   try {
     const value = await fn(controller.signal);
     // Detect a quiet `process.exitCode` mutation SYNCHRONOUSLY here — the instant
@@ -245,7 +331,7 @@ export async function wrapPiCall<T>(
     }
     throw wrapPiError(err);
   } finally {
-    guard.restoreExit();
+    guard.release();
     if (signal) signal.removeEventListener('abort', onExternalAbort);
     // Lazy logger — never resolved at import time (S1 import-side-effect rule).
     getLogger('pi-errors').debug({ aborted: controller.signal.aborted }, 'pi call boundary closed');

--- a/packages/core/src/llm/pi/pi-errors.ts
+++ b/packages/core/src/llm/pi/pi-errors.ts
@@ -1,0 +1,269 @@
+/**
+ * Pi error / exit containment (T11761 · S1 · T11897).
+ *
+ * The Pi agent loop runs **in-process** inside the Cleo daemon with ZERO
+ * authority. Two library packages are in the safe import set
+ * (`@earendil-works/pi-agent-core` + `@earendil-works/pi-ai`) and both are
+ * verified exit-clean, but the daemon MUST be structurally immune to a process
+ * termination originating from ANY Pi code path — present or future. This module
+ * is the containment boundary: it converts a `process.exit()` call or a
+ * `process.exitCode` mutation attempted while running Pi code into a typed
+ * {@link PiContainmentError} thrown back to the caller, and it restores the real
+ * process hooks in a `finally` so the trap never leaks past the wrapped call.
+ *
+ * Scope discipline (S1): NO `pi-ai`/`pi-agent-core` imports, NO DB access, NO
+ * LLM calls. Import-time side-effect free — the logger is resolved lazily
+ * (never at module top level).
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ */
+
+import { ExitCode } from '@cleocode/contracts';
+import { CleoError } from '../../errors.js';
+import { getLogger } from '../../logger.js';
+
+/**
+ * Stable string codes for the Pi-containment error surface.
+ *
+ * `CleoError` carries a NUMERIC {@link ExitCode}; these string codes are the
+ * machine-readable discriminators a caller switches on, carried on
+ * {@link PiContainmentError.piCode} (and mirrored into the LAFS error `details`
+ * via `CleoErrorDetails`). They are NOT exit codes themselves.
+ */
+export type PiContainmentCode =
+  /** Pi (or a transitive dep) called `process.exit()` while in-process. */
+  | 'E_PI_PROCESS_EXIT_TRAPPED'
+  /** Pi (or a transitive dep) mutated `process.exitCode` while in-process. */
+  | 'E_PI_EXIT_CODE_MUTATION_TRAPPED'
+  /** The wrapped Pi call was aborted via the supplied `AbortSignal`. */
+  | 'E_PI_ABORTED'
+  /** The wrapped Pi call threw an unexpected error. */
+  | 'E_PI_LOOP_FAILED';
+
+/**
+ * Typed containment error for the Pi in-process embed.
+ *
+ * Extends {@link CleoError} so it flows through the existing LAFS error
+ * projection (`toLAFSError`/`toProblemDetails`). It carries the Pi-specific
+ * string {@link PiContainmentCode} on {@link piCode} (the numeric `ExitCode`
+ * super-field is `INTERNAL`/`GENERAL_ERROR`-class — it is the daemon, not the
+ * caller, that is being protected, so the failure is an internal one).
+ */
+export class PiContainmentError extends CleoError {
+  /** Machine-readable Pi-containment discriminator. */
+  readonly piCode: PiContainmentCode;
+
+  /**
+   * @param piCode - The Pi-containment discriminator.
+   * @param message - Human-readable description.
+   * @param options - Optional `cause` and the numeric `ExitCode` (defaults to
+   *   {@link ExitCode.GENERAL_ERROR}).
+   */
+  constructor(
+    piCode: PiContainmentCode,
+    message: string,
+    options?: { cause?: unknown; exitCode?: ExitCode },
+  ) {
+    super(options?.exitCode ?? ExitCode.GENERAL_ERROR, message, {
+      cause: options?.cause,
+      details: { field: 'pi', piCode },
+    });
+    this.name = 'PiContainmentError';
+    this.piCode = piCode;
+  }
+}
+
+/**
+ * Type guard for {@link PiContainmentError} (cross-realm-safe via `piCode`).
+ *
+ * @param err - The value to test.
+ * @returns `true` when `err` is a {@link PiContainmentError}.
+ */
+export function isPiContainmentError(err: unknown): err is PiContainmentError {
+  return err instanceof PiContainmentError;
+}
+
+/**
+ * Convert an arbitrary thrown value into a {@link PiContainmentError}.
+ *
+ * A value that is ALREADY a {@link PiContainmentError} passes through unchanged
+ * (so an exit-trap error is not re-wrapped as a generic loop failure). Anything
+ * else becomes an `E_PI_LOOP_FAILED` carrying the original as `cause`.
+ *
+ * @param err - The thrown value.
+ * @returns A typed {@link PiContainmentError}.
+ */
+export function wrapPiError(err: unknown): PiContainmentError {
+  if (isPiContainmentError(err)) return err;
+  const message = err instanceof Error ? err.message : String(err);
+  return new PiContainmentError('E_PI_LOOP_FAILED', `Pi loop failed: ${message}`, { cause: err });
+}
+
+/**
+ * The scoped process-exit guard installed for the duration of one wrapped Pi
+ * call. The two concerns have DIFFERENT lifecycles (see {@link
+ * installProcessExitGuard}):
+ * - {@link checkExitCode} is invoked SYNCHRONOUSLY immediately after the wrapped
+ *   `fn` settles (before the outer `await` resolves) — this is the instant the
+ *   mutated value is still observable.
+ * - {@link restoreExit} is invoked in the `finally`.
+ */
+interface ProcessExitGuard {
+  /**
+   * Detect + neutralize a `process.exitCode` mutation. Compares the live value
+   * against the pre-trap snapshot; on a difference, writes the snapshot back via
+   * the native setter (so the daemon's eventual exit is unaffected) and returns
+   * the offending value. Idempotent — a second call returns `undefined`.
+   */
+  checkExitCode(): { mutatedExitCode: typeof process.exitCode } | undefined;
+  /** Reassign the original `process.exit`. MUST run exactly once in a `finally`. */
+  restoreExit(): void;
+}
+
+/**
+ * Install scoped guards around `process.exit` and `process.exitCode`.
+ *
+ * - `process.exit` is a plain writable function property, so it is REPLACED with
+ *   a function that THROWS a {@link PiContainmentError} instead of terminating;
+ *   {@link ProcessExitGuard.restoreExit} reassigns the original in the `finally`.
+ * - `process.exitCode` is, on modern Node, a NON-CONFIGURABLE native accessor —
+ *   it cannot be redefined to intercept writes (`Object.defineProperty`/`delete`
+ *   both throw). It IS writable via its native setter. So the guard uses
+ *   **snapshot + synchronous detect-and-restore** ({@link
+ *   ProcessExitGuard.checkExitCode}): the caller invokes it the instant `fn`
+ *   settles, while the mutated value is still observable, then writes the
+ *   snapshot back and surfaces `E_PI_EXIT_CODE_MUTATION_TRAPPED`. (Detecting
+ *   later — e.g. in `finally` after the outer `await` — is unreliable under some
+ *   test harnesses that reset `exitCode` when `process.exit` is reassigned.)
+ *
+ * Re-entrant-safe: a second overlapping wrapped call snapshots the
+ * already-trapped `process.exit` and the live `exitCode`; restore is a plain
+ * reassignment and compare — no `defineProperty` ever runs.
+ *
+ * @returns A scoped guard handle.
+ */
+function installProcessExitGuard(): ProcessExitGuard {
+  const originalExit = process.exit;
+  // Snapshot the value (NOT the descriptor — the property is non-configurable on
+  // modern Node, so we never redefine it; we compare-and-write via its setter).
+  const originalExitCodeValue: typeof process.exitCode = process.exitCode;
+  let exitCodeChecked = false;
+
+  // `process.exit(code?)` → throw, never terminate. `never` return type is
+  // preserved because the function always throws.
+  const trappedExit = ((code?: number): never => {
+    throw new PiContainmentError(
+      'E_PI_PROCESS_EXIT_TRAPPED',
+      `Pi attempted process.exit(${code ?? ''}) in-process; daemon-fatal exit neutralized`,
+    );
+  }) as typeof process.exit;
+  process.exit = trappedExit;
+
+  return {
+    checkExitCode(): { mutatedExitCode: typeof process.exitCode } | undefined {
+      if (exitCodeChecked) return undefined;
+      exitCodeChecked = true;
+      const current = process.exitCode;
+      if (current !== originalExitCodeValue) {
+        process.exitCode = originalExitCodeValue;
+        return { mutatedExitCode: current };
+      }
+      return undefined;
+    },
+    restoreExit(): void {
+      process.exit = originalExit;
+    },
+  };
+}
+
+/**
+ * Run a Pi-touching async function under full process-exit containment +
+ * abort routing.
+ *
+ * Behaviour:
+ * - Installs the {@link installProcessExitGuard} trap for the duration of `fn`
+ *   and restores the real hooks in a `finally` — a `process.exit()` call becomes
+ *   a thrown {@link PiContainmentError} immediately, and a `process.exitCode`
+ *   mutation is detected-and-restored at teardown then surfaced as a thrown
+ *   `E_PI_EXIT_CODE_MUTATION_TRAPPED` (the value never leaks into the daemon's
+ *   eventual exit code). Either way the daemon survives.
+ * - If `signal` is already aborted, rejects with `E_PI_ABORTED` WITHOUT invoking
+ *   `fn`. Otherwise the signal is propagated to `fn` (the caller threads it into
+ *   Pi's agent loop); an abort that surfaces as a thrown `AbortError`/`DOMException`
+ *   is normalized to `E_PI_ABORTED`.
+ * - Any other thrown value is normalized via {@link wrapPiError}.
+ *
+ * @typeParam T - The resolved value type of the wrapped call.
+ * @param fn - The Pi-touching async function. Receives the (live) `AbortSignal`
+ *   so it can thread cancellation into the agent loop.
+ * @param signal - Optional cancellation signal.
+ * @returns The resolved value of `fn`.
+ * @throws {PiContainmentError} On exit-trap, abort, or any failure from `fn`.
+ *
+ * @example
+ * ```ts
+ * const result = await wrapPiCall(async (sig) => runAgentLoop(prompts, ctx, cfg, emit, sig), signal);
+ * ```
+ */
+export async function wrapPiCall<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal?.aborted) {
+    throw new PiContainmentError('E_PI_ABORTED', 'Pi call aborted before start');
+  }
+
+  // A local controller is always passed to `fn` so cancellation has a single
+  // shape; when an external signal is supplied we mirror its abort into ours.
+  const controller = new AbortController();
+  const onExternalAbort = (): void => controller.abort(signal?.reason);
+  if (signal) signal.addEventListener('abort', onExternalAbort, { once: true });
+
+  const guard = installProcessExitGuard();
+  try {
+    const value = await fn(controller.signal);
+    // Detect a quiet `process.exitCode` mutation SYNCHRONOUSLY here — the instant
+    // `fn` settled — while the value is still observable. If Pi set it, the value
+    // is restored and a typed error replaces the clean return.
+    const mutation = guard.checkExitCode();
+    if (mutation !== undefined) {
+      throw new PiContainmentError(
+        'E_PI_EXIT_CODE_MUTATION_TRAPPED',
+        `Pi set process.exitCode=${String(mutation.mutatedExitCode)} in-process; neutralized`,
+      );
+    }
+    return value;
+  } catch (err) {
+    // A mutation can also accompany a thrown failure — neutralize the leak even
+    // though the thrown error (below) is the primary signal.
+    guard.checkExitCode();
+    if (err instanceof PiContainmentError) throw err;
+    if (isAbortError(err) || controller.signal.aborted) {
+      throw new PiContainmentError('E_PI_ABORTED', 'Pi call aborted', { cause: err });
+    }
+    throw wrapPiError(err);
+  } finally {
+    guard.restoreExit();
+    if (signal) signal.removeEventListener('abort', onExternalAbort);
+    // Lazy logger — never resolved at import time (S1 import-side-effect rule).
+    getLogger('pi-errors').debug({ aborted: controller.signal.aborted }, 'pi call boundary closed');
+  }
+}
+
+/**
+ * Whether a thrown value represents an abort (a `DOMException`/`Error` whose
+ * `name` is `AbortError`).
+ *
+ * @param err - The thrown value.
+ * @returns `true` when `err` is an abort error.
+ */
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    (err as { name?: unknown }).name === 'AbortError'
+  );
+}

--- a/packages/core/src/llm/pi/pi-execution-env.ts
+++ b/packages/core/src/llm/pi/pi-execution-env.ts
@@ -168,6 +168,21 @@ function execErr(code: string, message: string): PiResult<never, PiExecutionErro
   return { ok: false, error: { code, message } };
 }
 
+/**
+ * Whether `err` is a "file does not exist" failure (`ENOENT`). Used by
+ * {@link GuardedExecutionEnv.appendFile} to treat append-to-missing as
+ * append-creates (empty prefix) while still propagating every OTHER failure
+ * (guard denial, permission, …).
+ */
+function isMissingFileError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === 'ENOENT'
+  );
+}
+
 // ---------------------------------------------------------------------------
 // GuardedExecutionEnv
 // ---------------------------------------------------------------------------
@@ -319,13 +334,38 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
    * Append to a file. The atomic surface offers only whole-file atomic writes,
    * so this reads-then-writes the concatenation (still confined + guarded). A
    * missing file is treated as empty.
+   *
+   * Confinement happens EXACTLY ONCE here, then the read + write delegate
+   * straight to the guard with the already-resolved `abs`. Re-entering the
+   * public `readTextFile`/`writeFile` would re-`#confine` the value `#confine`
+   * just returned — and because `#confine` yields the SYMLINK-RESOLVED real path
+   * (e.g. macOS `/tmp`→`/private/tmp`, or a symlinked workspace root), that real
+   * path is `../`-outside the lexical `workspaceRoot`, so the second lexical
+   * gate would spuriously reject it (`E_PI_FS_DENIED`). Reading once through the
+   * guard — whose own allowlist canonicalizes both sides — avoids the
+   * double-confine while keeping the symlink-escape denial intact.
    */
   async appendFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
     const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
-    const existing = await this.readTextFile(abs);
-    const prefix = existing.ok ? existing.value : '';
-    return this.writeFile(abs, prefix + content);
+    // Read existing content directly via the guard (a missing file → ENOENT,
+    // treated as empty). Do NOT route through readTextFile: that would re-confine
+    // the resolved real path against the lexical root and falsely reject it.
+    let prefix = '';
+    try {
+      const res = await this.#guard.readFileText({ path: abs });
+      prefix = res.content;
+    } catch (err) {
+      // A missing file is the only non-fatal case (append-creates). Any other
+      // failure (guard denial, permission, …) propagates as the Pi error.
+      if (!isMissingFileError(err)) return this.#toFsErr(err, abs);
+    }
+    try {
+      await this.#guard.writeFileAtomic({ path: abs, content: prefix + content });
+      return ok(undefined);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
   }
 
   // --- metadata ------------------------------------------------------------

--- a/packages/core/src/llm/pi/pi-execution-env.ts
+++ b/packages/core/src/llm/pi/pi-execution-env.ts
@@ -1,0 +1,427 @@
+/**
+ * Guarded Pi `ExecutionEnv` (T11761 · S1 · T11897).
+ *
+ * Pi's agent loop performs ALL filesystem + shell work through a single
+ * pluggable seam: `ExecutionEnv extends FileSystem, Shell`. This module supplies
+ * Cleo's implementation of that seam — {@link GuardedExecutionEnv} — which routes
+ * every operation through the deny-first {@link ToolGuard} chokepoint and an
+ * injected **workspace boundary**, so Pi can touch nothing outside the
+ * allowlisted roots and runs no command on the denylist.
+ *
+ * Two layers of confinement (deny-first):
+ * 1. **Workspace boundary** — every fs path is resolved and MUST fall under the
+ *    injected `workspaceRoot`; a `../` escape or an absolute path outside the
+ *    root is rejected as a Pi `Result.err(FileError)` BEFORE the guard is even
+ *    consulted. (The guard's own `allowedRoots` is a second, redundant net.)
+ * 2. **ToolGuard** — the allowed operations delegate to the `ToolGuard` surface
+ *    (`readFileText`/`writeFileAtomic`/`pathExists`/`executeShell`/`runGit`),
+ *    which applies the project's path allowlist + shell denylist. A
+ *    `GuardDeniedError` from enforce-mode is CAUGHT and converted to a Pi
+ *    `Result.err` — Pi's `FileSystem`/`Shell` ops must NEVER throw.
+ *
+ * Every other capability (binary reads, raw temp/dir mutation, listing, …) for
+ * which there is no atomic primitive in v0 is DENIED with a typed error rather
+ * than reaching the real filesystem. The structural Pi interfaces are declared
+ * locally here (the `@earendil-works/pi-agent-core` package is not yet a
+ * dependency); S2 replaces these with the real type-only imports — the shapes
+ * match `@earendil-works/pi-agent-core@0.78.1` `harness/types.ts:268-332`.
+ *
+ * Scope discipline (S1): NO `pi-ai`/`pi-agent-core` imports, NO DB access, NO
+ * LLM calls. Import-time side-effect free.
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ */
+
+import { isAbsolute, relative, resolve as resolvePath } from 'node:path';
+import { GuardDeniedError, type ToolGuard } from '../../tools/guard.js';
+
+// ---------------------------------------------------------------------------
+// Structural Pi seam (local declarations — replaced by type-only pi imports in S2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pi's `Result<T, E>` discriminated union. Pi's `FileSystem`/`Shell` ops return
+ * this and MUST never throw — failures are encoded as `{ ok: false, error }`.
+ *
+ * Matches `@earendil-works/pi-agent-core@0.78.1` result shape.
+ */
+export type PiResult<T, E> =
+  | { readonly ok: true; readonly value: T }
+  | {
+      readonly ok: false;
+      readonly error: E;
+    };
+
+/** A filesystem failure surfaced to Pi (never thrown). */
+export interface PiFileError {
+  /** Stable failure kind. */
+  readonly code: string;
+  /** Human-readable description. */
+  readonly message: string;
+  /** The path the operation targeted, when applicable. */
+  readonly path?: string;
+}
+
+/** A shell-execution failure surfaced to Pi (never thrown). */
+export interface PiExecutionError {
+  /** Stable failure kind. */
+  readonly code: string;
+  /** Human-readable description. */
+  readonly message: string;
+}
+
+/** Metadata returned by `fileInfo`. */
+export interface PiFileInfo {
+  /** Whether the entry is a regular file. */
+  readonly isFile: boolean;
+  /** Whether the entry is a directory. */
+  readonly isDirectory: boolean;
+}
+
+/** Result of a `Shell.exec`. */
+export interface PiExecResult {
+  /** Captured standard output. */
+  readonly stdout: string;
+  /** Captured standard error. */
+  readonly stderr: string;
+  /** Process exit code (`null` when killed by signal/timeout). */
+  readonly exitCode: number | null;
+}
+
+/** Options for a `Shell.exec`. */
+export interface PiExecOptions {
+  /** Working directory. */
+  readonly cwd?: string;
+  /** Hard timeout in milliseconds. */
+  readonly timeout?: number;
+  /** Extra environment variables. */
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Pi's `FileSystem` interface (the fs half of `ExecutionEnv`). Every op returns
+ * a {@link PiResult} and must never throw. Mirrors
+ * `@earendil-works/pi-agent-core@0.78.1` `harness/types.ts:268-318`.
+ */
+export interface PiFileSystem {
+  cwd(): string;
+  absolutePath(path: string): string;
+  joinPath(...segments: string[]): string;
+  readTextFile(path: string): Promise<PiResult<string, PiFileError>>;
+  readTextLines(path: string): Promise<PiResult<string[], PiFileError>>;
+  readBinaryFile(path: string): Promise<PiResult<Uint8Array, PiFileError>>;
+  writeFile(path: string, content: string): Promise<PiResult<void, PiFileError>>;
+  appendFile(path: string, content: string): Promise<PiResult<void, PiFileError>>;
+  fileInfo(path: string): Promise<PiResult<PiFileInfo, PiFileError>>;
+  listDir(path: string): Promise<PiResult<string[], PiFileError>>;
+  canonicalPath(path: string): Promise<PiResult<string, PiFileError>>;
+  exists(path: string): Promise<PiResult<boolean, PiFileError>>;
+  createDir(path: string): Promise<PiResult<void, PiFileError>>;
+  remove(path: string): Promise<PiResult<void, PiFileError>>;
+  createTempDir(prefix?: string): Promise<PiResult<string, PiFileError>>;
+  createTempFile(prefix?: string): Promise<PiResult<string, PiFileError>>;
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Pi's `Shell` interface (the shell half of `ExecutionEnv`). Mirrors
+ * `@earendil-works/pi-agent-core@0.78.1` `harness/types.ts:321-328`.
+ */
+export interface PiShell {
+  exec(command: string, options?: PiExecOptions): Promise<PiResult<PiExecResult, PiExecutionError>>;
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Pi's `ExecutionEnv` — the single pluggable surface for all fs + process work.
+ * Mirrors `@earendil-works/pi-agent-core@0.78.1` `harness/types.ts:332`.
+ */
+export interface PiExecutionEnv extends PiFileSystem, PiShell {}
+
+// ---------------------------------------------------------------------------
+// Result constructors
+// ---------------------------------------------------------------------------
+
+/** Build a successful {@link PiResult}. */
+function ok<T>(value: T): PiResult<T, never> {
+  return { ok: true, value };
+}
+
+/** Build a failed {@link PiResult} with a {@link PiFileError}. */
+function fsErr(code: string, message: string, path?: string): PiResult<never, PiFileError> {
+  return { ok: false, error: { code, message, ...(path !== undefined ? { path } : {}) } };
+}
+
+/** Build a failed {@link PiResult} with a {@link PiExecutionError}. */
+function execErr(code: string, message: string): PiResult<never, PiExecutionError> {
+  return { ok: false, error: { code, message } };
+}
+
+// ---------------------------------------------------------------------------
+// GuardedExecutionEnv
+// ---------------------------------------------------------------------------
+
+/** Construction dependencies for {@link GuardedExecutionEnv}. */
+export interface GuardedExecutionEnvDeps {
+  /**
+   * The guarded primitive surface (path allowlist + shell denylist) the env
+   * delegates allowed operations to. Injected by the dispatcher — the env never
+   * constructs it (atomic primitives are Gate-11-bound to `core/src/tools`).
+   */
+  readonly guard: ToolGuard;
+  /**
+   * The absolute workspace root every fs path is confined under. A path that
+   * resolves outside this root is denied BEFORE the guard is consulted.
+   */
+  readonly workspaceRoot: string;
+}
+
+/**
+ * Deny-first {@link PiExecutionEnv} backed by the Cleo {@link ToolGuard} surface
+ * and a workspace boundary.
+ *
+ * - File reads/writes/existence checks route through the guard's atomic
+ *   primitives, confined to `workspaceRoot`.
+ * - `exec` routes through the guard's `executeShell` (shell denylist applies).
+ * - Capabilities with no atomic primitive in v0 (binary read, `listDir`,
+ *   `createDir`, `remove`, temp dir/file) are DENIED with a typed
+ *   `Result.err` — they never reach the real filesystem.
+ * - Pure path arithmetic (`cwd`/`absolutePath`/`joinPath`) is computed locally
+ *   (no fs access), anchored to `workspaceRoot`.
+ *
+ * Every method honours the Pi contract: it returns a {@link PiResult} and never
+ * throws — a {@link GuardDeniedError} from the guard is caught and converted.
+ */
+export class GuardedExecutionEnv implements PiExecutionEnv {
+  readonly #guard: ToolGuard;
+  readonly #root: string;
+
+  /**
+   * @param deps - The guard surface + the workspace root to confine to.
+   */
+  constructor(deps: GuardedExecutionEnvDeps) {
+    this.#guard = deps.guard;
+    this.#root = resolvePath(deps.workspaceRoot);
+  }
+
+  /**
+   * Resolve a (possibly relative) path against the workspace root and assert it
+   * stays inside the boundary. Returns the absolute path, or `null` when the
+   * path escapes (`../` traversal or an out-of-root absolute path).
+   */
+  #confine(path: string): string | null {
+    const abs = isAbsolute(path) ? resolvePath(path) : resolvePath(this.#root, path);
+    const rel = relative(this.#root, abs);
+    // Inside the root iff the relative path does not climb out (`..`) and is not
+    // itself an absolute path (different drive / root on the platform).
+    if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return abs;
+    return null;
+  }
+
+  // --- pure path arithmetic (no fs access) ---------------------------------
+
+  /** The workspace root (the in-process Pi run's working directory). */
+  cwd(): string {
+    return this.#root;
+  }
+
+  /** Resolve `path` to an absolute path anchored at the workspace root. */
+  absolutePath(path: string): string {
+    return isAbsolute(path) ? resolvePath(path) : resolvePath(this.#root, path);
+  }
+
+  /** Join path segments (pure). */
+  joinPath(...segments: string[]): string {
+    return resolvePath(this.#root, ...segments);
+  }
+
+  // --- file reads ----------------------------------------------------------
+
+  /** Read a file's text, confined to the workspace + guarded. */
+  async readTextFile(path: string): Promise<PiResult<string, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const res = await this.#guard.readFileText({ path: abs });
+      return ok(res.content);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Read a file's text as an array of lines. */
+  async readTextLines(path: string): Promise<PiResult<string[], PiFileError>> {
+    const res = await this.readTextFile(path);
+    return res.ok ? ok(res.value.split(/\r?\n/)) : res;
+  }
+
+  /**
+   * Binary read — DENIED in v0. The atomic `readFileText` primitive is
+   * text-only (`ReadFileInput.encoding` has no binary variant); a binary
+   * primitive must be added under `core/src/tools` (Gate 11) before this is
+   * supported. Deny-first: never reaches the filesystem.
+   */
+  async readBinaryFile(path: string): Promise<PiResult<Uint8Array, PiFileError>> {
+    return fsErr('E_PI_FS_UNSUPPORTED', 'binary read is not supported in v0', path);
+  }
+
+  // --- file writes ---------------------------------------------------------
+
+  /** Atomically write a file, confined to the workspace + guarded. */
+  async writeFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      await this.#guard.writeFileAtomic({ path: abs, content });
+      return ok(undefined);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /**
+   * Append to a file. The atomic surface offers only whole-file atomic writes,
+   * so this reads-then-writes the concatenation (still confined + guarded). A
+   * missing file is treated as empty.
+   */
+  async appendFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    const existing = await this.readTextFile(abs);
+    const prefix = existing.ok ? existing.value : '';
+    return this.writeFile(abs, prefix + content);
+  }
+
+  // --- metadata ------------------------------------------------------------
+
+  /** Report whether a path is a file or directory, confined + guarded. */
+  async fileInfo(path: string): Promise<PiResult<PiFileInfo, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const res = await this.#guard.pathExists({ path: abs });
+      if (!res.exists) return fsErr('E_PI_FS_NOT_FOUND', 'path does not exist', abs);
+      return ok({ isFile: res.kind === 'file', isDirectory: res.kind === 'directory' });
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Whether a path exists, confined + guarded. */
+  async exists(path: string): Promise<PiResult<boolean, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const res = await this.#guard.pathExists({ path: abs });
+      return ok(res.exists);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Canonicalize a path inside the workspace (pure resolve, no symlink walk). */
+  async canonicalPath(path: string): Promise<PiResult<string, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    return ok(abs);
+  }
+
+  // --- denied fs-mutating / listing ops (no atomic primitive in v0) --------
+
+  /** DENIED in v0 — no `listDir` atomic primitive. */
+  async listDir(path: string): Promise<PiResult<string[], PiFileError>> {
+    return fsErr('E_PI_FS_UNSUPPORTED', 'directory listing is not supported in v0', path);
+  }
+
+  /** DENIED in v0 — no `createDir` atomic primitive. */
+  async createDir(path: string): Promise<PiResult<void, PiFileError>> {
+    return fsErr('E_PI_FS_UNSUPPORTED', 'directory creation is not supported in v0', path);
+  }
+
+  /** DENIED in v0 — no `remove` atomic primitive. */
+  async remove(path: string): Promise<PiResult<void, PiFileError>> {
+    return fsErr('E_PI_FS_UNSUPPORTED', 'remove is not supported in v0', path);
+  }
+
+  /** DENIED in v0 — no temp-dir atomic primitive. */
+  async createTempDir(): Promise<PiResult<string, PiFileError>> {
+    return fsErr('E_PI_FS_UNSUPPORTED', 'temp dir creation is not supported in v0');
+  }
+
+  /** DENIED in v0 — no temp-file atomic primitive. */
+  async createTempFile(): Promise<PiResult<string, PiFileError>> {
+    return fsErr('E_PI_FS_UNSUPPORTED', 'temp file creation is not supported in v0');
+  }
+
+  // --- shell ---------------------------------------------------------------
+
+  /**
+   * Execute a command through the guard's shell surface (denylist applies). The
+   * Pi `command` string is a bare executable name (args are passed by Pi via the
+   * loop, but the v0 seam takes only `command`); we forward it as the guard's
+   * `command` with empty args. `cwd` is confined to the workspace.
+   */
+  async exec(
+    command: string,
+    options?: PiExecOptions,
+  ): Promise<PiResult<PiExecResult, PiExecutionError>> {
+    const cwd = options?.cwd ? this.#confine(options.cwd) : this.#root;
+    if (cwd === null) {
+      return execErr('E_PI_EXEC_DENIED', 'cwd escapes workspace boundary');
+    }
+    try {
+      const res = await this.#guard.executeShell({
+        command,
+        cwd,
+        ...(options?.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+        ...(options?.env !== undefined ? { env: options.env } : {}),
+      });
+      return ok({ stdout: res.stdout, stderr: res.stderr, exitCode: res.code });
+    } catch (err) {
+      if (err instanceof GuardDeniedError) {
+        return execErr('E_PI_EXEC_DENIED', err.message);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return execErr('E_PI_EXEC_FAILED', message);
+    }
+  }
+
+  // --- cleanup (best-effort, must not throw) -------------------------------
+
+  /** Best-effort cleanup; the guarded surface owns no resources, so a no-op. */
+  async cleanup(): Promise<void> {
+    // no-op — required on both FileSystem + Shell; owns nothing to release.
+  }
+
+  // --- error mapping -------------------------------------------------------
+
+  /** Convert a thrown error from the guarded surface into a Pi `Result.err`. */
+  #toFsErr(err: unknown, path: string): PiResult<never, PiFileError> {
+    if (err instanceof GuardDeniedError) {
+      return fsErr('E_PI_FS_DENIED', err.message, path);
+    }
+    const code =
+      typeof err === 'object' && err !== null && 'code' in err
+        ? String((err as { code?: unknown }).code)
+        : 'E_PI_FS_FAILED';
+    const message = err instanceof Error ? err.message : String(err);
+    return fsErr(code, message, path);
+  }
+}
+
+/**
+ * Construct a deny-first {@link GuardedExecutionEnv}.
+ *
+ * @param deps - The guard surface + the workspace root to confine to.
+ * @returns A {@link PiExecutionEnv} safe to hand to Pi's agent loop.
+ *
+ * @example
+ * ```ts
+ * const env = createGuardedExecutionEnv({ guard, workspaceRoot: projectRoot });
+ * ```
+ */
+export function createGuardedExecutionEnv(deps: GuardedExecutionEnvDeps): PiExecutionEnv {
+  return new GuardedExecutionEnv(deps);
+}

--- a/packages/core/src/llm/pi/pi-execution-env.ts
+++ b/packages/core/src/llm/pi/pi-execution-env.ts
@@ -9,15 +9,22 @@
  * allowlisted roots and runs no command on the denylist.
  *
  * Two layers of confinement (deny-first):
- * 1. **Workspace boundary** — every fs path is resolved and MUST fall under the
- *    injected `workspaceRoot`; a `../` escape or an absolute path outside the
- *    root is rejected as a Pi `Result.err(FileError)` BEFORE the guard is even
- *    consulted. (The guard's own `allowedRoots` is a second, redundant net.)
+ * 1. **Workspace boundary** — every fs path is canonicalized with SYMLINK
+ *    RESOLUTION (`fs.realpath` on the nearest existing ancestor) and the REAL
+ *    target MUST fall under the injected `workspaceRoot`; a `../` escape, an
+ *    out-of-root absolute path, OR a symlink (file or parent dir) whose real
+ *    target leaves the root is rejected as a Pi `Result.err(FileError)` BEFORE
+ *    the guard is consulted. A purely lexical check is symlink-blind, so the
+ *    boundary resolves symlinks first. (The guard's own `allowedRoots` is a
+ *    second, ALSO-symlink-resolving net.)
  * 2. **ToolGuard** — the allowed operations delegate to the `ToolGuard` surface
  *    (`readFileText`/`writeFileAtomic`/`pathExists`/`executeShell`/`runGit`),
- *    which applies the project's path allowlist + shell denylist. A
- *    `GuardDeniedError` from enforce-mode is CAUGHT and converted to a Pi
- *    `Result.err` — Pi's `FileSystem`/`Shell` ops must NEVER throw.
+ *    which applies the project's symlink-resolved path allowlist + shell
+ *    denylist + subprocess-env scrub. A `GuardDeniedError` from enforce-mode is
+ *    CAUGHT and converted to a Pi `Result.err` — Pi's `FileSystem`/`Shell` ops
+ *    must NEVER throw. The guard MUST be constructed in `enforce` mode (the
+ *    factory asserts it) — in `warn` mode its allowlist/denylist are advisory
+ *    and confinement would collapse to the workspace boundary alone.
  *
  * Every other capability (binary reads, raw temp/dir mutation, listing, …) for
  * which there is no atomic primitive in v0 is DENIED with a typed error rather
@@ -35,7 +42,9 @@
  */
 
 import { isAbsolute, relative, resolve as resolvePath } from 'node:path';
-import { GuardDeniedError, type ToolGuard } from '../../tools/guard.js';
+import { scrubSubprocessEnv } from '../../tools/env-scrub.js';
+import { canonicalizePath } from '../../tools/fs.js';
+import { GuardDeniedError, type GuardMode, type ToolGuard } from '../../tools/guard.js';
 
 // ---------------------------------------------------------------------------
 // Structural Pi seam (local declarations — replaced by type-only pi imports in S2)
@@ -207,16 +216,41 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
   }
 
   /**
-   * Resolve a (possibly relative) path against the workspace root and assert it
-   * stays inside the boundary. Returns the absolute path, or `null` when the
-   * path escapes (`../` traversal or an out-of-root absolute path).
+   * Lexically resolve a (possibly relative) path against the workspace root and
+   * assert it does not climb out. This is the fast FIRST gate only — it is
+   * symlink-blind, so {@link #confine} additionally re-checks the REAL target.
+   *
+   * @returns the lexically-resolved absolute path, or `null` on a `../`/absolute
+   *   escape.
    */
-  #confine(path: string): string | null {
+  #lexicalConfine(path: string): string | null {
     const abs = isAbsolute(path) ? resolvePath(path) : resolvePath(this.#root, path);
     const rel = relative(this.#root, abs);
-    // Inside the root iff the relative path does not climb out (`..`) and is not
-    // itself an absolute path (different drive / root on the platform).
     if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return abs;
+    return null;
+  }
+
+  /**
+   * Resolve a (possibly relative) path against the workspace root and assert its
+   * REAL filesystem target stays inside the boundary. Two gates:
+   * 1. lexical (`#lexicalConfine`) — rejects `../` / out-of-root absolute paths;
+   * 2. SYMLINK resolution (`canonicalizePath`) — follows every symlink component
+   *    (incl. a symlinked parent of a fresh write target) and re-checks
+   *    containment against the REAL path, defeating the classic symlink/TOCTOU
+   *    escape that a purely lexical check is blind to.
+   *
+   * @returns the symlink-resolved absolute path, or `null` when it escapes.
+   */
+  async #confine(path: string): Promise<string | null> {
+    const lexical = this.#lexicalConfine(path);
+    if (lexical === null) return null;
+    const real = await canonicalizePath(lexical);
+    // Compare against the REAL root too, so a workspace whose own path traverses
+    // a symlink does not spuriously reject its own contained files.
+    const realRoot = await canonicalizePath(this.#root);
+    const rel = relative(realRoot, real);
+    // The REAL target must not climb out of the (also-real) root.
+    if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return real;
     return null;
   }
 
@@ -241,7 +275,7 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
 
   /** Read a file's text, confined to the workspace + guarded. */
   async readTextFile(path: string): Promise<PiResult<string, PiFileError>> {
-    const abs = this.#confine(path);
+    const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
     try {
       const res = await this.#guard.readFileText({ path: abs });
@@ -271,7 +305,7 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
 
   /** Atomically write a file, confined to the workspace + guarded. */
   async writeFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
-    const abs = this.#confine(path);
+    const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
     try {
       await this.#guard.writeFileAtomic({ path: abs, content });
@@ -287,7 +321,7 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
    * missing file is treated as empty.
    */
   async appendFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
-    const abs = this.#confine(path);
+    const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
     const existing = await this.readTextFile(abs);
     const prefix = existing.ok ? existing.value : '';
@@ -298,7 +332,7 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
 
   /** Report whether a path is a file or directory, confined + guarded. */
   async fileInfo(path: string): Promise<PiResult<PiFileInfo, PiFileError>> {
-    const abs = this.#confine(path);
+    const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
     try {
       const res = await this.#guard.pathExists({ path: abs });
@@ -311,7 +345,7 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
 
   /** Whether a path exists, confined + guarded. */
   async exists(path: string): Promise<PiResult<boolean, PiFileError>> {
-    const abs = this.#confine(path);
+    const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
     try {
       const res = await this.#guard.pathExists({ path: abs });
@@ -321,9 +355,14 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
     }
   }
 
-  /** Canonicalize a path inside the workspace (pure resolve, no symlink walk). */
+  /**
+   * Canonicalize a path inside the workspace. SYMLINK-RESOLVING: `#confine`
+   * follows every symlink component via `fs.realpath`, so the returned value is
+   * the REAL on-disk location (matching Pi's `NodeExecutionEnv.canonicalPath`
+   * contract), and a path whose real target escapes the workspace is denied.
+   */
   async canonicalPath(path: string): Promise<PiResult<string, PiFileError>> {
-    const abs = this.#confine(path);
+    const abs = await this.#confine(path);
     if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
     return ok(abs);
   }
@@ -361,22 +400,38 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
    * Execute a command through the guard's shell surface (denylist applies). The
    * Pi `command` string is a bare executable name (args are passed by Pi via the
    * loop, but the v0 seam takes only `command`); we forward it as the guard's
-   * `command` with empty args. `cwd` is confined to the workspace.
+   * `command` with empty args. `cwd` is symlink-confined to the workspace.
+   *
+   * ## Env is SCRUBBED before it leaves this seam (T11897 · security)
+   *
+   * Pi's `options.env` is UNTRUSTED model-driven input. Forwarding it verbatim
+   * would let Pi set `LD_PRELOAD`/`NODE_OPTIONS`/`GIT_SSH_COMMAND` (arbitrary
+   * native code execution outside any allowlist) or hijack `PATH` to make a
+   * workspace-resident impostor satisfy an allowed command basename. So the env
+   * is run through {@link scrubSubprocessEnv} HERE — forbidden keys (loader
+   * hooks, `PATH`, secrets) are dropped and `PATH` is pinned to a trusted value
+   * — before it reaches the guard (which scrubs again as a redundant net, as
+   * does `defaultShellExecutor`). This also prevents the daemon's own secrets
+   * from leaking into the child (the scrubbed env never inherits `process.env`).
    */
   async exec(
     command: string,
     options?: PiExecOptions,
   ): Promise<PiResult<PiExecResult, PiExecutionError>> {
-    const cwd = options?.cwd ? this.#confine(options.cwd) : this.#root;
+    const cwd = options?.cwd ? await this.#confine(options.cwd) : this.#root;
     if (cwd === null) {
       return execErr('E_PI_EXEC_DENIED', 'cwd escapes workspace boundary');
     }
+    // Scrub Pi-supplied env to a minimal allowlist at the seam (defense in depth
+    // — the guard + executor scrub again). Pi can NOT inject a loader hook,
+    // hijack PATH, or read inherited daemon secrets through this channel.
+    const env = scrubSubprocessEnv({ extra: options?.env });
     try {
       const res = await this.#guard.executeShell({
         command,
         cwd,
+        env,
         ...(options?.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
-        ...(options?.env !== undefined ? { env: options.env } : {}),
       });
       return ok({ stdout: res.stdout, stderr: res.stderr, exitCode: res.code });
     } catch (err) {
@@ -412,16 +467,50 @@ export class GuardedExecutionEnv implements PiExecutionEnv {
 }
 
 /**
+ * Thrown by {@link createGuardedExecutionEnv} when the injected guard is NOT in
+ * `enforce` mode. In `warn` mode the guard's path allowlist + command denylist
+ * are advisory (log-and-proceed), so the second confinement net does not exist
+ * and the boundary would collapse to the workspace check alone. The Pi adapter
+ * therefore REFUSES a non-enforce guard rather than running untrusted Pi work
+ * behind an advisory boundary.
+ */
+export class PiGuardModeError extends Error {
+  /** Machine-readable code. */
+  readonly code = 'E_PI_GUARD_NOT_ENFORCING';
+  /**
+   * @param mode - The (non-enforce) mode the guard was constructed with.
+   */
+  constructor(mode: GuardMode) {
+    super(
+      `Pi ExecutionEnv requires an enforce-mode ToolGuard; got "${mode}". ` +
+        'In warn mode the path allowlist + command denylist are advisory and provide no boundary.',
+    );
+    this.name = 'PiGuardModeError';
+  }
+}
+
+/**
  * Construct a deny-first {@link GuardedExecutionEnv}.
+ *
+ * REQUIRES an `enforce`-mode guard: a `warn`-mode guard's allowlist/denylist are
+ * advisory, so handing untrusted Pi work behind one would leave confinement to
+ * the workspace boundary alone. The factory ASSERTS the mode and throws
+ * {@link PiGuardModeError} otherwise — the Pi adapter never silently degrades to
+ * an advisory boundary.
  *
  * @param deps - The guard surface + the workspace root to confine to.
  * @returns A {@link PiExecutionEnv} safe to hand to Pi's agent loop.
+ * @throws {PiGuardModeError} When `deps.guard.mode !== 'enforce'`.
  *
  * @example
  * ```ts
+ * const guard = createToolGuard({ allowedRoots: [projectRoot], mode: 'enforce' });
  * const env = createGuardedExecutionEnv({ guard, workspaceRoot: projectRoot });
  * ```
  */
 export function createGuardedExecutionEnv(deps: GuardedExecutionEnvDeps): PiExecutionEnv {
+  if (deps.guard.mode !== 'enforce') {
+    throw new PiGuardModeError(deps.guard.mode);
+  }
   return new GuardedExecutionEnv(deps);
 }

--- a/packages/core/src/tools/__tests__/env-scrub.test.ts
+++ b/packages/core/src/tools/__tests__/env-scrub.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for subprocess env scrubbing (T11897 · security).
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ * @saga T11387
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isForbiddenEnvName, scrubSubprocessEnv, TRUSTED_PATH } from '../env-scrub.js';
+
+describe('isForbiddenEnvName', () => {
+  it('rejects loader hooks (case-insensitive prefix)', () => {
+    for (const name of ['LD_PRELOAD', 'LD_LIBRARY_PATH', 'ld_preload', 'DYLD_INSERT_LIBRARIES']) {
+      expect(isForbiddenEnvName(name)).toBe(true);
+    }
+  });
+
+  it('rejects runtime hooks and PATH/IFS', () => {
+    for (const name of ['NODE_OPTIONS', 'GIT_SSH_COMMAND', 'BASH_ENV', 'PATH', 'IFS', 'CDPATH']) {
+      expect(isForbiddenEnvName(name)).toBe(true);
+    }
+  });
+
+  it('rejects credential-bearing names', () => {
+    for (const name of [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'CLEO_VAULT_SECRET',
+      'GITHUB_TOKEN',
+      'AWS_SECRET_ACCESS_KEY',
+      'DB_PASSWORD',
+      'OAUTH_CREDENTIAL',
+    ]) {
+      expect(isForbiddenEnvName(name)).toBe(true);
+    }
+  });
+
+  it('allows benign names', () => {
+    for (const name of ['LANG', 'TERM', 'HOME', 'CLEO_TEST', 'MY_FLAG']) {
+      expect(isForbiddenEnvName(name)).toBe(false);
+    }
+  });
+});
+
+describe('scrubSubprocessEnv', () => {
+  it('starts empty + pins PATH to the trusted value (never the parent PATH)', () => {
+    const env = scrubSubprocessEnv({ parentEnv: { PATH: '/evil/workspace:/bin' } });
+    expect(env.PATH).toBe(TRUSTED_PATH);
+    expect(env.PATH).not.toContain('/evil/workspace');
+  });
+
+  it('does NOT inherit the parent secrets / loader hooks', () => {
+    const env = scrubSubprocessEnv({
+      parentEnv: {
+        ANTHROPIC_API_KEY: 'sk-ant-secret',
+        CLEO_VAULT_SECRET: 'vault',
+        LD_PRELOAD: '/tmp/evil.so',
+        NODE_OPTIONS: '--require x',
+      },
+    });
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLEO_VAULT_SECRET).toBeUndefined();
+    expect(env.LD_PRELOAD).toBeUndefined();
+    expect(env.NODE_OPTIONS).toBeUndefined();
+  });
+
+  it('copies through benign parent vars (locale, term, home)', () => {
+    const env = scrubSubprocessEnv({
+      parentEnv: { LANG: 'en_US.UTF-8', TERM: 'xterm', HOME: '/home/u', SECRET_TOKEN: 'x' },
+    });
+    expect(env.LANG).toBe('en_US.UTF-8');
+    expect(env.TERM).toBe('xterm');
+    expect(env.HOME).toBe('/home/u');
+    expect(env.SECRET_TOKEN).toBeUndefined();
+  });
+
+  it('drops a forbidden key supplied via extra (untrusted caller cannot reintroduce an escape)', () => {
+    const env = scrubSubprocessEnv({
+      parentEnv: {},
+      extra: {
+        LD_PRELOAD: '/tmp/evil.so',
+        PATH: '/evil/workspace',
+        ANTHROPIC_API_KEY: 'leak',
+        SAFE: 'kept',
+      },
+    });
+    expect(env.LD_PRELOAD).toBeUndefined();
+    expect(env.PATH).toBe(TRUSTED_PATH); // not overridable via extra
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.SAFE).toBe('kept');
+  });
+
+  it('honours an explicit trusted path override', () => {
+    const env = scrubSubprocessEnv({ parentEnv: {}, path: '/opt/trusted/bin' });
+    expect(env.PATH).toBe('/opt/trusted/bin');
+  });
+});

--- a/packages/core/src/tools/__tests__/fs.test.ts
+++ b/packages/core/src/tools/__tests__/fs.test.ts
@@ -6,11 +6,11 @@
  * @saga T11387
  */
 
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { pathExists, readFileText, readJson, writeFileAtomic } from '../fs.js';
+import { canonicalizePath, pathExists, readFileText, readJson, writeFileAtomic } from '../fs.js';
 
 let dir: string;
 
@@ -63,6 +63,40 @@ describe('readJson', () => {
     const path = join(dir, 'bad.json');
     await writeFileAtomic({ path, content: '{ not json' });
     await expect(readJson(path)).rejects.toThrow();
+  });
+});
+
+describe('canonicalizePath (symlink-resolving)', () => {
+  it('resolves a file symlink to its REAL target', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'cleo-fs-outside-'));
+    try {
+      const realTarget = join(outside, 'secret.txt');
+      await writeFileAtomic({ path: realTarget, content: 's' });
+      const link = join(dir, 'link.txt');
+      symlinkSync(realTarget, link);
+      // realpathSync(outside) normalizes /var → /private/var on macOS etc.
+      expect(await canonicalizePath(link)).toBe(realpathSync(realTarget));
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a symlinked PARENT for a not-yet-existing child', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'cleo-fs-outside-'));
+    try {
+      const linkedDir = join(dir, 'sub');
+      symlinkSync(outside, linkedDir);
+      // sub/new.txt does not exist yet; canonicalize must reveal it lands OUTSIDE.
+      const resolved = await canonicalizePath(join(linkedDir, 'new.txt'));
+      expect(resolved).toBe(join(realpathSync(outside), 'new.txt'));
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the real path of a plain existing dir unchanged (no symlink)', async () => {
+    mkdirSync(join(dir, 'plain'));
+    expect(await canonicalizePath(join(dir, 'plain'))).toBe(realpathSync(join(dir, 'plain')));
   });
 });
 

--- a/packages/core/src/tools/env-scrub.ts
+++ b/packages/core/src/tools/env-scrub.ts
@@ -1,0 +1,204 @@
+/**
+ * Subprocess environment scrubbing (T11897 · S1 · security hardening).
+ *
+ * Building the environment a child process inherits is a SECURITY boundary, not
+ * a convenience. Two distinct threats are closed here:
+ *
+ * 1. **Sandbox escape via Pi-controlled env** — a model-driven loop that can
+ *    set `LD_PRELOAD`, `NODE_OPTIONS`, `GIT_SSH_COMMAND`, `DYLD_*`, or a custom
+ *    `PATH` gains arbitrary native code execution outside any command allowlist
+ *    (the OS loader / Node honour them) and can satisfy a basename denylist with
+ *    a workspace-resident impostor on a hijacked `PATH`. The scrubber NEVER
+ *    forwards any of these dangerous variables and PINS `PATH` to a trusted
+ *    absolute value.
+ * 2. **Daemon-secret exfiltration** — the daemon's own `process.env` carries
+ *    resolved provider credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …),
+ *    OAuth headers, and vault material (`CLEO_VAULT_*`). Inheriting the full
+ *    parent env into a Pi-spawned child means a single `env`/`printenv`/log line
+ *    exfiltrates them. The scrubber builds a MINIMAL, explicitly-constructed env
+ *    instead of inheriting `process.env`.
+ *
+ * The doctrine is **allowlist, not denylist**: the scrubbed env starts EMPTY and
+ * only a small set of benign, named variables are copied through from the parent
+ * (locale, terminal, home/user, tmp). Everything else — including every secret,
+ * every loader hook, and `PATH` itself — is reconstructed from trusted inputs.
+ *
+ * Pure function of input — no global/session coupling, import-time side-effect
+ * free (S1).
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11897
+ * @saga T11387
+ */
+
+import { delimiter } from 'node:path';
+
+/**
+ * The trusted, absolute `PATH` a scrubbed subprocess runs under. A fixed list of
+ * standard system binary directories — NEVER the caller's (possibly Pi-poisoned)
+ * `PATH`. Pinning this defeats the "workspace-resident impostor on a hijacked
+ * PATH satisfies an allowed basename" escape: the workspace is not on it.
+ */
+export const TRUSTED_PATH = [
+  '/usr/local/sbin',
+  '/usr/local/bin',
+  '/usr/sbin',
+  '/usr/bin',
+  '/sbin',
+  '/bin',
+].join(delimiter);
+
+/**
+ * Benign environment variables copied through from the parent when present.
+ * These carry NO secrets and NO code-execution surface — locale, terminal type,
+ * timezone, home/user identity, and the tmp dir. `PATH` is deliberately ABSENT
+ * (it is pinned to {@link TRUSTED_PATH}); every `*_API_KEY`, `*_TOKEN`,
+ * `LD_*`, `DYLD_*`, `NODE_OPTIONS`, and `GIT_SSH_COMMAND` is deliberately ABSENT.
+ */
+const PASSTHROUGH_KEYS: readonly string[] = [
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+  'TERM',
+  'TMPDIR',
+  'SHELL',
+] as const;
+
+/** Options for {@link scrubSubprocessEnv}. */
+export interface ScrubEnvOptions {
+  /**
+   * The parent environment to copy the benign {@link PASSTHROUGH_KEYS} from.
+   * Defaults to `process.env`. Injectable for tests so a clean env can be
+   * asserted without mutating the real process environment.
+   */
+  readonly parentEnv?: Readonly<Record<string, string | undefined>>;
+  /**
+   * Extra variables to set on the scrubbed env (e.g. a caller-supplied `env`
+   * merged ON TOP of the minimal base). These are themselves SCRUBBED — any
+   * dangerous key (loader hooks, `PATH`, secrets) is dropped, so an untrusted
+   * caller (Pi) cannot reintroduce an escape through this channel.
+   */
+  readonly extra?: Readonly<Record<string, string | undefined>>;
+  /**
+   * The trusted `PATH` to pin. Defaults to {@link TRUSTED_PATH}. Callers MUST
+   * pass an absolute, trusted value — never the inbound/Pi-controlled `PATH`.
+   */
+  readonly path?: string;
+}
+
+/**
+ * Variable-name prefixes that are NEVER forwarded into a scrubbed subprocess.
+ * These either grant arbitrary code execution to the child (loader/runtime
+ * hooks) or carry credentials. Matched case-INsensitively as a prefix so e.g.
+ * `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `ANTHROPIC_API_KEY`,
+ * `OPENAI_API_KEY`, `CLEO_VAULT_SECRET`, and `AWS_SECRET_ACCESS_KEY` are all
+ * caught. Used to filter the caller-supplied `extra` map.
+ */
+const FORBIDDEN_PREFIXES: readonly string[] = [
+  'LD_',
+  'DYLD_',
+  'NODE_OPTIONS',
+  'NODE_REPL_EXTERNAL_MODULE',
+  'GIT_SSH',
+  'GIT_PROXY',
+  'BASH_ENV',
+  'ENV',
+  'CDPATH',
+] as const;
+
+/**
+ * Exact variable names that are NEVER forwarded (in addition to
+ * {@link FORBIDDEN_PREFIXES}). `PATH` is pinned separately, so a caller cannot
+ * override it via `extra`.
+ */
+const FORBIDDEN_EXACT: ReadonlySet<string> = new Set(['PATH', 'IFS']);
+
+/**
+ * Substrings whose presence in a variable NAME marks it as a credential that is
+ * NEVER forwarded. Matched case-INsensitively. Catches `*_API_KEY`, `*_TOKEN`,
+ * `*_SECRET`, `*PASSWORD*`, OAuth material, and the vault namespace.
+ */
+const SECRET_NAME_SUBSTRINGS: readonly string[] = [
+  'API_KEY',
+  'APIKEY',
+  'SECRET',
+  'TOKEN',
+  'PASSWORD',
+  'PASSWD',
+  'CREDENTIAL',
+  'PRIVATE_KEY',
+  'ACCESS_KEY',
+  'AUTH',
+  'VAULT',
+  'SESSION_KEY',
+] as const;
+
+/**
+ * Whether a variable NAME is forbidden in a scrubbed subprocess env (a loader
+ * hook, `PATH`, or a credential).
+ *
+ * @param name - The environment variable name.
+ * @returns `true` when the variable must NOT be forwarded.
+ */
+export function isForbiddenEnvName(name: string): boolean {
+  const upper = name.toUpperCase();
+  if (FORBIDDEN_EXACT.has(upper)) return true;
+  if (FORBIDDEN_PREFIXES.some((p) => upper.startsWith(p))) return true;
+  if (SECRET_NAME_SUBSTRINGS.some((s) => upper.includes(s))) return true;
+  return false;
+}
+
+/**
+ * Build a MINIMAL, explicitly-constructed subprocess environment.
+ *
+ * The result starts EMPTY; only the benign {@link PASSTHROUGH_KEYS} present in
+ * `parentEnv` are copied, `PATH` is pinned to a trusted absolute value, and any
+ * caller-supplied `extra` is merged ON TOP after being filtered through
+ * {@link isForbiddenEnvName}. The daemon's secrets and any loader hooks in the
+ * parent environment are therefore NEVER visible to the child, and an untrusted
+ * caller cannot reintroduce an escape via `extra`.
+ *
+ * @param options - {@link ScrubEnvOptions}.
+ * @returns A fresh `Record<string, string>` safe to hand to `spawn(..., { env })`.
+ *
+ * @example
+ * ```ts
+ * // A Pi-supplied env that tries to inject a loader hook + hijack PATH:
+ * const env = scrubSubprocessEnv({
+ *   extra: { LD_PRELOAD: '/tmp/evil.so', PATH: '/workspace', SAFE: '1' },
+ * });
+ * // env has no LD_PRELOAD, PATH is the pinned TRUSTED_PATH, only SAFE survives.
+ * ```
+ */
+export function scrubSubprocessEnv(options: ScrubEnvOptions = {}): Record<string, string> {
+  const parentEnv = options.parentEnv ?? process.env;
+  const scrubbed: Record<string, string> = {};
+
+  for (const key of PASSTHROUGH_KEYS) {
+    const value = parentEnv[key];
+    if (typeof value === 'string' && value.length > 0 && !isForbiddenEnvName(key)) {
+      scrubbed[key] = value;
+    }
+  }
+
+  // Pin PATH to a trusted absolute value — never the inbound/parent PATH.
+  scrubbed.PATH = options.path ?? TRUSTED_PATH;
+
+  // Merge caller-supplied extras ON TOP, but drop any dangerous key so an
+  // untrusted caller (Pi) cannot reintroduce a loader hook, secret, or PATH
+  // override through this channel.
+  if (options.extra) {
+    for (const [key, value] of Object.entries(options.extra)) {
+      if (typeof value !== 'string') continue;
+      if (isForbiddenEnvName(key)) continue;
+      scrubbed[key] = value;
+    }
+  }
+
+  return scrubbed;
+}

--- a/packages/core/src/tools/fs.ts
+++ b/packages/core/src/tools/fs.ts
@@ -19,8 +19,8 @@
  * @saga T11387
  */
 
-import { mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir, readFile, realpath, rename, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
 import type {
   PathExistsInput,
   PathExistsResult,
@@ -29,6 +29,59 @@ import type {
   WriteFileInput,
   WriteFileResult,
 } from '@cleocode/contracts/tools/atomic';
+
+/**
+ * Symlink-resolving canonicalization of a (possibly not-yet-existing) path.
+ *
+ * A purely LEXICAL path check (`resolve` + `relative`) is symlink-BLIND: a
+ * symlink planted inside an allowed root can point anywhere on the host, so the
+ * lexical path stays "inside" while the real target is outside. This is the
+ * classic symlink/TOCTOU escape. {@link canonicalizePath} resolves the REAL
+ * filesystem location so a containment check can be made against it:
+ *
+ * - If the path EXISTS, its own realpath is returned (every symlink component,
+ *   including the final one, is followed to its real target).
+ * - If the path does NOT exist (a fresh write target), the nearest existing
+ *   ANCESTOR directory is realpath'd and the not-yet-existing tail segments are
+ *   re-appended. This prevents a symlinked PARENT directory from redirecting a
+ *   write outside the boundary while still allowing legitimate new files.
+ *
+ * The returned path is always absolute. Containment MUST be re-checked against
+ * THIS value, not the lexical one.
+ *
+ * @param path - The path to canonicalize (absolute or relative to `process.cwd()`).
+ * @returns The symlink-resolved absolute path.
+ *
+ * @example
+ * ```ts
+ * // root/innocent.txt -> /tmp/secret  ⇒  canonicalizePath('root/innocent.txt')
+ * // returns '/tmp/secret', revealing the escape to the containment check.
+ * const real = await canonicalizePath(join(root, 'innocent.txt'));
+ * ```
+ */
+export async function canonicalizePath(path: string): Promise<string> {
+  const abs = isAbsolute(path) ? resolvePath(path) : resolvePath(path);
+  // Walk up to the nearest existing ancestor, realpath THAT, then re-attach the
+  // non-existing tail. This catches a symlinked parent directory AND a symlinked
+  // final component (when it exists, realpath(abs) follows it directly).
+  const tail: string[] = [];
+  let cursor = abs;
+  for (;;) {
+    try {
+      const real = await realpath(cursor);
+      return tail.length === 0 ? real : join(real, ...tail);
+    } catch {
+      const parent = dirname(cursor);
+      if (parent === cursor) {
+        // Reached the filesystem root with nothing existing — return the lexical
+        // resolution (no symlink could have been involved on a missing chain).
+        return abs;
+      }
+      tail.unshift(basename(cursor));
+      cursor = parent;
+    }
+  }
+}
 
 /**
  * Read a file as text.

--- a/packages/core/src/tools/guard.ts
+++ b/packages/core/src/tools/guard.ts
@@ -51,7 +51,8 @@ import type {
   WriteFileResult,
 } from '@cleocode/contracts/tools/atomic';
 import { getLogger } from '../logger.js';
-import { pathExists, readFileText, readJson, writeFileAtomic } from './fs.js';
+import { scrubSubprocessEnv } from './env-scrub.js';
+import { canonicalizePath, pathExists, readFileText, readJson, writeFileAtomic } from './fs.js';
 import { executeShell, runGit, type ShellExecutor } from './shell.js';
 
 const log = getLogger('tool-guard');
@@ -147,6 +148,13 @@ export class GuardDeniedError extends Error {
 
 /** The guarded primitive surface returned by {@link createToolGuard}. */
 export interface ToolGuard {
+  /**
+   * The resolved enforcement posture this guard was constructed with. Exposed so
+   * a security-sensitive consumer (e.g. the Pi adapter) can ASSERT it received an
+   * `enforce`-mode guard before handing it untrusted work — in `warn` mode the
+   * allowlist/denylist are advisory (log-and-proceed) and provide no boundary.
+   */
+  readonly mode: GuardMode;
   readFileText(input: ReadFileInput): Promise<ReadFileResult>;
   readJson<T>(path: string): Promise<T>;
   writeFileAtomic(input: WriteFileInput): Promise<WriteFileResult>;
@@ -155,13 +163,32 @@ export interface ToolGuard {
   runGit(input: RunGitInput, executor?: ShellExecutor): Promise<ExecuteShellResult>;
 }
 
-/** True when `path` resolves under one of `roots`. */
-function isPathAllowed(path: string, roots: readonly string[]): boolean {
-  const abs = isAbsolute(path) ? path : resolvePath(path);
+/** True when the resolved absolute `abs` is equal to or under one of `roots`. */
+function isUnderRoots(abs: string, roots: readonly string[]): boolean {
   return roots.some((root) => {
     const r = resolvePath(root);
     return abs === r || abs.startsWith(`${r}/`);
   });
+}
+
+/**
+ * Whether `path` is allowed under `roots` after SYMLINK RESOLUTION.
+ *
+ * Both the candidate path AND each allowed root are canonicalized via
+ * {@link canonicalizePath} (which follows every symlink component, including a
+ * symlinked parent of a not-yet-existing write target) BEFORE the containment
+ * comparison. A purely lexical check is symlink-blind — a symlink planted inside
+ * an allowed root that points outside it would pass, then the underlying fs
+ * primitive would follow it. Resolving first closes that escape.
+ *
+ * @param path - The candidate path.
+ * @param roots - The allowed roots.
+ * @returns `true` when the real target is contained.
+ */
+async function isPathAllowed(path: string, roots: readonly string[]): Promise<boolean> {
+  const realAbs = await canonicalizePath(isAbsolute(path) ? path : resolvePath(path));
+  const realRoots = await Promise.all(roots.map((r) => canonicalizePath(resolvePath(r))));
+  return isUnderRoots(realAbs, realRoots);
 }
 
 /** The denied command name matched by the policy, or null when allowed. */
@@ -187,10 +214,12 @@ export function createToolGuard(policy: ToolGuardPolicy = {}): ToolGuard {
   // (held at 'warn' behind the owner-gated flip — T11474 · AC4).
   const mode: GuardMode = policy.mode ?? resolveDefaultGuardMode();
 
-  const denyFs = (op: string, path: string): boolean => {
+  const denyFs = async (op: string, path: string): Promise<boolean> => {
     if (!policy.allowedRoots || policy.allowedRoots.length === 0) return false;
-    if (isPathAllowed(path, policy.allowedRoots)) return false;
-    const msg = `tool-guard: fs.${op} path "${path}" is outside the allowed roots`;
+    // Symlink-resolving containment — a lexically-inside path whose REAL target
+    // (via a symlinked component) escapes the roots is rejected here.
+    if (await isPathAllowed(path, policy.allowedRoots)) return false;
+    const msg = `tool-guard: fs.${op} path "${path}" resolves outside the allowed roots`;
     if (mode === 'enforce') throw new GuardDeniedError(msg);
     log.warn({ op, path, allowedRoots: policy.allowedRoots }, msg);
     return false; // warn-then-proceed
@@ -211,25 +240,32 @@ export function createToolGuard(policy: ToolGuardPolicy = {}): ToolGuard {
   // surfaces as a REJECTED promise (not a synchronous throw) — the API contract
   // is `Promise<…>`, and callers (+ vitest `.rejects`) expect rejection.
   return {
+    mode,
     async readFileText(input) {
-      denyFs('readFileText', input.path);
+      await denyFs('readFileText', input.path);
       return readFileText(input);
     },
     async readJson<T>(path: string) {
-      denyFs('readJson', path);
+      await denyFs('readJson', path);
       return readJson<T>(path);
     },
     async writeFileAtomic(input) {
-      denyFs('writeFileAtomic', input.path);
+      await denyFs('writeFileAtomic', input.path);
       return writeFileAtomic(input);
     },
     async pathExists(input) {
-      denyFs('pathExists', input.path);
+      await denyFs('pathExists', input.path);
       return pathExists(input);
     },
     async executeShell(input, executor) {
       denyShell('executeShell', input.command);
-      return executeShell(input, executor);
+      // Scrub the child env at the chokepoint: never inherit the daemon's
+      // secrets, never forward a Pi-controlled loader hook / PATH. The
+      // caller-supplied `env` is merged ON TOP but itself scrubbed (a forbidden
+      // key — loader hook, PATH, secret — is dropped here). `defaultShellExecutor`
+      // also scrubs as a redundant net, but the guard is the policy point.
+      const env = scrubSubprocessEnv({ extra: input.env });
+      return executeShell({ ...input, env }, executor);
     },
     async runGit(input, executor) {
       denyShell('runGit', 'git');

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -82,6 +82,15 @@ export { scaffoldProject } from '../scaffold/scaffold-project.js';
 export * from '../sdk/index.js';
 // TaskTools (Category B) — pure-functional task graph SDK tools (T10068 / T9835)
 export * from '../task-tools/index.js';
+// Subprocess env scrubbing (T11897 · security) — the chokepoint builds a minimal,
+// allowlisted child env so daemon secrets never leak and a Pi-controlled loader
+// hook / PATH can never reach a spawned process.
+export {
+  isForbiddenEnvName,
+  type ScrubEnvOptions,
+  scrubSubprocessEnv,
+  TRUSTED_PATH,
+} from './env-scrub.js';
 // Atomic-tool guard chokepoint (E3 · T11407 · T11474) — the ONLY public route to
 // the fs/shell primitives. Raw primitives are intentionally not re-exported.
 export {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -25,6 +25,7 @@ import type {
   ExecuteShellResult,
   RunGitInput,
 } from '@cleocode/contracts/tools/atomic';
+import { scrubSubprocessEnv } from './env-scrub.js';
 
 /**
  * The process layer behind {@link executeShell}. Injecting a custom executor in
@@ -38,12 +39,24 @@ export type ShellExecutor = (input: ExecuteShellInput) => Promise<ExecuteShellRe
  * stderr and resolving `{ stdout, stderr, code }`. A `timeoutMs` kills the
  * process (code resolves to `null` on signal/timeout). Never rejects on a
  * non-zero exit — the exit code is the result, not an error.
+ *
+ * ## Environment is SCRUBBED, never inherited (T11897 · security)
+ *
+ * The child runs under a MINIMAL, explicitly-constructed environment built by
+ * {@link scrubSubprocessEnv} — it does NOT inherit the parent `process.env`.
+ * This is load-bearing: the parent (the Cleo daemon) holds resolved provider
+ * credentials (`ANTHROPIC_API_KEY`, vault material, OAuth headers); blindly
+ * forwarding the full env into a child spawned on behalf of an in-process Pi
+ * loop would let a single `env`/`printenv` exfiltrate them, and would forward a
+ * Pi-poisoned `LD_PRELOAD`/`PATH`/`NODE_OPTIONS` into the loader. The
+ * caller-supplied `input.env` is merged on top but itself scrubbed (forbidden
+ * keys dropped, `PATH` pinned). Benign vars (locale/term/home) pass through.
  */
 export const defaultShellExecutor: ShellExecutor = (input) =>
   new Promise<ExecuteShellResult>((resolve, reject) => {
     const child = spawn(input.command, [...(input.args ?? [])], {
       cwd: input.cwd,
-      env: input.env ? { ...process.env, ...input.env } : process.env,
+      env: scrubSubprocessEnv({ extra: input.env }),
       timeout: input.timeoutMs,
       shell: false,
     });


### PR DESCRIPTION
## Keystone context — PiAgentAdapter S1 of 3 (T11761)

Slice **S1** of the `PiAgentAdapter` build (ratified spec `t11761-pi-agent-adapter-spec`, epic **T10403**). The adapter embeds Pi's agent loop **in-process inside the Cleo daemon with ZERO authority**. S1 lays the **guard surface** every later slice plugs into: a deny-first `ExecutionEnv` Pi can hand all fs+shell work to, plus exit/error containment so a Pi code path cannot terminate the daemon. **No Pi loop, no LLM, no DB** — those land in S2/S3.

### S1 scope discipline (held)
- **ZERO `pi-ai` / `pi-agent-core` imports** — the structural Pi seam (`PiExecutionEnv`, `PiResult`, `PiFileError`, …) is declared **locally** in `pi-execution-env.ts`, matching `@earendil-works/pi-agent-core@0.78.1` `harness/types.ts:268-332`. S2 swaps these for the real type-only imports. (`pi-import-purity.test.ts` enforces it; the only string matches are in TSDoc.)
- **ZERO DB access, ZERO LLM calls.**
- **Import-time side-effect-free** — logger resolved lazily inside `wrapPiCall`'s `finally`, never at module top level.

## What ships

| File | Role |
|------|------|
| `llm/pi/pi-execution-env.ts` | `GuardedExecutionEnv` — deny-first `PiExecutionEnv`. Two confinement layers: workspace boundary (symlink-resolved) + `ToolGuard`. `createGuardedExecutionEnv` **refuses a non-`enforce` guard**. |
| `llm/pi/pi-errors.ts` | `PiContainmentError` + `wrapPiCall` (ref-counted process-global `process.exit` trap, `process.exitCode` snapshot/restore, abort routing) + `installDaemonExitGuard` (daemon-lifetime pin). |
| `tools/env-scrub.ts` | `scrubSubprocessEnv` — allowlist-not-denylist minimal child env; pins `PATH`, drops loader hooks + secrets. |
| `tools/fs.ts` | `canonicalizePath` — symlink-resolving canonicalization (realpath nearest existing ancestor + re-attach tail) for not-yet-existing write targets. |
| `tools/guard.ts` | `ToolGuard.mode` exposed; `isPathAllowed` now symlink-resolves both path and roots; `executeShell` scrubs child env at the chokepoint. |
| `tools/shell.ts` | `defaultShellExecutor` no longer inherits `process.env` — runs under scrubbed env. |

## Acceptance-criterion mapping

- **Deny-first `ExecutionEnv` routed through the guard chokepoint** → `GuardedExecutionEnv` delegates allowed ops to `ToolGuard.{readFileText,writeFileAtomic,pathExists,executeShell}`; every capability without a v0 atomic primitive (binary read, `listDir`, `createDir`, `remove`, temp dir/file) is **DENIED with a typed `Result.err`** and never reaches the fs.
- **Pi contract honoured** → every method returns a `PiResult` and **never throws**; a `GuardDeniedError` is caught and converted.
- **Exit-trap containment** → `wrapPiCall` converts a Pi `process.exit()` / `process.exitCode` mutation into a thrown `PiContainmentError`; `installDaemonExitGuard` pins it daemon-wide.
- **enforce-mode required** → `createGuardedExecutionEnv` throws `PiGuardModeError` for a `warn`-mode guard (advisory allowlist = no boundary).

## Attack-surface coverage (5 escapes closed)

1. **Symlink / TOCTOU escape** — a lexical path check is symlink-blind. `#confine` + `canonicalizePath` follow every symlink component (incl. a symlinked **parent** of a fresh write target) and re-check containment against the **real** target; the guard's `isPathAllowed` resolves both path and roots too.
2. **`PATH` hijack** — pinned to a fixed `TRUSTED_PATH`; the workspace is never on it, so a workspace-resident impostor can't satisfy an allowed basename.
3. **Loader-hook injection** — `LD_*`/`DYLD_*`/`NODE_OPTIONS`/`GIT_SSH_COMMAND`/`BASH_ENV`/… dropped from any caller-supplied `env`.
4. **Daemon-secret exfiltration** — child env is **built empty** (allowlist of benign vars), never inherits `process.env`; every `*_API_KEY`/`*_TOKEN`/`*_SECRET`/`VAULT*`/`AUTH*` is filtered.
5. **Async / detached exit leak** — the `process.exit` trap is **ref-counted + process-global** so a deferred/detached exit firing while any Pi call is active is still neutralized; `installDaemonExitGuard` closes the post-settle window for the daemon lifetime.

## Zero-`pi-ai`-import proof

```
$ grep -rE "from '@earendil-works|from '@mariozechner|from 'pi-ai" \
    packages/core/src/llm/pi/ packages/core/src/tools/
(no matches)
```
`pi-import-purity.test.ts` asserts this in CI.

## Gates

- `pnpm biome check` — clean (3542 files, no fixes)
- `pnpm run build` — success
- cgroup-wrapped core tests for the new/affected files — **74 passed (7 files)**: `pi-errors`, `pi-execution-env`, `pi-import-purity`, `pi-security-hardening`, `env-scrub`, `fs`, `guard`
- `cleo check arch` — 5/5 pass; Gates 10/11/13 pass (Gate 13 **−12 vs baseline**, no net-new)
- Pre-existing suite failures (16, in 6 worktree-`napi` files) reproduce **identically on `origin/main`** — caused by the unbuilt `@cleocode/worktree-napi` native binary in this environment; **this branch touches zero worktree files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
