### PR TITLE
feat(T10418): AgentToolRegistry engine — self-discovering agent-facing tool registry (T1739)

### DIFF
--- a/packages/contracts/src/llm/interfaces.ts
+++ b/packages/contracts/src/llm/interfaces.ts
@@ -174,6 +174,17 @@ export interface SendOptions {
    */
   readonly providerFlags?: Readonly<Record<string, unknown>>;
   /**
+   * Tools the model may call on this call (OpenAI-format {@link TransportTool}[]).
+   *
+   * When supplied, the session forwards them onto the {@link TransportRequest.tools}
+   * surface so the wire-level transport advertises them to the model. This is the
+   * per-call hook the in-process Pi embed threads its `Context.tools` through — the
+   * registry's `toOpenAITools()` output reaches the model via `streamFn` →
+   * `SendOptions.tools` → `TransportRequest.tools`. Omit (or pass empty) for a
+   * tool-free call. Transports that do not support tools MUST ignore it.
+   */
+  readonly tools?: readonly TransportTool[];
+  /**
    * Cancellation signal for this call.
    *
    * When supplied, a streaming consumer MUST stop iterating and tear the

--- a/packages/contracts/src/tools/atomic.ts
+++ b/packages/contracts/src/tools/atomic.ts
@@ -37,6 +37,27 @@ export const TOOL_CLASSES = ['fs', 'shell', 'search', 'net', 'notebook'] as cons
 export type ToolClass = (typeof TOOL_CLASSES)[number];
 
 /**
+ * Agent-facing **toolset** groups (T1739 · AC4 · epic T11456).
+ *
+ * Where {@link TOOL_CLASSES} groups primitives by their SIDE-EFFECT surface (and
+ * therefore by guardrail policy), a {@link Toolset} groups tools by the
+ * AGENT-FACING CAPABILITY a model selects when reasoning — the dimension Hermes'
+ * `tools/registry.py` exposes to the loop. The two axes are orthogonal: an `fs`
+ * class primitive belongs to the `file` toolset, a `shell` class primitive to the
+ * `terminal` toolset, a `net` class primitive to the `web` toolset, etc.
+ *
+ * - `terminal` — shell / process execution (`executeShell`, `runGit`).
+ * - `file` — filesystem read/write/search (`readFileText`, `writeFileAtomic`, …).
+ * - `web` — outbound network / fetch (`fetch`).
+ * - `agent` — sub-agent / delegation / task orchestration tools.
+ * - `media` — image / audio / notebook authoring (`notebookEdit`, …).
+ */
+export const AGENT_TOOLSETS = ['terminal', 'file', 'web', 'agent', 'media'] as const;
+
+/** One of the canonical {@link AGENT_TOOLSETS}. */
+export type Toolset = (typeof AGENT_TOOLSETS)[number];
+
+/**
  * Descriptor for a single registered tool primitive. The registry of these is
  * the SoT for "what atomic tools exist", consumed by the guardrail chokepoint
  * and (optionally) by the MCP adapter's tool catalog (T11411).

--- a/packages/core/src/llm/__tests__/concrete-session.test.ts
+++ b/packages/core/src/llm/__tests__/concrete-session.test.ts
@@ -183,6 +183,44 @@ describe('ConcreteSession', () => {
     expect(session.history()).toHaveLength(0);
   });
 
+  it('forwards SendOptions.tools onto TransportRequest.tools (T1739)', async () => {
+    const transport = makeMockTransport();
+    const session = new ConcreteSession({
+      transport,
+      model: 'claude-haiku-4-5-20251001',
+      credential: makeCredential(),
+      retryPolicy: NO_RETRY,
+    });
+
+    const tools = [
+      {
+        name: 'read_file',
+        description: 'Read a file',
+        inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+      },
+    ];
+    await session.send([{ role: 'user', content: 'Hi' }], { tools });
+
+    expect(transport.calls[0]?.request.tools).toEqual(tools);
+  });
+
+  it('omits TransportRequest.tools when no tools are supplied (T1739)', async () => {
+    const transport = makeMockTransport();
+    const session = new ConcreteSession({
+      transport,
+      model: 'claude-haiku-4-5-20251001',
+      credential: makeCredential(),
+      retryPolicy: NO_RETRY,
+    });
+
+    await session.send([{ role: 'user', content: 'Hi' }]);
+    expect(transport.calls[0]?.request.tools).toBeUndefined();
+
+    // An empty tools array is also omitted (providers reject an empty list).
+    await session.send([{ role: 'user', content: 'Hi' }], { tools: [] });
+    expect(transport.calls[1]?.request.tools).toBeUndefined();
+  });
+
   it('does NOT refresh api_key credentials before send', async () => {
     const session = new ConcreteSession({
       transport: makeMockTransport(),

--- a/packages/core/src/llm/concrete-session.ts
+++ b/packages/core/src/llm/concrete-session.ts
@@ -457,6 +457,10 @@ export class ConcreteSession implements LlmSession {
       maxTokens,
       cacheStrategy: opts?.cacheStrategy ?? null,
       ...(opts?.systemSuffix != null ? { system: opts.systemSuffix } : {}),
+      // Forward call-level tools onto the wire request so the transport advertises
+      // them to the model. Only set when non-empty — a tool-free call MUST omit the
+      // field so providers that reject an empty `tools` array are unaffected.
+      ...(opts?.tools && opts.tools.length > 0 ? { tools: [...opts.tools] } : {}),
     };
 
     // Auto-inject thinking budget when the provider supports it and the caller

--- a/packages/core/src/llm/pi/__tests__/pi-stream-fn-tools.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-stream-fn-tools.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tool wire-through for the Cleo-owned Pi `StreamFn` (T1739 — registry
+ * consumability).
+ *
+ * The agent registry (T1739) emits OpenAI-format tools via `toOpenAITools()`; the
+ * Pi loop carries them on `Context.tools`. {@link createPiStreamFn} MUST project
+ * those tools onto the per-call `SendOptions.tools` so `ConcreteSession` forwards
+ * them onto `TransportRequest.tools` and the wire-level transport advertises them
+ * to the model.
+ *
+ * These tests prove the `Context.tools → SendOptions.tools` link: the mocked
+ * transport session records the `SendOptions` it receives, and we assert the
+ * registry-shaped tools arrived (and that a tool-free context omits the field).
+ * The resolver + ModelRunner are mocked — no real credential / network is needed.
+ *
+ * @epic T10403
+ * @task T1739
+ */
+
+import type { NormalizedDelta } from '@cleocode/contracts';
+import type { TransportTool } from '@cleocode/contracts/llm/normalized-response.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks: resolver returns a credentialed envelope; ModelRunner returns a
+//     session whose stream is a FINITE generator that records its SendOptions. ---
+
+let receivedSendOptions: { tools?: readonly TransportTool[]; signal?: AbortSignal } | undefined;
+
+vi.mock('../../system-resolver.js', () => ({
+  resolveLLMForSystem: vi.fn(async () => ({
+    provider: 'anthropic',
+    model: 'mock-model',
+    client: null,
+    credential: {
+      provider: 'anthropic',
+      source: 'env',
+      authType: 'api_key',
+    },
+    sealedCredential: {
+      provider: 'anthropic',
+      account: 'mock',
+      fetch: async () => ({ __decryptedToken: 'DecryptedToken' as const, value: 'sk-mock' }),
+    },
+    source: 'role-config',
+    apiMode: 'anthropic_messages',
+    baseUrl: null,
+    authType: 'api_key',
+  })),
+}));
+
+vi.mock('../../model-runner.js', () => ({
+  ModelRunner: {
+    build: vi.fn(async () => ({
+      languageModel: null,
+      session: {
+        // A finite stream: one chunk, then done. Records the SendOptions so the
+        // test can assert the tool wire-through.
+        stream(
+          _messages: unknown,
+          opts?: { tools?: readonly TransportTool[]; signal?: AbortSignal },
+        ): AsyncIterable<NormalizedDelta> {
+          receivedSendOptions = opts;
+          let yielded = false;
+          return {
+            [Symbol.asyncIterator](): AsyncIterator<NormalizedDelta> {
+              return {
+                async next(): Promise<IteratorResult<NormalizedDelta>> {
+                  if (yielded) return { done: true, value: undefined };
+                  yielded = true;
+                  return {
+                    done: false,
+                    value: { text: 'ok', reasoning: '', stopReason: 'stop', usage: null },
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    })),
+  },
+}));
+
+// Imported AFTER the mocks so the producer binds to the mocked modules.
+const { createPiStreamFn } = await import('../pi-stream-fn.js');
+
+afterEach(() => {
+  receivedSendOptions = undefined;
+  vi.clearAllMocks();
+});
+
+/** Drain a Pi event stream until its terminal `done`/`error`/`end`. */
+async function drain(stream: {
+  [Symbol.asyncIterator](): AsyncIterator<{ type: string }>;
+}): Promise<string[]> {
+  const types: string[] = [];
+  for await (const ev of stream as AsyncIterable<{ type: string }>) {
+    types.push(ev.type);
+  }
+  return types;
+}
+
+describe('createPiStreamFn — tool wire-through (T1739 registry consumability)', () => {
+  it('projects Context.tools onto SendOptions.tools → the transport', async () => {
+    const streamFn = createPiStreamFn({
+      system: 'task-executor',
+      sessionId: 's-tools-1',
+      agentId: null,
+      parentSessionId: null,
+    });
+    // A registry-shaped Pi tool: { name, description, parameters: <JSON-schema> }.
+    const piTool = {
+      name: 'read_file',
+      description: 'Read a file from disk',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string' } },
+        required: ['path'],
+      },
+    };
+    const out = streamFn(
+      { id: 'm', name: 'm', api: 'anthropic-messages', provider: 'p' } as never,
+      { messages: [], tools: [piTool] } as never,
+    );
+    const types = await drain(out as never);
+    expect(types).toContain('done');
+    expect(receivedSendOptions?.tools).toHaveLength(1);
+    const wired = receivedSendOptions?.tools?.[0];
+    expect(wired?.name).toBe('read_file');
+    expect(wired?.description).toBe('Read a file from disk');
+    // The Pi Tool's `parameters` (TypeBox TSchema = JSON-schema object) passes
+    // through verbatim onto `inputSchema` — no typebox value-import at the boundary.
+    expect(wired?.inputSchema).toEqual(piTool.parameters);
+  });
+
+  it('omits SendOptions.tools when the context carries no tools', async () => {
+    const streamFn = createPiStreamFn({
+      system: 'task-executor',
+      sessionId: 's-tools-2',
+      agentId: null,
+      parentSessionId: null,
+    });
+    const out = streamFn(
+      { id: 'm', name: 'm', api: 'anthropic-messages', provider: 'p' } as never,
+      { messages: [] } as never,
+    );
+    const types = await drain(out as never);
+    expect(types).toContain('done');
+    // A tool-free context MUST NOT set `tools` (so providers that reject an empty
+    // tool list are unaffected).
+    expect(receivedSendOptions?.tools).toBeUndefined();
+  });
+});

--- a/packages/core/src/llm/pi/pi-stream-fn.ts
+++ b/packages/core/src/llm/pi/pi-stream-fn.ts
@@ -35,22 +35,37 @@
  * Gate-13 allowlist). The descriptor's `model` comes from the resolver
  * (registry / role-config), never a literal here.
  *
+ * ## Tool wire-through (T1739 — registry consumability)
+ *
+ * The Pi loop carries its tools (the agent registry's `toOpenAITools()` output) on
+ * `Context.tools`. {@link toTransportTools} projects them onto the per-call
+ * `SendOptions.tools`, which `ConcreteSession._buildRequest` forwards onto
+ * `TransportRequest.tools` — so the wire-level transport advertises them to the
+ * model. This closes the streamFn → transport tool link: registry tools given to
+ * the loop are reachable by the model. (Tool-CALL *execution* — binding Pi's
+ * `ExecutionEnv` onto the guarded surface — is a later subtask; only the schema
+ * advertisement flows here.)
+ *
  * ## Zod ↔ TypeBox quarantine (Gate 10)
  *
  * Pi tool schemas are TypeBox, but `pi-ai`'s `validateToolArguments` also accepts
  * plain JSON-schema tools. Cleo tool definitions are Zod (live in `core/src/llm/`).
  * {@link zodToolToTransportTool} converts a Zod schema → JSON Schema via Zod v4's
  * native `z.toJSONSchema` (NO `zod-to-json-schema` dep, NO typebox value-import),
- * so the cleo↔Pi tool boundary carries ZERO typebox. typebox remains a transitive
- * dep used only INSIDE `pi-agent-core`; it never appears in cleo source and never
- * reaches `packages/contracts/`.
+ * so the cleo↔Pi tool boundary carries ZERO typebox. {@link toTransportTools}
+ * passes the loop's Pi `Tool.parameters` (a TypeBox `TSchema` that is structurally
+ * a JSON Schema object) through verbatim — also WITHOUT a typebox value-import.
+ * typebox remains a transitive dep used only INSIDE `pi-agent-core`; it never
+ * appears in cleo source and never reaches `packages/contracts/`.
  *
  * @epic T10403
  * @task T11761
  * @task T11898
+ * @task T1739
  */
 
 import type { ResolvedLLMDescriptor } from '@cleocode/contracts';
+import type { SendOptions } from '@cleocode/contracts/llm/interfaces.js';
 import type {
   TransportMessage,
   TransportTool,
@@ -69,6 +84,7 @@ import type {
   SimpleStreamOptions,
   StopReason,
   TextContent,
+  Tool,
 } from '@earendil-works/pi-ai';
 // VALUE import: the FACTORY that builds the stream Pi's `StreamFn` MUST return.
 // `AssistantMessageEventStream` itself collides in the `pi-ai` barrel (re-exported
@@ -168,7 +184,10 @@ export function createPiStreamFn(ctx: PiAgentRunContext): StreamFn {
  * @param model - Pi's model descriptor for this call (id/provider/api carried for
  *   the terminal `AssistantMessage` shape; resolution is by `ctx.system`, NOT by
  *   this model id — the resolver/registry is the SSoT).
- * @param context - The Pi request context (system prompt + messages + tools).
+ * @param context - The Pi request context (system prompt + messages + tools). The
+ *   `tools` (the agent registry's `toOpenAITools()` output, set on `Context.tools`
+ *   by the loop) are projected onto the per-call `SendOptions.tools` →
+ *   `TransportRequest.tools`, so the wire-level transport advertises them.
  * @param _options - Pi stream options (reserved; thinking/temperature flow via
  *   the resolved descriptor's capabilities in a later subtask).
  * @param ctx - The Pi run context (system-of-use label + loop abort `signal`
@@ -222,7 +241,21 @@ async function produce(
     emitAborted(out, model);
     return;
   }
-  const stream = built.session.stream(messages, signal ? { signal } : undefined);
+  // Thread the loop's tools (the agent registry's `toOpenAITools()` output, set on
+  // `Context.tools` by the loop) onto the per-call `SendOptions` so the wire-level
+  // transport advertises them to the model. This is the streamFn → session.stream
+  // → `TransportRequest.tools` link that makes registry tools reachable by the
+  // model. Omitted when the loop carries no tools (a tool-free call).
+  const tools = toTransportTools(context);
+  const sendOpts: SendOptions =
+    signal && tools.length > 0
+      ? { signal, tools }
+      : signal
+        ? { signal }
+        : tools.length > 0
+          ? { tools }
+          : {};
+  const stream = built.session.stream(messages, sendOpts);
   const iterator = stream[Symbol.asyncIterator]();
   // Proactive teardown: the instant the signal aborts — even mid-`next()` await —
   // call the iterator's `return()` so a transport that ignores `SendOptions.signal`
@@ -348,6 +381,33 @@ function toTransportMessages(context: Context): TransportMessage[] {
     }
     return msg;
   });
+}
+
+/**
+ * Project the Pi {@link Context}'s tools onto OpenAI-format {@link TransportTool}[]
+ * for the wire request.
+ *
+ * The agent registry (T1739) emits OpenAI-format tools via `toOpenAITools()`; the
+ * Pi loop carries tools on `Context.tools` as Pi `Tool`s whose `parameters` is a
+ * TypeBox `TSchema` — which IS a plain JSON Schema object at runtime. We map it
+ * straight onto `inputSchema` WITHOUT importing typebox's `Value` (Gate-10 / Zod↔
+ * TypeBox quarantine): the schema object is passed through structurally. This is
+ * the `streamFn → SendOptions.tools → TransportRequest.tools` link that makes the
+ * registry's tools reachable by the model.
+ *
+ * @param context - The Pi request context.
+ * @returns OpenAI-format transport tools (empty when the context carries none).
+ */
+function toTransportTools(context: Context): readonly TransportTool[] {
+  const tools = (context as { tools?: readonly Tool[] }).tools;
+  if (!tools || tools.length === 0) return [];
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    // `t.parameters` is a TypeBox `TSchema`, structurally a JSON Schema object.
+    // Structural pass-through — no typebox value-import crosses the boundary.
+    inputSchema: t.parameters as unknown as Record<string, unknown>,
+  }));
 }
 
 /**

--- a/packages/core/src/llm/pi/pi-stream-fn.ts
+++ b/packages/core/src/llm/pi/pi-stream-fn.ts
@@ -80,8 +80,9 @@ import type {
 // registry is never CONSULTED — populated-but-unused, the accepted inert side
 // effect, not a leak.
 import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
-import { z } from 'zod';
+import type { z } from 'zod';
 import { getLogger } from '../../logger.js';
+import { zodSchemaToOpenAITool } from '../../tools/schema-gen.js';
 import { ModelRunner } from '../model-runner.js';
 import { resolveLLMForSystem } from '../system-resolver.js';
 import { wrapPiError } from './pi-errors.js';
@@ -108,23 +109,18 @@ export interface PiZodTool {
 /**
  * Convert a Cleo Zod-schema tool into a JSON-schema {@link TransportTool}.
  *
- * Uses Zod v4's native `z.toJSONSchema` — no `zod-to-json-schema` dependency and,
- * crucially, NO typebox value-import. The resulting `inputSchema` is a plain JSON
- * Schema object the transport passes through verbatim.
+ * Thin wrapper over the SINGLE shared generator
+ * {@link zodSchemaToOpenAITool} (`core/src/tools/schema-gen.ts`) so the Pi bridge
+ * and the agent registry (T1739 · AC3) share ONE conversion doctrine and cannot
+ * drift (DRY). Uses Zod v4's native `z.toJSONSchema` — no `zod-to-json-schema`
+ * dependency and, crucially, NO typebox value-import. The resulting `inputSchema`
+ * is a plain JSON Schema object the transport passes through verbatim.
  *
  * @param tool - The Cleo Zod tool.
  * @returns The transport-shaped JSON-schema tool.
  */
 export function zodToolToTransportTool(tool: PiZodTool): TransportTool {
-  // Zod v4's native `z.toJSONSchema` renders a plain JSON Schema object — NO
-  // `zod-to-json-schema` dep and NO typebox value-import at this boundary, so
-  // the cleo↔Pi tool surface carries zero typebox (Gate 10).
-  const inputSchema = z.toJSONSchema(tool.parameters) as Record<string, unknown>;
-  return {
-    name: tool.name,
-    description: tool.description,
-    inputSchema,
-  };
+  return zodSchemaToOpenAITool(tool);
 }
 
 const logger = getLogger('pi-stream-fn');

--- a/packages/core/src/tools/__tests__/agent-registry.test.ts
+++ b/packages/core/src/tools/__tests__/agent-registry.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the agent-facing tool registry (T1739 · epic T11456).
+ *
+ * Covers the 8 acceptance criteria:
+ *   AC1 register + dispatch · AC2 bounded discovery · AC3 OpenAI schema shape ·
+ *   AC4 toolset grouping · AC5 availability checks · AC6 thread-safe / frozen +
+ *   single-flight double-init · AC7 explicit init (built-ins, not at import) ·
+ *   AC8 (this file).
+ *
+ * @task T1739
+ * @epic T11456
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  AGENT_TOOL_REGISTER_FN,
+  AgentToolRegistry,
+  ALWAYS_AVAILABLE,
+  createAgentToolRegistry,
+} from '../agent-registry.js';
+import { createToolGuard } from '../guard.js';
+import { zodSchemaToOpenAITool } from '../schema-gen.js';
+
+/** A minimal custom tool descriptor for register/dispatch tests. */
+function echoTool(name = 'echo') {
+  return {
+    name,
+    class: 'fs' as const,
+    description: 'Echo back its message.',
+    toolset: 'agent' as const,
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({ message: z.string() }),
+    execute: async (args: Readonly<Record<string, unknown>>) => ({ echoed: args.message }),
+  };
+}
+
+describe('AgentToolRegistry — register + dispatch (AC1)', () => {
+  it('registers a tool, looks it up, and dispatches its executable', async () => {
+    const r = new AgentToolRegistry();
+    r.register(echoTool());
+    expect(r.size).toBe(1);
+    expect(r.get('echo')?.description).toBe('Echo back its message.');
+
+    const exec = r.getExecutable('echo');
+    expect(exec).toBeTypeOf('function');
+    const guard = createToolGuard();
+    const out = await exec?.({ message: 'hi' }, guard);
+    expect(out).toEqual({ echoed: 'hi' });
+  });
+
+  it('rejects duplicate tool names', () => {
+    const r = new AgentToolRegistry();
+    r.register(echoTool());
+    expect(() => r.register(echoTool())).toThrow(/duplicate/);
+  });
+
+  it('returns undefined for unknown tools', () => {
+    const r = new AgentToolRegistry();
+    expect(r.get('nope')).toBeUndefined();
+    expect(r.getExecutable('nope')).toBeUndefined();
+  });
+});
+
+describe('AgentToolRegistry — built-in atomic primitives (AC7 + wiring)', () => {
+  it('init() registers the built-in fs/shell tools so the registry is non-empty', async () => {
+    const r = await createAgentToolRegistry();
+    expect(r.initialised).toBe(true);
+    expect(r.size).toBeGreaterThanOrEqual(5);
+    for (const name of ['read_file', 'write_file', 'path_exists', 'run_command', 'run_git']) {
+      expect(r.get(name), `built-in ${name} should be registered`).toBeDefined();
+    }
+  });
+
+  it('a built-in tool routes its side effect through the guarded surface', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'cleo-agtool-'));
+    try {
+      const r = await createAgentToolRegistry();
+      const guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+      const write = r.getExecutable('write_file');
+      if (write === undefined) throw new Error('write_file built-in missing');
+      const res = (await write({ path: join(root, 'x.txt'), content: 'yo' }, guard)) as {
+        bytesWritten: number;
+      };
+      expect(res.bytesWritten).toBe(2);
+
+      const read = r.getExecutable('read_file');
+      if (read === undefined) throw new Error('read_file built-in missing');
+      const got = (await read({ path: join(root, 'x.txt') }, guard)) as { content: string };
+      expect(got.content).toBe('yo');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skipBuiltins leaves the registry empty', async () => {
+    const r = await createAgentToolRegistry({ skipBuiltins: true });
+    expect(r.size).toBe(0);
+  });
+});
+
+describe('AgentToolRegistry — OpenAI schema generation (AC3)', () => {
+  it('emits TransportTool shape with a JSON-Schema inputSchema', async () => {
+    const r = await createAgentToolRegistry();
+    const tools = r.toOpenAITools();
+    expect(tools.length).toBe(r.size);
+    const readFile = tools.find((t) => t.name === 'read_file');
+    expect(readFile).toBeDefined();
+    expect(readFile?.description).toContain('Read a file');
+    // JSON-Schema object form (Zod v4 z.toJSONSchema)
+    expect(readFile?.inputSchema).toMatchObject({ type: 'object' });
+    const props = (readFile?.inputSchema as { properties?: Record<string, unknown> }).properties;
+    expect(props).toHaveProperty('path');
+  });
+
+  it('the registry and the shared generator produce identical schemas (DRY)', async () => {
+    const r = await createAgentToolRegistry();
+    const tool = r.get('write_file');
+    if (tool === undefined) throw new Error('write_file built-in missing');
+    const viaRegistry = r.toOpenAITools().find((t) => t.name === 'write_file');
+    const viaGenerator = zodSchemaToOpenAITool({
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    });
+    expect(viaRegistry).toEqual(viaGenerator);
+  });
+
+  it('only AVAILABLE tools are emitted when a context is passed', async () => {
+    const r = await createAgentToolRegistry();
+    // run_git requires `git` on PATH; deny it.
+    const tools = r.toOpenAITools({ availableBinaries: [] });
+    expect(tools.find((t) => t.name === 'run_git')).toBeUndefined();
+    expect(tools.find((t) => t.name === 'read_file')).toBeDefined();
+  });
+});
+
+describe('AgentToolRegistry — toolset grouping (AC4)', () => {
+  it('byToolset() buckets every tool and always returns all 5 keys', async () => {
+    const r = await createAgentToolRegistry();
+    const grouped = r.byToolset();
+    expect(Object.keys(grouped).sort()).toEqual(
+      ['agent', 'file', 'media', 'terminal', 'web'].sort(),
+    );
+    expect(grouped.file.map((t) => t.name).sort()).toEqual(
+      ['path_exists', 'read_file', 'write_file'].sort(),
+    );
+    expect(grouped.terminal.map((t) => t.name).sort()).toEqual(['run_command', 'run_git'].sort());
+    // No net/notebook primitives implemented yet — empty but present.
+    expect(grouped.web).toEqual([]);
+    expect(grouped.media).toEqual([]);
+  });
+
+  it('byToolset(toolset) filters to a single group', async () => {
+    const r = await createAgentToolRegistry();
+    expect(r.byToolset('file').every((t) => t.toolset === 'file')).toBe(true);
+    expect(r.byToolset('web')).toEqual([]);
+  });
+});
+
+describe('AgentToolRegistry — availability checks (AC5)', () => {
+  it('available() filters out tools whose predicate is false', async () => {
+    const r = await createAgentToolRegistry();
+    const withoutGit = r.available({ availableBinaries: [] });
+    expect(withoutGit.find((t) => t.name === 'run_git')).toBeUndefined();
+    const withGit = r.available({ availableBinaries: ['git'] });
+    expect(withGit.find((t) => t.name === 'run_git')).toBeDefined();
+  });
+
+  it('a tool with no predicate is always available', async () => {
+    const r = new AgentToolRegistry();
+    r.register({ ...echoTool(), available: undefined });
+    await r.init({ skipBuiltins: true });
+    expect(r.available({}).map((t) => t.name)).toContain('echo');
+  });
+});
+
+describe('AgentToolRegistry — frozen-after-init + single-flight (AC6)', () => {
+  it('register() after init() throws (immutable)', async () => {
+    const r = await createAgentToolRegistry({ skipBuiltins: true });
+    expect(() => r.register(echoTool())).toThrow(/frozen/);
+  });
+
+  it('discover() after init() throws (immutable)', async () => {
+    const r = await createAgentToolRegistry({ skipBuiltins: true });
+    await expect(r.discover([])).rejects.toThrow(/frozen/);
+  });
+
+  it('double init() is idempotent (no duplicate registration)', async () => {
+    const r = new AgentToolRegistry();
+    await r.init();
+    const sizeAfterFirst = r.size;
+    await r.init();
+    expect(r.size).toBe(sizeAfterFirst);
+    expect(r.initialised).toBe(true);
+  });
+
+  it('concurrent init() calls coalesce into one (single-flight)', async () => {
+    const r = new AgentToolRegistry();
+    await Promise.all([r.init(), r.init(), r.init()]);
+    // Built-ins registered exactly once despite 3 concurrent inits.
+    expect(r.size).toBe(5);
+  });
+
+  it('list() returns a defensive copy (mutating it does not affect the registry)', async () => {
+    const r = await createAgentToolRegistry();
+    const before = r.size;
+    const copy = r.list() as unknown[];
+    copy.push({});
+    expect(r.size).toBe(before);
+  });
+});
+
+describe('AgentToolRegistry — bounded discovery (AC2)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cleo-agtool-discover-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('discovers + imports a *.agent-tool.js module that self-registers', async () => {
+    // A self-registering tool module using the marker export. ESM .js with a
+    // zod-free schema to avoid resolving deps in the temp dir.
+    const moduleSrc = `
+export function ${AGENT_TOOL_REGISTER_FN}(registry) {
+  registry.register({
+    name: 'discovered_tool',
+    class: 'fs',
+    description: 'A tool found by directory scan.',
+    toolset: 'agent',
+    stateless: true,
+    available: () => true,
+    parameters: { _zod: { def: { type: 'object' } }, type: 'object' },
+    execute: async () => ({ ok: true }),
+  });
+}
+`;
+    writeFileSync(join(dir, 'sample.agent-tool.js'), moduleSrc, 'utf8');
+    // A decoy non-tool file in the same dir — must NOT be imported.
+    writeFileSync(join(dir, 'ignore-me.js'), 'export const x = 1;', 'utf8');
+
+    const r = new AgentToolRegistry();
+    await r.init({ scanDirs: [dir], skipBuiltins: true });
+    expect(r.get('discovered_tool')).toBeDefined();
+    expect(r.size).toBe(1);
+  });
+
+  it('skips files lacking the register marker', async () => {
+    writeFileSync(join(dir, 'no-marker.agent-tool.js'), 'export const notRegister = 1;', 'utf8');
+    const r = new AgentToolRegistry();
+    await r.init({ scanDirs: [dir], skipBuiltins: true });
+    expect(r.size).toBe(0);
+  });
+
+  it('tolerates an unreadable scan dir without throwing', async () => {
+    const r = new AgentToolRegistry();
+    await expect(
+      r.init({ scanDirs: [join(dir, 'does-not-exist')], skipBuiltins: true }),
+    ).resolves.toBeUndefined();
+    expect(r.initialised).toBe(true);
+  });
+});

--- a/packages/core/src/tools/agent-registry.ts
+++ b/packages/core/src/tools/agent-registry.ts
@@ -1,0 +1,413 @@
+/**
+ * Agent-facing tool registry (T1739 · epic T11456 · SG-TOOLS).
+ *
+ * EXTENDS the CORE-SDK tool layer (`core/src/tools/*`) with an AGENT-FACING
+ * registry alongside the existing skill-tools engine — the cleocode analogue of
+ * Hermes' `tools/registry.py`. Where {@link ./fs.js}/{@link ./shell.js} are the
+ * raw side-effecting primitives and {@link ./guard.js} is the deny-first
+ * chokepoint, THIS module is what an agent loop (the Pi adapter / ModelRunner)
+ * consults to learn "which tools exist, what is each tool's OpenAI-format schema,
+ * which toolset does it belong to, is it available right now, and how do I run
+ * it". It owns NO side-effects of its own: every registered tool's executable is
+ * bound over an injected {@link GuardedToolSurface}, so all fs/shell work still
+ * funnels through {@link createToolGuard} — there is no raw-primitive bypass.
+ *
+ * ## Responsibilities (the 8 acceptance criteria)
+ *
+ * - **AC1** — the {@link AgentToolRegistry} class lives here.
+ * - **AC2** — {@link AgentToolRegistry.discover} performs a BOUNDED directory
+ *   scan for agent-tool modules (a lightweight source scan for the registration
+ *   marker, then a dynamic import of only the matching modules) — NOT a heavy
+ *   whole-tree AST parse, and NEVER at module import.
+ * - **AC3** — {@link AgentToolRegistry.toOpenAITools} emits the OpenAI-format
+ *   {@link TransportTool}[] the Pi adapter / transport wire layer consume, via
+ *   the single shared {@link zodSchemaToOpenAITool} generator (DRY).
+ * - **AC4** — every tool declares a {@link Toolset} group (`terminal | file |
+ *   web | agent | media`); {@link AgentToolRegistry.byToolset} buckets them.
+ * - **AC5** — every tool declares an {@link AvailabilityCheck} predicate, so a
+ *   tool can be hidden when its preconditions (e.g. network egress, a binary on
+ *   PATH) are not met for the current {@link ToolAvailabilityContext}.
+ * - **AC6** — the registry is effectively IMMUTABLE after {@link
+ *   AgentToolRegistry.init}: registration is rejected once initialised and
+ *   `init()` is single-flight (concurrent callers await one shared promise), so
+ *   there is no shared-mutable-state race.
+ * - **AC7** — auto-discovery is exposed as an EXPLICIT {@link
+ *   AgentToolRegistry.init} called at startup. Module import registers nothing
+ *   and runs no heavy work (lazy {@link getLogger}; no scan at import).
+ *
+ * @task T1739
+ * @epic T11456
+ * @see ./guard.js — the deny-first chokepoint every tool executable routes through
+ * @see ./schema-gen.js — the single OpenAI-format schema generator (AC3)
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { TransportTool } from '@cleocode/contracts/llm/normalized-response.js';
+import type { ToolClass, ToolPrimitiveDescriptor, Toolset } from '@cleocode/contracts/tools/atomic';
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import type { z } from 'zod';
+import { getLogger } from '../logger.js';
+import { registerBuiltinAgentTools } from './builtin-agent-tools.js';
+import { zodSchemaToOpenAITool } from './schema-gen.js';
+
+// Lazy subsystem logger — `getLogger` is safe pre-init and triggers NO heavy
+// work at module import (AC7).
+const log = getLogger('agent-tool-registry');
+
+/**
+ * The marker an agent-tool module must export for the bounded directory scan
+ * (AC2) to dynamically import it: a function `registerAgentTools(registry)` that
+ * self-registers the module's tools. The scan greps for this identifier in the
+ * source before importing, so non-tool modules are never loaded.
+ */
+export const AGENT_TOOL_REGISTER_FN = 'registerAgentTools';
+
+/**
+ * Context handed to an {@link AvailabilityCheck}. Carries the ambient signals a
+ * tool needs to decide whether it can run right now, without coupling the
+ * registry to any one consumer's environment shape.
+ */
+export interface ToolAvailabilityContext {
+  /** Whether outbound network egress is permitted in this run. */
+  readonly networkEgressAllowed?: boolean;
+  /** Executable basenames known to be resolvable on `PATH` (e.g. `['git']`). */
+  readonly availableBinaries?: readonly string[];
+  /** Free-form capability flags a tool may gate on (forward-compatible). */
+  readonly capabilities?: Readonly<Record<string, boolean>>;
+}
+
+/**
+ * Availability predicate (AC5). Returns `true` when the tool can be offered to
+ * the model for the given {@link ToolAvailabilityContext}. MUST be a pure, fast,
+ * synchronous function of its input — it is evaluated every time the available
+ * toolset is enumerated.
+ */
+export type AvailabilityCheck = (ctx: ToolAvailabilityContext) => boolean;
+
+/** An {@link AvailabilityCheck} that always reports available. */
+export const ALWAYS_AVAILABLE: AvailabilityCheck = () => true;
+
+/**
+ * The bound, ready-to-invoke executable for a registered tool. Receives the
+ * model-supplied arguments (already JSON-parsed) and the injected
+ * {@link GuardedToolSurface} it must perform all side effects through, and
+ * returns an opaque result the caller serialises back to the model.
+ */
+export type AgentToolExecutable = (
+  args: Readonly<Record<string, unknown>>,
+  tools: GuardedToolSurface,
+) => Promise<unknown>;
+
+/**
+ * A single agent-facing tool registration. Composes the atomic-tool taxonomy
+ * descriptor ({@link ToolPrimitiveDescriptor}) with the agent-facing fields the
+ * loop needs: a Zod parameter schema (→ OpenAI schema, AC3), a {@link Toolset}
+ * group (AC4), an {@link AvailabilityCheck} (AC5), and the bound
+ * {@link AgentToolExecutable}.
+ */
+export interface AgentToolDescriptor {
+  /** Stable, model-visible tool name (unique within a registry). */
+  readonly name: string;
+  /** The side-effect class this tool's underlying primitive belongs to. */
+  readonly class: ToolClass;
+  /** Human-readable description shown to the model. */
+  readonly description: string;
+  /** Agent-facing toolset group (AC4). */
+  readonly toolset: Toolset;
+  /** Zod schema for the tool's input parameters (→ OpenAI schema via AC3). */
+  readonly parameters: z.ZodType;
+  /** Whether the underlying primitive is a pure function of its input. */
+  readonly stateless: boolean;
+  /** Availability predicate (AC5). Defaults to {@link ALWAYS_AVAILABLE}. */
+  readonly available?: AvailabilityCheck;
+  /** Bound executable — performs work through the guarded surface only. */
+  readonly execute: AgentToolExecutable;
+}
+
+/**
+ * Options for {@link AgentToolRegistry.discover} / {@link AgentToolRegistry.init}.
+ */
+export interface AgentToolDiscoveryOptions {
+  /**
+   * Absolute directories to scan for agent-tool modules (AC2). Each `*.ts`/`*.js`
+   * file exporting {@link AGENT_TOOL_REGISTER_FN} is dynamically imported and its
+   * `registerAgentTools(registry)` invoked. Omit to register ONLY the built-in
+   * atomic primitives.
+   */
+  readonly scanDirs?: readonly string[];
+  /**
+   * Skip registering the built-in atomic primitives (fs/shell). Defaults to
+   * `false` — the built-ins are registered so the registry is never empty and
+   * the Pi adapter can consume them immediately.
+   */
+  readonly skipBuiltins?: boolean;
+}
+
+/** Convert a registry entry into its taxonomy descriptor (lossless subset). */
+function toPrimitiveDescriptor(t: AgentToolDescriptor): ToolPrimitiveDescriptor {
+  return {
+    name: t.name,
+    class: t.class,
+    responsibility: t.description,
+    stateless: t.stateless,
+  };
+}
+
+/**
+ * The agent-facing tool registry (AC1).
+ *
+ * Lifecycle: construct → {@link register} built-ins/custom tools (or let
+ * {@link init} do it) → {@link init} (idempotent, single-flight) → read-only
+ * queries ({@link list}, {@link byToolset}, {@link available},
+ * {@link toOpenAITools}, {@link getExecutable}). After `init()` the tool set is
+ * frozen; a late {@link register} throws (AC6).
+ *
+ * @example
+ * ```ts
+ * const registry = new AgentToolRegistry();
+ * await registry.init(); // registers built-in atomic primitives (AC7)
+ * const openai = registry.toOpenAITools();          // AC3
+ * const fileTools = registry.byToolset('file');     // AC4
+ * const usable = registry.available({ networkEgressAllowed: false }); // AC5
+ * ```
+ */
+export class AgentToolRegistry {
+  /** name → descriptor. Mutated only before {@link #initialised} flips true. */
+  readonly #tools = new Map<string, AgentToolDescriptor>();
+
+  /** Frozen-after-init guard (AC6). */
+  #initialised = false;
+
+  /** Single-flight init promise so concurrent {@link init} calls coalesce (AC6). */
+  #initPromise: Promise<void> | null = null;
+
+  /** Whether {@link init} has completed (the tool set is frozen). */
+  get initialised(): boolean {
+    return this.#initialised;
+  }
+
+  /** Number of registered tools. */
+  get size(): number {
+    return this.#tools.size;
+  }
+
+  /**
+   * Register a single agent tool. Rejects duplicate names and any registration
+   * after {@link init} has completed (AC6 — the registry is immutable post-init).
+   *
+   * @param tool - The tool to register.
+   * @throws Error when the registry is already initialised, or the name is taken.
+   */
+  register(tool: AgentToolDescriptor): void {
+    if (this.#initialised) {
+      throw new Error(
+        `agent-tool-registry: cannot register "${tool.name}" after init() — the registry is frozen`,
+      );
+    }
+    if (this.#tools.has(tool.name)) {
+      throw new Error(`agent-tool-registry: duplicate tool name "${tool.name}"`);
+    }
+    this.#tools.set(tool.name, tool);
+  }
+
+  /**
+   * Initialise the registry (AC7): register the built-in atomic primitives
+   * (unless `skipBuiltins`), run bounded module discovery over `scanDirs`
+   * (AC2), then FREEZE the tool set. Idempotent and single-flight — concurrent
+   * callers await one shared promise and a second call after completion is a
+   * no-op (AC6).
+   *
+   * @param options - Discovery options ({@link AgentToolDiscoveryOptions}).
+   */
+  async init(options: AgentToolDiscoveryOptions = {}): Promise<void> {
+    if (this.#initialised) return;
+    if (this.#initPromise) return this.#initPromise;
+    this.#initPromise = this.#runInit(options);
+    try {
+      await this.#initPromise;
+    } finally {
+      this.#initPromise = null;
+    }
+  }
+
+  /** Inner init body — guarded by the single-flight latch in {@link init}. */
+  async #runInit(options: AgentToolDiscoveryOptions): Promise<void> {
+    if (options.skipBuiltins !== true) {
+      registerBuiltinAgentTools(this);
+    }
+    if (options.scanDirs && options.scanDirs.length > 0) {
+      await this.discover(options.scanDirs);
+    }
+    this.#initialised = true;
+    log.debug({ count: this.#tools.size }, 'agent-tool-registry initialised');
+  }
+
+  /**
+   * Bounded discovery (AC2): for each directory, read its entries (NON-recursive,
+   * bounded), grep each `*.agent-tool.{ts,js}` candidate's SOURCE for the
+   * {@link AGENT_TOOL_REGISTER_FN} export marker, and dynamically import ONLY the
+   * matching modules — then invoke each module's `registerAgentTools(this)`.
+   *
+   * This is a lightweight source scan rather than a whole-tree AST parse: it does
+   * the minimum work to locate self-registering tool modules without loading the
+   * whole package. It is invoked from {@link init} (explicit startup) and never at
+   * module import (AC7). May also be called directly before `init()` for tests.
+   *
+   * @param scanDirs - Absolute directories to scan.
+   * @throws Error when called after the registry is frozen (AC6).
+   */
+  async discover(scanDirs: readonly string[]): Promise<void> {
+    if (this.#initialised) {
+      throw new Error(
+        'agent-tool-registry: cannot discover() after init() — the registry is frozen',
+      );
+    }
+    for (const dir of scanDirs) {
+      let entries: string[];
+      try {
+        entries = await readdir(dir);
+      } catch (err) {
+        log.warn({ dir, err }, 'agent-tool-registry: scan dir unreadable — skipped');
+        continue;
+      }
+      for (const entry of entries) {
+        if (!/\.agent-tool\.(ts|js)$/.test(entry)) continue;
+        const full = join(dir, entry);
+        // Source-marker scan: only import a module that actually exports the
+        // registration fn. Cheaper + safer than importing every file.
+        let src: string;
+        try {
+          src = await readFile(full, 'utf8');
+        } catch (err) {
+          log.warn({ full, err }, 'agent-tool-registry: candidate unreadable — skipped');
+          continue;
+        }
+        if (!src.includes(AGENT_TOOL_REGISTER_FN)) continue;
+        const mod: unknown = await import(full);
+        const register = (mod as Record<string, unknown>)[AGENT_TOOL_REGISTER_FN];
+        if (typeof register !== 'function') {
+          log.warn(
+            { full },
+            'agent-tool-registry: module has no callable registerAgentTools — skipped',
+          );
+          continue;
+        }
+        (register as (r: AgentToolRegistry) => void)(this);
+      }
+    }
+  }
+
+  /**
+   * Look up a registered tool by name.
+   *
+   * @param name - The tool name.
+   * @returns The descriptor, or `undefined` when unknown.
+   */
+  get(name: string): AgentToolDescriptor | undefined {
+    return this.#tools.get(name);
+  }
+
+  /**
+   * All registered tools in deterministic (insertion) order. The returned array
+   * is a fresh copy — mutating it never affects the registry (AC6).
+   */
+  list(): readonly AgentToolDescriptor[] {
+    return [...this.#tools.values()];
+  }
+
+  /**
+   * Tools grouped by {@link Toolset} (AC4). Every {@link Toolset} key is present
+   * (empty array when no tool occupies it), so consumers can render a stable
+   * grouping without missing-key checks.
+   */
+  byToolset(): Record<Toolset, readonly AgentToolDescriptor[]>;
+  /**
+   * Tools belonging to a single {@link Toolset} (AC4).
+   *
+   * @param toolset - The toolset to filter by.
+   */
+  byToolset(toolset: Toolset): readonly AgentToolDescriptor[];
+  byToolset(
+    toolset?: Toolset,
+  ): Record<Toolset, readonly AgentToolDescriptor[]> | readonly AgentToolDescriptor[] {
+    if (toolset !== undefined) {
+      return this.list().filter((t) => t.toolset === toolset);
+    }
+    const grouped: Record<Toolset, AgentToolDescriptor[]> = {
+      terminal: [],
+      file: [],
+      web: [],
+      agent: [],
+      media: [],
+    };
+    for (const t of this.#tools.values()) {
+      grouped[t.toolset].push(t);
+    }
+    return grouped;
+  }
+
+  /**
+   * The subset of tools available for the given context (AC5). A tool without an
+   * explicit {@link AgentToolDescriptor.available} predicate is treated as
+   * {@link ALWAYS_AVAILABLE}.
+   *
+   * @param ctx - The availability context.
+   * @returns Tools whose predicate returns `true`, in registration order.
+   */
+  available(ctx: ToolAvailabilityContext = {}): readonly AgentToolDescriptor[] {
+    return this.list().filter((t) => (t.available ?? ALWAYS_AVAILABLE)(ctx));
+  }
+
+  /**
+   * Emit the OpenAI-format {@link TransportTool}[] for the model (AC3) — the
+   * shape the Pi adapter / ModelRunner transport layer consume. Generated via the
+   * single shared {@link zodSchemaToOpenAITool} generator so the registry and the
+   * Pi streamFn never drift.
+   *
+   * @param ctx - When provided, only AVAILABLE tools (AC5) are emitted; otherwise
+   *   every registered tool is emitted.
+   * @returns OpenAI-format tool definitions in deterministic order.
+   */
+  toOpenAITools(ctx?: ToolAvailabilityContext): readonly TransportTool[] {
+    const tools = ctx ? this.available(ctx) : this.list();
+    return tools.map((t) =>
+      zodSchemaToOpenAITool({ name: t.name, description: t.description, parameters: t.parameters }),
+    );
+  }
+
+  /**
+   * The bound executable for a tool (the name→handler dispatch map, AC1).
+   *
+   * @param name - The tool name.
+   * @returns The {@link AgentToolExecutable}, or `undefined` when unknown.
+   */
+  getExecutable(name: string): AgentToolExecutable | undefined {
+    return this.#tools.get(name)?.execute;
+  }
+
+  /**
+   * The taxonomy descriptors ({@link ToolPrimitiveDescriptor}) for every
+   * registered tool — the lossless subset compatible with the canonical
+   * `ATOMIC_TOOL_PRIMITIVES` registry, for callers that want the class taxonomy
+   * without the agent-facing schema/executable.
+   */
+  primitiveDescriptors(): readonly ToolPrimitiveDescriptor[] {
+    return this.list().map(toPrimitiveDescriptor);
+  }
+}
+
+/**
+ * Build and initialise an {@link AgentToolRegistry} in one call (AC7 convenience).
+ * Equivalent to `new AgentToolRegistry()` + `await registry.init(options)`.
+ *
+ * @param options - Discovery options.
+ * @returns A frozen, ready-to-query registry.
+ */
+export async function createAgentToolRegistry(
+  options: AgentToolDiscoveryOptions = {},
+): Promise<AgentToolRegistry> {
+  const registry = new AgentToolRegistry();
+  await registry.init(options);
+  return registry;
+}

--- a/packages/core/src/tools/builtin-agent-tools.ts
+++ b/packages/core/src/tools/builtin-agent-tools.ts
@@ -1,0 +1,143 @@
+/**
+ * Built-in agent tools (T1739 · epic T11456 · SG-TOOLS).
+ *
+ * Wires the existing CORE-SDK atomic primitives ({@link ./fs.js} +
+ * {@link ./shell.js}) into the agent-facing {@link ./agent-registry.js |
+ * AgentToolRegistry} as its FIRST registered tools, so the registry is never
+ * empty and the Pi adapter / ModelRunner can consume them immediately. Every
+ * built-in tool:
+ *
+ *   - declares a Zod parameter schema (→ OpenAI-format schema via AC3);
+ *   - declares its agent-facing {@link Toolset} group (AC4) and side-effect
+ *     {@link ToolClass};
+ *   - declares an {@link AvailabilityCheck} (AC5) — e.g. `run_git` is only
+ *     available when a `git` binary is known to be on PATH;
+ *   - performs ALL side effects through the injected {@link GuardedToolSurface}
+ *     (NEVER raw `fs`/`shell`), so the deny-first guard chokepoint
+ *     ({@link ./guard.js}) policy still applies — there is no bypass.
+ *
+ * The model-visible names are snake_case (OpenAI-function convention); the
+ * underlying primitive names live in `@cleocode/contracts/tools/atomic`.
+ *
+ * @task T1739
+ * @epic T11456
+ */
+
+import { z } from 'zod';
+import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
+import { ALWAYS_AVAILABLE } from './agent-registry.js';
+
+/** Available only when the named binary is known on PATH (AC5 example). */
+function binaryAvailable(name: string): AvailabilityCheck {
+  return (ctx) => ctx.availableBinaries === undefined || ctx.availableBinaries.includes(name);
+}
+
+/**
+ * Register the built-in atomic-primitive tools into `registry`.
+ *
+ * Invoked by {@link AgentToolRegistry.init} (unless `skipBuiltins`). Pure
+ * registration — no I/O, no scan; the tools' side effects happen later through
+ * the {@link GuardedToolSurface} their executables receive.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerBuiltinAgentTools(registry: AgentToolRegistry): void {
+  // --- file toolset (fs class) ---------------------------------------------
+  registry.register({
+    name: 'read_file',
+    class: 'fs',
+    description: 'Read a file as UTF-8 text.',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      path: z.string().describe('Absolute path to the file to read.'),
+    }),
+    execute: async (args, tools) => {
+      const path = String(args.path);
+      return tools.readFileText({ path });
+    },
+  });
+
+  registry.register({
+    name: 'write_file',
+    class: 'fs',
+    description: 'Atomically write a file (tmp-then-rename), creating parent dirs.',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      path: z.string().describe('Absolute path to write.'),
+      content: z.string().describe('File content to write.'),
+    }),
+    execute: async (args, tools) => {
+      const path = String(args.path);
+      const content = String(args.content);
+      return tools.writeFileAtomic({ path, content });
+    },
+  });
+
+  registry.register({
+    name: 'path_exists',
+    class: 'fs',
+    description: 'Test whether a path exists and what kind of entry it is.',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      path: z.string().describe('Absolute path to test.'),
+    }),
+    execute: async (args, tools) => {
+      const path = String(args.path);
+      return tools.pathExists({ path });
+    },
+  });
+
+  // --- terminal toolset (shell class) --------------------------------------
+  registry.register({
+    name: 'run_command',
+    class: 'shell',
+    description: 'Run a single executable (argv form, no shell) with cwd/timeout.',
+    toolset: 'terminal',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      command: z.string().describe('Executable to run (NOT a shell string).'),
+      args: z.array(z.string()).optional().describe('Arguments for the command.'),
+      cwd: z.string().optional().describe('Working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (args, tools) => {
+      const command = String(args.command);
+      const argv = Array.isArray(args.args) ? args.args.map(String) : undefined;
+      const cwd = args.cwd === undefined ? undefined : String(args.cwd);
+      const timeoutMs = typeof args.timeoutMs === 'number' ? args.timeoutMs : undefined;
+      return tools.executeShell({ command, args: argv, cwd, timeoutMs });
+    },
+  });
+
+  registry.register({
+    name: 'run_git',
+    class: 'shell',
+    description: 'Run a git subcommand and capture stdout/stderr/exit-code.',
+    toolset: 'terminal',
+    stateless: true,
+    available: binaryAvailable('git'),
+    parameters: z.object({
+      args: z.array(z.string()).describe("Git arguments, e.g. ['status', '--porcelain']."),
+      cwd: z.string().optional().describe('Repository working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (args, tools) => {
+      const gitArgs = Array.isArray(args.args) ? args.args.map(String) : [];
+      const cwd = args.cwd === undefined ? undefined : String(args.cwd);
+      const timeoutMs = typeof args.timeoutMs === 'number' ? args.timeoutMs : undefined;
+      return tools.runGit({ args: gitArgs, cwd, timeoutMs });
+    },
+  });
+
+  // Note: `web` (net) and `media` (notebook) primitives are NOT yet implemented
+  // in `core/src/tools/*` (only their contracts exist in atomic.ts). Those
+  // toolsets are intentionally empty until S3+ ships their primitives; the
+  // registry already supports them (AC4) so registration is a one-liner then.
+}

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -82,6 +82,23 @@ export { scaffoldProject } from '../scaffold/scaffold-project.js';
 export * from '../sdk/index.js';
 // TaskTools (Category B) — pure-functional task graph SDK tools (T10068 / T9835)
 export * from '../task-tools/index.js';
+// Agent-facing tool registry (T1739 · E-TOOLS · epic T11456) — the Hermes
+// `tools/registry.py` analogue. Self-discovering, OpenAI-format schema-emitting,
+// toolset-grouped, availability-gated, frozen-after-init registry. Side effects
+// always route through the guarded surface; auto-discovery is an EXPLICIT init()
+// (NOT at module import — AC7).
+export {
+  AGENT_TOOL_REGISTER_FN,
+  type AgentToolDescriptor,
+  type AgentToolDiscoveryOptions,
+  type AgentToolExecutable,
+  AgentToolRegistry,
+  ALWAYS_AVAILABLE,
+  type AvailabilityCheck,
+  createAgentToolRegistry,
+  type ToolAvailabilityContext,
+} from './agent-registry.js';
+export { registerBuiltinAgentTools } from './builtin-agent-tools.js';
 // Subprocess env scrubbing (T11897 · security) — the chokepoint builds a minimal,
 // allowlisted child env so daemon secrets never leak and a Pi-controlled loader
 // hook / PATH can never reach a spawned process.
@@ -103,6 +120,7 @@ export {
   type ToolGuard,
   type ToolGuardPolicy,
 } from './guard.js';
+export { type ZodSchemaTool, zodSchemaToOpenAITool } from './schema-gen.js';
 // Injectable shell executor (E3 · T11406) — threaded into the guard's
 // executeShell/runGit; substitutes the subprocess layer in tests/sandboxes.
 export { defaultShellExecutor, type ShellExecutor } from './shell.js';

--- a/packages/core/src/tools/schema-gen.ts
+++ b/packages/core/src/tools/schema-gen.ts
@@ -1,0 +1,69 @@
+/**
+ * OpenAI-format tool-schema generation (T1739 · AC3 · epic T11456).
+ *
+ * The SINGLE generator that turns a Cleo Zod parameter schema into the
+ * OpenAI / JSON-Schema {@link TransportTool} shape the ModelRunner + transport
+ * wire layer (and the Pi adapter) consume. Both the agent-facing
+ * {@link ./agent-registry.js | AgentToolRegistry} (AC3) and the Pi streamFn
+ * bridge (`core/src/llm/pi/pi-stream-fn.ts`) call THIS function, so there is one
+ * conversion doctrine and no drift (DRY).
+ *
+ * Uses Zod v4's native `z.toJSONSchema` — NO `zod-to-json-schema` dependency and
+ * NO typebox value-import, so the cleo↔Pi tool surface carries zero typebox
+ * (Gate 10). The resulting `inputSchema` is a plain JSON-Schema object the
+ * transport passes through verbatim after any provider-specific adaptation.
+ *
+ * @task T1739
+ * @epic T11456
+ */
+
+import type { TransportTool } from '@cleocode/contracts/llm/normalized-response.js';
+import { z } from 'zod';
+
+/**
+ * A name + description + Zod-schema tool definition, in the shape the schema
+ * generator consumes. Both the agent registry's {@link
+ * ./agent-registry.js | AgentToolDescriptor} and the Pi streamFn's `PiZodTool`
+ * structurally satisfy this, so one generator serves both.
+ */
+export interface ZodSchemaTool {
+  /** Tool name as the provider / model will see it. */
+  readonly name: string;
+  /** Human-readable description for the model. */
+  readonly description: string;
+  /** Zod schema for the tool's input parameters. */
+  readonly parameters: z.ZodType;
+}
+
+/**
+ * Convert a Cleo Zod-schema tool into the OpenAI-format JSON-Schema
+ * {@link TransportTool}.
+ *
+ * The conversion is purely a function of its input (no I/O, no global state), so
+ * it is safe to call at any time, including during a lazy
+ * {@link ./agent-registry.js | AgentToolRegistry} discovery pass.
+ *
+ * @param tool - The Cleo Zod tool ({@link ZodSchemaTool}).
+ * @returns The transport-shaped JSON-Schema tool (OpenAI function format).
+ *
+ * @example
+ * ```ts
+ * const t = zodSchemaToOpenAITool({
+ *   name: 'read_file',
+ *   description: 'Read a file as text',
+ *   parameters: z.object({ path: z.string() }),
+ * });
+ * // t.inputSchema === { type: 'object', properties: { path: { type: 'string' } }, ... }
+ * ```
+ */
+export function zodSchemaToOpenAITool(tool: ZodSchemaTool): TransportTool {
+  // Zod v4's native `z.toJSONSchema` renders a plain JSON-Schema object — NO
+  // `zod-to-json-schema` dep and NO typebox value-import at this boundary, so
+  // every tool surface (registry + Pi bridge) carries zero typebox (Gate 10).
+  const inputSchema = z.toJSONSchema(tool.parameters) as Record<string, unknown>;
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema,
+  };
+}


### PR DESCRIPTION
## What

Adds the **agent-facing tool registry** the Pi adapter / ModelRunner consume — the cleocode analogue of Hermes' `tools/registry.py`. First step of P4 (tools/skills) under epic **T10418** (SG-TOOLS, T11456).

The registry lives in `packages/core/src/tools/` (Gate-11 home for atomic tool primitives). It answers, for an agent loop: *which tools exist, what is each tool's OpenAI-format schema, which toolset does it belong to, is it available right now, and how do I run it.* It owns **no** side effects — every registered tool's executable is bound over an injected `GuardedToolSurface`, so all fs/shell work still funnels through the deny-first `createToolGuard` chokepoint (no raw-primitive bypass).

## Acceptance criteria

- **AC1** — `AgentToolRegistry` class + name→executable dispatch map.
- **AC2** — `discover()` does a **bounded** directory scan (source-marker grep for `registerAgentTools`, then dynamic import of only matching `*.agent-tool.{ts,js}` modules) — not a whole-tree AST parse, and **never at module import**.
- **AC3** — `toOpenAITools()` emits OpenAI-format `TransportTool[]` via the single shared `zodSchemaToOpenAITool` generator (`schema-gen.ts`), which the Pi `streamFn` now also delegates to (DRY — no drift).
- **AC4** — every tool declares a `Toolset` group (`terminal | file | web | agent | media`); `byToolset()` buckets them. New `AGENT_TOOLSETS` / `Toolset` type added to `contracts/tools/atomic.ts` (orthogonal to the side-effect `ToolClass` axis).
- **AC5** — every tool declares an `AvailabilityCheck` predicate (e.g. `run_git` only when `git` is on PATH); `available(ctx)` filters them.
- **AC6** — the registry is **immutable after `init()`**: late `register()`/`discover()` throw, and `init()` is single-flight (concurrent callers await one shared promise) — no shared-mutable-state race.
- **AC7** — auto-discovery is an **explicit** `init()` at startup; module import registers nothing and runs no heavy work (lazy logger, no scan at import).

## Schemas (the shape the Pi adapter + ModelRunner consume)

`zodSchemaToOpenAITool` renders a Cleo Zod parameter schema → plain JSON-Schema `TransportTool` via Zod v4's native `z.toJSONSchema` — **no `zod-to-json-schema` dep, no typebox value-import**, so the cleo↔Pi tool surface carries zero typebox (Gate 10). The Pi `streamFn` now threads `Context.tools` → `SendOptions.tools` → `TransportRequest.tools`, closing the streamFn→transport link so registry tools are reachable by the model (schema advertisement; tool-call *execution* binding is a later subtask).

## Gates

- `pnpm biome check --write .` — clean (no fixes).
- `pnpm run build` — success.
- Core tests (cgroup-wrapped, `--maxWorkers=2`): the 3 new test files pass **49/49**. Full-suite failures are in code untouched by this PR (e.g. `spawn/worktree-merge.test.ts`, byte-identical to `origin/main`) — known worker-fork environmental flake, not introduced here.
- `node scripts/lint-tools-vs-skills-boundary.mjs` — **Gate-11 clean** (no net-new out-of-home primitive; baseline 1). Primitives defined only under `core/src/tools` + `contracts/src/tools`.
- `node scripts/lint-no-runtime-in-contracts.mjs` — **net-add clean** (`AGENT_TOOLSETS` is const data, not a runtime helper; `--strict` remains at the pre-existing E5 baseline, unchanged by this PR).
- `cleo check arch` — 5/5 gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)