### PR TITLE
feat(T10418): core agent tools — terminal/file/patch/search/git over the guarded surface (T1741)

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/tools/atomic.d.ts",
       "import": "./dist/tools/atomic.js"
     },
+    "./tools/agent-tools": {
+      "types": "./dist/tools/agent-tools.d.ts",
+      "import": "./dist/tools/agent-tools.js"
+    },
     "./tools/composite": {
       "types": "./dist/tools/composite.d.ts",
       "import": "./dist/tools/composite.js"

--- a/packages/contracts/src/__tests__/skill-executor-contract.test.ts
+++ b/packages/contracts/src/__tests__/skill-executor-contract.test.ts
@@ -43,6 +43,9 @@ const fakeTools: GuardedToolSurface = {
   async executeShell(_input): Promise<ExecuteShellResult> {
     return { stdout: '', stderr: '', code: 0 };
   },
+  async executePty(_input) {
+    return { stdout: '', stderr: '', code: 0, mode: 'spawn', ptyFellBack: false };
+  },
   async runGit(_input): Promise<ExecuteShellResult> {
     return { stdout: '', stderr: '', code: 0 };
   },

--- a/packages/contracts/src/tools/agent-tools.ts
+++ b/packages/contracts/src/tools/agent-tools.ts
@@ -1,0 +1,270 @@
+/**
+ * Agent-facing tool family I/O contracts (T1741 · epic T11456 · SG-TOOLS).
+ *
+ * The shared, types-only I/O shapes for the six CORE agent-tool families wired
+ * into the {@link ./atomic.js | atomic} primitive layer and surfaced through the
+ * `AgentToolRegistry` (`packages/core/src/tools/agent-registry.ts`):
+ *
+ *   - **terminal** — `run_shell` with PTY + non-PTY modes ({@link RunShellInput}).
+ *   - **file/read** — `read_file` with pagination ({@link ReadFilePagedInput}).
+ *   - **file/patch** — `apply_patch` with fuzzy hunk matching ({@link ApplyPatchInput}).
+ *   - **search** — `search_files` over ripgrep ({@link SearchFilesInput}).
+ *   - **git** — status / diff / log / commit ({@link GitStatusInput} …).
+ *
+ * These compose OVER the atomic `fs`/`shell`/`search` primitives — they never
+ * introduce a new side-effect surface. The implementations
+ * (`packages/core/src/tools/builtin/*`) perform ALL work through the injected
+ * `GuardedToolSurface` (deny-first chokepoint), so the same guardrail policy
+ * applies. Types-only — no runtime logic (Gate 10 `contracts-purity`).
+ *
+ * @epic T11456
+ * @task T1741
+ * @see ./atomic.js — the raw primitive I/O shapes these compose over
+ */
+
+// ---------------------------------------------------------------------------
+// terminal — run_shell (PTY + non-PTY)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execution mode for {@link RunShellInput}.
+ *
+ * - `pty` — allocate a pseudo-terminal (line-discipline, colour, interactive
+ *   programs). Requires the OPTIONAL `node-pty` native dep; when it cannot be
+ *   loaded the implementation transparently falls back to `spawn`.
+ * - `spawn` — plain `child_process.spawn` (no TTY). Always available.
+ * - `auto` — prefer `pty` when `node-pty` is loadable, else `spawn`.
+ */
+export type ShellRunMode = 'pty' | 'spawn' | 'auto';
+
+/** Input for the `run_shell` terminal tool. */
+export interface RunShellInput {
+  /** Executable to run (argv form — NOT a shell string; no shell interpolation). */
+  readonly command: string;
+  /** Arguments for {@link RunShellInput.command}. */
+  readonly args?: readonly string[];
+  /** Working directory. */
+  readonly cwd?: string;
+  /** Extra environment variables (scrubbed at the guard chokepoint). */
+  readonly env?: Readonly<Record<string, string>>;
+  /** Hard timeout in milliseconds; the process is killed when exceeded. */
+  readonly timeoutMs?: number;
+  /** Execution mode. Defaults to `auto`. */
+  readonly mode?: ShellRunMode;
+  /** PTY column count (PTY mode only). Defaults to 80. */
+  readonly cols?: number;
+  /** PTY row count (PTY mode only). Defaults to 24. */
+  readonly rows?: number;
+}
+
+/** Result of the `run_shell` terminal tool. */
+export interface RunShellResult {
+  /**
+   * Combined output. In `spawn` mode this is stdout; in `pty` mode stdout and
+   * stderr are interleaved on the single PTY stream (as a real terminal does).
+   */
+  readonly stdout: string;
+  /** Captured standard error. Empty in PTY mode (merged into {@link RunShellResult.stdout}). */
+  readonly stderr: string;
+  /** Process exit code (0 = success). `null` when killed by signal/timeout. */
+  readonly code: number | null;
+  /** The mode that actually ran (`pty` downgrades to `spawn` when unavailable). */
+  readonly mode: 'pty' | 'spawn';
+  /** Whether a PTY was requested but unavailable, so `spawn` was used instead. */
+  readonly ptyFellBack: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// file — read_file (pagination)
+// ---------------------------------------------------------------------------
+
+/** Input for the paginated `read_file` tool. */
+export interface ReadFilePagedInput {
+  /** Absolute path to read. */
+  readonly path: string;
+  /** 0-based line offset to start from. Defaults to 0. */
+  readonly offset?: number;
+  /** Maximum number of lines to return. Omit for "to end of file". */
+  readonly limit?: number;
+}
+
+/** Result of a paginated read. */
+export interface ReadFilePagedResult {
+  /** Absolute path that was read. */
+  readonly path: string;
+  /** The selected slice of lines (joined with `\n`). */
+  readonly content: string;
+  /** 0-based line offset the slice began at. */
+  readonly offset: number;
+  /** Number of lines returned. */
+  readonly lineCount: number;
+  /** Total number of lines in the file. */
+  readonly totalLines: number;
+  /** Whether more lines exist after the returned slice. */
+  readonly hasMore: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// file — apply_patch (fuzzy)
+// ---------------------------------------------------------------------------
+
+/** Input for the `apply_patch` tool (fuzzy, whitespace-tolerant replacement). */
+export interface ApplyPatchInput {
+  /** Absolute path of the file to patch. */
+  readonly path: string;
+  /** Exact-or-fuzzy block of original text to locate. */
+  readonly oldText: string;
+  /** Replacement text. */
+  readonly newText: string;
+  /**
+   * Permit fuzzy (leading/trailing whitespace-insensitive) matching when an
+   * exact match is not found. Defaults to `true`.
+   */
+  readonly fuzzy?: boolean;
+}
+
+/** Result of an `apply_patch`. */
+export interface ApplyPatchResult {
+  /** Absolute path that was patched. */
+  readonly path: string;
+  /** Whether the replacement was applied. */
+  readonly applied: boolean;
+  /** How the match was located: exact, fuzzy (whitespace-normalised), or none. */
+  readonly matchKind: 'exact' | 'fuzzy' | 'none';
+  /** 0-based line where the replacement began (when applied). */
+  readonly startLine?: number;
+}
+
+// ---------------------------------------------------------------------------
+// search — search_files (ripgrep)
+// ---------------------------------------------------------------------------
+
+/** Input for the ripgrep-backed `search_files` tool. */
+export interface SearchFilesInput {
+  /** Pattern to search for (regex by default — see {@link SearchFilesInput.fixedStrings}). */
+  readonly pattern: string;
+  /** Root directory to search under. */
+  readonly root: string;
+  /** Treat {@link SearchFilesInput.pattern} as a literal string, not a regex. */
+  readonly fixedStrings?: boolean;
+  /** Case-insensitive matching. */
+  readonly ignoreCase?: boolean;
+  /** Restrict to files matching this ripgrep glob (e.g. `*.ts`). */
+  readonly glob?: string;
+  /** Cap on returned matches. Defaults to 1000. */
+  readonly maxResults?: number;
+}
+
+/** A single `search_files` match. */
+export interface SearchFilesMatch {
+  /** Absolute (or root-relative) path of the matching file. */
+  readonly path: string;
+  /** 1-based line number of the match. */
+  readonly line: number;
+  /** The matching line's text (trailing newline stripped). */
+  readonly text: string;
+}
+
+/** Result of `search_files`. */
+export interface SearchFilesResult {
+  /** Matches in ripgrep order. */
+  readonly matches: readonly SearchFilesMatch[];
+  /** Whether {@link SearchFilesInput.maxResults} truncated the results. */
+  readonly truncated: boolean;
+  /**
+   * `true` when ripgrep (`rg`) was unavailable and the search degraded to a
+   * built-in scan, so callers can surface reduced fidelity.
+   */
+  readonly degraded: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// git — status / diff / log / commit
+// ---------------------------------------------------------------------------
+
+/** Common options for the git tools. */
+export interface GitToolBase {
+  /** Repository working directory. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+  /** Hard timeout in milliseconds. */
+  readonly timeoutMs?: number;
+}
+
+/** Input for `git_status`. */
+export interface GitStatusInput extends GitToolBase {}
+
+/** One porcelain-v1 status entry. */
+export interface GitStatusEntry {
+  /** Two-char XY porcelain status code (e.g. ` M`, `A `, `??`). */
+  readonly status: string;
+  /** Path the status applies to. */
+  readonly path: string;
+}
+
+/** Result of `git_status`. */
+export interface GitStatusResult {
+  /** The current branch name (`HEAD` when detached/unknown). */
+  readonly branch: string;
+  /** Parsed porcelain entries. */
+  readonly entries: readonly GitStatusEntry[];
+  /** Whether the working tree has any uncommitted changes. */
+  readonly clean: boolean;
+}
+
+/** Input for `git_diff`. */
+export interface GitDiffInput extends GitToolBase {
+  /** Show staged (`--cached`) changes instead of the working tree. */
+  readonly staged?: boolean;
+  /** Restrict the diff to these paths. */
+  readonly paths?: readonly string[];
+}
+
+/** Result of `git_diff`. */
+export interface GitDiffResult {
+  /** The unified diff text (empty when there are no changes). */
+  readonly diff: string;
+}
+
+/** Input for `git_log`. */
+export interface GitLogInput extends GitToolBase {
+  /** Maximum number of commits to return. Defaults to 20. */
+  readonly maxCount?: number;
+}
+
+/** One commit in a `git_log` result. */
+export interface GitLogEntry {
+  /** Full commit SHA. */
+  readonly sha: string;
+  /** Author name. */
+  readonly author: string;
+  /** ISO-8601 author date. */
+  readonly date: string;
+  /** Commit subject (first line). */
+  readonly subject: string;
+}
+
+/** Result of `git_log`. */
+export interface GitLogResult {
+  /** Commits newest-first. */
+  readonly commits: readonly GitLogEntry[];
+}
+
+/** Input for `git_commit`. */
+export interface GitCommitInput extends GitToolBase {
+  /** Commit message. */
+  readonly message: string;
+  /** Stage all tracked modifications first (`-a`). Defaults to `false`. */
+  readonly all?: boolean;
+  /** Explicit paths to stage before committing. */
+  readonly paths?: readonly string[];
+}
+
+/** Result of `git_commit`. */
+export interface GitCommitResult {
+  /** Whether the commit was created. */
+  readonly committed: boolean;
+  /** The new commit SHA (when created). */
+  readonly sha?: string;
+  /** Git's stdout/stderr summary (e.g. "nothing to commit"). */
+  readonly summary: string;
+}

--- a/packages/contracts/src/tools/index.ts
+++ b/packages/contracts/src/tools/index.ts
@@ -7,6 +7,30 @@
  * @epic T9835
  */
 
+// === Agent-facing tool families (T1741 / T11456) ===
+export type {
+  ApplyPatchInput,
+  ApplyPatchResult,
+  GitCommitInput,
+  GitCommitResult,
+  GitDiffInput,
+  GitDiffResult,
+  GitLogEntry,
+  GitLogInput,
+  GitLogResult,
+  GitStatusEntry,
+  GitStatusInput,
+  GitStatusResult,
+  GitToolBase,
+  ReadFilePagedInput,
+  ReadFilePagedResult,
+  RunShellInput,
+  RunShellResult,
+  SearchFilesInput,
+  SearchFilesMatch,
+  SearchFilesResult,
+  ShellRunMode,
+} from './agent-tools.js';
 export type { FetchBrainEntriesInput, FetchBrainEntriesOutput } from './brain-fetch.js';
 export type { ObserveBrainInput, ObserveBrainOutput } from './brain-observe.js';
 // === BrainTools (T10070 / T9835c) ===

--- a/packages/contracts/src/tools/skill-executor.ts
+++ b/packages/contracts/src/tools/skill-executor.ts
@@ -44,6 +44,7 @@
  * @see ./atomic.js — the tool I/O shapes this seam composes over
  */
 
+import type { RunShellInput, RunShellResult } from './agent-tools.js';
 import type {
   ExecuteShellInput,
   ExecuteShellResult,
@@ -86,6 +87,12 @@ export interface GuardedToolSurface {
   pathExists(input: PathExistsInput): Promise<PathExistsResult>;
   /** Run a command with explicit cwd/env/timeout through the guard. */
   executeShell(input: ExecuteShellInput): Promise<ExecuteShellResult>;
+  /**
+   * Run a command under a pseudo-terminal (PTY) through the guard, falling back
+   * to a non-PTY spawn when a PTY backend is unavailable. Subject to the same
+   * deny-first command policy + env scrubbing as {@link GuardedToolSurface.executeShell}.
+   */
+  executePty(input: RunShellInput): Promise<RunShellResult>;
   /** Run a git subcommand through the guard. */
   runGit(input: RunGitInput): Promise<ExecuteShellResult>;
 }

--- a/packages/core/src/llm/pi/__tests__/pi-agent-adapter.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-agent-adapter.test.ts
@@ -44,6 +44,9 @@ function fakeTools(): GuardedToolSurface {
     async executeShell() {
       return { stdout: '', stderr: '', code: 0 };
     },
+    async executePty() {
+      return { stdout: '', stderr: '', code: 0, mode: 'spawn' as const, ptyFellBack: false };
+    },
     async runGit() {
       return { stdout: '', stderr: '', code: 0 };
     },

--- a/packages/core/src/llm/pi/__tests__/pi-anthropic-turn.integration.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-anthropic-turn.integration.test.ts
@@ -55,6 +55,9 @@ function recordingTools(reads: string[]): GuardedToolSurface {
     async executeShell() {
       return { stdout: '', stderr: '', code: 0 };
     },
+    async executePty() {
+      return { stdout: '', stderr: '', code: 0, mode: 'spawn' as const, ptyFellBack: false };
+    },
     async runGit() {
       return { stdout: '', stderr: '', code: 0 };
     },

--- a/packages/core/src/llm/pi/__tests__/single-envelope-stdout.test.ts
+++ b/packages/core/src/llm/pi/__tests__/single-envelope-stdout.test.ts
@@ -64,6 +64,9 @@ function noopTools() {
     async executeShell() {
       return { stdout: '', stderr: '', code: 0 };
     },
+    async executePty() {
+      return { stdout: '', stderr: '', code: 0, mode: 'spawn' as const, ptyFellBack: false };
+    },
     async runGit() {
       return { stdout: '', stderr: '', code: 0 };
     },

--- a/packages/core/src/playbooks/__tests__/skill-node-executor.test.ts
+++ b/packages/core/src/playbooks/__tests__/skill-node-executor.test.ts
@@ -60,6 +60,9 @@ const NOOP_TOOLS: GuardedToolSurface = {
   async executeShell() {
     return { stdout: '', stderr: '', code: 0 };
   },
+  async executePty() {
+    return { stdout: '', stderr: '', code: 0, mode: 'spawn' as const, ptyFellBack: false };
+  },
   async runGit() {
     return { stdout: '', stderr: '', code: 0 };
   },

--- a/packages/core/src/skills/__tests__/skill-executor-adapter.test.ts
+++ b/packages/core/src/skills/__tests__/skill-executor-adapter.test.ts
@@ -72,6 +72,10 @@ function makeGuardSpy(): { tools: GuardedToolSurface; calls: string[] } {
       calls.push('executeShell');
       return { stdout: '', stderr: '', code: 0 };
     },
+    async executePty() {
+      calls.push('executePty');
+      return { stdout: '', stderr: '', code: 0, mode: 'spawn' as const, ptyFellBack: false };
+    },
     async runGit() {
       calls.push('runGit');
       return { stdout: '', stderr: '', code: 0 };

--- a/packages/core/src/tools/__tests__/agent-registry.test.ts
+++ b/packages/core/src/tools/__tests__/agent-registry.test.ts
@@ -146,10 +146,13 @@ describe('AgentToolRegistry — toolset grouping (AC4)', () => {
     expect(Object.keys(grouped).sort()).toEqual(
       ['agent', 'file', 'media', 'terminal', 'web'].sort(),
     );
-    expect(grouped.file.map((t) => t.name).sort()).toEqual(
-      ['path_exists', 'read_file', 'write_file'].sort(),
-    );
-    expect(grouped.terminal.map((t) => t.name).sort()).toEqual(['run_command', 'run_git'].sort());
+    // The thin built-ins (T1739) PLUS the richer T1741 families share the file
+    // and terminal toolsets — assert the built-ins are present (superset check)
+    // rather than an exact list, so adding families doesn't break this test.
+    const fileNames = grouped.file.map((t) => t.name);
+    expect(fileNames).toEqual(expect.arrayContaining(['path_exists', 'read_file', 'write_file']));
+    const terminalNames = grouped.terminal.map((t) => t.name);
+    expect(terminalNames).toEqual(expect.arrayContaining(['run_command', 'run_git']));
     // No net/notebook primitives implemented yet — empty but present.
     expect(grouped.web).toEqual([]);
     expect(grouped.media).toEqual([]);
@@ -200,10 +203,14 @@ describe('AgentToolRegistry — frozen-after-init + single-flight (AC6)', () => 
   });
 
   it('concurrent init() calls coalesce into one (single-flight)', async () => {
+    // Control: a single init() establishes the canonical built-in count.
+    const control = new AgentToolRegistry();
+    await control.init();
     const r = new AgentToolRegistry();
     await Promise.all([r.init(), r.init(), r.init()]);
-    // Built-ins registered exactly once despite 3 concurrent inits.
-    expect(r.size).toBe(5);
+    // Built-ins registered exactly once despite 3 concurrent inits — same count
+    // as a single init (no duplicate registration race).
+    expect(r.size).toBe(control.size);
   });
 
   it('list() returns a defensive copy (mutating it does not affect the registry)', async () => {

--- a/packages/core/src/tools/__tests__/agent-tool-families.test.ts
+++ b/packages/core/src/tools/__tests__/agent-tool-families.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Tests for the agent-facing tool families (T1741 · epic T11456).
+ *
+ * Covers the 8 acceptance criteria with MOCKED backends (AC8) — no real network,
+ * no destructive fs outside `mkdtemp` temp dirs, no real git/ripgrep dependency:
+ *   AC1 run_shell PTY + non-PTY (spawn fallback) · AC2 read_file pagination ·
+ *   AC3 write_file atomic · AC4 apply_patch fuzzy · AC5 search_files ripgrep +
+ *   graceful degradation · AC6 git status/diff/log/commit · AC7 all registered
+ *   in the AgentToolRegistry (surfaced via toOpenAITools).
+ *
+ * The pure helpers are tested directly; the tool executables are driven through
+ * a hand-rolled fake {@link GuardedToolSurface} that records calls and returns
+ * canned results, so no subprocess/fs is ever touched.
+ *
+ * @task T1741
+ * @epic T11456
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  ExecuteShellInput,
+  ExecuteShellResult,
+  ReadFileResult,
+  RunGitInput,
+  WriteFileResult,
+} from '@cleocode/contracts/tools/atomic';
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { describe, expect, it } from 'vitest';
+import { createAgentToolRegistry } from '../agent-registry.js';
+import {
+  applyFuzzyPatch,
+  paginateLines,
+  parseGitLog,
+  parseGitStatus,
+  parseRipgrepOutput,
+} from '../agent-tool-families.js';
+import { createToolGuard } from '../guard.js';
+
+/** A recording fake of the guarded surface. Backends are fully mocked (AC8). */
+function fakeSurface(handlers: {
+  readFileText?: (path: string) => string;
+  executeShell?: (input: ExecuteShellInput) => ExecuteShellResult | Error;
+  runGit?: (input: RunGitInput) => ExecuteShellResult;
+}): {
+  tools: GuardedToolSurface;
+  writes: Array<{ path: string; content: string }>;
+  shellCalls: ExecuteShellInput[];
+  gitCalls: RunGitInput[];
+} {
+  const writes: Array<{ path: string; content: string }> = [];
+  const shellCalls: ExecuteShellInput[] = [];
+  const gitCalls: RunGitInput[] = [];
+  const tools: GuardedToolSurface = {
+    async readFileText(input): Promise<ReadFileResult> {
+      return { path: input.path, content: handlers.readFileText?.(input.path) ?? '' };
+    },
+    async readJson<T>(): Promise<T> {
+      return {} as T;
+    },
+    async writeFileAtomic(input): Promise<WriteFileResult> {
+      writes.push({ path: input.path, content: input.content });
+      return { path: input.path, bytesWritten: Buffer.byteLength(input.content) };
+    },
+    async pathExists() {
+      return { exists: false };
+    },
+    async executeShell(input): Promise<ExecuteShellResult> {
+      shellCalls.push(input);
+      const out = handlers.executeShell?.(input);
+      if (out instanceof Error) throw out;
+      return out ?? { stdout: '', stderr: '', code: 0 };
+    },
+    async executePty(input) {
+      shellCalls.push({ command: input.command, args: input.args });
+      return { stdout: '(pty)', stderr: '', code: 0, mode: 'spawn', ptyFellBack: true };
+    },
+    async runGit(input): Promise<ExecuteShellResult> {
+      gitCalls.push(input);
+      return handlers.runGit?.(input) ?? { stdout: '', stderr: '', code: 0 };
+    },
+  };
+  return { tools, writes, shellCalls, gitCalls };
+}
+
+// ===========================================================================
+// Pure helpers
+// ===========================================================================
+
+describe('paginateLines (AC2)', () => {
+  const content = ['l0', 'l1', 'l2', 'l3', 'l4'].join('\n');
+
+  it('returns the whole file when no offset/limit', () => {
+    const r = paginateLines(content, '/f', 0);
+    expect(r.lineCount).toBe(5);
+    expect(r.totalLines).toBe(5);
+    expect(r.hasMore).toBe(false);
+    expect(r.content).toBe(content);
+  });
+
+  it('slices by offset + limit and reports hasMore', () => {
+    const r = paginateLines(content, '/f', 1, 2);
+    expect(r.offset).toBe(1);
+    expect(r.content).toBe('l1\nl2');
+    expect(r.lineCount).toBe(2);
+    expect(r.hasMore).toBe(true);
+  });
+
+  it('clamps an out-of-range offset', () => {
+    const r = paginateLines(content, '/f', 99, 10);
+    expect(r.offset).toBe(5);
+    expect(r.lineCount).toBe(0);
+    expect(r.hasMore).toBe(false);
+  });
+
+  it('handles an empty file', () => {
+    const r = paginateLines('', '/f');
+    expect(r.totalLines).toBe(0);
+    expect(r.lineCount).toBe(0);
+    expect(r.content).toBe('');
+  });
+});
+
+describe('applyFuzzyPatch (AC4)', () => {
+  it('applies an exact substring match', () => {
+    const out = applyFuzzyPatch('alpha beta gamma', 'beta', 'BETA');
+    expect(out.matchKind).toBe('exact');
+    expect(out.content).toBe('alpha BETA gamma');
+  });
+
+  it('falls back to whitespace-tolerant fuzzy matching', () => {
+    const file = ['function f() {', '    return 1;', '}'].join('\n');
+    // Note the different indentation of the needle — exact would miss it.
+    const out = applyFuzzyPatch(file, 'return 1;', 'return 2;');
+    expect(out.matchKind).toBe('exact'); // substring still present
+    expect(out.content).toContain('return 2;');
+  });
+
+  it('fuzzy-matches a multi-line block with differing indentation', () => {
+    const file = ['  a();', '  b();', '  c();'].join('\n');
+    const out = applyFuzzyPatch(file, 'a();\nb();', 'X();');
+    expect(out.matchKind).toBe('fuzzy');
+    expect(out.startLine).toBe(0);
+    expect(out.content).toBe(['X();', '  c();'].join('\n'));
+  });
+
+  it('reports none when nothing matches', () => {
+    const out = applyFuzzyPatch('hello world', 'absent', 'x');
+    expect(out.matchKind).toBe('none');
+    expect(out.content).toBe('hello world');
+  });
+
+  it('respects fuzzy=false (no fuzzy fallback)', () => {
+    const file = ['  a();', '  b();'].join('\n');
+    const out = applyFuzzyPatch(file, 'a();\nb();', 'X();', false);
+    expect(out.matchKind).toBe('none');
+  });
+});
+
+describe('parseRipgrepOutput (AC5)', () => {
+  it('parses path:line:text', () => {
+    const { matches, truncated } = parseRipgrepOutput('src/a.ts:12:const x = 1;\n', 10);
+    expect(truncated).toBe(false);
+    expect(matches).toEqual([{ path: 'src/a.ts', line: 12, text: 'const x = 1;' }]);
+  });
+
+  it('parses --vimgrep path:line:col:text', () => {
+    const { matches } = parseRipgrepOutput('a.ts:3:5:foo\n', 10);
+    expect(matches[0]).toEqual({ path: 'a.ts', line: 3, text: 'foo' });
+  });
+
+  it('truncates at maxResults', () => {
+    const stdout = ['a:1:x', 'b:2:y', 'c:3:z'].join('\n');
+    const { matches, truncated } = parseRipgrepOutput(stdout, 2);
+    expect(matches.length).toBe(2);
+    expect(truncated).toBe(true);
+  });
+});
+
+describe('parseGitStatus + parseGitLog (AC6)', () => {
+  it('parses porcelain status', () => {
+    const entries = parseGitStatus(' M src/a.ts\n?? new.ts\n');
+    expect(entries).toEqual([
+      { status: ' M', path: 'src/a.ts' },
+      { status: '??', path: 'new.ts' },
+    ]);
+  });
+
+  it('parses unit-separated git log', () => {
+    const line = ['abc123', 'Ada', '2026-01-01T00:00:00Z', 'init'].join('');
+    const commits = parseGitLog(line);
+    expect(commits).toEqual([
+      { sha: 'abc123', author: 'Ada', date: '2026-01-01T00:00:00Z', subject: 'init' },
+    ]);
+  });
+});
+
+// ===========================================================================
+// Registry wiring (AC7) + executables over the fake guarded surface
+// ===========================================================================
+
+describe('agent tool families — registered in the registry (AC7)', () => {
+  it('registers all six families and surfaces them via toOpenAITools', async () => {
+    const r = await createAgentToolRegistry();
+    for (const name of [
+      'run_shell',
+      'read_file_paged',
+      'write_file_atomic',
+      'apply_patch',
+      'search_files',
+      'git_status',
+      'git_diff',
+      'git_log',
+      'git_commit',
+    ]) {
+      expect(r.get(name), `${name} should be registered`).toBeDefined();
+    }
+    const openai = r.toOpenAITools();
+    expect(openai.find((t) => t.name === 'run_shell')?.inputSchema).toMatchObject({
+      type: 'object',
+    });
+    expect(openai.find((t) => t.name === 'git_commit')).toBeDefined();
+  });
+
+  it('git tools are hidden when git is not on PATH (AC5/AC6 availability)', async () => {
+    const r = await createAgentToolRegistry();
+    const names = r.available({ availableBinaries: [] }).map((t) => t.name);
+    expect(names).not.toContain('git_status');
+    expect(names).toContain('run_shell'); // always available
+    expect(names).toContain('search_files');
+  });
+});
+
+describe('run_shell executable (AC1)', () => {
+  it('routes through the guarded PTY surface (spawn fallback)', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, shellCalls } = fakeSurface({});
+    const exec = r.getExecutable('run_shell');
+    if (exec === undefined) throw new Error('run_shell missing');
+    const out = (await exec({ command: 'echo', args: ['hi'], mode: 'auto' }, tools)) as {
+      mode: string;
+      ptyFellBack: boolean;
+    };
+    expect(shellCalls[0]?.command).toBe('echo');
+    expect(out.ptyFellBack).toBe(true);
+  });
+});
+
+describe('read_file_paged executable (AC2)', () => {
+  it('reads via the guard and paginates', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools } = fakeSurface({ readFileText: () => 'a\nb\nc\nd' });
+    const exec = r.getExecutable('read_file_paged');
+    if (exec === undefined) throw new Error('read_file_paged missing');
+    const out = (await exec({ path: '/f', offset: 1, limit: 2 }, tools)) as { content: string };
+    expect(out.content).toBe('b\nc');
+  });
+});
+
+describe('write_file_atomic + apply_patch executables (AC3/AC4)', () => {
+  it('write_file_atomic writes through the guard', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, writes } = fakeSurface({});
+    const exec = r.getExecutable('write_file_atomic');
+    if (exec === undefined) throw new Error('write_file_atomic missing');
+    await exec({ path: '/f', content: 'data' }, tools);
+    expect(writes).toEqual([{ path: '/f', content: 'data' }]);
+  });
+
+  it('apply_patch reads, patches, and writes through the guard', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, writes } = fakeSurface({ readFileText: () => 'foo bar baz' });
+    const exec = r.getExecutable('apply_patch');
+    if (exec === undefined) throw new Error('apply_patch missing');
+    const out = (await exec({ path: '/f', oldText: 'bar', newText: 'BAR' }, tools)) as {
+      applied: boolean;
+      matchKind: string;
+    };
+    expect(out.applied).toBe(true);
+    expect(out.matchKind).toBe('exact');
+    expect(writes[0]?.content).toBe('foo BAR baz');
+  });
+
+  it('apply_patch does not write when there is no match', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, writes } = fakeSurface({ readFileText: () => 'foo' });
+    const exec = r.getExecutable('apply_patch');
+    if (exec === undefined) throw new Error('apply_patch missing');
+    const out = (await exec({ path: '/f', oldText: 'absent', newText: 'x' }, tools)) as {
+      applied: boolean;
+    };
+    expect(out.applied).toBe(false);
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('search_files executable (AC5)', () => {
+  it('uses ripgrep when available', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, shellCalls } = fakeSurface({
+      executeShell: (input) =>
+        input.command === 'rg'
+          ? { stdout: 'a.ts:1:hit\n', stderr: '', code: 0 }
+          : { stdout: '', stderr: '', code: 0 },
+    });
+    const exec = r.getExecutable('search_files');
+    if (exec === undefined) throw new Error('search_files missing');
+    const out = (await exec({ pattern: 'hit', root: '/repo' }, tools)) as {
+      matches: unknown[];
+      degraded: boolean;
+    };
+    expect(shellCalls[0]?.command).toBe('rg');
+    expect(out.degraded).toBe(false);
+    expect(out.matches).toEqual([{ path: 'a.ts', line: 1, text: 'hit' }]);
+  });
+
+  it('degrades to grep when ripgrep is absent (graceful degradation)', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, shellCalls } = fakeSurface({
+      executeShell: (input) => {
+        if (input.command === 'rg') return new Error('spawn rg ENOENT');
+        return { stdout: 'b.ts:2:hit\n', stderr: '', code: 0 };
+      },
+    });
+    const exec = r.getExecutable('search_files');
+    if (exec === undefined) throw new Error('search_files missing');
+    const out = (await exec({ pattern: 'hit', root: '/repo' }, tools)) as {
+      matches: unknown[];
+      degraded: boolean;
+    };
+    expect(shellCalls.map((c) => c.command)).toEqual(['rg', 'grep']);
+    expect(out.degraded).toBe(true);
+    expect(out.matches).toEqual([{ path: 'b.ts', line: 2, text: 'hit' }]);
+  });
+
+  it('reports empty+degraded when neither rg nor grep exist', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools } = fakeSurface({ executeShell: () => new Error('ENOENT') });
+    const exec = r.getExecutable('search_files');
+    if (exec === undefined) throw new Error('search_files missing');
+    const out = (await exec({ pattern: 'x', root: '/repo' }, tools)) as {
+      matches: unknown[];
+      degraded: boolean;
+    };
+    expect(out.matches).toEqual([]);
+    expect(out.degraded).toBe(true);
+  });
+});
+
+describe('git family executables (AC6)', () => {
+  it('git_status parses branch + porcelain', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools } = fakeSurface({
+      runGit: (input) => {
+        if (input.args[0] === 'rev-parse') return { stdout: 'main\n', stderr: '', code: 0 };
+        return { stdout: ' M a.ts\n', stderr: '', code: 0 };
+      },
+    });
+    const exec = r.getExecutable('git_status');
+    if (exec === undefined) throw new Error('git_status missing');
+    const out = (await exec({ cwd: '/repo' }, tools)) as {
+      branch: string;
+      clean: boolean;
+      entries: unknown[];
+    };
+    expect(out.branch).toBe('main');
+    expect(out.clean).toBe(false);
+    expect(out.entries).toEqual([{ status: ' M', path: 'a.ts' }]);
+  });
+
+  it('git_diff passes --cached when staged', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, gitCalls } = fakeSurface({
+      runGit: () => ({ stdout: 'diff --git ...', stderr: '', code: 0 }),
+    });
+    const exec = r.getExecutable('git_diff');
+    if (exec === undefined) throw new Error('git_diff missing');
+    const out = (await exec({ staged: true, cwd: '/repo' }, tools)) as { diff: string };
+    expect(gitCalls[0]?.args).toEqual(['diff', '--cached']);
+    expect(out.diff).toContain('diff --git');
+  });
+
+  it('git_log parses commits', async () => {
+    const r = await createAgentToolRegistry();
+    const sep = '';
+    const { tools } = fakeSurface({
+      runGit: () => ({
+        stdout: ['s1', 'A', 'd1', 'subj'].join(sep),
+        stderr: '',
+        code: 0,
+      }),
+    });
+    const exec = r.getExecutable('git_log');
+    if (exec === undefined) throw new Error('git_log missing');
+    const out = (await exec({ maxCount: 5 }, tools)) as { commits: Array<{ sha: string }> };
+    expect(out.commits[0]?.sha).toBe('s1');
+  });
+
+  it('git_commit stages paths, commits, and returns the new sha', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools, gitCalls } = fakeSurface({
+      runGit: (input) => {
+        if (input.args[0] === 'rev-parse') return { stdout: 'deadbeef\n', stderr: '', code: 0 };
+        if (input.args[0] === 'commit') return { stdout: '1 file changed', stderr: '', code: 0 };
+        return { stdout: '', stderr: '', code: 0 };
+      },
+    });
+    const exec = r.getExecutable('git_commit');
+    if (exec === undefined) throw new Error('git_commit missing');
+    const out = (await exec({ message: 'msg', paths: ['a.ts'], cwd: '/repo' }, tools)) as {
+      committed: boolean;
+      sha?: string;
+    };
+    expect(gitCalls[0]?.args).toEqual(['add', '--', 'a.ts']);
+    expect(gitCalls[1]?.args).toEqual(['commit', '-m', 'msg']);
+    expect(out.committed).toBe(true);
+    expect(out.sha).toBe('deadbeef');
+  });
+
+  it('git_commit reports not-committed on a non-zero exit', async () => {
+    const r = await createAgentToolRegistry();
+    const { tools } = fakeSurface({
+      runGit: () => ({ stdout: 'nothing to commit', stderr: '', code: 1 }),
+    });
+    const exec = r.getExecutable('git_commit');
+    if (exec === undefined) throw new Error('git_commit missing');
+    const out = (await exec({ message: 'msg' }, tools)) as { committed: boolean; summary: string };
+    expect(out.committed).toBe(false);
+    expect(out.summary).toContain('nothing to commit');
+  });
+});
+
+// ===========================================================================
+// End-to-end through the REAL guard (denylist + temp-dir fs only) — still no
+// network, no destructive fs outside the temp dir.
+// ===========================================================================
+
+describe('apply_patch end-to-end through the real guard (AC3/AC4/AC8)', () => {
+  it('patches a file inside an allowed root', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'cleo-t1741-'));
+    try {
+      const r = await createAgentToolRegistry();
+      const guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+      const path = join(root, 'f.txt');
+      const write = r.getExecutable('write_file_atomic');
+      const patch = r.getExecutable('apply_patch');
+      const read = r.getExecutable('read_file_paged');
+      if (write === undefined || patch === undefined || read === undefined) {
+        throw new Error('family executables missing');
+      }
+      await write({ path, content: 'one\ntwo\nthree' }, guard);
+      const res = (await patch({ path, oldText: 'two', newText: 'TWO' }, guard)) as {
+        applied: boolean;
+      };
+      expect(res.applied).toBe(true);
+      const got = (await read({ path }, guard)) as { content: string };
+      expect(got.content).toBe('one\nTWO\nthree');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/tools/__tests__/pty.test.ts
+++ b/packages/core/src/tools/__tests__/pty.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the PTY shell runner (T1741 · epic T11456 · AC1/AC8).
+ *
+ * Exercises the ALWAYS-available non-PTY `spawn` path and the PTY/auto fallback.
+ * `node-pty` is an OPTIONAL dep and is NOT installed in CI, so the `auto`/`pty`
+ * modes degrade to `spawn` with `ptyFellBack: true` — which is exactly the
+ * behaviour asserted here. No network; the only subprocess is `node -e` (always
+ * present in this toolchain).
+ *
+ * @task T1741
+ * @epic T11456
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runPty } from '../pty.js';
+
+const NODE = process.execPath;
+
+describe('runPty — non-PTY spawn mode (AC1)', () => {
+  it('captures stdout + exit code in spawn mode', async () => {
+    const res = await runPty({
+      command: NODE,
+      args: ['-e', 'process.stdout.write("hello")'],
+      mode: 'spawn',
+    });
+    expect(res.mode).toBe('spawn');
+    expect(res.ptyFellBack).toBe(false);
+    expect(res.stdout).toContain('hello');
+    expect(res.code).toBe(0);
+  });
+
+  it('reports a non-zero exit code', async () => {
+    const res = await runPty({
+      command: NODE,
+      args: ['-e', 'process.exit(7)'],
+      mode: 'spawn',
+    });
+    expect(res.code).toBe(7);
+  });
+});
+
+describe('runPty — auto/pty mode (AC1)', () => {
+  it('degrades to spawn with ptyFellBack when node-pty is unavailable', async () => {
+    const res = await runPty({
+      command: NODE,
+      args: ['-e', 'process.stdout.write("yo")'],
+      mode: 'auto',
+    });
+    // node-pty is not a project dependency, so auto resolves to spawn fallback.
+    expect(res.mode).toBe('spawn');
+    expect(res.ptyFellBack).toBe(true);
+    expect(res.stdout).toContain('yo');
+    expect(res.code).toBe(0);
+  });
+});

--- a/packages/core/src/tools/agent-tool-families.ts
+++ b/packages/core/src/tools/agent-tool-families.ts
@@ -1,0 +1,595 @@
+/**
+ * Agent-facing tool FAMILIES — terminal, file, search, git (T1741 · epic T11456).
+ *
+ * The six richer tool families layered over the atomic primitives and registered
+ * into the {@link ./agent-registry.js | AgentToolRegistry}, on top of the thin
+ * built-ins in {@link ./builtin-agent-tools.js}:
+ *
+ *   - **AC1** `run_shell` — terminal execution with PTY + non-PTY (spawn) modes
+ *     (PTY via the OPTIONAL, lazily-loaded `node-pty`; transparent spawn fallback).
+ *   - **AC2** `read_file_paged` — file read with `offset`/`limit` pagination.
+ *   - **AC3** `write_file_atomic` — atomic (tmp-then-rename) write.
+ *   - **AC4** `apply_patch` — fuzzy (whitespace-tolerant) text replacement.
+ *   - **AC5** `search_files` — ripgrep-backed search with graceful degradation
+ *     to `grep` when `rg` is absent.
+ *   - **AC6** `git_status` / `git_diff` / `git_log` / `git_commit` — workspace-
+ *     confined git operations.
+ *
+ * Every family performs ALL side effects through the injected
+ * {@link GuardedToolSurface} (deny-first chokepoint) — there is NO raw `fs` /
+ * `child_process` use here. The pure helpers (patch matching, search-output
+ * parsing, git parsing) are exported for direct unit testing with mocked
+ * backends (AC8). Import-time side-effect-free.
+ *
+ * @epic T11456
+ * @task T1741
+ * @see ./guard.js — the deny-first chokepoint every executable routes through
+ */
+
+import type {
+  ApplyPatchResult,
+  GitLogEntry,
+  GitStatusEntry,
+  ReadFilePagedResult,
+  SearchFilesMatch,
+} from '@cleocode/contracts/tools/agent-tools';
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { z } from 'zod';
+import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
+import { ALWAYS_AVAILABLE } from './agent-registry.js';
+
+/** Available only when the named binary is known on PATH (AC5/AC6 example). */
+function binaryAvailable(name: string): AvailabilityCheck {
+  return (ctx) => ctx.availableBinaries === undefined || ctx.availableBinaries.includes(name);
+}
+
+// ===========================================================================
+// AC2 — paginated read (pure slice helper + tool)
+// ===========================================================================
+
+/**
+ * Slice a file's text into a paginated window. Pure helper — no I/O — so it is
+ * unit-testable in isolation (AC8).
+ *
+ * @param content - The full file text.
+ * @param offset - 0-based starting line (clamped to `[0, totalLines]`).
+ * @param limit - Max lines to return; `undefined` → to end of file.
+ * @returns The paginated {@link ReadFilePagedResult} body for `path`.
+ */
+export function paginateLines(
+  content: string,
+  path: string,
+  offset = 0,
+  limit?: number,
+): ReadFilePagedResult {
+  const lines = content === '' ? [] : content.split('\n');
+  const totalLines = lines.length;
+  const start = Math.max(0, Math.min(offset, totalLines));
+  const end = limit === undefined ? totalLines : Math.min(start + Math.max(0, limit), totalLines);
+  const slice = lines.slice(start, end);
+  return {
+    path,
+    content: slice.join('\n'),
+    offset: start,
+    lineCount: slice.length,
+    totalLines,
+    hasMore: end < totalLines,
+  };
+}
+
+// ===========================================================================
+// AC4 — fuzzy patch (pure matcher + applier)
+// ===========================================================================
+
+/** Outcome of {@link applyFuzzyPatch} — the new content + how it matched. */
+export interface FuzzyPatchOutcome {
+  /** The patched content (unchanged when `matchKind === 'none'`). */
+  readonly content: string;
+  /** How `oldText` was located. */
+  readonly matchKind: ApplyPatchResult['matchKind'];
+  /** 0-based line where the replacement began (when applied). */
+  readonly startLine?: number;
+}
+
+/** Normalise a block for fuzzy comparison: trim each line, drop blank edges. */
+function normaliseBlock(block: string): string[] {
+  return block
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((_l, i, arr) => {
+      // keep interior; trim leading/trailing all-blank lines
+      if (arr[i] !== '') return true;
+      const beforeAllBlank = arr.slice(0, i).every((x) => x === '');
+      const afterAllBlank = arr.slice(i + 1).every((x) => x === '');
+      return !(beforeAllBlank || afterAllBlank);
+    });
+}
+
+/**
+ * Apply a text replacement, falling back to whitespace-tolerant fuzzy matching
+ * when an exact substring match is not found. Pure function of its inputs — no
+ * I/O — so it is unit-testable with no filesystem (AC8).
+ *
+ * Strategy:
+ *  1. **Exact** — a verbatim `indexOf(oldText)` substring replacement (first hit).
+ *  2. **Fuzzy** (when enabled) — compare `oldText` line-trimmed against every
+ *     same-length window of the file's line-trimmed lines; the first window that
+ *     matches is replaced (preserving the file's other lines).
+ *  3. **None** — no match; content returned unchanged.
+ *
+ * @param content - The current file content.
+ * @param oldText - The block to locate.
+ * @param newText - The replacement.
+ * @param fuzzy - Permit fuzzy matching (default `true`).
+ * @returns The {@link FuzzyPatchOutcome}.
+ */
+export function applyFuzzyPatch(
+  content: string,
+  oldText: string,
+  newText: string,
+  fuzzy = true,
+): FuzzyPatchOutcome {
+  // 1) exact substring
+  const idx = content.indexOf(oldText);
+  if (idx !== -1) {
+    const startLine = content.slice(0, idx).split('\n').length - 1;
+    const patched = `${content.slice(0, idx)}${newText}${content.slice(idx + oldText.length)}`;
+    return { content: patched, matchKind: 'exact', startLine };
+  }
+  if (!fuzzy) {
+    return { content, matchKind: 'none' };
+  }
+  // 2) fuzzy line-window match (whitespace-insensitive)
+  const fileLines = content.split('\n');
+  const needle = normaliseBlock(oldText);
+  if (needle.length === 0) {
+    return { content, matchKind: 'none' };
+  }
+  for (let i = 0; i + needle.length <= fileLines.length; i++) {
+    const window = fileLines.slice(i, i + needle.length).map((l) => l.trim());
+    if (window.every((line, j) => line === needle[j])) {
+      const replacementLines = newText.split('\n');
+      const patchedLines = [
+        ...fileLines.slice(0, i),
+        ...replacementLines,
+        ...fileLines.slice(i + needle.length),
+      ];
+      return { content: patchedLines.join('\n'), matchKind: 'fuzzy', startLine: i };
+    }
+  }
+  return { content, matchKind: 'none' };
+}
+
+// ===========================================================================
+// AC5 — ripgrep search-output parsing
+// ===========================================================================
+
+/**
+ * Parse ripgrep `--vimgrep`/`-n` style output (`path:line:col:text` or
+ * `path:line:text`) into structured matches. Pure helper (AC8).
+ *
+ * @param stdout - ripgrep stdout.
+ * @param maxResults - Cap on returned matches.
+ * @returns The parsed matches and whether the cap truncated them.
+ */
+export function parseRipgrepOutput(
+  stdout: string,
+  maxResults: number,
+): { matches: SearchFilesMatch[]; truncated: boolean } {
+  const matches: SearchFilesMatch[] = [];
+  const lines = stdout.split('\n').filter((l) => l.length > 0);
+  for (const raw of lines) {
+    // path may contain ':' (rare); split on the FIRST two/three colons carefully.
+    // rg -n emits `path:line:text`; rg --vimgrep emits `path:line:col:text`.
+    const m = /^(.*?):(\d+):(?:(\d+):)?(.*)$/.exec(raw);
+    if (m === null) continue;
+    const path = m[1];
+    const line = Number.parseInt(m[2], 10);
+    const text = m[4] ?? '';
+    if (Number.isNaN(line)) continue;
+    matches.push({ path, line, text });
+    if (matches.length >= maxResults) {
+      return { matches, truncated: true };
+    }
+  }
+  return { matches, truncated: false };
+}
+
+// ===========================================================================
+// AC6 — git output parsing
+// ===========================================================================
+
+/**
+ * Parse `git status --porcelain=v1` output into structured entries. Pure (AC8).
+ *
+ * @param stdout - porcelain-v1 stdout.
+ * @returns The parsed status entries.
+ */
+export function parseGitStatus(stdout: string): GitStatusEntry[] {
+  const entries: GitStatusEntry[] = [];
+  for (const raw of stdout.split('\n')) {
+    if (raw.length < 4) continue;
+    const status = raw.slice(0, 2);
+    const path = raw.slice(3);
+    entries.push({ status, path });
+  }
+  return entries;
+}
+
+/** The record separator used in the {@link GIT_LOG_FORMAT} pretty format. */
+const GIT_LOG_FIELD_SEP = '';
+
+/**
+ * The `--pretty=format:` argument for {@link parseGitLog} — SHA, author name,
+ * ISO date, subject, unit-separated.
+ */
+export const GIT_LOG_FORMAT = `%H${GIT_LOG_FIELD_SEP}%an${GIT_LOG_FIELD_SEP}%aI${GIT_LOG_FIELD_SEP}%s`;
+
+/**
+ * Parse `git log --pretty=format:<GIT_LOG_FORMAT>` output. Pure (AC8).
+ *
+ * @param stdout - The git-log stdout.
+ * @returns The parsed commit entries, newest-first.
+ */
+export function parseGitLog(stdout: string): GitLogEntry[] {
+  const commits: GitLogEntry[] = [];
+  for (const raw of stdout.split('\n')) {
+    if (raw.length === 0) continue;
+    const [sha, author, date, subject] = raw.split(GIT_LOG_FIELD_SEP);
+    if (sha === undefined) continue;
+    commits.push({
+      sha,
+      author: author ?? '',
+      date: date ?? '',
+      subject: subject ?? '',
+    });
+  }
+  return commits;
+}
+
+/**
+ * Run a guarded ripgrep search, degrading to `grep -rn` when `rg` is absent.
+ * All execution flows through {@link GuardedToolSurface.executeShell}.
+ *
+ * @param tools - The guarded surface.
+ * @param args - Search parameters (already normalised).
+ * @returns Matches, truncation flag, and whether the search degraded.
+ */
+async function guardedSearch(
+  tools: GuardedToolSurface,
+  args: {
+    pattern: string;
+    root: string;
+    fixedStrings: boolean;
+    ignoreCase: boolean;
+    glob?: string;
+    maxResults: number;
+    timeoutMs?: number;
+  },
+): Promise<{ matches: SearchFilesMatch[]; truncated: boolean; degraded: boolean }> {
+  const rgArgs = ['--no-heading', '--line-number', '--color=never'];
+  if (args.fixedStrings) rgArgs.push('--fixed-strings');
+  if (args.ignoreCase) rgArgs.push('--ignore-case');
+  if (args.glob !== undefined) rgArgs.push('--glob', args.glob);
+  rgArgs.push('--max-count', String(args.maxResults), '--', args.pattern, args.root);
+  try {
+    const res = await tools.executeShell({
+      command: 'rg',
+      args: rgArgs,
+      timeoutMs: args.timeoutMs,
+    });
+    // rg exit 0 = matches, 1 = no matches (both fine), 2 = error.
+    if (res.code === 2) {
+      return { matches: [], truncated: false, degraded: false };
+    }
+    const { matches, truncated } = parseRipgrepOutput(res.stdout, args.maxResults);
+    return { matches, truncated, degraded: false };
+  } catch {
+    // rg not on PATH (spawn ENOENT) — degrade to grep.
+    return grepFallback(tools, args);
+  }
+}
+
+/** Degraded `grep -rn` fallback when ripgrep is unavailable. */
+async function grepFallback(
+  tools: GuardedToolSurface,
+  args: {
+    pattern: string;
+    root: string;
+    fixedStrings: boolean;
+    ignoreCase: boolean;
+    maxResults: number;
+    timeoutMs?: number;
+  },
+): Promise<{ matches: SearchFilesMatch[]; truncated: boolean; degraded: boolean }> {
+  const grepArgs = ['-rn'];
+  if (args.fixedStrings) grepArgs.push('-F');
+  if (args.ignoreCase) grepArgs.push('-i');
+  grepArgs.push('--', args.pattern, args.root);
+  try {
+    const res = await tools.executeShell({
+      command: 'grep',
+      args: grepArgs,
+      timeoutMs: args.timeoutMs,
+    });
+    const { matches, truncated } = parseRipgrepOutput(res.stdout, args.maxResults);
+    return { matches, truncated, degraded: true };
+  } catch {
+    // Neither rg nor grep available — report empty, degraded.
+    return { matches: [], truncated: false, degraded: true };
+  }
+}
+
+/**
+ * Register the agent-facing tool FAMILIES (terminal, file, search, git) into
+ * `registry`. Pure registration — no I/O, no scan; side effects happen later
+ * through the injected {@link GuardedToolSurface}.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentToolFamilies(registry: AgentToolRegistry): void {
+  // --- AC1: terminal — run_shell (PTY + non-PTY) ---------------------------
+  registry.register({
+    name: 'run_shell',
+    class: 'shell',
+    description:
+      'Run a command under a PTY (or non-PTY spawn fallback) with cwd/env/timeout. ' +
+      'argv form — never a shell string.',
+    toolset: 'terminal',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      command: z.string().describe('Executable to run (NOT a shell string).'),
+      args: z.array(z.string()).optional().describe('Arguments for the command.'),
+      cwd: z.string().optional().describe('Working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+      mode: z
+        .enum(['pty', 'spawn', 'auto'])
+        .optional()
+        .describe("Execution mode: 'pty', 'spawn', or 'auto' (default)."),
+      cols: z.number().int().positive().optional().describe('PTY column count (PTY mode).'),
+      rows: z.number().int().positive().optional().describe('PTY row count (PTY mode).'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const command = String(rawArgs.command);
+      const argv = Array.isArray(rawArgs.args) ? rawArgs.args.map(String) : undefined;
+      const cwd = rawArgs.cwd === undefined ? undefined : String(rawArgs.cwd);
+      const timeoutMs = typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined;
+      const mode =
+        rawArgs.mode === 'pty' || rawArgs.mode === 'spawn' || rawArgs.mode === 'auto'
+          ? rawArgs.mode
+          : undefined;
+      const cols = typeof rawArgs.cols === 'number' ? rawArgs.cols : undefined;
+      const rows = typeof rawArgs.rows === 'number' ? rawArgs.rows : undefined;
+      return tools.executePty({ command, args: argv, cwd, timeoutMs, mode, cols, rows });
+    },
+  });
+
+  // --- AC2: file — read_file_paged ----------------------------------------
+  registry.register({
+    name: 'read_file_paged',
+    class: 'fs',
+    description: 'Read a file with line pagination (offset/limit).',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      path: z.string().describe('Absolute path to read.'),
+      offset: z.number().int().min(0).optional().describe('0-based start line.'),
+      limit: z.number().int().positive().optional().describe('Max lines to return.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const path = String(rawArgs.path);
+      const offset = typeof rawArgs.offset === 'number' ? rawArgs.offset : 0;
+      const limit = typeof rawArgs.limit === 'number' ? rawArgs.limit : undefined;
+      const { content } = await tools.readFileText({ path });
+      return paginateLines(content, path, offset, limit);
+    },
+  });
+
+  // --- AC3: file — write_file_atomic --------------------------------------
+  registry.register({
+    name: 'write_file_atomic',
+    class: 'fs',
+    description: 'Atomically write a file (tmp-then-rename), creating parent dirs.',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      path: z.string().describe('Absolute path to write.'),
+      content: z.string().describe('File content to write.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const path = String(rawArgs.path);
+      const content = String(rawArgs.content);
+      return tools.writeFileAtomic({ path, content });
+    },
+  });
+
+  // --- AC4: file — apply_patch (fuzzy) ------------------------------------
+  registry.register({
+    name: 'apply_patch',
+    class: 'fs',
+    description: 'Replace a block of text in a file (exact, then fuzzy whitespace-tolerant match).',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      path: z.string().describe('Absolute path of the file to patch.'),
+      oldText: z.string().describe('Block of original text to locate.'),
+      newText: z.string().describe('Replacement text.'),
+      fuzzy: z.boolean().optional().describe('Permit fuzzy matching (default true).'),
+    }),
+    execute: async (rawArgs, tools): Promise<ApplyPatchResult> => {
+      const path = String(rawArgs.path);
+      const oldText = String(rawArgs.oldText);
+      const newText = String(rawArgs.newText);
+      const fuzzy = rawArgs.fuzzy === undefined ? true : Boolean(rawArgs.fuzzy);
+      const { content } = await tools.readFileText({ path });
+      const outcome = applyFuzzyPatch(content, oldText, newText, fuzzy);
+      if (outcome.matchKind === 'none') {
+        return { path, applied: false, matchKind: 'none' };
+      }
+      await tools.writeFileAtomic({ path, content: outcome.content });
+      return {
+        path,
+        applied: true,
+        matchKind: outcome.matchKind,
+        startLine: outcome.startLine,
+      };
+    },
+  });
+
+  // --- AC5: search — search_files (ripgrep, grep fallback) ----------------
+  registry.register({
+    name: 'search_files',
+    class: 'search',
+    description: 'Search file contents under a root via ripgrep (grep fallback when rg is absent).',
+    toolset: 'file',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      pattern: z.string().describe('Pattern to search for (regex unless fixedStrings).'),
+      root: z.string().describe('Root directory to search under.'),
+      fixedStrings: z.boolean().optional().describe('Treat pattern as a literal string.'),
+      ignoreCase: z.boolean().optional().describe('Case-insensitive matching.'),
+      glob: z.string().optional().describe('Restrict to files matching this glob.'),
+      maxResults: z.number().int().positive().optional().describe('Cap on matches (default 1000).'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const maxResults = typeof rawArgs.maxResults === 'number' ? rawArgs.maxResults : 1000;
+      return guardedSearch(tools, {
+        pattern: String(rawArgs.pattern),
+        root: String(rawArgs.root),
+        fixedStrings: Boolean(rawArgs.fixedStrings),
+        ignoreCase: Boolean(rawArgs.ignoreCase),
+        glob: rawArgs.glob === undefined ? undefined : String(rawArgs.glob),
+        maxResults,
+        timeoutMs: typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined,
+      });
+    },
+  });
+
+  // --- AC6: git — status / diff / log / commit ----------------------------
+  const gitAvailable = binaryAvailable('git');
+
+  registry.register({
+    name: 'git_status',
+    class: 'shell',
+    description: 'Show the working-tree status (branch + porcelain entries).',
+    toolset: 'terminal',
+    stateless: true,
+    available: gitAvailable,
+    parameters: z.object({
+      cwd: z.string().optional().describe('Repository working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const cwd = rawArgs.cwd === undefined ? undefined : String(rawArgs.cwd);
+      const timeoutMs = typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined;
+      const branchRes = await tools.runGit({
+        args: ['rev-parse', '--abbrev-ref', 'HEAD'],
+        cwd,
+        timeoutMs,
+      });
+      const statusRes = await tools.runGit({
+        args: ['status', '--porcelain=v1'],
+        cwd,
+        timeoutMs,
+      });
+      const entries = parseGitStatus(statusRes.stdout);
+      return {
+        branch: branchRes.stdout.trim() || 'HEAD',
+        entries,
+        clean: entries.length === 0,
+      };
+    },
+  });
+
+  registry.register({
+    name: 'git_diff',
+    class: 'shell',
+    description: 'Show the unified diff of working-tree or staged changes.',
+    toolset: 'terminal',
+    stateless: true,
+    available: gitAvailable,
+    parameters: z.object({
+      staged: z.boolean().optional().describe('Show staged (--cached) changes.'),
+      paths: z.array(z.string()).optional().describe('Restrict to these paths.'),
+      cwd: z.string().optional().describe('Repository working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const cwd = rawArgs.cwd === undefined ? undefined : String(rawArgs.cwd);
+      const timeoutMs = typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined;
+      const gitArgs = ['diff'];
+      if (rawArgs.staged === true) gitArgs.push('--cached');
+      if (Array.isArray(rawArgs.paths) && rawArgs.paths.length > 0) {
+        gitArgs.push('--', ...rawArgs.paths.map(String));
+      }
+      const res = await tools.runGit({ args: gitArgs, cwd, timeoutMs });
+      return { diff: res.stdout };
+    },
+  });
+
+  registry.register({
+    name: 'git_log',
+    class: 'shell',
+    description: 'List recent commits (sha, author, date, subject).',
+    toolset: 'terminal',
+    stateless: true,
+    available: gitAvailable,
+    parameters: z.object({
+      maxCount: z.number().int().positive().optional().describe('Max commits (default 20).'),
+      cwd: z.string().optional().describe('Repository working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const cwd = rawArgs.cwd === undefined ? undefined : String(rawArgs.cwd);
+      const timeoutMs = typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined;
+      const maxCount = typeof rawArgs.maxCount === 'number' ? rawArgs.maxCount : 20;
+      const res = await tools.runGit({
+        args: ['log', `--max-count=${maxCount}`, `--pretty=format:${GIT_LOG_FORMAT}`],
+        cwd,
+        timeoutMs,
+      });
+      return { commits: parseGitLog(res.stdout) };
+    },
+  });
+
+  registry.register({
+    name: 'git_commit',
+    class: 'shell',
+    description: 'Create a commit (optionally staging tracked changes or explicit paths).',
+    toolset: 'terminal',
+    stateless: true,
+    available: gitAvailable,
+    parameters: z.object({
+      message: z.string().describe('Commit message.'),
+      all: z.boolean().optional().describe('Stage all tracked modifications first (-a).'),
+      paths: z.array(z.string()).optional().describe('Explicit paths to stage before committing.'),
+      cwd: z.string().optional().describe('Repository working directory.'),
+      timeoutMs: z.number().int().positive().optional().describe('Hard timeout in ms.'),
+    }),
+    execute: async (rawArgs, tools) => {
+      const cwd = rawArgs.cwd === undefined ? undefined : String(rawArgs.cwd);
+      const timeoutMs = typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined;
+      const message = String(rawArgs.message);
+      if (Array.isArray(rawArgs.paths) && rawArgs.paths.length > 0) {
+        await tools.runGit({ args: ['add', '--', ...rawArgs.paths.map(String)], cwd, timeoutMs });
+      }
+      const commitArgs = ['commit', '-m', message];
+      if (rawArgs.all === true) commitArgs.splice(1, 0, '-a');
+      const res = await tools.runGit({ args: commitArgs, cwd, timeoutMs });
+      const committed = res.code === 0;
+      let sha: string | undefined;
+      if (committed) {
+        const head = await tools.runGit({ args: ['rev-parse', 'HEAD'], cwd, timeoutMs });
+        sha = head.stdout.trim() || undefined;
+      }
+      const summary = `${res.stdout}${res.stderr}`.trim();
+      return { committed, sha, summary };
+    },
+  });
+}

--- a/packages/core/src/tools/builtin-agent-tools.ts
+++ b/packages/core/src/tools/builtin-agent-tools.ts
@@ -26,6 +26,7 @@
 import { z } from 'zod';
 import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
 import { ALWAYS_AVAILABLE } from './agent-registry.js';
+import { registerAgentToolFamilies } from './agent-tool-families.js';
 
 /** Available only when the named binary is known on PATH (AC5 example). */
 function binaryAvailable(name: string): AvailabilityCheck {
@@ -140,4 +141,10 @@ export function registerBuiltinAgentTools(registry: AgentToolRegistry): void {
   // in `core/src/tools/*` (only their contracts exist in atomic.ts). Those
   // toolsets are intentionally empty until S3+ ships their primitives; the
   // registry already supports them (AC4) so registration is a one-liner then.
+
+  // The richer agent-facing tool families (T1741): terminal `run_shell` (PTY +
+  // spawn), paginated `read_file_paged`, atomic `write_file_atomic`, fuzzy
+  // `apply_patch`, ripgrep `search_files`, and the git family
+  // (status/diff/log/commit). All route through the same guarded surface.
+  registerAgentToolFamilies(registry);
 }

--- a/packages/core/src/tools/guard.ts
+++ b/packages/core/src/tools/guard.ts
@@ -39,6 +39,7 @@
  */
 
 import { isAbsolute, resolve as resolvePath } from 'node:path';
+import type { RunShellInput, RunShellResult } from '@cleocode/contracts/tools/agent-tools';
 import type {
   ExecuteShellInput,
   ExecuteShellResult,
@@ -53,6 +54,7 @@ import type {
 import { getLogger } from '../logger.js';
 import { scrubSubprocessEnv } from './env-scrub.js';
 import { canonicalizePath, pathExists, readFileText, readJson, writeFileAtomic } from './fs.js';
+import { runPty } from './pty.js';
 import { executeShell, runGit, type ShellExecutor } from './shell.js';
 
 const log = getLogger('tool-guard');
@@ -160,6 +162,13 @@ export interface ToolGuard {
   writeFileAtomic(input: WriteFileInput): Promise<WriteFileResult>;
   pathExists(input: PathExistsInput): Promise<PathExistsResult>;
   executeShell(input: ExecuteShellInput, executor?: ShellExecutor): Promise<ExecuteShellResult>;
+  /**
+   * Run a command under a PTY (or a non-PTY spawn fallback) through the guard.
+   * The command basename is checked against the denylist BEFORE any process is
+   * spawned and the child env is scrubbed — same policy point as
+   * {@link ToolGuard.executeShell}.
+   */
+  executePty(input: RunShellInput): Promise<RunShellResult>;
   runGit(input: RunGitInput, executor?: ShellExecutor): Promise<ExecuteShellResult>;
 }
 
@@ -266,6 +275,14 @@ export function createToolGuard(policy: ToolGuardPolicy = {}): ToolGuard {
       // also scrubs as a redundant net, but the guard is the policy point.
       const env = scrubSubprocessEnv({ extra: input.env });
       return executeShell({ ...input, env }, executor);
+    },
+    async executePty(input) {
+      // Same policy point as executeShell: deny-check the command basename
+      // BEFORE spawning any PTY/process. `runPty` re-scrubs the env internally
+      // (PTY + spawn paths both use `scrubSubprocessEnv`), so the daemon's
+      // secrets and any Pi-controlled loader hook can never reach the child.
+      denyShell('executePty', input.command);
+      return runPty(input);
     },
     async runGit(input, executor) {
       denyShell('runGit', 'git');

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -98,6 +98,21 @@ export {
   createAgentToolRegistry,
   type ToolAvailabilityContext,
 } from './agent-registry.js';
+// Agent-facing tool families (T1741 · epic T11456) — terminal `run_shell` (PTY +
+// non-PTY spawn fallback), paginated `read_file_paged`, atomic `write_file_atomic`,
+// fuzzy `apply_patch`, ripgrep `search_files`, and the git family. Pure helpers
+// (pagination, fuzzy patch, rg/git output parsing) are exported for direct unit
+// testing; every executable routes side effects through the guarded surface.
+export {
+  applyFuzzyPatch,
+  type FuzzyPatchOutcome,
+  GIT_LOG_FORMAT,
+  paginateLines,
+  parseGitLog,
+  parseGitStatus,
+  parseRipgrepOutput,
+  registerAgentToolFamilies,
+} from './agent-tool-families.js';
 export { registerBuiltinAgentTools } from './builtin-agent-tools.js';
 // Subprocess env scrubbing (T11897 · security) — the chokepoint builds a minimal,
 // allowlisted child env so daemon secrets never leak and a Pi-controlled loader
@@ -120,6 +135,9 @@ export {
   type ToolGuard,
   type ToolGuardPolicy,
 } from './guard.js';
+// PTY shell runner (T1741) — the terminal toolset's execution backend; lazily +
+// optionally loads `node-pty`, transparently degrading to non-PTY `spawn`.
+export { runPty } from './pty.js';
 export { type ZodSchemaTool, zodSchemaToOpenAITool } from './schema-gen.js';
 // Injectable shell executor (E3 · T11406) — threaded into the guard's
 // executeShell/runGit; substitutes the subprocess layer in tests/sandboxes.

--- a/packages/core/src/tools/pty.ts
+++ b/packages/core/src/tools/pty.ts
@@ -1,0 +1,198 @@
+/**
+ * Pseudo-terminal (PTY) shell runner (T1741 · epic T11456 · SG-TOOLS).
+ *
+ * The `terminal` toolset's execution backend. Runs a command under a PTY when
+ * the OPTIONAL `node-pty` native dependency is loadable, otherwise transparently
+ * degrades to a plain `child_process.spawn` (the {@link defaultShellExecutor}
+ * path) so the tool ALWAYS works without a heavy native dep. `node-pty` is
+ * loaded lazily via dynamic `import()` inside the runner — NEVER at module
+ * import — so this file is import-time side-effect-free (and adds no startup
+ * cost / hard dependency).
+ *
+ * The child runs under the SCRUBBED, explicitly-constructed environment from
+ * {@link scrubSubprocessEnv} (same security posture as the non-PTY path): the
+ * daemon's secrets are never inherited and a Pi-controlled loader hook / PATH
+ * can never reach the spawned process. This runner is invoked ONLY from the
+ * guard chokepoint ({@link ./guard.js}), so the command denylist applies before
+ * any process is spawned — there is no raw bypass.
+ *
+ * @epic T11456
+ * @task T1741
+ * @see ./guard.js — the deny-first chokepoint that wraps this runner
+ */
+
+import { spawn } from 'node:child_process';
+import type { RunShellInput, RunShellResult } from '@cleocode/contracts/tools/agent-tools';
+import { getLogger } from '../logger.js';
+import { scrubSubprocessEnv } from './env-scrub.js';
+
+const log = getLogger('tool-pty');
+
+/** Default PTY geometry. */
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+
+/**
+ * The minimal structural shape of the `node-pty` module we use. Declared
+ * locally so this file carries NO type dependency on the optional package —
+ * the dynamic import is shape-checked against this, not against `@types/node-pty`.
+ */
+interface NodePtyModule {
+  spawn(
+    file: string,
+    args: readonly string[],
+    options: {
+      readonly name?: string;
+      readonly cols?: number;
+      readonly rows?: number;
+      readonly cwd?: string;
+      readonly env?: Record<string, string>;
+    },
+  ): NodePtyProcess;
+}
+
+/** The minimal structural shape of a spawned `node-pty` process. */
+interface NodePtyProcess {
+  onData(cb: (data: string) => void): void;
+  onExit(cb: (e: { exitCode: number; signal?: number }) => void): void;
+  kill(signal?: string): void;
+}
+
+/**
+ * Attempt to lazily load `node-pty`. Returns `null` when the optional dep is not
+ * installed or fails to load (any reason), so the caller can degrade to spawn.
+ *
+ * The import specifier is held in a variable so bundlers/TS do not treat the
+ * missing optional dep as a hard, statically-resolved dependency.
+ *
+ * @returns The loaded module shape, or `null` when unavailable.
+ */
+async function loadNodePty(): Promise<NodePtyModule | null> {
+  const specifier = 'node-pty';
+  try {
+    const mod: unknown = await import(specifier);
+    const candidate = (mod as { default?: unknown }).default ?? mod;
+    if (
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      typeof (candidate as { spawn?: unknown }).spawn === 'function'
+    ) {
+      return candidate as NodePtyModule;
+    }
+    return null;
+  } catch (err) {
+    log.debug({ err }, 'node-pty not loadable — falling back to non-PTY spawn');
+    return null;
+  }
+}
+
+/**
+ * Run a command under a non-PTY `spawn`, capturing stdout/stderr/exit-code.
+ * This is the always-available fallback when `node-pty` is absent or `spawn`
+ * mode was explicitly requested.
+ *
+ * @param input - {@link RunShellInput}.
+ * @param ptyFellBack - Whether this spawn is a fallback from a requested PTY.
+ * @returns The {@link RunShellResult} (`mode: 'spawn'`).
+ */
+function runSpawn(input: RunShellInput, ptyFellBack: boolean): Promise<RunShellResult> {
+  return new Promise<RunShellResult>((resolve, reject) => {
+    const child = spawn(input.command, [...(input.args ?? [])], {
+      cwd: input.cwd,
+      env: scrubSubprocessEnv({ extra: input.env }),
+      timeout: input.timeoutMs,
+      shell: false,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d: Buffer) => {
+      stdout += d.toString('utf8');
+    });
+    child.stderr?.on('data', (d: Buffer) => {
+      stderr += d.toString('utf8');
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ stdout, stderr, code, mode: 'spawn', ptyFellBack });
+    });
+  });
+}
+
+/**
+ * Run a command under a PTY via the lazily-loaded `node-pty`. The PTY interleaves
+ * stdout + stderr on a single stream (as a real terminal does), so the result's
+ * `stderr` is empty and all output lands in `stdout`.
+ *
+ * @param pty - The loaded `node-pty` module.
+ * @param input - {@link RunShellInput}.
+ * @returns The {@link RunShellResult} (`mode: 'pty'`).
+ */
+function runWithPty(pty: NodePtyModule, input: RunShellInput): Promise<RunShellResult> {
+  return new Promise<RunShellResult>((resolve, reject) => {
+    let proc: NodePtyProcess;
+    try {
+      proc = pty.spawn(input.command, [...(input.args ?? [])], {
+        name: 'xterm-256color',
+        cols: input.cols ?? DEFAULT_COLS,
+        rows: input.rows ?? DEFAULT_ROWS,
+        cwd: input.cwd,
+        env: scrubSubprocessEnv({ extra: input.env }),
+      });
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    let stdout = '';
+    let timer: NodeJS.Timeout | undefined;
+    if (typeof input.timeoutMs === 'number' && input.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        proc.kill();
+      }, input.timeoutMs);
+    }
+    proc.onData((data) => {
+      stdout += data;
+    });
+    proc.onExit(({ exitCode, signal }) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr: '',
+        code: typeof signal === 'number' && signal > 0 ? null : exitCode,
+        mode: 'pty',
+        ptyFellBack: false,
+      });
+    });
+  });
+}
+
+/**
+ * Run a command under a PTY when possible, else a non-PTY spawn.
+ *
+ * - `spawn` mode → always {@link runSpawn}.
+ * - `pty` / `auto` mode → attempt {@link loadNodePty}; on success {@link runWithPty},
+ *   otherwise degrade to {@link runSpawn} with `ptyFellBack: true`.
+ *
+ * The actual process is always launched under the scrubbed subprocess env. This
+ * function performs NO policy decision of its own — it is the executor the guard
+ * chokepoint ({@link ./guard.js}) invokes AFTER its denylist check passes.
+ *
+ * @param input - {@link RunShellInput}.
+ * @returns The {@link RunShellResult}.
+ *
+ * @example
+ * ```ts
+ * const res = await runPty({ command: 'echo', args: ['hi'], mode: 'auto' });
+ * // res.mode === 'pty' when node-pty is installed, else 'spawn' (ptyFellBack: true)
+ * ```
+ */
+export async function runPty(input: RunShellInput): Promise<RunShellResult> {
+  const mode = input.mode ?? 'auto';
+  if (mode === 'spawn') {
+    return runSpawn(input, false);
+  }
+  const pty = await loadNodePty();
+  if (pty === null) {
+    return runSpawn(input, true);
+  }
+  return runWithPty(pty, input);
+}


### PR DESCRIPTION
Six agent-facing tool families layered over the merged `AgentToolRegistry` (#1013) and the existing atomic primitives (`fs.ts`, `shell.ts`, `guard.ts`/`GuardedToolSurface`). These are the Pi loop's core capabilities — the cleocode analogue of Hermes' core tool set.

## What's registered (in `AgentToolRegistry`)

- **AC1 terminal** — `run_shell`: PTY execution via the OPTIONAL, lazily-loaded `node-pty`, with a transparent non-PTY `spawn` fallback (`mode: pty | spawn | auto`).
- **AC2 file/read** — `read_file_paged`: line pagination (`offset`/`limit`, `hasMore`).
- **AC3 file/write** — `write_file_atomic`: tmp-then-rename atomic write.
- **AC4 file/patch** — `apply_patch`: exact-then-fuzzy (whitespace-tolerant) block replacement.
- **AC5 search** — `search_files`: ripgrep-backed, graceful degradation to `grep` when `rg` is absent.
- **AC6 git** — `git_status` / `git_diff` / `git_log` / `git_commit`, gated on a `git` binary on PATH.

## Safety + boundaries

- Every tool routes ALL file/shell side effects through the EXISTING `GuardedToolSurface` (deny-first, workspace-confined) — `guard.ts` deny-checks the command basename and scrubs the child env BEFORE any process spawns. No raw `fs`/`child_process` outside the guard.
- No heavy new deps: `node-pty` is lazy/optional (spawn fallback), `rg` via spawn (grep fallback), `git` via spawn.
- Gate 11 (tools-vs-skills): all primitives DEFINED only under `packages/core/src/tools` (+ types in `packages/contracts/src/tools/agent-tools.ts`). PASS — no net-new out-of-home definition.
- Gate 10 (contracts-purity): `agent-tools.ts` is types-only. PASS strict.
- Import-time side-effect-free; zero `any`; TSDoc on all exports; ESM `.js`; kebab-case.

## Tests (mocked backends, AC8)

- 62 tests across 4 files pass in isolation (`agent-tool-families`, `agent-registry`, `pty`, `guard`): pure helpers (pagination, fuzzy patch, ripgrep/git output parsing) tested directly; executables driven through a recording fake `GuardedToolSurface`; one end-to-end test through the REAL guard inside an `mkdtemp` temp dir. No real network, no destructive fs outside temp dirs.

## Gates

`pnpm biome check` clean · `pnpm build` (contracts + core) clean · `cleo check arch` 5/5 PASS · Gate 10 + Gate 11 PASS.

Note: the full core suite has 15 pre-existing, unrelated failures in `src/spawn/__tests__/worktree-merge.test.ts` ("integrateWorktree not available in test fallback") — that test needs real git integration plumbing and fails identically on `main`; this PR adds zero lines to `spawn/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)