### PR TITLE
feat(T10409): vault storage foundation — global-salt KDF (T11710) + accounts table (T11709)

### DIFF
--- a/packages/core/migrations/drizzle-cleo-global/20260608010000_t11709-accounts-credential-pool/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260608010000_t11709-accounts-credential-pool/migration.sql
@@ -1,0 +1,72 @@
+-- T11709 (EP-PROVIDER-VAULT · epic T10410 · saga SG-VAULT-CORE T10409) — the
+-- pooled-LLM-credential `accounts` table in the consolidated GLOBAL cleo.db
+-- (drizzle-cleo-global scope ONLY — this is a cross-project, machine-wide
+-- credential pool with no project-tier analog, so it is NOT mirrored into
+-- drizzle-cleo-project).
+--
+-- One row per LLM credential ("account") for one provider: the encrypted
+-- secret/refresh material plus rotation / cooldown / health metadata the pool
+-- runner consults to select the next live account and retire dead ones. Replaces
+-- the legacy plaintext JSON blob with a queryable, `cleo health`-visible table.
+--
+-- `secret_enc` / `refresh_enc` are encryptGlobal() ciphertext (T11710), NEVER
+-- plaintext. This is DISTINCT from `agent_registry_accounts` (the better-auth
+-- OAuth-account table) — different physical name, different purpose.
+--
+-- ## Active-account pointer (raw partial unique index)
+--
+-- `is_active` is the per-provider "currently-selected" pointer: AT MOST ONE row
+-- per `provider` may carry `is_active = 1`. drizzle-orm cannot model a partial
+-- `WHERE` unique index, so it is emitted here as raw SQL (the established repo
+-- pattern — cf. `_writer_leases.active`, T11627 · `project_agent_refs.enabled`).
+-- The drizzle schema (accounts.ts) declares only the full-column table plus the
+-- non-partial `(provider, label)` unique index that drizzle CAN emit.
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-global) which already creates dozens of tables, so `accounts` is NEVER the
+-- first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables. No journal pre-create is required.
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op. Each
+-- statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11709
+-- @epic T10410
+-- @saga T10409
+
+CREATE TABLE IF NOT EXISTS `accounts` (
+  `id` integer PRIMARY KEY NOT NULL,
+  `provider` text NOT NULL,
+  `label` text NOT NULL,
+  `auth_type` text NOT NULL,
+  `secret_enc` text,
+  `refresh_enc` text,
+  `expires_at` text,
+  `priority` integer NOT NULL DEFAULT 0,
+  `source` text,
+  `status` text NOT NULL DEFAULT 'ok',
+  `last_error_code` text,
+  `cooldown_reset_at` text,
+  `request_count` integer NOT NULL DEFAULT 0,
+  `metadata` text NOT NULL DEFAULT '{}',
+  `is_active` integer NOT NULL DEFAULT 0,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  CHECK ("status" IN ('ok', 'exhausted', 'dead')),
+  CHECK ("is_active" IN (0, 1)),
+  CHECK ("expires_at" IS NULL OR "expires_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("cooldown_reset_at" IS NULL OR "cooldown_reset_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_accounts_provider_label` ON `accounts` (`provider`, `label`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_accounts_active_provider` ON `accounts` (`provider`) WHERE `is_active` = 1;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_accounts_provider_status_priority` ON `accounts` (`provider`, `status`, `priority`);

--- a/packages/core/src/crypto/__tests__/global-kdf.test.ts
+++ b/packages/core/src/crypto/__tests__/global-kdf.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Global-KDF (ADR-037 §5) test suite for `encryptGlobal` / `decryptGlobal`.
+ *
+ * The global KDF derives an AES-256 key from
+ * `HMAC-SHA256(machine-key || globalSalt, id)` — project-independent, so a
+ * single global credential decrypts from any project on the same machine.
+ *
+ * These tests prove:
+ *   1. `encryptGlobal` → `decryptGlobal` round-trips plaintext for a given id.
+ *   2. A different id derives a different key and fails the GCM auth tag.
+ *   3. The ciphertext keeps the versioned `0x01 + 12B IV + 16B authTag` format.
+ *
+ * @see packages/core/src/crypto/credentials.ts
+ * @see packages/core/src/store/global-salt.ts
+ * @task T11710
+ */
+
+import { describe, expect, it } from 'vitest';
+import { decryptGlobal, encryptGlobal } from '../credentials.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Stable identity bindings (agentIds / credential ids). */
+const ID_A = 'agent-global-a';
+const ID_B = 'agent-global-b';
+
+/** Ciphertext framing constants — mirror credentials.ts. */
+const VERSION_BYTE = 0x01;
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+describe('global KDF (encryptGlobal / decryptGlobal)', () => {
+  // --------------------------------------------------------------------------
+  // Round-trip
+  // --------------------------------------------------------------------------
+
+  describe('round-trip', () => {
+    it('round-trips a realistic LLM API key for a given id', async () => {
+      const apiKey = 'sk-ant-oat01-abc123XYZ_realistic_global_llm_key';
+      const ciphertext = await encryptGlobal(apiKey, ID_A);
+      const result = await decryptGlobal(ciphertext, ID_A);
+      expect(result).toBe(apiKey);
+    });
+
+    it('round-trips an empty string', async () => {
+      const ciphertext = await encryptGlobal('', ID_A);
+      const result = await decryptGlobal(ciphertext, ID_A);
+      expect(result).toBe('');
+    });
+
+    it('round-trips a unicode payload', async () => {
+      const plaintext = '日本語テスト — émojis 🔑 are fine too';
+      const ciphertext = await encryptGlobal(plaintext, ID_B);
+      const result = await decryptGlobal(ciphertext, ID_B);
+      expect(result).toBe(plaintext);
+    });
+
+    it('produces different ciphertexts on successive encryptions (random IV)', async () => {
+      const plaintext = 'same-global-plaintext';
+      const ct1 = await encryptGlobal(plaintext, ID_A);
+      const ct2 = await encryptGlobal(plaintext, ID_A);
+      expect(ct1).not.toBe(ct2);
+      expect(await decryptGlobal(ct1, ID_A)).toBe(plaintext);
+      expect(await decryptGlobal(ct2, ID_A)).toBe(plaintext);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Identity isolation — a different id must fail the auth tag
+  // --------------------------------------------------------------------------
+
+  describe('identity isolation', () => {
+    it('rejects ciphertext when decrypted under a different id (auth tag fails)', async () => {
+      const plaintext = 'secret-bound-to-id-a';
+      const ciphertext = await encryptGlobal(plaintext, ID_A);
+      // ID_B derives a different key — GCM auth tag verification MUST fail.
+      await expect(decryptGlobal(ciphertext, ID_B)).rejects.toThrow();
+    });
+
+    it('accepts ciphertext when the id matches exactly', async () => {
+      const plaintext = 'cross-check-global';
+      const ciphertext = await encryptGlobal(plaintext, ID_B);
+      await expect(decryptGlobal(ciphertext, ID_B)).resolves.toBe(plaintext);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Ciphertext format — versioned 0x01 + 12B IV + 16B authTag
+  // --------------------------------------------------------------------------
+
+  describe('ciphertext format', () => {
+    it('emits a 0x01 version byte and the expected framing', async () => {
+      const plaintext = 'format-check';
+      const ciphertext = await encryptGlobal(plaintext, ID_A);
+      const packed = Buffer.from(ciphertext, 'base64');
+
+      // version(1) + iv(12) + ciphertext(len) + authTag(16)
+      expect(packed[0]).toBe(VERSION_BYTE);
+      const expectedLen = 1 + IV_LENGTH + Buffer.byteLength(plaintext, 'utf8') + AUTH_TAG_LENGTH;
+      expect(packed.length).toBe(expectedLen);
+    });
+
+    it('rejects ciphertext with an unknown version byte', async () => {
+      // version(0x02) + iv(12) + 0 ciphertext + authTag(16) satisfies min length.
+      const fakeVersion = Buffer.alloc(1 + IV_LENGTH + AUTH_TAG_LENGTH);
+      fakeVersion[0] = 0x02;
+      const encoded = fakeVersion.toString('base64');
+      await expect(decryptGlobal(encoded, ID_A)).rejects.toThrow(/[Uu]nknown ciphertext version/);
+    });
+
+    it('rejects ciphertext that is too short', async () => {
+      const tooShort = Buffer.from('tooshort!!').toString('base64');
+      await expect(decryptGlobal(tooShort, ID_A)).rejects.toThrow('ciphertext too short');
+    });
+  });
+});

--- a/packages/core/src/crypto/credentials.ts
+++ b/packages/core/src/crypto/credentials.ts
@@ -19,6 +19,7 @@ import { execFileSync } from 'node:child_process';
 import { createCipheriv, createDecipheriv, createHmac, randomBytes } from 'node:crypto';
 import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { getGlobalSalt } from '../store/global-salt.js';
 
 /** AES-256-GCM constants. */
 const ALGORITHM = 'aes-256-gcm' as const;
@@ -235,6 +236,129 @@ export async function decrypt(ciphertext: string, projectPath: string): Promise<
       'Cannot decrypt credentials. Machine key mismatch or corrupted data. ' +
         'If this database was moved from another machine, re-register agents: ' +
         'cleo agent register --id <id> --api-key <key>',
+    );
+  }
+}
+
+// ============================================================================
+// Global (project-independent) KDF — ADR-037 §5
+// ============================================================================
+
+/**
+ * Derive a per-identity, machine-bound encryption key that is independent of
+ * any project path.
+ *
+ * Implements the ADR-037 §5 KDF:
+ * ```
+ * key = HMAC-SHA256(machine-key || globalSalt, id)
+ * ```
+ *
+ * Unlike {@link deriveProjectKey}, the derived key is bound to the machine
+ * (via the 32-byte machine-key) AND a machine-local 32-byte global salt, but
+ * NOT to a project directory. This lets globally-scoped credentials (e.g. LLM
+ * API keys stored in the global signaldock) decrypt consistently from any
+ * project on the same machine.
+ *
+ * The global salt is sourced from the existing {@link getGlobalSalt}
+ * subsystem (`store/global-salt.ts`) — it is never re-implemented here.
+ *
+ * @param id - The stable identity binding the ciphertext (e.g. an agentId or
+ *   credential id). The same `id` MUST be supplied to {@link decryptGlobal};
+ *   a different `id` yields a different key and fails the GCM auth tag.
+ * @returns A 32-byte AES-256 key derived from machine-key + global-salt + id.
+ *
+ * @see ADR-037 §5 — KDF design (`HMAC-SHA256(machine-key || globalSalt, id)`)
+ * @see getGlobalSalt — global-salt source of truth (store/global-salt.ts)
+ * @task T11710
+ */
+async function deriveGlobalKey(id: string): Promise<Buffer> {
+  const machineKey = await getMachineKey();
+  const globalSalt = getGlobalSalt();
+  // HMAC key = machine-key || globalSalt (concatenation); message = id.
+  const hmacKey = Buffer.concat([machineKey, globalSalt]);
+  return createHmac('sha256', hmacKey).update(id).digest();
+}
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM with a global, machine-bound key.
+ *
+ * Output format is byte-identical to {@link encrypt}:
+ * base64(version + iv + ciphertext + authTag)
+ *   - version: 1 byte (0x01 = AES-256-GCM)
+ *   - iv: 12 bytes
+ *   - ciphertext: variable length
+ *   - authTag: 16 bytes
+ *
+ * The encryption key is derived via {@link deriveGlobalKey} (machine-key +
+ * global-salt + `id`), so the resulting ciphertext decrypts from any project
+ * on the same machine — unlike the project-bound {@link encrypt}.
+ *
+ * @param plaintext - The string to encrypt (e.g. an LLM API key).
+ * @param id - The stable identity used for key derivation (e.g. an agentId).
+ * @returns Base64-encoded ciphertext.
+ *
+ * @see decryptGlobal — the inverse operation.
+ * @task T11710
+ */
+export async function encryptGlobal(plaintext: string, id: string): Promise<string> {
+  const key = await deriveGlobalKey(id);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  // Pack: version + iv + ciphertext + authTag (matches encrypt() format exactly).
+  const version = Buffer.from([CIPHERTEXT_VERSION]);
+  const packed = Buffer.concat([version, iv, encrypted, authTag]);
+  return packed.toString('base64');
+}
+
+/**
+ * Decrypt a base64-encoded ciphertext produced by {@link encryptGlobal} using
+ * the global, machine-bound key derived from `id`.
+ *
+ * @param ciphertext - Base64-encoded string from {@link encryptGlobal}.
+ * @param id - The identity used at encryption time. A mismatched `id` derives a
+ *   different key and fails the GCM auth tag (throws).
+ * @returns The original plaintext string.
+ * @throws If decryption fails (wrong id, corrupted data, or machine-key/
+ *   global-salt mismatch).
+ *
+ * @see encryptGlobal — the inverse operation.
+ * @task T11710
+ */
+export async function decryptGlobal(ciphertext: string, id: string): Promise<string> {
+  const key = await deriveGlobalKey(id);
+  const packed = Buffer.from(ciphertext, 'base64');
+
+  if (packed.length < 1 + IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error('Cannot decrypt credentials: ciphertext too short');
+  }
+
+  const version = packed[0];
+  if (version !== CIPHERTEXT_VERSION) {
+    throw new Error(
+      `Unknown ciphertext version (${version}). Expected ${CIPHERTEXT_VERSION}. ` +
+        'Re-register agents to re-encrypt with the current format.',
+    );
+  }
+
+  const iv = packed.subarray(1, 1 + IV_LENGTH);
+  const authTag = packed.subarray(packed.length - AUTH_TAG_LENGTH);
+  const encrypted = packed.subarray(1 + IV_LENGTH, packed.length - AUTH_TAG_LENGTH);
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+
+  try {
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch {
+    throw new Error(
+      'Cannot decrypt global credentials. Machine key / global-salt mismatch, ' +
+        'wrong id, or corrupted data. If this database was moved from another ' +
+        'machine, re-register the credential under its original id.',
     );
   }
 }

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2604,7 +2604,7 @@ export {
 export { ConduitClient } from './conduit/conduit-client.js';
 export { createConduit } from './conduit/factory.js';
 export { HttpTransport } from './conduit/http-transport.js';
-export { decrypt, encrypt } from './crypto/credentials.js';
+export { decrypt, decryptGlobal, encrypt, encryptGlobal } from './crypto/credentials.js';
 export { getOutputContract, OUTPUT_CONTRACTS } from './dispatch/contracts/output-contracts.js';
 // T11692 (DHQ-057) — SDK describeOperation + OUTPUT contract accessor.
 // Re-exported from the internal barrel so the CLI dispatch adapter

--- a/packages/core/src/store/__tests__/accounts-credential-pool.test.ts
+++ b/packages/core/src/store/__tests__/accounts-credential-pool.test.ts
@@ -1,0 +1,208 @@
+/**
+ * T11709 — `accounts` LLM-credential-pool table round-trip on the GLOBAL cleo.db.
+ *
+ * Proves the AC: opening the consolidated global `cleo.db` (which applies the
+ * `drizzle-cleo-global` migration set, including the new
+ * `…_t11709-accounts-credential-pool` forward migration) materialises the
+ * `accounts` table, that a row inserts + selects cleanly (round-trip), and that
+ * the raw-SQL partial unique index enforces AT MOST ONE active account per
+ * provider (`is_active = 1`) while the `(provider, label)` unique index forbids a
+ * duplicate label within a provider.
+ *
+ * Every test runs against a TEMP-DIR cleo.db — never `.cleo/*.db`.
+ *
+ * @task T11709
+ * @epic T10410
+ * @saga T10409
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from '../dual-scope-db.js';
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `accounts-pool-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+/** Open + migrate an isolated temp GLOBAL cleo.db; return its native handle. */
+async function openGlobalTemp(): Promise<DatabaseSync> {
+  const dbPath = join(testRoot, 'cleo.db');
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return (handle.db as unknown as { $client: DatabaseSync }).$client;
+}
+
+describe('accounts (LLM credential pool) — global cleo.db migration', () => {
+  it('migration materialises the `accounts` table', async () => {
+    const db = await openGlobalTemp();
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='accounts'")
+      .get() as { name: string } | undefined;
+    expect(row?.name).toBe('accounts');
+  }, 30_000);
+
+  it('inserts and selects a credential row round-trip', async () => {
+    const db = await openGlobalTemp();
+
+    db.prepare(
+      `INSERT INTO accounts
+         (provider, label, auth_type, secret_enc, priority, source, status, request_count, metadata, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run('anthropic', 'work-key', 'api-key', 'CIPHERTEXT', 10, 'env', 'ok', 0, '{}', 1);
+
+    const got = db
+      .prepare(
+        `SELECT provider, label, auth_type, secret_enc, priority, source, status,
+                request_count, metadata, is_active
+           FROM accounts WHERE provider = ? AND label = ?`,
+      )
+      .get('anthropic', 'work-key') as
+      | {
+          provider: string;
+          label: string;
+          auth_type: string;
+          secret_enc: string;
+          priority: number;
+          source: string;
+          status: string;
+          request_count: number;
+          metadata: string;
+          is_active: number;
+        }
+      | undefined;
+
+    expect(got).toBeDefined();
+    expect(got?.provider).toBe('anthropic');
+    expect(got?.label).toBe('work-key');
+    expect(got?.auth_type).toBe('api-key');
+    expect(got?.secret_enc).toBe('CIPHERTEXT');
+    expect(got?.priority).toBe(10);
+    expect(got?.source).toBe('env');
+    expect(got?.status).toBe('ok');
+    expect(got?.request_count).toBe(0);
+    expect(got?.metadata).toBe('{}');
+    expect(got?.is_active).toBe(1);
+  }, 30_000);
+
+  it('applies column defaults (status=ok, priority=0, request_count=0, metadata={}, is_active=0, timestamps)', async () => {
+    const db = await openGlobalTemp();
+    db.prepare('INSERT INTO accounts (provider, label, auth_type) VALUES (?, ?, ?)').run(
+      'openai',
+      'default-row',
+      'api-key',
+    );
+    const got = db
+      .prepare(
+        `SELECT status, priority, request_count, metadata, is_active, created_at, updated_at
+           FROM accounts WHERE provider = 'openai' AND label = 'default-row'`,
+      )
+      .get() as
+      | {
+          status: string;
+          priority: number;
+          request_count: number;
+          metadata: string;
+          is_active: number;
+          created_at: string;
+          updated_at: string;
+        }
+      | undefined;
+    expect(got?.status).toBe('ok');
+    expect(got?.priority).toBe(0);
+    expect(got?.request_count).toBe(0);
+    expect(got?.metadata).toBe('{}');
+    expect(got?.is_active).toBe(0);
+    // datetime('now') default → ISO-8601-ish 'YYYY-MM-DD HH:MM:SS'.
+    expect(got?.created_at).toMatch(/^\d{4}-\d{2}-\d{2} /);
+    expect(got?.updated_at).toMatch(/^\d{4}-\d{2}-\d{2} /);
+  }, 30_000);
+
+  it('the `(provider, label)` unique index forbids a duplicate label within a provider', async () => {
+    const db = await openGlobalTemp();
+    db.prepare('INSERT INTO accounts (provider, label, auth_type) VALUES (?, ?, ?)').run(
+      'anthropic',
+      'dup',
+      'api-key',
+    );
+    expect(() =>
+      db
+        .prepare('INSERT INTO accounts (provider, label, auth_type) VALUES (?, ?, ?)')
+        .run('anthropic', 'dup', 'oauth'),
+    ).toThrow();
+    // Same label under a DIFFERENT provider is allowed.
+    expect(() =>
+      db
+        .prepare('INSERT INTO accounts (provider, label, auth_type) VALUES (?, ?, ?)')
+        .run('openai', 'dup', 'api-key'),
+    ).not.toThrow();
+  }, 30_000);
+
+  it('the raw partial unique index allows AT MOST ONE active account per provider', async () => {
+    const db = await openGlobalTemp();
+    // The partial unique index must exist (drizzle cannot emit it — raw SQL).
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='ux_accounts_active_provider'",
+      )
+      .get() as { name: string } | undefined;
+    expect(idx?.name).toBe('ux_accounts_active_provider');
+
+    // First active account for the provider is fine.
+    db.prepare(
+      'INSERT INTO accounts (provider, label, auth_type, is_active) VALUES (?, ?, ?, 1)',
+    ).run('anthropic', 'primary', 'api-key');
+    // A SECOND active account for the SAME provider violates the partial unique index.
+    expect(() =>
+      db
+        .prepare('INSERT INTO accounts (provider, label, auth_type, is_active) VALUES (?, ?, ?, 1)')
+        .run('anthropic', 'secondary', 'api-key'),
+    ).toThrow();
+    // An INACTIVE second account for the same provider is allowed (WHERE is_active = 1
+    // excludes is_active = 0 rows from the unique constraint).
+    expect(() =>
+      db
+        .prepare('INSERT INTO accounts (provider, label, auth_type, is_active) VALUES (?, ?, ?, 0)')
+        .run('anthropic', 'standby', 'api-key'),
+    ).not.toThrow();
+    // A DIFFERENT provider may also have its own single active account.
+    expect(() =>
+      db
+        .prepare('INSERT INTO accounts (provider, label, auth_type, is_active) VALUES (?, ?, ?, 1)')
+        .run('openai', 'primary', 'api-key'),
+    ).not.toThrow();
+  }, 30_000);
+
+  it('the `status` CHECK rejects an out-of-enum value', async () => {
+    const db = await openGlobalTemp();
+    expect(() =>
+      db
+        .prepare('INSERT INTO accounts (provider, label, auth_type, status) VALUES (?, ?, ?, ?)')
+        .run('anthropic', 'bad-status', 'api-key', 'zombie'),
+    ).toThrow();
+    // The three legal statuses all insert cleanly.
+    for (const status of ['ok', 'exhausted', 'dead'] as const) {
+      expect(() =>
+        db
+          .prepare('INSERT INTO accounts (provider, label, auth_type, status) VALUES (?, ?, ?, ?)')
+          .run('anthropic', `s-${status}`, 'api-key', status),
+      ).not.toThrow();
+    }
+  }, 30_000);
+});

--- a/packages/core/src/store/schema/cleo-global/accounts.ts
+++ b/packages/core/src/store/schema/cleo-global/accounts.ts
@@ -1,0 +1,150 @@
+/**
+ * Global-scope `cleo.db` — **LLM credential pool** (`accounts`, 1 table).
+ *
+ * EP-PROVIDER-VAULT (epic T10410 · task T11709 · saga SG-VAULT-CORE T10409). This
+ * table is the queryable, `cleo health`-visible home for the **pooled LLM provider
+ * credentials** that today live as a plaintext JSON blob with no schema, no index,
+ * and no health surface. Each row is one credential ("account") for one provider —
+ * an API key or OAuth token pair — plus the rotation / cooldown / health metadata
+ * the pool runner uses to pick the next live account and to retire dead ones.
+ *
+ * ## NOT `agent_registry_accounts` (do not confuse the two)
+ *
+ * The consolidated global `cleo.db` ALSO carries `agent_registry_accounts` — the
+ * better-auth OAuth-account table from the agent-identity tier (the cloud-sync
+ * `accounts` source, renamed under T11622). That table is a SaaS account record;
+ * THIS table (`accounts`, bare) is the local machine-wide LLM-credential pool. The
+ * two never overlap: the physical names differ (`accounts` vs
+ * `agent_registry_accounts`) and the JS exports differ (`accounts` here vs
+ * `agentRegistryAccounts`). The bare name `accounts` is the credential pool.
+ *
+ * ## Encrypted at rest (global KDF — T11710)
+ *
+ * `secretEnc` / `refreshEnc` are ciphertext, NEVER plaintext. They are produced by
+ * `encryptGlobal()` (packages/core/src/crypto/credentials.ts, T11710) — the
+ * project-INDEPENDENT KDF `HMAC-SHA256(machine-key || globalSalt, id)` reusing the
+ * machine-local `getGlobalSalt()` (store/global-salt.ts). The ciphertext keeps the
+ * versioned `0x01 + 12B IV + 16B authTag` framing. Global (not project-bound)
+ * encryption is required because an LLM credential must decrypt consistently for
+ * the same machine regardless of which project's cwd the pool is read from.
+ *
+ * ## Active-account pointer (`isActive`)
+ *
+ * `isActive` is the per-provider "currently-selected" pointer: AT MOST ONE row per
+ * `provider` may carry `isActive = 1`. drizzle-orm cannot model a partial-`WHERE`
+ * unique index, so the one-active-per-provider invariant is enforced by a raw-SQL
+ * **partial unique index** `ux_accounts_active_provider ON accounts (provider)
+ * WHERE is_active = 1` emitted in the forward migration (the established repo
+ * pattern — cf. `_writer_leases.active`, T11627). This module declares only the
+ * full-column table plus the non-partial `(provider, label)` unique index, which
+ * drizzle CAN emit.
+ *
+ * @task T11709
+ * @epic T10410
+ * @saga T10409
+ * @see ../../../crypto/credentials.ts — `encryptGlobal` / `decryptGlobal` (T11710)
+ * @see ../../global-salt.ts — `getGlobalSalt` (the reused machine-local salt)
+ * @see ./agent-registry.ts — `agentRegistryAccounts` (the UNRELATED OAuth-account table)
+ * @see ../../../../migrations/drizzle-cleo-global — the forward migration (raw partial index)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
+/**
+ * Legal `accounts.status` values — the health lifecycle of a pooled credential.
+ *
+ * - `ok` — usable; the pool may select it.
+ * - `exhausted` — rate-limited / quota-hit; usable again after `cooldownResetAt`.
+ * - `dead` — permanently unusable (revoked key, hard auth failure); never selected.
+ *
+ * @task T11709
+ */
+export const ACCOUNT_STATUSES = ['ok', 'exhausted', 'dead'] as const;
+
+/** TypeScript union derived from {@link ACCOUNT_STATUSES}. */
+export type AccountStatus = (typeof ACCOUNT_STATUSES)[number];
+
+/**
+ * `accounts` — the machine-wide pooled-LLM-credential table.
+ *
+ * One row per credential ("account") for one provider. Carries the encrypted
+ * secret/refresh material plus the rotation, cooldown, and health metadata the
+ * pool runner consults to choose the next live account (highest `priority` among
+ * `status = 'ok'`) and to retire dead ones. The `(provider, label)` pair is unique;
+ * `isActive` is the per-provider active pointer (one active row per provider,
+ * enforced by the raw-SQL partial unique index in the migration).
+ *
+ * @task T11709
+ */
+export const accounts = sqliteTable(
+  'accounts',
+  {
+    /** Surrogate primary key (autoincrement via INTEGER PRIMARY KEY rowid alias). */
+    id: integer('id').primaryKey(),
+    /** Provider key (e.g. `anthropic` | `openai` | `google`). Selection is per-provider. */
+    provider: text('provider').notNull(),
+    /**
+     * Human-readable credential label, unique WITHIN a provider (e.g. `work-key`,
+     * `personal-oauth`). The `(provider, label)` pair is the natural unique key.
+     */
+    label: text('label').notNull(),
+    /** Credential kind — `api-key` | `oauth` (drives which `*_enc` columns are populated). */
+    authType: text('auth_type').notNull(),
+    /**
+     * Encrypted primary secret (API key or OAuth access token), `encryptGlobal()`
+     * ciphertext (`0x01 + 12B IV + 16B authTag` framing, T11710). NEVER plaintext.
+     */
+    secretEnc: text('secret_enc'),
+    /**
+     * Encrypted OAuth refresh token, `encryptGlobal()` ciphertext. NULL for an
+     * `api-key` credential (no refresh material).
+     */
+    refreshEnc: text('refresh_enc'),
+    /** ISO-8601 UTC expiry of the secret; NULL for a non-expiring API key. */
+    expiresAt: text('expires_at'),
+    /** Selection priority — HIGHER is preferred. The pool picks the highest live priority. */
+    priority: integer('priority').notNull().default(0),
+    /** Provenance — where this credential came from (e.g. `env` | `oauth-flow` | `import`). */
+    source: text('source'),
+    /**
+     * Health lifecycle — `ok` | `exhausted` | `dead` ({@link ACCOUNT_STATUSES}).
+     * Only `ok` rows are eligible for selection.
+     */
+    status: text('status', { enum: ACCOUNT_STATUSES }).notNull().default('ok'),
+    /** Last transport/provider error code observed (e.g. `429` | `invalid_api_key`); NULL when healthy. */
+    lastErrorCode: text('last_error_code'),
+    /**
+     * ISO-8601 UTC instant an `exhausted` credential becomes eligible again; NULL
+     * when not cooling down. The pool skips an `exhausted` row until `now >= this`.
+     */
+    cooldownResetAt: text('cooldown_reset_at'),
+    /** Monotonic count of requests served by this credential (rotation telemetry). */
+    requestCount: integer('request_count').notNull().default(0),
+    /** Free-form JSON blob for forward-compatible per-credential metadata (serialized TEXT). */
+    metadata: text('metadata').notNull().default('{}'),
+    /**
+     * Per-provider active-pointer. AT MOST ONE row per `provider` carries `true`,
+     * enforced by the raw-SQL partial unique index `ux_accounts_active_provider`
+     * (drizzle cannot model a partial-`WHERE` unique). Defaults to `false`.
+     */
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(false),
+    /** ISO-8601 UTC row-creation instant. Defaults to write time. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant. Defaults to write time; bumped on mutation. */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // The natural unique key: a label is unique within a provider. drizzle CAN
+    // emit this (non-partial) unique; the per-provider active pointer is the
+    // SEPARATE partial unique index emitted as raw SQL in the migration.
+    unique('ux_accounts_provider_label').on(table.provider, table.label),
+    // Selection index — the pool scans live rows per provider ordered by priority.
+    index('idx_accounts_provider_status_priority').on(table.provider, table.status, table.priority),
+  ],
+);
+
+/** Row type for `accounts` SELECT queries. */
+export type AccountRow = typeof accounts.$inferSelect;
+/** Row type for `accounts` INSERT/UPSERT operations. */
+export type NewAccountRow = typeof accounts.$inferInsert;

--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -93,6 +93,7 @@
  */
 
 export * from '../cleo-shared/index.js';
+export * from './accounts.js';
 export * from './agent-registry.js';
 export * from './nexus.js';
 export * from './session-manifest.js';


### PR DESCRIPTION
## Vault credential storage foundation (ADR-037 · saga T10409 SG-VAULT-CORE · epic T10410 EP-PROVIDER-VAULT)

The persisted, schema'd, health-visible home for pooled LLM provider credentials — replacing today's plaintext JSON blob with no schema, no index, and no `cleo health` surface.

### T11710 — global-salt KDF for LLM creds (`crypto/credentials.ts`, ADR-037 §5)

- Adds `encryptGlobal()` / `decryptGlobal()` backed by a **project-independent** KDF: `deriveGlobalKey(id) = HMAC-SHA256(machine-key || globalSalt, id)`.
- **Reuses the existing `getGlobalSalt()`** from `store/global-salt.ts` — the salt is NOT re-implemented.
- Global creds (LLM API keys) now decrypt consistently across projects on the same machine, closing the `deriveProjectKey` path-binding gap.
- Existing project-bound `encrypt`/`decrypt` left **fully intact** — no silent invalidation of agent-registry creds.
- Ciphertext keeps the versioned `0x01 + 12B IV + 16B authTag` format, byte-identical framing to `encrypt()`.
- `global-kdf.test.ts` proves round-trip and that a different `id` fails the GCM auth tag.

### T11709 — `accounts` LLM-credential-pool table (cleo-global) + forward migration

- New `store/schema/cleo-global/accounts.ts`: drizzle `accounts` table (provider, label, authType, secretEnc, refreshEnc, expiresAt, priority, source, status enum `ok|exhausted|dead`, lastErrorCode, cooldownResetAt, requestCount, metadata, `isActive` active-pointer, created/updated).
- `secret_enc`/`refresh_enc` hold `encryptGlobal()` ciphertext (T11710), **NEVER plaintext**.
- Hermes `PooledCredential` surface with a per-provider **active-account pointer** — at most one `is_active = 1` row per provider.
- Distinct from the better-auth `agent_registry_accounts` table (different physical name + JS export).
- Forward migration `…_t11709-accounts-credential-pool` (**global-only** — no project-tier analog, NOT mirrored into drizzle-cleo-project):
  - `--> statement-breakpoint` separators (node:sqlite multi-statement safety).
  - `(provider, label)` unique index + a **raw-SQL partial unique index** `ux_accounts_active_provider … WHERE is_active = 1` (drizzle cannot emit partial `WHERE`; the established `_writer_leases` pattern).
  - Sequenced **last** (`20260608010000`), runs AFTER the consolidation baseline so `accounts` is never the first CREATE on a fresh DB (page-2 invariant satisfied).

### Gates

- `pnpm biome check` — clean
- `pnpm run build` — success
- core tests (cgroup-wrapped, `--maxWorkers=2`) — new `global-kdf.test.ts` + `accounts-credential-pool.test.ts` pass 15/15
- `lint-no-direct-db-open.mjs --strict` — zero violations
- `cleo check arch` — 5/5 pass
- scope: 7 files, no leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)