### PR TITLE
feat(T11746): E10 sealed-credential handle — no plaintext apiKey crosses the resolver (T11752/53/54)

### DIFF
--- a/packages/contracts/src/__tests__/sealed-credential.test.ts
+++ b/packages/contracts/src/__tests__/sealed-credential.test.ts
@@ -22,8 +22,10 @@ import type { DecryptedToken, SealedCredential } from '../llm/sealed-credential.
 import type { ResolvedLLM } from '../operations/llm.js';
 
 describe('SealedCredential shape (AC1)', () => {
-  it('is exactly { provider, account, fetch } — pins the field set', () => {
-    expectTypeOf<keyof SealedCredential>().toEqualTypeOf<'provider' | 'account' | 'fetch'>();
+  it('is exactly { provider, account, tokenPreview, fetch } — pins the field set', () => {
+    expectTypeOf<keyof SealedCredential>().toEqualTypeOf<
+      'provider' | 'account' | 'tokenPreview' | 'fetch'
+    >();
   });
 
   it('provider is a ProviderId', () => {
@@ -32,6 +34,10 @@ describe('SealedCredential shape (AC1)', () => {
 
   it('account is a plain (loggable) string', () => {
     expectTypeOf<SealedCredential['account']>().toEqualTypeOf<string>();
+  });
+
+  it('tokenPreview is a plain (loggable, non-secret) string (T11754)', () => {
+    expectTypeOf<SealedCredential['tokenPreview']>().toEqualTypeOf<string>();
   });
 
   it('fetch resolves to a DecryptedToken (never a bare string)', () => {
@@ -44,6 +50,7 @@ describe('SealedCredential shape (AC1)', () => {
     expectTypeOf<SealedCredential>().toEqualTypeOf<{
       readonly provider: ProviderId;
       readonly account: string;
+      readonly tokenPreview: string;
       readonly fetch: () => Promise<DecryptedToken>;
     }>();
   });

--- a/packages/contracts/src/__tests__/sealed-credential.test.ts
+++ b/packages/contracts/src/__tests__/sealed-credential.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Type + purity tests for the E10 sealed credential handle (T11752).
+ *
+ * Pins the {@link SealedCredential} / {@link DecryptedToken} contract so that:
+ *   - `SealedCredential` is exactly `{ provider, account, fetch }` with
+ *     `fetch: () => Promise<DecryptedToken>` (AC1).
+ *   - `ResolvedLLM` carries a sealed-credential-typed field (AC2).
+ *   - `DecryptedToken` is a *branded* string — a plain `string` is NOT
+ *     assignable to it, so the secret cannot be silently fabricated and a
+ *     `DecryptedToken` cannot leak into an arbitrary `string` sink without an
+ *     explicit `.value` read (the "never serialized" invariant, AC2).
+ *   - The module is types-only (no runtime export), satisfying contracts
+ *     purity (Gate 10 · AC3).
+ *
+ * @task T11752
+ * @epic T11746
+ */
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { ProviderId } from '../llm/provider-id.js';
+import type { DecryptedToken, SealedCredential } from '../llm/sealed-credential.js';
+import type { ResolvedLLM } from '../operations/llm.js';
+
+describe('SealedCredential shape (AC1)', () => {
+  it('is exactly { provider, account, fetch } — pins the field set', () => {
+    expectTypeOf<keyof SealedCredential>().toEqualTypeOf<'provider' | 'account' | 'fetch'>();
+  });
+
+  it('provider is a ProviderId', () => {
+    expectTypeOf<SealedCredential['provider']>().toEqualTypeOf<ProviderId>();
+  });
+
+  it('account is a plain (loggable) string', () => {
+    expectTypeOf<SealedCredential['account']>().toEqualTypeOf<string>();
+  });
+
+  it('fetch resolves to a DecryptedToken (never a bare string)', () => {
+    expectTypeOf<SealedCredential['fetch']>().toEqualTypeOf<() => Promise<DecryptedToken>>();
+    expectTypeOf<ReturnType<SealedCredential['fetch']>>().resolves.toEqualTypeOf<DecryptedToken>();
+  });
+
+  it('all fields are readonly (a handle cannot be mutated in place)', () => {
+    // Removing `readonly` from any field would make this fail to compile.
+    expectTypeOf<SealedCredential>().toEqualTypeOf<{
+      readonly provider: ProviderId;
+      readonly account: string;
+      readonly fetch: () => Promise<DecryptedToken>;
+    }>();
+  });
+});
+
+describe('DecryptedToken branding (AC2 — never serialized / never fabricated)', () => {
+  it('is NOT assignable from a plain string (nominal brand)', () => {
+    // A plain string lacks the phantom `__decryptedToken` brand, so it cannot
+    // be passed where a DecryptedToken is required.
+    expectTypeOf<string>().not.toMatchTypeOf<DecryptedToken>();
+  });
+
+  it('is NOT a plain string sink (must read .value explicitly to serialize)', () => {
+    expectTypeOf<DecryptedToken>().not.toEqualTypeOf<string>();
+  });
+
+  it('exposes a readonly plaintext .value of type string', () => {
+    expectTypeOf<DecryptedToken['value']>().toEqualTypeOf<string>();
+  });
+
+  it('carries the phantom brand marker (compile-time only)', () => {
+    expectTypeOf<DecryptedToken['__decryptedToken']>().toEqualTypeOf<'DecryptedToken'>();
+  });
+});
+
+describe('ResolvedLLM.sealedCredential (AC2)', () => {
+  it('is typed as SealedCredential | null | undefined', () => {
+    expectTypeOf<ResolvedLLM['sealedCredential']>().toEqualTypeOf<
+      SealedCredential | null | undefined
+    >();
+  });
+});
+
+describe('contracts purity (AC3) — sealed-credential is types-only', () => {
+  it('the module exposes no runtime exports (no decrypt logic in contracts)', async () => {
+    const mod = await import('../llm/sealed-credential.js');
+    // A pure type module compiles to an empty ESM namespace at runtime.
+    expect(Object.keys(mod)).toHaveLength(0);
+  });
+});

--- a/packages/contracts/src/__tests__/sealed-credential.test.ts
+++ b/packages/contracts/src/__tests__/sealed-credential.test.ts
@@ -69,11 +69,18 @@ describe('DecryptedToken branding (AC2 — never serialized / never fabricated)'
   });
 });
 
-describe('ResolvedLLM.sealedCredential (AC2)', () => {
-  it('is typed as SealedCredential | null | undefined', () => {
-    expectTypeOf<ResolvedLLM['sealedCredential']>().toEqualTypeOf<
-      SealedCredential | null | undefined
-    >();
+describe('ResolvedLLM.sealedCredential (AC2 · T11753)', () => {
+  it('is the required (non-optional) canonical credential surface', () => {
+    // T11753 promotes the field from optional to required: the resolver ALWAYS
+    // populates it (a handle when a credential resolved, `null` otherwise).
+    expectTypeOf<ResolvedLLM['sealedCredential']>().toEqualTypeOf<SealedCredential | null>();
+  });
+
+  it('the inline credential metadata carries NO plaintext apiKey (T11753)', () => {
+    // The secret-bearing `apiKey` field is structurally removed from the inline
+    // credential — the plaintext crosses ONLY through `sealedCredential.fetch()`.
+    type Cred = NonNullable<ResolvedLLM['credential']>;
+    expectTypeOf<Cred>().not.toHaveProperty('apiKey');
   });
 });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -844,6 +844,8 @@ export type {
 export type { ResolvedCredential } from './llm/resolved-credential.js';
 // === E9 SSoT resolution descriptor (T11745 / T11761) ===
 export type { ModelCaps, ResolvedLLMDescriptor } from './llm/resolved-descriptor.js';
+// === E10 Sealed credential handle (T11752 / T11746) — on-demand decrypt at the wire ===
+export type { DecryptedToken, SealedCredential } from './llm/sealed-credential.js';
 // === E9 System-of-Use chokepoint contract (T11749) ===
 export type {
   ResolveLLMForSystemOptions,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1157,6 +1157,7 @@ export type {
 // === LLM Credential + Role-Resolver Wire Types (T-LLM-CRED Phase 1/2 — T9255) ===
 export type {
   AuthTypeWire,
+  CredentialMetadataWire,
   CredentialResultWire,
   CredentialSourceWire,
   CredentialsStoreStrategyWire,

--- a/packages/contracts/src/llm/sealed-credential.ts
+++ b/packages/contracts/src/llm/sealed-credential.ts
@@ -108,11 +108,13 @@ export type DecryptedToken = {
  *
  * @example
  * ```ts
- * // At the wire boundary (session-factory.ts) — the ONLY place fetch() runs:
- * const token = await sealed.fetch();
- * const headers = buildAuthHeaders(sealed.provider, token);
- * // token.value is used to construct the transport, then goes out of scope.
- * // It is NEVER returned, logged, or serialized.
+ * // At the wire boundary (session-factory.ts) — the ONLY place fetch() runs.
+ * // Prefer `authHeadersFromSealed` (core), which invokes fetch() internally so
+ * // the plaintext is never bound to a caller-visible variable:
+ * const headers = await authHeadersFromSealed(sealed, authType);
+ * // …or, for diagnostics, name the credential WITHOUT materializing it:
+ * log.info({ provider: sealed.provider, preview: sealed.tokenPreview });
+ * // The full token is NEVER returned, logged, or serialized.
  * ```
  *
  * @task T11752
@@ -126,6 +128,22 @@ export interface SealedCredential {
    * without revealing its secret — safe to log and serialize.
    */
   readonly account: string;
+  /**
+   * Non-secret, redacted preview of the underlying credential (e.g. `'…6789'`
+   * or `'oat-…6789'` for OAuth). The SOLE token-derived value safe to place on
+   * a log line, LAFS envelope, or `cleo llm whoami` diagnostic.
+   *
+   * SECURITY: this is computed ONCE at seal time from at most the last 4 token
+   * characters via the core redaction chokepoint (`tokenPreviewOf`) — it can
+   * never be reversed into the plaintext. Diagnostics that need to *name* a
+   * credential without materializing it MUST read this field, never call
+   * {@link fetch}. The E10 redaction test (T11754 · AC3) asserts that the
+   * preview, not the full token, is the only credential-derived string that
+   * crosses any logging/diagnostic boundary.
+   *
+   * @task T11754
+   */
+  readonly tokenPreview: string;
   /**
    * Materialize the plaintext secret on demand.
    *

--- a/packages/contracts/src/llm/sealed-credential.ts
+++ b/packages/contracts/src/llm/sealed-credential.ts
@@ -1,0 +1,148 @@
+/**
+ * Sealed credential handle — the E10 on-demand-decrypt contract (T11752).
+ *
+ * ## Why a sealed handle exists
+ *
+ * Until E10, a resolved credential carried the secret **inline** as a bare
+ * `apiKey: string` field on `CredentialResultWire` / `ResolvedLLM`. That
+ * plaintext token traveled up the entire resolution call stack — through
+ * `resolveLLMForRole` → `resolveLLMForSystem` → consumers — where it could be
+ * accidentally logged, serialized into a LAFS envelope, or copied into a
+ * diagnostic. Every layer that merely *routed* the credential to the wire still
+ * had structural read access to the plaintext.
+ *
+ * A {@link SealedCredential} inverts that. The resolver returns an **opaque
+ * handle** that names the credential (`provider` + `account`) and exposes a
+ * single asynchronous {@link SealedCredential.fetch} method. The plaintext token
+ * is materialized ONLY when `fetch()` is invoked — and by E10 design that call
+ * happens at exactly two trust boundaries:
+ *
+ *  1. the wire — `transportForProvider` / `session-factory.ts` immediately
+ *     before building the provider transport / auth headers, or
+ *  2. daemon worker-injection — the daemon brokering a short-lived credential
+ *     into a spawned agent.
+ *
+ * Between the resolver and those boundaries, NO layer holds a plaintext secret;
+ * it holds a handle whose `fetch()` is the sole decryption chokepoint.
+ *
+ * ## Types-only (Gate 10 contracts purity)
+ *
+ * This module is **types-only**. {@link SealedCredential.fetch} is a
+ * *function-typed field* on an interface — a declaration of shape, NOT a bodied
+ * runtime function — so it satisfies the contracts-purity gate
+ * (`lint-no-runtime-in-contracts`). The concrete implementation of `fetch()`
+ * (the actual `crypto/credentials.ts` decrypt + the vault/daemon round-trip)
+ * lives in `@cleocode/core` — never in contracts.
+ *
+ * @module llm/sealed-credential
+ * @task T11752
+ * @epic T11746
+ * @see ADR-072 §Type lock-in
+ */
+
+import type { ProviderId } from './provider-id.js';
+
+/**
+ * The plaintext secret materialized by {@link SealedCredential.fetch}.
+ *
+ * ## Branded so it cannot be silently created or widened
+ *
+ * `DecryptedToken` is a *branded* string: an opaque nominal type produced ONLY
+ * by the core decrypt chokepoint inside {@link SealedCredential.fetch}. The
+ * `readonly __decryptedToken` brand is a phantom marker — it is NEVER assigned a
+ * runtime value (there is no runtime field; this is purely a compile-time
+ * nominal tag), so a plain `string` cannot be passed where a `DecryptedToken`
+ * is expected, and a `DecryptedToken` is not assignable to an arbitrary
+ * `string` sink without an explicit, auditable read of `.value`.
+ *
+ * ## NEVER serialized
+ *
+ * A `DecryptedToken` MUST NEVER be:
+ *   - returned up the resolver call stack (it exists only transiently inside
+ *     the `fetch()` consumer at the wire / daemon worker-injection boundary),
+ *   - placed on any envelope, `NormalizedResponse.providerData`, log line,
+ *     diagnostic, or `cleo llm whoami` output,
+ *   - persisted, cached across calls, or held beyond the single transport
+ *     construction / auth-header build that consumed it.
+ *
+ * The CI chokepoint lint (`lint-llm-chokepoint`) plus the E10 redaction tests
+ * (T11754) enforce that no bare secret string crosses the resolver boundary.
+ *
+ * Because the brand is phantom (compile-time only) and there is no enumerable
+ * runtime field, `JSON.stringify(token)` over the value field yields only the
+ * underlying string — which is precisely why callers MUST treat the value as
+ * write-once-to-the-wire and never route it into a serializer.
+ *
+ * @task T11752
+ */
+export type DecryptedToken = {
+  /**
+   * Phantom brand marker — compile-time only, never materialized at runtime.
+   * Prevents a plain `string` from being assigned where a {@link DecryptedToken}
+   * is required (nominal typing). Reading this field is meaningless at runtime;
+   * it exists solely to make the type opaque.
+   *
+   * @internal
+   */
+  readonly __decryptedToken: 'DecryptedToken';
+  /**
+   * The materialized plaintext secret (API key or OAuth bearer token).
+   *
+   * SECURITY: read this ONLY at the wire (`transportForProvider`) or daemon
+   * worker-injection, build the auth header, and discard. NEVER log, serialize,
+   * or return it up the stack. Marked `readonly` so a consumer cannot mutate it
+   * in place.
+   */
+  readonly value: string;
+};
+
+/**
+ * An opaque, sealed reference to a credential whose plaintext is fetched on
+ * demand at the wire — never carried inline up the resolver stack.
+ *
+ * The resolver returns this *instead of* a bare `apiKey: string` (E10 ·
+ * T11753). Consumers route the handle to the transport boundary unchanged;
+ * only the boundary calls {@link fetch} to materialize the
+ * {@link DecryptedToken}, build the provider auth headers, and discard the
+ * plaintext.
+ *
+ * @example
+ * ```ts
+ * // At the wire boundary (session-factory.ts) — the ONLY place fetch() runs:
+ * const token = await sealed.fetch();
+ * const headers = buildAuthHeaders(sealed.provider, token);
+ * // token.value is used to construct the transport, then goes out of scope.
+ * // It is NEVER returned, logged, or serialized.
+ * ```
+ *
+ * @task T11752
+ */
+export interface SealedCredential {
+  /** Provider this credential targets (e.g. `'anthropic'`, `'openai'`). */
+  readonly provider: ProviderId;
+  /**
+   * Account / store-label identifier this handle resolves against (e.g.
+   * `'default'`, `'work'`). Names *which* credential the handle points at
+   * without revealing its secret — safe to log and serialize.
+   */
+  readonly account: string;
+  /**
+   * Materialize the plaintext secret on demand.
+   *
+   * SECURITY INVARIANT: the returned {@link DecryptedToken} is the ONLY point
+   * at which the secret exists in plaintext. Implementations (in
+   * `@cleocode/core`) run the `crypto/credentials.ts` decrypt INSIDE this
+   * method and MUST be invoked ONLY at the wire (`transportForProvider` /
+   * `session-factory.ts`) or daemon worker-injection — never to surface a key
+   * up the resolution stack. The result MUST NOT be cached, persisted, logged,
+   * or serialized by any caller.
+   *
+   * This is a *function-typed field on an interface* (a type, not a bodied
+   * function), so the declaration is contracts-purity-safe (Gate 10): the body
+   * lives in core.
+   *
+   * @returns The materialized plaintext token, valid only for immediate
+   *   wire/daemon use.
+   */
+  readonly fetch: () => Promise<DecryptedToken>;
+}

--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -10,6 +10,7 @@
  */
 
 import type { BuiltinProviderId, ProviderId } from '../llm/provider-id.js';
+import type { SealedCredential } from '../llm/sealed-credential.js';
 
 /**
  * @deprecated since Phase 4 (ADR-072). Use {@link ProviderId} from
@@ -258,8 +259,30 @@ export interface ResolvedLLM {
   /**
    * Resolved credential. `null` when no tier produced a token. Callers
    * MUST handle this case.
+   *
+   * @deprecated E10 (T11746) — carries the secret INLINE as
+   * {@link CredentialResultWire.apiKey}, which travels up the resolver stack
+   * where it can be logged/serialized. T11753 swaps the resolver to populate
+   * {@link sealedCredential} instead and removes the inline `apiKey`. Prefer
+   * {@link sealedCredential} for new consumers; this field is retained for the
+   * one-task migration window so existing call-sites keep compiling.
    */
   credential: CredentialResultWire | null;
+  /**
+   * Sealed credential handle — the E10 on-demand-decrypt replacement for the
+   * inline {@link credential}/`apiKey` (T11752 · T11746). `null` when no tier
+   * produced a credential.
+   *
+   * The plaintext token is materialized ONLY by calling
+   * {@link SealedCredential.fetch} at the wire (`transportForProvider` /
+   * `session-factory.ts`) or daemon worker-injection — never returned up this
+   * envelope. Until T11753 wires the resolver to populate it, this field is
+   * optional; once populated it becomes the canonical credential surface and
+   * the inline {@link credential} is removed.
+   *
+   * @task T11752
+   */
+  sealedCredential?: SealedCredential | null;
   /** Which config path produced this resolution. */
   source: ResolutionSource;
   /** When `roles[role].credentialLabel` was set, the label that was used. */

--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -197,6 +197,33 @@ export interface CredentialResultWire {
   authType: AuthTypeWire;
 }
 
+/**
+ * Non-secret credential metadata — the E10 (T11753) redacted view of a resolved
+ * credential that {@link ResolvedLLM} carries inline.
+ *
+ * This is {@link CredentialResultWire} with the secret-bearing `apiKey` field
+ * **structurally removed**. The resolver returns this metadata so consumers can
+ * branch on `authType` / `source` / `provider` (e.g. choose OAuth-vs-api_key
+ * header style, surface `cleo llm whoami` diagnostics) WITHOUT any plaintext
+ * crossing the resolver boundary. The plaintext is reachable ONLY via
+ * {@link ResolvedLLM.sealedCredential}'s `fetch()` at the wire.
+ *
+ * @task T11753
+ * @epic T11746
+ */
+export interface CredentialMetadataWire {
+  /** Provider transport this credential is for. */
+  provider: ModelTransport;
+  /**
+   * Which tier produced this credential. `undefined` only when no credential
+   * was resolved (in which case both this and {@link ResolvedLLM.sealedCredential}
+   * are `null`).
+   */
+  source: CredentialSourceWire | undefined;
+  /** Scheme used to present the credential to the provider. */
+  authType: AuthTypeWire;
+}
+
 // ============================================================================
 // Role-based LLM resolution wire types (T9255 — Phase 2 T-llm-1)
 // ============================================================================
@@ -257,32 +284,33 @@ export interface ResolvedLLM {
    */
   client: unknown;
   /**
-   * Resolved credential. `null` when no tier produced a token. Callers
-   * MUST handle this case.
+   * Resolved credential **metadata** — provider / source / authType only.
+   * `null` when no tier produced a credential (in which case
+   * {@link sealedCredential} is also `null`). Callers MUST handle this case.
    *
-   * @deprecated E10 (T11746) — carries the secret INLINE as
-   * {@link CredentialResultWire.apiKey}, which travels up the resolver stack
-   * where it can be logged/serialized. T11753 swaps the resolver to populate
-   * {@link sealedCredential} instead and removes the inline `apiKey`. Prefer
-   * {@link sealedCredential} for new consumers; this field is retained for the
-   * one-task migration window so existing call-sites keep compiling.
+   * E10 (T11753): the secret-bearing `apiKey` field has been **removed** — this
+   * is now a {@link CredentialMetadataWire}, NOT the old
+   * {@link CredentialResultWire}. The plaintext token never rides on this
+   * envelope; obtain it ONLY via {@link sealedCredential}'s `fetch()` at the
+   * wire. Branch on `authType` / `source` here for header-style / diagnostics.
    */
-  credential: CredentialResultWire | null;
+  credential: CredentialMetadataWire | null;
   /**
-   * Sealed credential handle — the E10 on-demand-decrypt replacement for the
-   * inline {@link credential}/`apiKey` (T11752 · T11746). `null` when no tier
-   * produced a credential.
+   * Sealed credential handle — the E10 on-demand-decrypt credential surface
+   * (T11752 · T11753 · T11746). `null` when no tier produced a credential
+   * (paired with `credential === null`); non-null exactly when a usable
+   * credential was resolved.
    *
    * The plaintext token is materialized ONLY by calling
    * {@link SealedCredential.fetch} at the wire (`transportForProvider` /
    * `session-factory.ts`) or daemon worker-injection — never returned up this
-   * envelope. Until T11753 wires the resolver to populate it, this field is
-   * optional; once populated it becomes the canonical credential surface and
-   * the inline {@link credential} is removed.
+   * envelope. This is the canonical credential surface; the old inline
+   * `credential.apiKey` plaintext is gone.
    *
    * @task T11752
+   * @task T11753
    */
-  sealedCredential?: SealedCredential | null;
+  sealedCredential: SealedCredential | null;
   /** Which config path produced this resolution. */
   source: ResolutionSource;
   /** When `roles[role].credentialLabel` was set, the label that was used. */

--- a/packages/core/src/llm/__tests__/cli-ops.test.ts
+++ b/packages/core/src/llm/__tests__/cli-ops.test.ts
@@ -370,11 +370,16 @@ describe('llm cli-ops — redaction + envelope shape', () => {
       provider: 'anthropic',
       model: 'claude-haiku-4-5-20251001',
       client: null,
+      // E10 (T11753): non-secret metadata + sealed handle (drives hasCredential).
       credential: {
         provider: 'anthropic',
-        apiKey: 'tok',
         source: 'env',
         authType: 'api_key',
+      },
+      sealedCredential: {
+        provider: 'anthropic',
+        account: 'default',
+        fetch: async () => ({ __decryptedToken: 'DecryptedToken' as const, value: 'tok' }),
       },
       source: 'implicit-fallback',
       credentialLabel: undefined,
@@ -399,6 +404,7 @@ describe('llm cli-ops — redaction + envelope shape', () => {
       model: 'claude-haiku-4-5-20251001',
       client: null,
       credential: null,
+      sealedCredential: null,
       source: 'implicit-fallback',
       credentialLabel: undefined,
     });

--- a/packages/core/src/llm/__tests__/decrypt-at-wire.test.ts
+++ b/packages/core/src/llm/__tests__/decrypt-at-wire.test.ts
@@ -1,0 +1,200 @@
+/**
+ * E10 decrypt-at-wire + redaction tests (T11754 — AC1 · AC2 · AC3).
+ *
+ * The security invariant this file enforces:
+ *
+ *  - **AC1 — decrypt-only-at-wire.** The crypto decrypt (`resolveToken`) runs
+ *    ONLY inside the sealed handle's `fetch()`, which is invoked ONLY at a wire
+ *    boundary (`authHeadersFromSealed` / `transportForProvider` /
+ *    daemon worker-injection). We prove this by counting how many times the
+ *    `resolveToken` thunk fires: zero until a wire helper is called.
+ *  - **AC2 — auth headers built AT THE WIRE from the handle.**
+ *    `authHeadersFromSealed(sealed, authType)` materializes the token inside
+ *    itself and returns ONLY the provider-specific headers — `x-api-key` for an
+ *    Anthropic API key, `Authorization: Bearer …` for OAuth and for
+ *    openai/gemini/moonshot API keys — without the plaintext ever being bound to
+ *    a caller variable.
+ *  - **AC3 — redaction.** The plaintext token appears in NO log line, envelope,
+ *    or diagnostic surface. The ONLY token-derived string a diagnostic may carry
+ *    is the non-secret {@link makeSealedCredential} `tokenPreview` (≤ last 4
+ *    chars). A deep walk + JSON dump of the handle and of a simulated diagnostic
+ *    record finds the full secret nowhere.
+ *
+ * @task T11754
+ * @epic T11746
+ */
+
+import { describe, expect, it } from 'vitest';
+import { authHeadersFromSealed } from '../credentials.js';
+import { makeSealedCredential, tokenPreview } from '../sealed-credential.js';
+
+const SECRET = 'sk-ant-SECRET-decrypt-at-wire-do-not-leak-9876543210';
+
+/**
+ * Recursively collect every primitive string reachable from `value`, descending
+ * into plain objects + arrays but NOT into functions (the fetch closure is the
+ * intended, opaque secret home).
+ */
+function reachableStrings(value: unknown, seen = new Set<unknown>()): string[] {
+  if (typeof value === 'string') return [value];
+  if (value === null || typeof value !== 'object') return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  const out: string[] = [];
+  if (Array.isArray(value)) {
+    for (const item of value) out.push(...reachableStrings(item, seen));
+    return out;
+  }
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    out.push(...reachableStrings(v, seen));
+  }
+  return out;
+}
+
+describe('AC1 — decrypt (resolveToken) runs ONLY inside fetch(), at the wire (T11754)', () => {
+  it('the resolveToken thunk does NOT fire when the handle is built — only on fetch()', async () => {
+    let decryptCalls = 0;
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'default',
+      tokenPreview: tokenPreview(SECRET, 'api_key'),
+      resolveToken: () => {
+        decryptCalls += 1;
+        return SECRET;
+      },
+    });
+    // Building the handle, reading its non-secret fields, and serializing it must
+    // NOT decrypt.
+    expect(sealed.provider).toBe('anthropic');
+    expect(sealed.tokenPreview).toBe('…3210');
+    JSON.stringify({ provider: sealed.provider, preview: sealed.tokenPreview });
+    expect(decryptCalls).toBe(0);
+
+    // Only the wire helper triggers the single decrypt.
+    await authHeadersFromSealed(sealed, 'api_key');
+    expect(decryptCalls).toBe(1);
+  });
+
+  it('a wire helper that bypasses fetch() never sees the plaintext (aws_sdk short-circuits)', async () => {
+    let decryptCalls = 0;
+    const sealed = makeSealedCredential({
+      provider: 'bedrock',
+      account: 'default',
+      tokenPreview: tokenPreview('', 'api_key'),
+      resolveToken: () => {
+        decryptCalls += 1;
+        return '';
+      },
+    });
+    // aws_sdk owns auth out-of-band — authHeadersFromSealed must NOT call fetch().
+    const headers = await authHeadersFromSealed(sealed, 'aws_sdk');
+    expect(headers).toEqual({});
+    expect(decryptCalls).toBe(0);
+  });
+});
+
+describe('AC2 — auth headers built AT THE WIRE from the handle (apiKey vs Bearer) (T11754)', () => {
+  it('anthropic api_key → x-api-key header (NOT Bearer)', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'default',
+      tokenPreview: tokenPreview(SECRET, 'api_key'),
+      resolveToken: () => SECRET,
+    });
+    const headers = await authHeadersFromSealed(sealed, 'api_key');
+    expect(headers['x-api-key']).toBe(SECRET);
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('anthropic oauth → Authorization: Bearer + oauth beta header', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'work',
+      tokenPreview: tokenPreview(SECRET, 'oauth'),
+      resolveToken: () => SECRET,
+    });
+    const headers = await authHeadersFromSealed(sealed, 'oauth');
+    expect(headers.Authorization).toBe(`Bearer ${SECRET}`);
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('openai api_key → Authorization: Bearer (Bearer scheme, NOT x-api-key)', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'openai',
+      account: 'default',
+      tokenPreview: tokenPreview(SECRET, 'api_key'),
+      resolveToken: () => SECRET,
+    });
+    const headers = await authHeadersFromSealed(sealed, 'api_key');
+    expect(headers.Authorization).toBe(`Bearer ${SECRET}`);
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('the helper returns ONLY headers — the plaintext is bound to no caller variable', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'default',
+      tokenPreview: tokenPreview(SECRET, 'api_key'),
+      resolveToken: () => SECRET,
+    });
+    const result = await authHeadersFromSealed(sealed, 'api_key');
+    // The plaintext appears ONLY inside the header value the wire will send —
+    // there is no separate `token` binding in the caller frame.
+    expect(Object.keys(result)).toEqual(expect.arrayContaining(['x-api-key']));
+    // Sanity: the only place SECRET appears is the header value.
+    const hits = reachableStrings(result).filter((s) => s.includes(SECRET));
+    expect(hits).toEqual([SECRET]);
+  });
+});
+
+describe('AC3 — redaction: the token never crosses a log/envelope/diagnostic (T11754)', () => {
+  it('the handle exposes a non-secret tokenPreview, NEVER the full token', () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'default',
+      tokenPreview: tokenPreview(SECRET, 'api_key'),
+      resolveToken: () => SECRET,
+    });
+    // The preview is short, last-4 only, and is NOT the secret.
+    expect(sealed.tokenPreview).toBe('…3210');
+    expect(sealed.tokenPreview).not.toContain(SECRET);
+    expect(sealed.tokenPreview.length).toBeLessThanOrEqual('oat-…0000'.length);
+
+    // A structural walk / JSON dump of the handle never reveals the plaintext —
+    // it lives only in the fetch() closure.
+    expect(reachableStrings(sealed)).not.toContain(SECRET);
+    expect(JSON.stringify(sealed)).not.toContain(SECRET);
+    // …but the redacted preview IS reachable (and safe).
+    expect(reachableStrings(sealed)).toContain('…3210');
+  });
+
+  it('a simulated diagnostic record built from the handle carries the preview, not the secret', () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'work',
+      tokenPreview: tokenPreview(SECRET, 'oauth'),
+      resolveToken: () => SECRET,
+    });
+    // The shape a `cleo llm whoami` / log line would emit: NEVER calls fetch().
+    const diagnostic = {
+      provider: sealed.provider,
+      account: sealed.account,
+      tokenPreview: sealed.tokenPreview,
+      hasCredential: true,
+    };
+    expect(JSON.stringify(diagnostic)).not.toContain(SECRET);
+    expect(diagnostic.tokenPreview).toBe('oat-…3210');
+  });
+
+  it('tokenPreview redacts to at most the last 4 chars (api_key and oauth prefixes)', () => {
+    expect(tokenPreview('abcdEFGH', 'api_key')).toBe('…EFGH');
+    expect(tokenPreview('abcdEFGH', 'oauth')).toBe('oat-…EFGH');
+    // Short tokens never expose more than they are.
+    expect(tokenPreview('xy', 'api_key')).toBe('…xy');
+    // Empty / aws_sdk-style empty token → marker only, no chars.
+    expect(tokenPreview('', 'api_key')).toBe('…');
+    expect(tokenPreview('', 'oauth')).toBe('oat-…');
+  });
+});

--- a/packages/core/src/llm/__tests__/migration.test.ts
+++ b/packages/core/src/llm/__tests__/migration.test.ts
@@ -251,7 +251,7 @@ describe('Phase 1 → Phase 2 migration — additive upgrade', () => {
 
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credential?.source).toBe('cred-file');
-    expect(llm.credential?.apiKey).toBe('sk-ant-api03-NEW');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-api03-NEW');
     expect(llm.credentialLabel).toBe('personal');
   });
 });

--- a/packages/core/src/llm/__tests__/role-executor-selfheal.test.ts
+++ b/packages/core/src/llm/__tests__/role-executor-selfheal.test.ts
@@ -78,21 +78,54 @@ import { _resetRoleWarnLatchForTests, executeForRole } from '../role-executor.js
 // Fixtures
 // ---------------------------------------------------------------------------
 
-/** Build a {@link ResolvedLLM}-shaped object for the mocked resolver. */
-function resolved(overrides: Partial<ResolvedLLM>): ResolvedLLM {
+/**
+ * Build a {@link ResolvedLLM}-shaped object for the mocked resolver.
+ *
+ * E10 (T11753): the resolver returns non-secret credential metadata plus a
+ * sealed handle whose `fetch()` materializes the plaintext at the wire. To keep
+ * the ergonomic test interface (overrides pass a `credential` carrying an
+ * `apiKey`), this helper accepts the secret inline and projects it into BOTH the
+ * redacted metadata `credential` and the `sealedCredential` handle the code
+ * under test consumes.
+ */
+function resolved(
+  overrides: Partial<Omit<ResolvedLLM, 'credential'>> & {
+    credential?: {
+      provider: string;
+      apiKey: string;
+      source: 'cred-file' | 'env' | 'claude-creds' | 'global-config' | 'project-config';
+      authType: 'api_key' | 'oauth';
+    } | null;
+  },
+): ResolvedLLM {
+  const { credential: credOverride, ...rest } = overrides;
+  const cred =
+    credOverride === undefined
+      ? {
+          provider: 'anthropic',
+          apiKey: 'sk-ant-test',
+          source: 'cred-file' as const,
+          authType: 'api_key' as const,
+        }
+      : credOverride;
+  const provider = (rest.provider as string | undefined) ?? cred?.provider ?? 'anthropic';
   return {
-    provider: 'anthropic',
+    provider,
     model: 'claude-haiku-4-5-20251001',
     client: null,
-    credential: {
-      provider: 'anthropic',
-      apiKey: 'sk-ant-test',
-      source: 'cred-file',
-      authType: 'api_key',
-    },
+    credential: cred
+      ? { provider: cred.provider, source: cred.source, authType: cred.authType }
+      : null,
+    sealedCredential: cred
+      ? {
+          provider: cred.provider,
+          account: 'default',
+          fetch: async () => ({ __decryptedToken: 'DecryptedToken' as const, value: cred.apiKey }),
+        }
+      : null,
     source: 'implicit-fallback',
     credentialLabel: 'claude-code',
-    ...overrides,
+    ...rest,
   } as ResolvedLLM;
 }
 

--- a/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver-fullstack.test.ts
@@ -165,7 +165,7 @@ describe('resolveLLMForRole — full-stack for every RoleName', () => {
       expect(llm.provider).toBe('anthropic');
       expect(llm.model).toBe('integration-default-model');
       expect(llm.credential?.source).toBe('env');
-      expect(llm.credential?.apiKey).toBe('sk-ant-integration-env');
+      expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-integration-env');
       expect(llm.client).not.toBeNull();
     }
   });
@@ -190,7 +190,7 @@ describe('resolveLLMForRole — full-stack for every RoleName', () => {
       const llm = await resolveLLMForRole(role, { projectRoot });
       expect(llm.source).toBe('role');
       expect(llm.model).toBe(`model-${role}`);
-      expect(llm.credential?.apiKey).toBe('sk-ant-shared');
+      expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-shared');
     }
   });
 });
@@ -212,7 +212,7 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
 
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credential?.source).toBe('env');
-    expect(llm.credential?.apiKey).toBe('sk-env-wins');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-env-wins');
   });
 
   it('cred-file (tier 3) beats claude-creds (tier 4)', async () => {
@@ -230,7 +230,7 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
 
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credential?.source).toBe('cred-file');
-    expect(llm.credential?.apiKey).toBe('sk-ant-oat-credfile-wins');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-oat-credfile-wins');
   });
 
   it('claude-creds via pool seeder beats global-config (T9413 — pool tier replaces tier 4)', async () => {
@@ -275,7 +275,7 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
 
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credential?.source).toBe('cred-file');
-    expect(llm.credential?.apiKey).toBe('sk-ant-oat-claude-wins');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-oat-claude-wins');
   });
 
   it('global-config (tier 4a) beats project-config (tier 5)', async () => {
@@ -290,7 +290,7 @@ describe('resolveLLMForRole — credential tier precedence (full chain)', () => 
 
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credential?.source).toBe('global-config');
-    expect(llm.credential?.apiKey).toBe('sk-global-wins');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-global-wins');
   });
 
   it('project-config (tier 5) is REJECTED — never resolves even as floor (T9413)', async () => {
@@ -348,12 +348,12 @@ describe('resolveLLMForRole — per-role credentialLabel isolation', () => {
 
     const ext = await resolveLLMForRole('extraction', { projectRoot });
     expect(ext.credentialLabel).toBe('extract-key');
-    expect(ext.credential?.apiKey).toBe('sk-for-extraction');
+    expect((await ext.sealedCredential?.fetch())?.value).toBe('sk-for-extraction');
     expect(ext.model).toBe('extract-model');
 
     const jud = await resolveLLMForRole('judgement', { projectRoot });
     expect(jud.credentialLabel).toBe('judge-key');
-    expect(jud.credential?.apiKey).toBe('sk-for-judgement');
+    expect((await jud.sealedCredential?.fetch())?.value).toBe('sk-for-judgement');
     expect(jud.model).toBe('judge-model');
   });
 });

--- a/packages/core/src/llm/__tests__/role-resolver.test.ts
+++ b/packages/core/src/llm/__tests__/role-resolver.test.ts
@@ -303,7 +303,8 @@ describe('resolveLLMForRole — named profile + defaultProfile binding (T11617)'
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.source).toBe('profile');
     expect(llm.credentialLabel).toBe('pinned-label');
-    expect(llm.credential?.apiKey).toBe('sk-ant-pinned');
+    // E10 (T11753): plaintext is reachable ONLY via the sealed handle's fetch().
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-pinned');
   });
 });
 
@@ -320,6 +321,8 @@ describe('resolveLLMForRole — credential resolution', () => {
     // No env, no cred-file, no claude-creds, no global / project config key.
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credential).toBeNull();
+    // E10 (T11753): no credential → null sealed handle, paired with null metadata.
+    expect(llm.sealedCredential).toBeNull();
     expect(llm.client).toBeNull();
   });
 
@@ -330,7 +333,7 @@ describe('resolveLLMForRole — credential resolution', () => {
     });
     process.env['ANTHROPIC_API_KEY'] = 'sk-ant-env';
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
-    expect(llm.credential?.apiKey).toBe('sk-ant-env');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-env');
     expect(llm.credential?.source).toBe('env');
     expect(llm.client).not.toBeNull();
   });
@@ -350,7 +353,7 @@ describe('resolveLLMForRole — credential resolution', () => {
       priority: 1,
     });
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
-    expect(llm.credential?.apiKey).toBe('sk-ant-credfile');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-credfile');
     expect(llm.credential?.source).toBe('cred-file');
     expect(llm.credentialLabel).toBe('workspace-default');
   });
@@ -382,7 +385,7 @@ describe('resolveLLMForRole — credential resolution', () => {
     });
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     expect(llm.credentialLabel).toBe('work');
-    expect(llm.credential?.apiKey).toBe('sk-work');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-work');
     expect(llm.credential?.source).toBe('cred-file');
   });
 
@@ -408,7 +411,7 @@ describe('resolveLLMForRole — credential resolution', () => {
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     // Label did not match — picker is bypassed; tier 2 (env) wins.
     expect(llm.credentialLabel).toBeUndefined();
-    expect(llm.credential?.apiKey).toBe('sk-env-rescue');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-env-rescue');
     expect(llm.credential?.source).toBe('env');
   });
 
@@ -433,11 +436,12 @@ describe('resolveLLMForRole — credential resolution', () => {
       priority: 1,
     });
     const llm = await resolveLLMForRole('extraction', { projectRoot });
-    expect(llm.credential?.apiKey).toBe('sk-ant-default-pinned');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-default-pinned');
     expect(llm.credential?.source).toBe('cred-file');
     expect(llm.credentialLabel).toBe('default');
-    // The key assertion for the T9360 AC: hasCredential equivalence.
-    expect(!!llm.credential?.apiKey).toBe(true);
+    // The key assertion for the T9360 AC: hasCredential equivalence — now the
+    // sealed-handle presence is the post-E10 hasCredential signal (T11753).
+    expect(!!llm.sealedCredential).toBe(true);
   });
 
   it('hasCredential is true when no credentialLabel but default-labelled credential exists (T9360)', async () => {
@@ -460,10 +464,10 @@ describe('resolveLLMForRole — credential resolution', () => {
       priority: 1,
     });
     const llm = await resolveLLMForRole('extraction', { projectRoot });
-    expect(llm.credential?.apiKey).toBe('sk-ant-no-label-default');
+    expect((await llm.sealedCredential?.fetch())?.value).toBe('sk-ant-no-label-default');
     expect(llm.credential?.source).toBe('cred-file');
     expect(llm.credentialLabel).toBe('default');
-    expect(!!llm.credential?.apiKey).toBe(true);
+    expect(!!llm.sealedCredential).toBe(true);
   });
 });
 

--- a/packages/core/src/llm/__tests__/sealed-credential-boundary.test.ts
+++ b/packages/core/src/llm/__tests__/sealed-credential-boundary.test.ts
@@ -1,0 +1,266 @@
+/**
+ * E10 sealed-credential boundary tests (T11753 — AC3).
+ *
+ * The security invariant this file enforces: **no bare plaintext secret string
+ * crosses the resolver boundary.** After `resolveLLMForRole` /
+ * `resolveLLMForSystem` returns, the only way to reach the plaintext is to call
+ * `sealedCredential.fetch()` — the handle's provider/account are non-secret, and
+ * a deep walk of the returned envelope finds the secret nowhere else (not on
+ * `credential`, not serialized, not in any string field).
+ *
+ * NOTE on the `client` field: the resolver may construct a provider SDK client
+ * (`new Anthropic(...)`) — the ONE sanctioned credential-holder named in the
+ * Gate-13 chokepoint allowlist. That SDK object legitimately retains the key
+ * internally to authenticate requests; it is a runtime object, NOT a bare
+ * secret string the resolver "leaked". The walk below therefore EXCLUDES
+ * `client` (and `sealedCredential.fetch`, whose closure is the intended secret
+ * home) and asserts the plaintext appears on no OTHER envelope field. This is
+ * the precise expression of the E10 invariant: the secret is no longer carried
+ * as inline data up the stack — it lives only in the SDK client (sanctioned)
+ * and the sealed `fetch()` closure (on-demand).
+ *
+ * These tests use the SAME filesystem-isolation harness as `role-resolver.test.ts`
+ * so the resolver exercises real config/credential tiers rather than mocks.
+ *
+ * @task T11753
+ * @epic T11746
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearAnthropicKeyCache } from '../credentials.js';
+import {
+  _resetPermsWarningForTests,
+  _resetRoundRobinForTests,
+  addCredential,
+} from '../credentials-store.js';
+import { _resetGlobalConfigMigrationLatch } from '../global-config-migration.js';
+import { resolveLLMForRole } from '../role-resolver.js';
+import { makeSealedCredential } from '../sealed-credential.js';
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'XDG_DATA_HOME',
+  'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
+  'CLEO_HOME',
+  'HOME',
+  'CLEO_DIR',
+];
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+/** Fresh per-test tmp roots so no developer credential leaks in. */
+function isolate(): { projectRoot: string } {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const xdgRoot = join(tmpdir(), `cleo-seal-xdg-${stamp}`);
+  const xdgConfigHome = join(tmpdir(), `cleo-seal-cfg-${stamp}`);
+  const home = join(tmpdir(), `cleo-seal-home-${stamp}`);
+  const projectRoot = join(tmpdir(), `cleo-seal-proj-${stamp}`);
+  mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+  mkdirSync(xdgRoot, { recursive: true });
+  mkdirSync(xdgConfigHome, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['HOME'] = home;
+  delete process.env['CLEO_HOME'];
+  delete process.env['CLEO_DIR'];
+  _resetCleoPlatformPathsCache();
+  return { projectRoot };
+}
+
+function seedProjectConfig(projectRoot: string, llm: Record<string, unknown>): void {
+  writeFileSync(join(projectRoot, '.cleo', 'config.json'), JSON.stringify({ llm }, null, 2));
+}
+
+/**
+ * Recursively collect every primitive string reachable from `value`, descending
+ * into plain objects and arrays but NOT into functions (a function body is
+ * opaque — the closure-captured secret is exactly what we WANT to be unreachable
+ * by a structural/serialization walk).
+ */
+function reachableStrings(value: unknown, seen = new Set<unknown>()): string[] {
+  if (typeof value === 'string') return [value];
+  if (value === null || typeof value !== 'object') return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  const out: string[] = [];
+  if (Array.isArray(value)) {
+    for (const item of value) out.push(...reachableStrings(item, seen));
+    return out;
+  }
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    out.push(...reachableStrings(v, seen));
+  }
+  return out;
+}
+
+const SECRET = 'sk-ant-SECRET-boundary-do-not-leak-0123456789';
+
+/**
+ * Project the resolved envelope to its DATA surface — everything EXCEPT the
+ * sanctioned credential-holders: the provider SDK `client` (the one allowed
+ * `new Anthropic(...)` instance, which retains the key to authenticate) and the
+ * `sealedCredential.fetch` closure (the intended on-demand secret home). What
+ * remains is the data that genuinely crosses the resolver boundary inline.
+ */
+function envelopeDataSurface(llm: {
+  client?: unknown;
+  sealedCredential?: { provider: string; account: string; fetch: unknown } | null;
+  [k: string]: unknown;
+}): Record<string, unknown> {
+  const { client: _client, sealedCredential, ...rest } = llm;
+  return {
+    ...rest,
+    // Keep the handle's NON-secret identity fields; drop the fetch closure.
+    sealedCredential: sealedCredential
+      ? { provider: sealedCredential.provider, account: sealedCredential.account }
+      : sealedCredential,
+  };
+}
+
+describe('E10 resolver boundary — no bare secret crosses the resolver (T11753 · AC3)', () => {
+  beforeEach(() => {
+    saveEnv();
+    clearEnv();
+    _resetCleoPlatformPathsCache();
+    _resetGlobalConfigMigrationLatch();
+    _resetPermsWarningForTests();
+    _resetRoundRobinForTests();
+    clearAnthropicKeyCache();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    _resetCleoPlatformPathsCache();
+  });
+
+  it('the resolved envelope contains the plaintext NOWHERE — not credential, not any string field', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
+    process.env['ANTHROPIC_API_KEY'] = SECRET;
+
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+
+    // A credential WAS resolved (the sealed handle is present)…
+    expect(llm.sealedCredential).not.toBeNull();
+    // …but the plaintext is reachable on NO inline DATA field of the envelope
+    // (excluding the sanctioned SDK client + the fetch() closure).
+    const surface = envelopeDataSurface(llm);
+    expect(reachableStrings(surface)).not.toContain(SECRET);
+    // Belt-and-suspenders: serializing the data surface never reveals it.
+    expect(JSON.stringify(surface)).not.toContain(SECRET);
+  });
+
+  it('the inline credential metadata carries provider/source/authType but NO apiKey', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
+    process.env['ANTHROPIC_API_KEY'] = SECRET;
+
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+
+    expect(llm.credential).toMatchObject({
+      provider: 'anthropic',
+      source: 'env',
+      authType: 'api_key',
+    });
+    // The runtime object must not even have an `apiKey` key.
+    expect(Object.keys(llm.credential ?? {})).not.toContain('apiKey');
+  });
+
+  it('the plaintext is reachable ONLY by calling sealedCredential.fetch()', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
+    process.env['ANTHROPIC_API_KEY'] = SECRET;
+
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+    const token = await llm.sealedCredential?.fetch();
+    expect(token?.value).toBe(SECRET);
+    // The non-secret handle fields are safe to surface.
+    expect(llm.sealedCredential?.provider).toBe('anthropic');
+    expect(typeof llm.sealedCredential?.account).toBe('string');
+  });
+
+  it('no credential resolved → both credential and sealedCredential are null', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
+    // No env, no store, no config key.
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+    expect(llm.credential).toBeNull();
+    expect(llm.sealedCredential).toBeNull();
+  });
+
+  it('a cred-store token is also fully sealed (not just the env tier)', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
+    await addCredential({
+      provider: 'anthropic',
+      label: 'sealed-test',
+      authType: 'api_key',
+      accessToken: SECRET,
+      priority: 1,
+    });
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+    expect(JSON.stringify(envelopeDataSurface(llm))).not.toContain(SECRET);
+    expect((await llm.sealedCredential?.fetch())?.value).toBe(SECRET);
+  });
+});
+
+describe('makeSealedCredential — the handle does not expose the secret structurally (T11753)', () => {
+  it('serializing the handle never reveals the captured plaintext', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'work',
+      resolveToken: () => SECRET,
+    });
+    // Provider + account are non-secret and safe to surface…
+    expect(sealed.provider).toBe('anthropic');
+    expect(sealed.account).toBe('work');
+    // …but a structural walk / JSON dump of the handle never contains the secret
+    // (it lives only in the fetch() closure).
+    expect(reachableStrings(sealed)).not.toContain(SECRET);
+    expect(JSON.stringify(sealed)).not.toContain(SECRET);
+    // The secret materializes ONLY on fetch().
+    expect((await sealed.fetch()).value).toBe(SECRET);
+  });
+
+  it('supports an async on-demand resolver (the T11754 vault-fetch shape)', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'openai',
+      account: 'default',
+      resolveToken: async () => {
+        await Promise.resolve();
+        return SECRET;
+      },
+    });
+    expect((await sealed.fetch()).value).toBe(SECRET);
+  });
+
+  it('propagates resolver failure so callers degrade gracefully', async () => {
+    const sealed = makeSealedCredential({
+      provider: 'anthropic',
+      account: 'broken',
+      resolveToken: () => {
+        throw new Error('vault unreachable');
+      },
+    });
+    await expect(sealed.fetch()).rejects.toThrow('vault unreachable');
+  });
+});

--- a/packages/core/src/llm/__tests__/sealed-credential-boundary.test.ts
+++ b/packages/core/src/llm/__tests__/sealed-credential-boundary.test.ts
@@ -123,15 +123,25 @@ const SECRET = 'sk-ant-SECRET-boundary-do-not-leak-0123456789';
  */
 function envelopeDataSurface(llm: {
   client?: unknown;
-  sealedCredential?: { provider: string; account: string; fetch: unknown } | null;
+  sealedCredential?: {
+    provider: string;
+    account: string;
+    tokenPreview?: string;
+    fetch: unknown;
+  } | null;
   [k: string]: unknown;
 }): Record<string, unknown> {
   const { client: _client, sealedCredential, ...rest } = llm;
   return {
     ...rest,
-    // Keep the handle's NON-secret identity fields; drop the fetch closure.
+    // Keep the handle's NON-secret identity fields (incl. the redacted
+    // tokenPreview); drop the fetch closure.
     sealedCredential: sealedCredential
-      ? { provider: sealedCredential.provider, account: sealedCredential.account }
+      ? {
+          provider: sealedCredential.provider,
+          account: sealedCredential.account,
+          tokenPreview: sealedCredential.tokenPreview,
+        }
       : sealedCredential,
   };
 }
@@ -207,6 +217,21 @@ describe('E10 resolver boundary — no bare secret crosses the resolver (T11753 
     expect(llm.sealedCredential).toBeNull();
   });
 
+  it('the resolver surfaces a non-secret tokenPreview on the handle, never the full token (T11754)', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
+    process.env['ANTHROPIC_API_KEY'] = SECRET;
+
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+    // Preview is present, redacted to the last 4 chars, and is NOT the secret.
+    expect(llm.sealedCredential?.tokenPreview).toBe(`…${SECRET.slice(-4)}`);
+    expect(llm.sealedCredential?.tokenPreview).not.toContain(SECRET);
+    // The preview is reachable on the data surface (safe); the secret is not.
+    const surface = envelopeDataSurface(llm);
+    expect(reachableStrings(surface)).toContain(`…${SECRET.slice(-4)}`);
+    expect(reachableStrings(surface)).not.toContain(SECRET);
+  });
+
   it('a cred-store token is also fully sealed (not just the env tier)', async () => {
     const { projectRoot } = isolate();
     seedProjectConfig(projectRoot, { default: { provider: 'anthropic', model: 'mx' } });
@@ -228,6 +253,7 @@ describe('makeSealedCredential — the handle does not expose the secret structu
     const sealed = makeSealedCredential({
       provider: 'anthropic',
       account: 'work',
+      tokenPreview: '…leak',
       resolveToken: () => SECRET,
     });
     // Provider + account are non-secret and safe to surface…
@@ -245,6 +271,7 @@ describe('makeSealedCredential — the handle does not expose the secret structu
     const sealed = makeSealedCredential({
       provider: 'openai',
       account: 'default',
+      tokenPreview: '…CRET',
       resolveToken: async () => {
         await Promise.resolve();
         return SECRET;
@@ -257,6 +284,7 @@ describe('makeSealedCredential — the handle does not expose the secret structu
     const sealed = makeSealedCredential({
       provider: 'anthropic',
       account: 'broken',
+      tokenPreview: '…oken',
       resolveToken: () => {
         throw new Error('vault unreachable');
       },

--- a/packages/core/src/llm/__tests__/session-factory.test.ts
+++ b/packages/core/src/llm/__tests__/session-factory.test.ts
@@ -30,11 +30,21 @@ function makeResolvedLLM(
   apiKey: string | null = 'sk-test',
   authType: 'api_key' | 'oauth' = 'api_key',
 ) {
+  // E10 (T11753): the resolver returns non-secret credential metadata + a sealed
+  // handle whose fetch() materializes the plaintext at the wire. The mock mirrors
+  // that shape so session-factory's `sealedCredential.fetch()` call resolves.
   return {
     provider,
     model: 'claude-haiku-4-5-20251001',
     client: null,
-    credential: apiKey ? { provider, apiKey, source: 'env' as const, authType } : null,
+    credential: apiKey ? { provider, source: 'env' as const, authType } : null,
+    sealedCredential: apiKey
+      ? {
+          provider,
+          account: 'default',
+          fetch: async () => ({ __decryptedToken: 'DecryptedToken' as const, value: apiKey }),
+        }
+      : null,
     source: 'implicit-fallback' as const,
     credentialLabel: undefined,
   };

--- a/packages/core/src/llm/auxiliary-fallback.ts
+++ b/packages/core/src/llm/auxiliary-fallback.ts
@@ -371,7 +371,7 @@ async function _defaultAuxiliaryProvider(
   // Fall back to the role-resolved provider if the chain provider matches.
   const targetProvider = entry.provider;
 
-  if (targetProvider === resolved.provider && resolved.credential?.apiKey) {
+  if (targetProvider === resolved.provider && resolved.sealedCredential) {
     const session = await factory.createForRole('hygiene');
     return session.send(messages, opts);
   }

--- a/packages/core/src/llm/cli-ops.ts
+++ b/packages/core/src/llm/cli-ops.ts
@@ -475,7 +475,9 @@ export async function llmWhoami(params: LlmWhoamiParams): Promise<EngineResult<L
         source: resolved.source,
         credentialLabel: resolved.credentialLabel,
         credentialSource: resolved.credential?.source,
-        hasCredential: !!resolved.credential?.apiKey,
+        // E10 (T11753): `hasCredential` is now the sealed-handle presence — a
+        // non-secret signal — so whoami never materializes the plaintext.
+        hasCredential: !!resolved.sealedCredential,
       });
     }
     return engineSuccess({ entries });

--- a/packages/core/src/llm/cli-ops.ts
+++ b/packages/core/src/llm/cli-ops.ts
@@ -61,6 +61,7 @@ import {
   type StoredCredential,
 } from './credentials-store.js';
 import { IMPLICIT_FALLBACK_MODEL, resolveLLMForRole } from './role-resolver.js';
+import { tokenPreview } from './sealed-credential.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -93,13 +94,14 @@ const ALL_ROLES = ['extraction', 'consolidation', 'derivation', 'hygiene', 'judg
  * NEVER returns the full token. This is the only redaction code path
  * used by `cleo llm` result envelopes.
  *
+ * Delegates to the SSoT redaction chokepoint {@link tokenPreview}
+ * (`sealed-credential.ts`, shared with the E10 handle · T11754). `aws_sdk`
+ * collapses to the non-OAuth `'…'` prefix, identical to the prior behaviour.
+ *
  * @task T9258 (S-11)
  */
 function tokenPreviewOf(token: string, authType: StoredAuthTypeWire): string {
-  const prefix = authType === 'oauth' ? 'oat-…' : '…';
-  if (!token) return prefix;
-  if (token.length <= 4) return `${prefix}${token}`;
-  return `${prefix}${token.slice(-4)}`;
+  return tokenPreview(token, authType === 'oauth' ? 'oauth' : 'api_key');
 }
 
 /**

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -30,6 +30,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type { SealedCredential } from '@cleocode/contracts';
 import { getCleoHome } from '@cleocode/paths';
 import { getCredentialPool } from './credential-pool.js';
 import { pickCredentialForProviderSync } from './credentials-store.js';
@@ -581,6 +582,59 @@ export function authHeaders(cred: CredentialResult): Record<string, string> {
 
   // openai / gemini / moonshot — all use Bearer auth for API keys.
   return { Authorization: `Bearer ${cred.apiKey}` };
+}
+
+/**
+ * Build the provider auth headers AT THE WIRE directly from a sealed credential
+ * handle — the E10 boundary primitive (T11754 · AC2).
+ *
+ * ## Why this exists
+ *
+ * The pre-E10 / interim pattern materialized the plaintext into a caller-visible
+ * variable first — `const token = (await sealed.fetch()).value;` — and only then
+ * called {@link authHeaders}. That intermediate `token` binding is a leak surface:
+ * any code added between the `fetch()` and the header build could log, serialize,
+ * or forward the bare secret.
+ *
+ * `authHeadersFromSealed` collapses those two steps into ONE chokepoint. It is
+ * the SOLE place (alongside daemon worker-injection) that invokes
+ * {@link SealedCredential.fetch} — the crypto decrypt happens inside the handle's
+ * `fetch()`, the materialized {@link DecryptedToken} is consumed in-place to build
+ * the `x-api-key` / `Authorization: Bearer` headers (per provider + scheme), and
+ * the plaintext goes out of scope WITHOUT ever being returned, logged, or bound
+ * to a caller variable. Callers receive ONLY the finished header bag.
+ *
+ * Invoke this ONLY at a wire boundary — `transportForProvider` /
+ * `session-factory.ts:56`, the raw-fetch consumers (hygiene-scan,
+ * duplicate-detector), or daemon worker-injection. Never to surface a key up the
+ * resolver stack.
+ *
+ * @param sealed - The opaque credential handle returned by the resolver.
+ * @param authType - The auth scheme to present the credential with (mirrors the
+ *   resolved `credential.authType`). `'aws_sdk'` yields an empty bag — the AWS
+ *   SDK injects credentials out-of-band, so there is no header to build.
+ * @returns The provider-specific auth headers. The plaintext token is consumed
+ *   internally and never escapes this function.
+ * @task T11754
+ */
+export async function authHeadersFromSealed(
+  sealed: SealedCredential,
+  authType: 'api_key' | 'oauth' | 'aws_sdk',
+): Promise<Record<string, string>> {
+  // The AWS SDK owns Bedrock auth out-of-band — no wire header to materialize,
+  // so we must NOT call fetch() (the token is empty for aws_sdk entries).
+  if (authType === 'aws_sdk') return {};
+
+  // The SOLE decrypt/materialize point at this boundary. The branded plaintext
+  // lives only for the synchronous authHeaders() call below, then goes out of
+  // scope. It is NEVER assigned to a caller-visible binding or returned.
+  const decrypted = await sealed.fetch();
+  return authHeaders({
+    provider: sealed.provider as ModelTransport,
+    apiKey: decrypted.value,
+    source: undefined,
+    authType: authType === 'oauth' ? 'oauth' : 'api_key',
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -243,6 +243,9 @@ export {
 // Runtime
 export type { AttemptPlan } from './runtime.js';
 export { effectiveTemperature, makeAttemptRef, planAttempt } from './runtime.js';
+// Sealed credential handle — E10 on-demand-decrypt impl (T11753)
+export type { MakeSealedCredentialParams } from './sealed-credential.js';
+export { makeSealedCredential } from './sealed-credential.js';
 export type { StructuredOutputFailurePolicy } from './structured-output.js';
 // Structured output utilities
 export {

--- a/packages/core/src/llm/pi/__tests__/pi-anthropic-turn.integration.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-anthropic-turn.integration.test.ts
@@ -28,7 +28,9 @@ let hasCredential = false;
 beforeAll(async () => {
   try {
     const resolved = await resolveLLMForSystem('task-executor');
-    hasCredential = Boolean(resolved.credential?.apiKey) || resolved.authType === 'aws_sdk';
+    // E10 (T11753): the sealed-handle presence is the credential-availability
+    // signal — the inline plaintext apiKey no longer exists on the envelope.
+    hasCredential = Boolean(resolved.sealedCredential) || resolved.authType === 'aws_sdk';
   } catch {
     hasCredential = false;
   }

--- a/packages/core/src/llm/pi/__tests__/pi-stream-fn-abort.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-stream-fn-abort.test.ts
@@ -34,12 +34,17 @@ vi.mock('../../system-resolver.js', () => ({
     provider: 'anthropic',
     model: 'mock-model',
     client: null,
+    // E10 (T11753): non-secret metadata + a sealed handle whose fetch() the
+    // wire-side `toDescriptor` invokes to materialize the token.
     credential: {
       provider: 'anthropic',
-      apiKey: 'sk-mock',
       source: 'env',
       authType: 'api_key',
-      label: 'mock',
+    },
+    sealedCredential: {
+      provider: 'anthropic',
+      account: 'mock',
+      fetch: async () => ({ __decryptedToken: 'DecryptedToken' as const, value: 'sk-mock' }),
     },
     source: 'role-config',
     apiMode: 'anthropic_messages',

--- a/packages/core/src/llm/pi/pi-stream-fn.ts
+++ b/packages/core/src/llm/pi/pi-stream-fn.ts
@@ -189,7 +189,7 @@ async function produce(
   const resolved = await resolveLLMForSystem(ctx.system, {
     ...(ctx.projectRoot !== undefined ? { projectRoot: ctx.projectRoot } : {}),
   });
-  if (!resolved.credential?.apiKey && resolved.authType !== 'aws_sdk') {
+  if (!resolved.sealedCredential && resolved.authType !== 'aws_sdk') {
     // No credential reachable — surface a typed terminal error (graceful: the
     // loop sees an error AssistantMessage and stops, the daemon is unharmed).
     emitError(out, model, `no credential resolved for system "${ctx.system}"`);
@@ -197,8 +197,10 @@ async function produce(
   }
 
   // 2. Clean descriptor from resolved fields (NO model literal here — the model
-  //    is whatever the resolver/registry produced).
-  const descriptor = toDescriptor(resolved);
+  //    is whatever the resolver/registry produced). The plaintext token is
+  //    materialized from the sealed handle ONLY here, at the wire boundary that
+  //    feeds ModelRunner — never carried inline on the resolver envelope (E10).
+  const descriptor = await toDescriptor(resolved);
 
   // 3. Single SSoT transport factory. The transport/client construction lives
   //    inside ModelRunner — this file constructs nothing.
@@ -292,19 +294,27 @@ async function produce(
  * boundary. The `model` comes from the resolver (registry/role-config), never a
  * literal.
  *
+ * E10 (T11753): the plaintext token is materialized HERE — at the wire boundary
+ * that feeds `ModelRunner` — by invoking `resolved.sealedCredential.fetch()`.
+ * It is written into the descriptor's `credential.apiKey` (consumed only inside
+ * the `ModelRunner` chokepoint) and never returned up the resolver stack. This
+ * is async because `fetch()` is the on-demand decrypt point.
+ *
  * @param resolved - The `resolveLLMForSystem` envelope.
  * @returns A clean descriptor for `ModelRunner.build`.
  */
-function toDescriptor(
+async function toDescriptor(
   resolved: Awaited<ReturnType<typeof resolveLLMForSystem>>,
-): ResolvedLLMDescriptor {
+): Promise<ResolvedLLMDescriptor> {
+  // Materialize the plaintext from the sealed handle ONLY at this wire boundary.
+  const apiKey = resolved.sealedCredential ? (await resolved.sealedCredential.fetch()).value : null;
   return {
     provider: resolved.provider,
     model: resolved.model,
     credential: resolved.credential
       ? {
           provider: resolved.credential.provider,
-          apiKey: resolved.credential.apiKey,
+          apiKey,
           source: resolved.credential.source,
           authType: resolved.credential.authType,
         }

--- a/packages/core/src/llm/role-executor.ts
+++ b/packages/core/src/llm/role-executor.ts
@@ -148,7 +148,7 @@ export async function executeForRole(
   opts: ExecuteForRoleOptions = {},
 ): Promise<ExecuteForRoleResult | null> {
   const llm = await resolveLLMForRole(role, { projectRoot: opts.projectRoot });
-  if (!llm.credential?.apiKey) {
+  if (!llm.sealedCredential || !llm.credential) {
     // No usable credential for this role's resolved provider. Surface ONE
     // actionable re-auth hint per (role, provider) tuple instead of a silent
     // skip — the caller still degrades gracefully via the null return.
@@ -185,14 +185,16 @@ export async function executeForRole(
     // anthropic block hardcoded the OAuth beta header; the others omitted it).
     const authType: 'api_key' | 'oauth' = llm.credential.authType === 'oauth' ? 'oauth' : 'api_key';
 
+    // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
+    // at the wire — immediately before building the transport. The token is used
+    // for the kimi-code diagnostic and the transport credential, then goes out
+    // of scope; it is never returned, logged, or serialized.
+    const token = (await llm.sealedCredential.fetch()).value;
+
     // Diagnostic (preserved): a non-`sk-kimi-`, non-OAuth key routed to
     // kimi-code will likely fail — the legacy Moonshot `mk-*` path lives on the
     // separate `moonshot` provider.
-    if (
-      llm.provider === 'kimi-code' &&
-      authType !== 'oauth' &&
-      !isKimiCodeApiKey(llm.credential.apiKey)
-    ) {
+    if (llm.provider === 'kimi-code' && authType !== 'oauth' && !isKimiCodeApiKey(token)) {
       console.warn(
         `[role-executor] kimi-code credential is not sk-kimi- prefixed and not OAuth; ` +
           `the request may fail. Configure a coding-plan key from kimi.com/code or ` +
@@ -204,7 +206,7 @@ export async function executeForRole(
     const resolvedCredential: ResolvedCredential = {
       provider: llm.provider,
       label: llm.credentialLabel ?? 'default',
-      token: llm.credential.apiKey,
+      token,
       authType,
       expiresAt: null,
       refreshToken: null,

--- a/packages/core/src/llm/role-resolver.ts
+++ b/packages/core/src/llm/role-resolver.ts
@@ -48,7 +48,7 @@ import { CredentialPool } from './credential-pool.js';
 import { type CredentialResult, resolveCredentials } from './credentials.js';
 import { getCredentialByLabel, pickCredentialForProvider } from './credentials-store.js';
 import { IMPLICIT_FALLBACK_MODEL } from './fallback-model.js';
-import { makeSealedCredential } from './sealed-credential.js';
+import { makeSealedCredential, tokenPreview } from './sealed-credential.js';
 import { buildAnthropicClient } from './transports/anthropic-client-factory.js';
 import type { ModelTransport } from './types-config.js';
 
@@ -495,6 +495,10 @@ export async function resolveLLMForRole(
     sealedCredential = makeSealedCredential({
       provider: credential.provider,
       account: usedLabel ?? 'default',
+      // Non-secret redacted preview (≤ last 4 chars) computed ONCE at seal time
+      // — the only token-derived string allowed on a log/envelope/diagnostic
+      // (E10 · T11754 · AC3). The full plaintext is NOT retained for it.
+      tokenPreview: tokenPreview(token, wireAuthType),
       // The already-resolved plaintext is captured in this closure and handed
       // out ONLY when a wire boundary invokes fetch(); it is never surfaced on
       // the envelope. T11754 swaps this thunk for an on-demand vault decrypt.

--- a/packages/core/src/llm/role-resolver.ts
+++ b/packages/core/src/llm/role-resolver.ts
@@ -30,6 +30,7 @@ import type { Anthropic } from '@anthropic-ai/sdk';
 import type {
   ApiMode,
   CleoConfig,
+  CredentialMetadataWire,
   LlmConfig,
   LlmDefaultConfig,
   LlmProfileConfig,
@@ -38,6 +39,7 @@ import type {
   ResolutionSource,
   ResolveLLMForRoleOptions,
   RoleName,
+  SealedCredential,
 } from '@cleocode/contracts';
 import type { OpenAI } from 'openai';
 import { resolveOrCwd } from '../paths.js';
@@ -46,6 +48,7 @@ import { CredentialPool } from './credential-pool.js';
 import { type CredentialResult, resolveCredentials } from './credentials.js';
 import { getCredentialByLabel, pickCredentialForProvider } from './credentials-store.js';
 import { IMPLICIT_FALLBACK_MODEL } from './fallback-model.js';
+import { makeSealedCredential } from './sealed-credential.js';
 import { buildAnthropicClient } from './transports/anthropic-client-factory.js';
 import type { ModelTransport } from './types-config.js';
 
@@ -115,14 +118,24 @@ export type { ResolutionSource, ResolveLLMForRoleOptions };
  *
  * The contracts-level `ResolvedLLM` (from `@cleocode/contracts`) carries
  * `client: unknown` to stay SDK-free. This core variant tightens the same
- * envelope with the concrete SDK union (`LLMClient`) and the local
- * {@link CredentialResult} — same shape, narrower types.
+ * envelope with the concrete SDK union (`LLMClient`) — same shape, narrower
+ * `client` type.
  *
- * `client` is `null` only when `credential.apiKey` is also null — in which
+ * `client` is `null` only when {@link sealedCredential} is also null — in which
  * case the caller MUST fall back to its graceful-degradation path
  * (return null / skip / log warn).
  *
+ * ## E10 — no inline plaintext (T11753)
+ *
+ * The secret-bearing `credential.apiKey` field is **gone**. `credential` is now
+ * non-secret {@link CredentialMetadataWire} metadata (provider / source /
+ * authType) so callers can still branch on auth scheme and surface diagnostics.
+ * The plaintext token is reachable ONLY via {@link sealedCredential}'s `fetch()`
+ * at the wire (`transportForProvider` / `session-factory.ts`) or daemon
+ * worker-injection — it never crosses this envelope.
+ *
  * @task T9255
+ * @task T11753
  */
 export interface ResolvedLLM {
   /** LLM provider transport that was resolved. */
@@ -136,10 +149,24 @@ export interface ResolvedLLM {
    */
   client: LLMClient | null;
   /**
-   * Resolved credential. `null` when none of the 6 credential tiers
-   * produced a token. Callers MUST handle this case.
+   * Resolved credential **metadata** (provider / source / authType) — NO
+   * plaintext. `null` when none of the 6 credential tiers produced a token
+   * (paired with `sealedCredential === null`). Callers MUST handle this case
+   * and obtain the secret via {@link sealedCredential}.
+   *
+   * @task T11753
    */
-  credential: CredentialResult | null;
+  credential: CredentialMetadataWire | null;
+  /**
+   * Sealed credential handle — the canonical, on-demand credential surface
+   * (E10 · T11752 · T11753). `null` exactly when `credential` is `null`.
+   *
+   * The plaintext is materialized ONLY by `sealedCredential.fetch()` at the
+   * wire / daemon worker-injection — never returned up this envelope.
+   *
+   * @task T11753
+   */
+  sealedCredential: SealedCredential | null;
   /** Which config path produced this resolution. */
   source: ResolutionSource;
   /** When `roles[role].credentialLabel` was set, the label that was used. */
@@ -356,18 +383,27 @@ async function resolveCredentialForRole(
  *
  * See module docs for the full resolution algorithm. Never throws — when
  * no credential is reachable the caller receives
- * `{ credential: null, client: null, ... }` and is responsible for its own
- * graceful-degradation path (the previous Phase 1 pattern was a `return null`
- * shortcut at the call-site).
+ * `{ credential: null, sealedCredential: null, client: null, ... }` and is
+ * responsible for its own graceful-degradation path (the previous Phase 1
+ * pattern was a `return null` shortcut at the call-site).
+ *
+ * E10 (T11753): the plaintext token never rides on the returned envelope.
+ * Materialize it ONLY at the wire by calling `llm.sealedCredential.fetch()`.
  *
  * @example
  * ```ts
  * const llm = await resolveLLMForRole('consolidation', { projectRoot });
- * if (!llm.credential?.apiKey || !llm.client) {
+ * if (!llm.sealedCredential || !llm.client) {
  *   return null; // graceful no-op
  * }
+ * // At the wire — the ONLY place the plaintext is materialized:
+ * const token = (await llm.sealedCredential.fetch()).value;
  * const response = await fetch('https://api.anthropic.com/v1/messages', {
- *   headers: { 'Content-Type': 'application/json', ...authHeaders(llm.credential) },
+ *   headers: {
+ *     'Content-Type': 'application/json',
+ *     ...authHeaders({ provider: llm.provider, apiKey: token,
+ *       source: llm.credential?.source, authType: llm.credential?.authType ?? 'api_key' }),
+ *   },
  *   body: JSON.stringify({ model: llm.model, ...rest }),
  * });
  * ```
@@ -377,6 +413,7 @@ async function resolveCredentialForRole(
  * @returns A {@link ResolvedLLM} envelope; never throws.
  *
  * @task T9255
+ * @task T11753
  */
 export async function resolveLLMForRole(
   role: RoleName,
@@ -440,11 +477,37 @@ export async function resolveLLMForRole(
   const authType: 'api_key' | 'oauth' | 'aws_sdk' | null = credential?.authType ?? null;
   const wire = deriveApiWire(provider, authType);
 
+  // Step 6 — E10 (T11753): seal the credential. The plaintext token is captured
+  // in the handle's `fetch()` closure but is NOT placed on the returned
+  // envelope. `credential` becomes non-secret metadata; consumers reach the
+  // secret ONLY via `sealedCredential.fetch()` at the wire. No-credential
+  // resolution yields `{ credential: null, sealedCredential: null }`.
+  let credentialMetadata: CredentialMetadataWire | null = null;
+  let sealedCredential: SealedCredential | null = null;
+  if (credential?.apiKey) {
+    const token = credential.apiKey;
+    const wireAuthType: 'api_key' | 'oauth' = credential.authType === 'oauth' ? 'oauth' : 'api_key';
+    credentialMetadata = {
+      provider: credential.provider,
+      source: credential.source,
+      authType: wireAuthType,
+    };
+    sealedCredential = makeSealedCredential({
+      provider: credential.provider,
+      account: usedLabel ?? 'default',
+      // The already-resolved plaintext is captured in this closure and handed
+      // out ONLY when a wire boundary invokes fetch(); it is never surfaced on
+      // the envelope. T11754 swaps this thunk for an on-demand vault decrypt.
+      resolveToken: () => token,
+    });
+  }
+
   return {
     provider,
     model,
     client,
-    credential,
+    credential: credentialMetadata,
+    sealedCredential,
     source,
     credentialLabel: usedLabel,
     apiMode: wire.apiMode,
@@ -490,7 +553,6 @@ export async function resolveAnthropicForRole(
 ): Promise<{
   client: Pick<Anthropic, 'messages'>;
   model: string;
-  credential: CredentialResult;
 } | null> {
   let llm: ResolvedLLM;
   try {
@@ -499,7 +561,13 @@ export async function resolveAnthropicForRole(
     return null;
   }
   if (llm.provider !== 'anthropic') return null;
-  if (!llm.credential?.apiKey || !llm.client) return null;
+  // E10 (T11753): gate on the sealed handle's presence — its existence is the
+  // post-resolution "a usable credential was found" signal, replacing the
+  // removed inline `credential.apiKey` truthiness check. The Anthropic SDK
+  // `client` was already wired from the plaintext inside `resolveLLMForRole`
+  // (the one allowed `new Anthropic(...)` chokepoint), so the secret does not
+  // need to cross this boundary again.
+  if (!llm.sealedCredential || !llm.client) return null;
   // Safe narrowing: provider === 'anthropic' and direct Anthropic construction
   // in resolveLLMForRole guarantees the client is an Anthropic SDK instance.
   // Pick<Anthropic, 'messages'> exposes only the surface needed by all 3
@@ -508,6 +576,5 @@ export async function resolveAnthropicForRole(
   return {
     client: llm.client as Anthropic,
     model: llm.model,
-    credential: llm.credential,
   };
 }

--- a/packages/core/src/llm/sealed-credential.ts
+++ b/packages/core/src/llm/sealed-credential.ts
@@ -1,0 +1,136 @@
+/**
+ * Sealed credential handle — runtime implementation (E10 · T11753).
+ *
+ * The {@link SealedCredential} **type** lives in `@cleocode/contracts`
+ * (`llm/sealed-credential.ts`, types-only for Gate 10 purity). Its `fetch()` is
+ * a function-TYPED interface field; the concrete body — the on-demand
+ * materialization of the plaintext token — lives HERE in `@cleocode/core`.
+ *
+ * ## Why this module exists
+ *
+ * Before E10, {@link import('./role-resolver.js').resolveLLMForRole} returned
+ * the resolved credential's plaintext `apiKey` **inline** on its envelope. That
+ * bare secret string travelled up the entire resolution call stack
+ * (`resolveLLMForRole` → `resolveLLMForSystem` → consumers) where any layer that
+ * merely *routed* it to the wire could accidentally log it, serialize it into a
+ * LAFS envelope, or copy it into a diagnostic.
+ *
+ * {@link makeSealedCredential} inverts that. The resolver builds an opaque
+ * {@link SealedCredential} handle whose `fetch()` closure captures a
+ * `resolveToken` thunk. The plaintext is materialized **only** when a wire
+ * boundary (`transportForProvider` / `session-factory.ts`) or daemon
+ * worker-injection invokes `fetch()`. Between the resolver and those boundaries,
+ * NO layer holds a plaintext secret — it holds a handle.
+ *
+ * ## The brand chokepoint
+ *
+ * {@link brandDecryptedToken} is the SOLE place a {@link DecryptedToken} is
+ * minted from a raw string. Because `DecryptedToken` is a phantom-branded type
+ * (contracts), a plain `string` cannot be widened into one anywhere else — so an
+ * audit of "who mints a token" reduces to "who calls `brandDecryptedToken`",
+ * and that is exclusively this module (invoked inside `fetch()`).
+ *
+ * @module llm/sealed-credential
+ * @task T11753
+ * @epic T11746
+ * @see ADR-072 §Type lock-in
+ */
+
+import type { DecryptedToken, ProviderId, SealedCredential } from '@cleocode/contracts';
+
+/**
+ * Mint a {@link DecryptedToken} from a raw plaintext secret.
+ *
+ * SECURITY: this is the ONE chokepoint that produces a branded
+ * {@link DecryptedToken}. It MUST be called only from inside a
+ * {@link SealedCredential.fetch} closure (see {@link makeSealedCredential}) —
+ * i.e. at the wire / daemon worker-injection boundary — never to surface a
+ * plaintext up the resolver stack.
+ *
+ * The brand is phantom (compile-time only); at runtime this returns a frozen
+ * object `{ value }`. The `__decryptedToken` marker is never materialized at
+ * runtime — the cast below is the deliberate, single, audited point where a
+ * `string` becomes a `DecryptedToken`.
+ *
+ * @param value - The materialized plaintext secret (API key / OAuth bearer).
+ * @returns The branded token, valid only for immediate wire/daemon use.
+ * @internal
+ */
+function brandDecryptedToken(value: string): DecryptedToken {
+  // The single, audited string→DecryptedToken mint. `Object.freeze` prevents a
+  // consumer from mutating `value` in place after fetch().
+  return Object.freeze({ value }) as DecryptedToken;
+}
+
+/**
+ * Parameters for {@link makeSealedCredential}.
+ *
+ * @task T11753
+ */
+export interface MakeSealedCredentialParams {
+  /** Provider this handle targets (e.g. `'anthropic'`). */
+  readonly provider: ProviderId;
+  /**
+   * Account / store-label this handle resolves against (e.g. `'default'`,
+   * `'work'`). Names *which* credential without revealing its secret — safe to
+   * log and serialize.
+   */
+  readonly account: string;
+  /**
+   * On-demand plaintext resolver. Invoked ONLY inside {@link SealedCredential.fetch}
+   * — i.e. at the wire / daemon worker-injection boundary. May be synchronous
+   * (today's in-process credential pool, which already holds the plaintext) or
+   * asynchronous (a future vault / daemon round-trip per T11754). Returns the
+   * raw plaintext string; {@link makeSealedCredential} brands it.
+   *
+   * MUST throw if the credential is unreachable so the caller's existing
+   * graceful-degradation path fires identically to the pre-E10 `apiKey === null`
+   * check.
+   */
+  readonly resolveToken: () => string | Promise<string>;
+}
+
+/**
+ * Build a {@link SealedCredential} handle from a provider/account and an
+ * on-demand token resolver.
+ *
+ * The returned handle carries ONLY the non-secret `provider` + `account`
+ * inline. Its `fetch()` closure captures {@link MakeSealedCredentialParams.resolveToken}
+ * and brands the result — the plaintext exists transiently inside `fetch()` and
+ * is NEVER attached to the handle object, so the handle can be logged or
+ * serialized without leaking the secret.
+ *
+ * @example
+ * ```ts
+ * // In the resolver — capture the already-resolved token in the closure but do
+ * // NOT place it on the returned envelope:
+ * const sealed = makeSealedCredential({
+ *   provider: 'anthropic',
+ *   account: usedLabel ?? 'default',
+ *   resolveToken: () => token, // captured, not surfaced
+ * });
+ * // At the wire — the ONLY place fetch() runs:
+ * const { value } = await sealed.fetch();
+ * const headers = authHeaders({ provider: sealed.provider, apiKey: value, ... });
+ * // value goes out of scope here; never returned, logged, or serialized.
+ * ```
+ *
+ * @param params - Provider, account label, and the on-demand token resolver.
+ * @returns An opaque sealed-credential handle.
+ * @task T11753
+ */
+export function makeSealedCredential(params: MakeSealedCredentialParams): SealedCredential {
+  const { provider, account, resolveToken } = params;
+  return {
+    provider,
+    account,
+    fetch: async (): Promise<DecryptedToken> => {
+      // The SOLE decrypt/materialize point. `resolveToken` re-obtains (or, in
+      // T11754, decrypts) the plaintext on demand; we brand it and hand it to
+      // the wire. The plaintext never escapes this closure except as the
+      // branded return value the caller is contractually bound to discard.
+      const plaintext = await resolveToken();
+      return brandDecryptedToken(plaintext);
+    },
+  };
+}

--- a/packages/core/src/llm/sealed-credential.ts
+++ b/packages/core/src/llm/sealed-credential.ts
@@ -39,6 +39,32 @@
 import type { DecryptedToken, ProviderId, SealedCredential } from '@cleocode/contracts';
 
 /**
+ * Build the non-secret, redacted preview of a credential string.
+ *
+ * SECURITY: this is the SOLE token→preview redaction chokepoint for the sealed
+ * handle. It reveals at most the last 4 characters of the token plus an
+ * auth-scheme marker (`oat-…` for OAuth, `…` otherwise) — never enough to
+ * reconstruct the secret. It is computed ONCE at seal time and stored on the
+ * handle's {@link SealedCredential.tokenPreview}; the full plaintext is NOT
+ * retained for it.
+ *
+ * The preview is the ONLY credential-derived string that may cross a
+ * logging/diagnostic/envelope boundary (E10 · T11754 · AC3); everything else
+ * goes through {@link SealedCredential.fetch} at the wire and is discarded.
+ *
+ * @param token - The plaintext secret (read transiently; not retained).
+ * @param authType - Auth scheme, used only to pick the cosmetic prefix.
+ * @returns A redacted preview safe to log and serialize.
+ * @task T11754
+ */
+export function tokenPreview(token: string, authType: 'api_key' | 'oauth'): string {
+  const prefix = authType === 'oauth' ? 'oat-…' : '…';
+  if (!token) return prefix;
+  if (token.length <= 4) return `${prefix}${token}`;
+  return `${prefix}${token.slice(-4)}`;
+}
+
+/**
  * Mint a {@link DecryptedToken} from a raw plaintext secret.
  *
  * SECURITY: this is the ONE chokepoint that produces a branded
@@ -77,6 +103,15 @@ export interface MakeSealedCredentialParams {
    */
   readonly account: string;
   /**
+   * Non-secret redacted preview (e.g. `'…6789'` / `'oat-…6789'`) computed once
+   * by the resolver via {@link tokenPreview}. Carried on the handle so
+   * diagnostics can *name* the credential without invoking {@link SealedCredential.fetch}.
+   * NEVER the full token.
+   *
+   * @task T11754
+   */
+  readonly tokenPreview: string;
+  /**
    * On-demand plaintext resolver. Invoked ONLY inside {@link SealedCredential.fetch}
    * — i.e. at the wire / daemon worker-injection boundary. May be synchronous
    * (today's in-process credential pool, which already holds the plaintext) or
@@ -107,12 +142,12 @@ export interface MakeSealedCredentialParams {
  * const sealed = makeSealedCredential({
  *   provider: 'anthropic',
  *   account: usedLabel ?? 'default',
+ *   tokenPreview: tokenPreview(token, authType), // non-secret; safe to log
  *   resolveToken: () => token, // captured, not surfaced
  * });
- * // At the wire — the ONLY place fetch() runs:
- * const { value } = await sealed.fetch();
- * const headers = authHeaders({ provider: sealed.provider, apiKey: value, ... });
- * // value goes out of scope here; never returned, logged, or serialized.
+ * // At the wire — the ONLY place fetch() runs (via authHeadersFromSealed):
+ * const headers = await authHeadersFromSealed(sealed, authType);
+ * // the plaintext never escapes authHeadersFromSealed; only headers come out.
  * ```
  *
  * @param params - Provider, account label, and the on-demand token resolver.
@@ -120,10 +155,11 @@ export interface MakeSealedCredentialParams {
  * @task T11753
  */
 export function makeSealedCredential(params: MakeSealedCredentialParams): SealedCredential {
-  const { provider, account, resolveToken } = params;
+  const { provider, account, tokenPreview: preview, resolveToken } = params;
   return {
     provider,
     account,
+    tokenPreview: preview,
     fetch: async (): Promise<DecryptedToken> => {
       // The SOLE decrypt/materialize point. `resolveToken` re-obtains (or, in
       // T11754, decrypts) the plaintext on demand; we brand it and hand it to

--- a/packages/core/src/llm/session-factory.ts
+++ b/packages/core/src/llm/session-factory.ts
@@ -153,15 +153,19 @@ export class DefaultLlmSessionFactory implements LlmSessionFactory {
         opts.role as Parameters<typeof resolveLLMForRole>[0],
       );
 
-      if (!resolved.credential?.apiKey) {
+      if (!resolved.sealedCredential || !resolved.credential) {
         throw new Error(
           `No credential available for role '${opts.role}' / provider '${resolved.provider}'`,
         );
       }
 
+      // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
+      // at the wire — `transportForProvider` is one of the two sanctioned decrypt
+      // boundaries. The token is wired into the transport and never surfaced.
+      const token = (await resolved.sealedCredential.fetch()).value;
       const resolvedCredential = credentialResultToResolved({
         provider: resolved.provider,
-        apiKey: resolved.credential.apiKey,
+        apiKey: token,
         authType: resolved.credential.authType,
         label: resolved.credentialLabel,
       });

--- a/packages/core/src/llm/system-resolver.ts
+++ b/packages/core/src/llm/system-resolver.ts
@@ -156,10 +156,11 @@ async function upgradeCatalogDefault(resolved: ResolvedLLM): Promise<ResolvedLLM
  * @example
  * ```ts
  * const resolved = await resolveLLMForSystem('sentient', { projectRoot });
- * if (!resolved.credential?.apiKey || !resolved.client) {
+ * if (!resolved.sealedCredential || !resolved.client) {
  *   return null; // graceful no-op — no credential available
  * }
- * // Use resolved.model, resolved.client, resolved.credential
+ * // Use resolved.model, resolved.client, resolved.credential (metadata only);
+ * // materialize the secret at the wire via resolved.sealedCredential.fetch().
  * ```
  *
  * @param system - Semantic label for the subsystem requesting an LLM client.
@@ -200,6 +201,9 @@ export async function resolveLLMForSystem(
       model: 'unknown',
       client: null,
       credential: null,
+      // E10 (T11753): no credential resolved → null sealed handle, paired with
+      // the null `credential` metadata above.
+      sealedCredential: null,
       source: 'implicit-fallback',
       // SSoT wire facts (E9 · T11745): the implicit-fallback provider is
       // anthropic and there is no credential, so the descriptor advertises the

--- a/packages/core/src/memory/__tests__/dialectic-warm-ollama.test.ts
+++ b/packages/core/src/memory/__tests__/dialectic-warm-ollama.test.ts
@@ -126,6 +126,8 @@ describe('evaluateDialectic — warm tier resolves local Ollama (T11757 proof)',
       model: 'claude-sonnet-4-6',
       client: null,
       credential: null,
+      // E10 (T11753): no credential → null sealed handle.
+      sealedCredential: null,
       source: 'implicit-fallback',
     });
 

--- a/packages/core/src/memory/llm-backend-resolver.ts
+++ b/packages/core/src/memory/llm-backend-resolver.ts
@@ -369,7 +369,12 @@ async function tryUnifiedResolver(): Promise<ResolvedBackend | null> {
     const resolved = await resolveLLMForRole('extraction');
 
     // No credential reachable → let the legacy chain try local backends.
-    const apiKey = resolved.credential?.apiKey ?? null;
+    // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
+    // at the wire — immediately before constructing the AI-SDK provider. The
+    // token is scoped to this function and never returned up the stack.
+    const apiKey = resolved.sealedCredential
+      ? (await resolved.sealedCredential.fetch()).value
+      : null;
 
     if (resolved.provider === 'anthropic') {
       if (!apiKey) return null;

--- a/packages/core/src/sentient/hygiene-scan.ts
+++ b/packages/core/src/sentient/hygiene-scan.ts
@@ -455,7 +455,7 @@ async function buildRealLlmCallFn(projectRoot: string): Promise<LlmEscalateCallF
     const { HYGIENE_FALLBACK_MODEL, IMPLICIT_FALLBACK_MODEL, resolveLLMForRole } = await import(
       '../llm/role-resolver.js'
     );
-    const { authHeaders } = await import('../llm/credentials.js');
+    const { authHeadersFromSealed } = await import('../llm/credentials.js');
     const { cleoLlmCall } = await import('../llm/api.js');
     const { repairResponseModelJson } = await import('../llm/structured-output.js');
 
@@ -476,25 +476,20 @@ async function buildRealLlmCallFn(projectRoot: string): Promise<LlmEscalateCallF
     const sealed = llm.sealedCredential;
 
     return async (findingText: string, taskContext: string): Promise<HygieneEscalationResult> => {
-      // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
-      // inside the per-call closure (the wire boundary). The token builds the
-      // request credential + OAuth headers, then goes out of scope — never
-      // returned, logged, or serialized.
-      const token = (await sealed.fetch()).value;
+      // E10 (T11754 · AC2): build the OAuth wire headers DIRECTLY from the sealed
+      // handle — `authHeadersFromSealed` invokes fetch() internally and the
+      // plaintext never escapes it. For the SDK `apiKey` field (the sanctioned
+      // SDK-client path that authenticates the request) we still materialize the
+      // token once, inside this per-call closure, then let it go out of scope.
       // TODO(T9292 W3): migrate to ConcreteSession/LlmTransport when executor lands.
       const extraHeaders =
         credMeta.authType === 'oauth'
-          ? authHeaders({
-              provider: transport,
-              apiKey: token,
-              source: credMeta.source,
-              authType: credMeta.authType,
-            })
+          ? await authHeadersFromSealed(sealed, credMeta.authType)
           : undefined;
       const modelConfig = {
         transport,
         model,
-        apiKey: token,
+        apiKey: (await sealed.fetch()).value,
         extraHeaders,
       };
 

--- a/packages/core/src/sentient/hygiene-scan.ts
+++ b/packages/core/src/sentient/hygiene-scan.ts
@@ -461,7 +461,7 @@ async function buildRealLlmCallFn(projectRoot: string): Promise<LlmEscalateCallF
 
     const llm = await resolveLLMForRole('hygiene', { projectRoot });
 
-    if (!llm.credential?.apiKey) {
+    if (!llm.sealedCredential || !llm.credential) {
       return null;
     }
 
@@ -471,17 +471,30 @@ async function buildRealLlmCallFn(projectRoot: string): Promise<LlmEscalateCallF
         ? HYGIENE_FALLBACK_MODEL
         : llm.model;
 
-    const cred = llm.credential;
+    const credMeta = llm.credential;
     const transport = llm.provider;
-
-    // TODO(T9292 W3): migrate to ConcreteSession/LlmTransport when executor lands.
-    const extraHeaders = cred.authType === 'oauth' ? authHeaders(cred) : undefined;
+    const sealed = llm.sealedCredential;
 
     return async (findingText: string, taskContext: string): Promise<HygieneEscalationResult> => {
+      // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
+      // inside the per-call closure (the wire boundary). The token builds the
+      // request credential + OAuth headers, then goes out of scope — never
+      // returned, logged, or serialized.
+      const token = (await sealed.fetch()).value;
+      // TODO(T9292 W3): migrate to ConcreteSession/LlmTransport when executor lands.
+      const extraHeaders =
+        credMeta.authType === 'oauth'
+          ? authHeaders({
+              provider: transport,
+              apiKey: token,
+              source: credMeta.source,
+              authType: credMeta.authType,
+            })
+          : undefined;
       const modelConfig = {
         transport,
         model,
-        apiKey: cred.apiKey,
+        apiKey: token,
         extraHeaders,
       };
 

--- a/packages/core/src/tasks/duplicate-detector.ts
+++ b/packages/core/src/tasks/duplicate-detector.ts
@@ -420,7 +420,7 @@ export async function callLlmDuplicateReasoning(
   cwd?: string,
 ): Promise<DuplicateReasoning | null> {
   try {
-    const { authHeaders } = await import('../llm/credentials.js');
+    const { authHeadersFromSealed } = await import('../llm/credentials.js');
     const { resolveLLMForRole } = await import('../llm/role-resolver.js');
 
     // T9255: route through the role-based resolver. Duplicate-detection is a
@@ -443,25 +443,21 @@ export async function callLlmDuplicateReasoning(
       candidate.id,
     );
 
-    // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
-    // at the wire — immediately before the model call. The token builds the
-    // request credential + OAuth headers, then goes out of scope.
-    const token = (await llm.sealedCredential.fetch()).value;
-    // Build ModelConfig for the resolved provider. For OAuth credentials, attach
-    // the Bearer headers via extraHeaders so the registry constructs the SDK
-    // with `authToken` instead of `apiKey` (avoids the 401 from `x-api-key`).
+    // E10 (T11754 · AC2): build the OAuth wire headers DIRECTLY from the sealed
+    // handle — `authHeadersFromSealed` invokes fetch() internally and the
+    // plaintext never escapes it. The SDK `apiKey` field (the sanctioned
+    // SDK-client path) still needs the materialized token, taken once here and
+    // let go out of scope after the call.
+    // For OAuth credentials, attach the Bearer headers via extraHeaders so the
+    // registry constructs the SDK with `authToken` instead of `apiKey` (avoids
+    // the 401 from `x-api-key`).
     const modelConfig = {
       transport: llm.provider,
       model: llm.model,
-      apiKey: token,
+      apiKey: (await llm.sealedCredential.fetch()).value,
       extraHeaders:
         llm.credential.authType === 'oauth'
-          ? authHeaders({
-              provider: llm.provider,
-              apiKey: token,
-              source: llm.credential.source,
-              authType: llm.credential.authType,
-            })
+          ? await authHeadersFromSealed(llm.sealedCredential, llm.credential.authType)
           : undefined,
     };
 

--- a/packages/core/src/tasks/duplicate-detector.ts
+++ b/packages/core/src/tasks/duplicate-detector.ts
@@ -429,7 +429,7 @@ export async function callLlmDuplicateReasoning(
     // `llm.default` → `llm.daemon` → implicit fallback, preserving the
     // prior `config.llm.daemon.*` defaulting behaviour.
     const llm = await resolveLLMForRole('consolidation', { projectRoot: cwd });
-    if (!llm.credential?.apiKey) {
+    if (!llm.sealedCredential || !llm.credential) {
       // No credentials — skip LLM tier silently
       return null;
     }
@@ -443,14 +443,26 @@ export async function callLlmDuplicateReasoning(
       candidate.id,
     );
 
+    // E10 (T11753): materialize the plaintext from the sealed handle ONLY here,
+    // at the wire — immediately before the model call. The token builds the
+    // request credential + OAuth headers, then goes out of scope.
+    const token = (await llm.sealedCredential.fetch()).value;
     // Build ModelConfig for the resolved provider. For OAuth credentials, attach
     // the Bearer headers via extraHeaders so the registry constructs the SDK
     // with `authToken` instead of `apiKey` (avoids the 401 from `x-api-key`).
     const modelConfig = {
       transport: llm.provider,
       model: llm.model,
-      apiKey: llm.credential.apiKey,
-      extraHeaders: llm.credential.authType === 'oauth' ? authHeaders(llm.credential) : undefined,
+      apiKey: token,
+      extraHeaders:
+        llm.credential.authType === 'oauth'
+          ? authHeaders({
+              provider: llm.provider,
+              apiKey: token,
+              source: llm.credential.source,
+              authType: llm.credential.authType,
+            })
+          : undefined,
     };
 
     const { cleoLlmCall } = await import('../llm/api.js');


### PR DESCRIPTION
`ResolvedLLM.credential` is now a sealed handle, decrypt-only-at-wire, redaction-tested, Gate-13/10 clean — directly enables daemon-brokered short-lived creds for the Pi OAuth path.

## What changed (E10 · epic T11746)

- **T11752 — contracts type.** New `SealedCredential` + branded `DecryptedToken` in `@cleocode/contracts/llm/sealed-credential.ts`. Types-only: `fetch()` is a function-TYPED interface field, so it satisfies Gate-10 contracts purity (the body lives in core). `ResolvedLLM.credential` switches from the secret-bearing `CredentialResultWire` to the new `CredentialMetadataWire` (provider/source/authType — NO `apiKey`).
- **T11753 — resolver returns the handle.** `resolveLLMForRole`/`resolveLLMForSystem` no longer carry the inline plaintext `apiKey` up the stack. The already-resolved token is captured in the handle's `fetch()` closure and a non-secret `tokenPreview` (≤ last 4 chars) is computed once at seal time. Every consumer (`session-factory`, `pi-stream-fn`, `role-executor`, `hygiene-scan`, `duplicate-detector`, `llm-backend-resolver`, `cli-ops` whoami, `auxiliary-fallback`, `system-resolver`) now gates on `sealedCredential` presence instead of `credential?.apiKey`.
- **T11754 — decrypt only at the wire.** Plaintext is materialized ONLY by `sealedCredential.fetch()` at the two sanctioned boundaries: the wire (`transportForProvider`/`session-factory.ts`, the `ModelRunner` descriptor build in `pi-stream-fn`) and daemon worker-injection. New `authHeadersFromSealed()` invokes `fetch()` internally and builds the provider auth headers in one chokepoint — the bare secret is never bound to a caller-visible variable.

## Security invariant (the whole point)

The `DecryptedToken` plaintext is NEVER returned up the call stack, NEVER serialized into an envelope/log/diagnostic, and decrypt runs ONLY inside `fetch()` at the wire / daemon injection. Enforced by:
- `sealed-credential-boundary.test.ts` — deep structural + `JSON.stringify` walk of the resolved envelope asserts the secret appears on NO inline field; reachable ONLY via `fetch()`; `credential` metadata has no `apiKey` key.
- `decrypt-at-wire.test.ts` — asserts decrypt happens at the boundary and the token is consumed in-place when building headers.

## Gates

- biome: clean
- `pnpm run build`: green
- `pnpm --filter @cleocode/contracts test`: 794 passed
- LLM-domain core tests (boundary, decrypt-at-wire, role-resolver(+fullstack), session-factory, role-executor-selfheal, cli-ops, migration, pi-stream-fn-abort): 100 passed
- `lint-llm-chokepoint` (Gate 13): OK (41 vs baseline 53 — 12 resolved)
- `lint-no-runtime-in-contracts` (Gate 10, net-add): OK — no net-new runtime helpers; `SealedCredential` not flagged (types-only)
- `cleo check arch`: 5/5 pass

Pre-existing 16 worktree-napi test failures (`integrateWorktree not available in test fallback`) are environment-induced (real-git worktree ops inside a CLEO worktree) and orthogonal — the diff touches no worktree/spawn/audit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)