### PR TITLE
feat(T10418): web + browser agent tools (Playwright optional/lazy) — T1742

### DIFF
--- a/packages/contracts/src/tools/index.ts
+++ b/packages/contracts/src/tools/index.ts
@@ -65,3 +65,25 @@ export type {
   ScoreTaskInput,
   ScoreTaskResult,
 } from './score-task-priority.js';
+// === Web + browser agent tools (T1742 / T11456) ===
+export type {
+  AccessibilityNode,
+  BrowserActionResult,
+  BrowserClickInput,
+  BrowserNavigateInput,
+  BrowserPageState,
+  BrowserPressInput,
+  BrowserScrollDirection,
+  BrowserScrollInput,
+  BrowserScrollResult,
+  BrowserSnapshotResult,
+  BrowserTypeInput,
+  BrowserVisionInput,
+  BrowserVisionResult,
+  WebExtractInput,
+  WebExtractResult,
+  WebSearchBackendId,
+  WebSearchHit,
+  WebSearchInput,
+  WebSearchResult,
+} from './web-tools.js';

--- a/packages/contracts/src/tools/web-tools.ts
+++ b/packages/contracts/src/tools/web-tools.ts
@@ -1,0 +1,247 @@
+/**
+ * Web + browser agent-tool I/O contracts (T1742 · epic T11456 · SG-TOOLS).
+ *
+ * The shared, types-only I/O shapes for the `web` toolset surfaced through the
+ * `AgentToolRegistry` (`packages/core/src/tools/agent-registry.ts`), on top of
+ * the terminal/file/search/git families ({@link ./agent-tools.js}):
+ *
+ *   - **web_search** — pluggable, backend-agnostic web search
+ *     ({@link WebSearchInput} / {@link WebSearchResult}). NO hard paid-API dep:
+ *     a backend is resolved at call time and the tool degrades gracefully to an
+ *     `unavailable` result when none is configured.
+ *   - **web_extract** — fetch a URL and convert its HTML body to markdown
+ *     ({@link WebExtractInput} / {@link WebExtractResult}).
+ *   - **browser_*** — Playwright-driven browser automation
+ *     ({@link BrowserNavigateInput} … {@link BrowserVisionResult}). Playwright is
+ *     an OPTIONAL, lazily-loaded dependency — these tools' `available()` predicate
+ *     returns `false` (with an install hint) when it is absent.
+ *
+ * The web tools compose over the `net` side-effect surface; the browser tools
+ * over a Playwright-managed `shell`-class process. Like every agent tool, their
+ * executables perform side effects through the injected `GuardedToolSurface` (or,
+ * for the AI call in {@link BrowserVisionResult}, through the E9
+ * `resolveLLMForSystem` chokepoint) — never a raw provider/network bypass.
+ * Types-only — no runtime logic (Gate 10 `contracts-purity`).
+ *
+ * @epic T11456
+ * @task T1742
+ * @see ./agent-tools.js — the terminal/file/search/git family I/O shapes
+ */
+
+// ---------------------------------------------------------------------------
+// web_search — pluggable, backend-agnostic
+// ---------------------------------------------------------------------------
+
+/**
+ * Identifier of a {@link WebSearchInput} backend.
+ *
+ * - `duckduckgo` — DuckDuckGo's keyless HTML endpoint (no API key required).
+ * - `searxng` — a self-hosted / public SearXNG JSON instance (URL via config/env).
+ * - `auto` — try each configured backend in priority order, first success wins.
+ *
+ * NONE require a paid API key; the set is open by design so a deployment can
+ * register its own backend. The string union here is the canonical builtin set.
+ */
+export type WebSearchBackendId = 'duckduckgo' | 'searxng' | 'auto';
+
+/** Input for the `web_search` tool. */
+export interface WebSearchInput {
+  /** Free-text search query. */
+  readonly query: string;
+  /** Maximum number of results to return. Defaults to 10. */
+  readonly maxResults?: number;
+  /**
+   * Preferred backend. Defaults to `auto` — the first configured/reachable
+   * backend answers. An explicit id pins a single backend.
+   */
+  readonly backend?: WebSearchBackendId;
+}
+
+/** A single web-search hit. */
+export interface WebSearchHit {
+  /** Result title. */
+  readonly title: string;
+  /** Absolute result URL. */
+  readonly url: string;
+  /** Snippet / description (may be empty). */
+  readonly snippet: string;
+}
+
+/** Result of `web_search`. */
+export interface WebSearchResult {
+  /** The originating query (echoed for traceability). */
+  readonly query: string;
+  /** Hits in backend-ranked order (empty when none / unavailable). */
+  readonly results: readonly WebSearchHit[];
+  /** The backend that actually answered, or `null` when none was available. */
+  readonly backend: WebSearchBackendId | null;
+  /**
+   * `true` when NO backend could answer (none configured, network egress
+   * denied, or every backend failed). Callers MUST treat this as a soft
+   * "no search capability" signal — it is NOT an error.
+   */
+  readonly unavailable: boolean;
+  /** Human-readable reason when {@link WebSearchResult.unavailable} is `true`. */
+  readonly reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// web_extract — URL → markdown
+// ---------------------------------------------------------------------------
+
+/** Input for the `web_extract` tool. */
+export interface WebExtractInput {
+  /** Absolute URL to fetch and convert. */
+  readonly url: string;
+  /** Hard timeout in milliseconds. Defaults to 30000. */
+  readonly timeoutMs?: number;
+  /**
+   * Cap on the markdown length (characters). Output beyond this is truncated
+   * and {@link WebExtractResult.truncated} set. Defaults to 100000.
+   */
+  readonly maxChars?: number;
+}
+
+/** Result of `web_extract`. */
+export interface WebExtractResult {
+  /** The fetched URL. */
+  readonly url: string;
+  /** HTTP status code of the fetch. */
+  readonly status: number;
+  /** Document `<title>`, when present. */
+  readonly title: string;
+  /** The page body converted to markdown. */
+  readonly markdown: string;
+  /** Whether {@link WebExtractInput.maxChars} truncated the markdown. */
+  readonly truncated: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// browser_* — Playwright-driven automation
+// ---------------------------------------------------------------------------
+
+/** Input for `browser_navigate`. */
+export interface BrowserNavigateInput {
+  /** Absolute URL to navigate the browser to. */
+  readonly url: string;
+  /**
+   * When to consider navigation complete. Defaults to `load`.
+   * Mirrors Playwright's `waitUntil` states.
+   */
+  readonly waitUntil?: 'load' | 'domcontentloaded' | 'networkidle';
+  /** Per-navigation timeout in milliseconds. Defaults to 30000. */
+  readonly timeoutMs?: number;
+}
+
+/** Result common to navigation / interaction browser tools. */
+export interface BrowserPageState {
+  /** The page's current URL after the operation. */
+  readonly url: string;
+  /** The page's `document.title` after the operation. */
+  readonly title: string;
+}
+
+/** Input for `browser_click`. */
+export interface BrowserClickInput {
+  /** A CSS / Playwright selector for the element to click. */
+  readonly selector: string;
+  /** Per-action timeout in milliseconds. Defaults to 15000. */
+  readonly timeoutMs?: number;
+}
+
+/** Input for `browser_type`. */
+export interface BrowserTypeInput {
+  /** A CSS / Playwright selector for the input element. */
+  readonly selector: string;
+  /** The text to type into the element. */
+  readonly text: string;
+  /** Clear the field before typing. Defaults to `true`. */
+  readonly clear?: boolean;
+  /** Per-action timeout in milliseconds. Defaults to 15000. */
+  readonly timeoutMs?: number;
+}
+
+/** Input for `browser_press` (a single key / chord). */
+export interface BrowserPressInput {
+  /**
+   * The key (or `Modifier+Key` chord) to press, in Playwright key syntax
+   * (e.g. `Enter`, `Tab`, `Control+A`, `ArrowDown`).
+   */
+  readonly key: string;
+  /** Optional selector to focus before pressing. */
+  readonly selector?: string;
+  /** Per-action timeout in milliseconds. Defaults to 15000. */
+  readonly timeoutMs?: number;
+}
+
+/** Result of a `browser_click` / `browser_type` / `browser_press` action. */
+export interface BrowserActionResult extends BrowserPageState {
+  /** The action that was performed. */
+  readonly action: 'click' | 'type' | 'press';
+}
+
+/** A single node in the {@link BrowserSnapshotResult} accessibility tree. */
+export interface AccessibilityNode {
+  /** ARIA role (e.g. `button`, `link`, `textbox`). */
+  readonly role: string;
+  /** Accessible name, when present. */
+  readonly name?: string;
+  /** Current value (form controls). */
+  readonly value?: string;
+  /** Child nodes (depth-first). */
+  readonly children?: readonly AccessibilityNode[];
+}
+
+/** Result of `browser_snapshot` — the page accessibility tree. */
+export interface BrowserSnapshotResult extends BrowserPageState {
+  /** The root of the accessibility tree, or `null` when none is available. */
+  readonly tree: AccessibilityNode | null;
+}
+
+/** Scroll direction for `browser_scroll`. */
+export type BrowserScrollDirection = 'up' | 'down';
+
+/** Input for `browser_scroll`. */
+export interface BrowserScrollInput {
+  /** Direction to scroll. */
+  readonly direction: BrowserScrollDirection;
+  /**
+   * Pixels to scroll by. Defaults to roughly one viewport height (800px).
+   */
+  readonly amountPx?: number;
+}
+
+/** Result of `browser_scroll`. */
+export interface BrowserScrollResult extends BrowserPageState {
+  /** The direction that was scrolled. */
+  readonly direction: BrowserScrollDirection;
+  /** The vertical scroll position (pixels from top) after scrolling. */
+  readonly scrollY: number;
+}
+
+/** Input for `browser_vision` (screenshot + AI analysis). */
+export interface BrowserVisionInput {
+  /**
+   * The question / instruction the vision model should answer about the current
+   * page screenshot (e.g. "What is the primary call-to-action on this page?").
+   */
+  readonly prompt: string;
+  /** Capture the full scrollable page rather than just the viewport. Defaults to `false`. */
+  readonly fullPage?: boolean;
+}
+
+/** Result of `browser_vision`. */
+export interface BrowserVisionResult extends BrowserPageState {
+  /**
+   * The vision model's textual analysis of the screenshot, or `null` when no
+   * LLM credential was reachable (graceful degradation — NOT an error).
+   */
+  readonly analysis: string | null;
+  /** The model id that produced {@link BrowserVisionResult.analysis}, when available. */
+  readonly model?: string;
+  /**
+   * `true` when the AI call was skipped because no LLM credential resolved
+   * through the E9 chokepoint. The screenshot was still captured.
+   */
+  readonly aiUnavailable: boolean;
+}

--- a/packages/core/src/tools/__tests__/agent-registry.test.ts
+++ b/packages/core/src/tools/__tests__/agent-registry.test.ts
@@ -153,15 +153,23 @@ describe('AgentToolRegistry — toolset grouping (AC4)', () => {
     expect(fileNames).toEqual(expect.arrayContaining(['path_exists', 'read_file', 'write_file']));
     const terminalNames = grouped.terminal.map((t) => t.name);
     expect(terminalNames).toEqual(expect.arrayContaining(['run_command', 'run_git']));
-    // No net/notebook primitives implemented yet — empty but present.
-    expect(grouped.web).toEqual([]);
+    // The web toolset (T1742): web_search/web_extract + the browser_* family.
+    // Superset check so adding tools doesn't break this assertion.
+    const webNames = grouped.web.map((t) => t.name);
+    expect(webNames).toEqual(
+      expect.arrayContaining(['web_search', 'web_extract', 'browser_navigate']),
+    );
+    // No notebook primitives implemented yet — empty but present.
     expect(grouped.media).toEqual([]);
   });
 
   it('byToolset(toolset) filters to a single group', async () => {
     const r = await createAgentToolRegistry();
     expect(r.byToolset('file').every((t) => t.toolset === 'file')).toBe(true);
-    expect(r.byToolset('web')).toEqual([]);
+    // The web toolset is now populated (T1742); every member reports toolset 'web'.
+    const web = r.byToolset('web');
+    expect(web.length).toBeGreaterThan(0);
+    expect(web.every((t) => t.toolset === 'web')).toBe(true);
   });
 });
 

--- a/packages/core/src/tools/__tests__/browser-vision.test.ts
+++ b/packages/core/src/tools/__tests__/browser-vision.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for `browser_vision` (T1742 · AC6 · epic T11456).
+ *
+ * `browser_vision` captures a page screenshot and analyses it with a vision
+ * model. The AI call MUST route through the E9 `resolveLLMForSystem` chokepoint +
+ * sealed-credential handle and the single `ModelRunner` — never a raw provider
+ * call. These tests mock BOTH the resolver and the runner (no real credential, no
+ * real network, no real browser launch · AC9) and assert:
+ *
+ *   1. the screenshot is captured and sent as a multimodal user turn;
+ *   2. the resolver's sealed credential is `fetch()`-materialized (only at the
+ *      wire) and the model's text is returned;
+ *   3. when NO credential resolves, the tool degrades gracefully — the screenshot
+ *      is still captured and `aiUnavailable: true` is returned (not an error).
+ *
+ * The resolver/runner modules are dynamically imported INSIDE the executable, so
+ * `vi.mock` of their module paths intercepts them.
+ *
+ * @task T1742
+ * @epic T11456
+ */
+
+import type { TransportMessage } from '@cleocode/contracts/llm/normalized-response.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// --- Capture the messages handed to the (mocked) session.send. ---
+let sentMessages: TransportMessage[] | undefined;
+let sealedFetched = false;
+
+const resolveLLMForSystem = vi.fn();
+const modelRunnerBuild = vi.fn();
+
+vi.mock('../../llm/system-resolver.js', () => ({
+  resolveLLMForSystem: (...args: unknown[]) => resolveLLMForSystem(...args),
+}));
+
+vi.mock('../../llm/model-runner.js', () => ({
+  ModelRunner: {
+    build: (...args: unknown[]) => modelRunnerBuild(...args),
+  },
+}));
+
+// Imported AFTER the mocks so the executable's dynamic imports bind to them.
+const { AgentToolRegistry } = await import('../agent-registry.js');
+const { BrowserSession } = await import('../browser-driver.js');
+const { registerWebAgentTools } = await import('../web-agent-tools.js');
+
+afterEach(() => {
+  sentMessages = undefined;
+  sealedFetched = false;
+  vi.clearAllMocks();
+});
+
+/** A fake Playwright that takes screenshots — no real browser. */
+function fakeBrowserLoader(): () => Promise<unknown> {
+  const page = {
+    async goto(): Promise<unknown> {
+      return undefined;
+    },
+    url: () => 'https://shot.io',
+    async title(): Promise<string> {
+      return 'Shot Page';
+    },
+    locator() {
+      return { click: async () => {}, fill: async () => {}, focus: async () => {} };
+    },
+    keyboard: { press: async () => {} },
+    accessibility: { snapshot: async () => null },
+    async screenshot(): Promise<Buffer> {
+      return Buffer.from('SCREENSHOTBYTES');
+    },
+    async evaluate<T>(): Promise<T> {
+      return 0 as unknown as T;
+    },
+  };
+  const browser = { newPage: async () => page, close: async () => {} };
+  return async () => ({ chromium: { launch: async () => browser } });
+}
+
+/** Build a registry with `browser_vision` over a fake browser. */
+async function visionRegistry(): Promise<{
+  exec: NonNullable<ReturnType<InstanceType<typeof AgentToolRegistry>['getExecutable']>>;
+}> {
+  const session = new BrowserSession(fakeBrowserLoader() as never);
+  const r = new AgentToolRegistry();
+  registerWebAgentTools(r, { browser: session });
+  await r.init({ skipBuiltins: true });
+  // Prime the session by navigating (so screenshot has a page).
+  const nav = r.getExecutable('browser_navigate');
+  await nav?.({ url: 'https://shot.io' }, undefined as never);
+  const exec = r.getExecutable('browser_vision');
+  if (exec === undefined) throw new Error('browser_vision missing');
+  return { exec };
+}
+
+describe('browser_vision (AC6) — AI call routes through the E9 chokepoint', () => {
+  it('captures a screenshot and sends it as a multimodal turn; returns the analysis', async () => {
+    resolveLLMForSystem.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'mock-vision-model',
+      client: null,
+      credential: { provider: 'anthropic', source: 'env', authType: 'api_key' },
+      sealedCredential: {
+        provider: 'anthropic',
+        account: 'mock',
+        tokenPreview: '…mock',
+        fetch: async () => {
+          sealedFetched = true;
+          return { value: 'sk-mock' };
+        },
+      },
+      source: 'role-config',
+      apiMode: 'anthropic_messages',
+      baseUrl: null,
+      authType: 'api_key',
+    });
+    modelRunnerBuild.mockResolvedValue({
+      languageModel: null,
+      session: {
+        async send(messages: TransportMessage[]) {
+          sentMessages = messages;
+          return { content: 'A login form with a blue button.', toolCalls: null };
+        },
+      },
+    });
+
+    const { exec } = await visionRegistry();
+    const out = (await exec({ prompt: 'Describe the page' }, undefined as never)) as {
+      analysis: string | null;
+      aiUnavailable: boolean;
+      model?: string;
+      url: string;
+    };
+
+    // Resolution went through the E9 chokepoint with the task-executor system.
+    expect(resolveLLMForSystem).toHaveBeenCalledWith('task-executor', expect.any(Object));
+    // The sealed credential was materialized only at the wire.
+    expect(sealedFetched).toBe(true);
+    // The screenshot rode along as a base64 image block in a single user turn.
+    expect(sentMessages).toHaveLength(1);
+    const content = sentMessages?.[0]?.content;
+    expect(Array.isArray(content)).toBe(true);
+    const blocks = content as ReadonlyArray<{ type: string; source?: { mediaType: string } }>;
+    expect(blocks.find((b) => b.type === 'text')).toBeDefined();
+    const image = blocks.find((b) => b.type === 'image');
+    expect(image?.source?.mediaType).toBe('image/png');
+    // The model's text analysis is returned.
+    expect(out.analysis).toBe('A login form with a blue button.');
+    expect(out.aiUnavailable).toBe(false);
+    expect(out.model).toBe('mock-vision-model');
+    expect(out.url).toBe('https://shot.io');
+  });
+
+  it('degrades gracefully (aiUnavailable, screenshot still captured) when no credential resolves', async () => {
+    resolveLLMForSystem.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'unknown',
+      client: null,
+      credential: null,
+      sealedCredential: null,
+      source: 'implicit-fallback',
+      apiMode: 'anthropic_messages',
+      baseUrl: null,
+      authType: null,
+    });
+
+    const { exec } = await visionRegistry();
+    const out = (await exec({ prompt: 'Describe the page' }, undefined as never)) as {
+      analysis: string | null;
+      aiUnavailable: boolean;
+      url: string;
+      title: string;
+    };
+
+    // No raw provider construction; the runner was never built.
+    expect(modelRunnerBuild).not.toHaveBeenCalled();
+    expect(out.analysis).toBeNull();
+    expect(out.aiUnavailable).toBe(true);
+    // The screenshot context (url/title) was still captured.
+    expect(out.url).toBe('https://shot.io');
+    expect(out.title).toBe('Shot Page');
+  });
+});

--- a/packages/core/src/tools/__tests__/web-agent-tools.test.ts
+++ b/packages/core/src/tools/__tests__/web-agent-tools.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Tests for the web + browser agent-tool family (T1742 · epic T11456).
+ *
+ * Covers the 9 acceptance criteria with FULLY-MOCKED backends (AC9) — no real
+ * network, no real browser launch, no real LLM credential:
+ *   AC1 web_search pluggable backends + graceful-when-unconfigured ·
+ *   AC2 web_extract HTML→markdown · AC3 browser_navigate (mocked Playwright) ·
+ *   AC4 browser_click/type/press · AC5 browser_snapshot (a11y tree) ·
+ *   AC6 browser_vision (covered in web-browser-vision.test.ts — resolver mocked) ·
+ *   AC7 browser_scroll up/down · AC8 all registered + browser availability gating ·
+ *   AC9 (this file) — mocked Playwright module + mocked HTTP fetch.
+ *
+ * The pure helpers (HTML→markdown, the search-backend parsers) are tested
+ * directly; the executables are driven through an injected mock {@link HttpFetch}
+ * and an injected {@link BrowserSession} backed by a FAKE Playwright loader, so no
+ * subprocess / network / browser is ever touched.
+ *
+ * @task T1742
+ * @epic T11456
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AgentToolRegistry } from '../agent-registry.js';
+import { BrowserSession } from '../browser-driver.js';
+import { registerBuiltinAgentTools } from '../builtin-agent-tools.js';
+import { registerWebAgentTools } from '../web-agent-tools.js';
+import {
+  extractTitle,
+  type HttpFetch,
+  htmlToMarkdown,
+  makeSearxngBackend,
+  parseDuckDuckGoHtml,
+  parseSearxngJson,
+  resolveSearchBackends,
+} from '../web-search-backends.js';
+
+// ===========================================================================
+// Test doubles
+// ===========================================================================
+
+/** A mock {@link HttpFetch} that maps a URL substring → canned response body. */
+function mockHttp(routes: Array<{ match: string; status?: number; body: string }>): {
+  http: HttpFetch;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const http: HttpFetch = async (url) => {
+    calls.push(url);
+    const route = routes.find((r) => url.includes(r.match));
+    if (route === undefined) throw new Error(`mockHttp: no route for ${url}`);
+    return {
+      status: route.status ?? 200,
+      async text() {
+        return route.body;
+      },
+      headers: { get: () => null },
+    };
+  };
+  return { http, calls };
+}
+
+/** Build a fake Playwright module recording every page action it performs. */
+function fakePlaywright(): {
+  loader: () => Promise<unknown>;
+  actions: string[];
+  setUrl: (u: string) => void;
+} {
+  const actions: string[] = [];
+  let currentUrl = 'about:blank';
+  const page = {
+    async goto(url: string): Promise<unknown> {
+      actions.push(`goto:${url}`);
+      currentUrl = url;
+      return undefined;
+    },
+    url: () => currentUrl,
+    async title(): Promise<string> {
+      return 'Mock Page';
+    },
+    locator(selector: string) {
+      return {
+        async click(): Promise<void> {
+          actions.push(`click:${selector}`);
+        },
+        async fill(value: string): Promise<void> {
+          actions.push(`fill:${selector}:${value}`);
+        },
+        async focus(): Promise<void> {
+          actions.push(`focus:${selector}`);
+        },
+      };
+    },
+    keyboard: {
+      async press(key: string): Promise<void> {
+        actions.push(`press:${key}`);
+      },
+    },
+    accessibility: {
+      async snapshot() {
+        actions.push('snapshot');
+        return { role: 'WebArea', name: 'Mock Page', children: [{ role: 'button', name: 'Go' }] };
+      },
+    },
+    async screenshot(): Promise<Buffer> {
+      actions.push('screenshot');
+      return Buffer.from('PNGDATA');
+    },
+    async evaluate<T>(_fn: string): Promise<T> {
+      actions.push('evaluate');
+      return 800 as unknown as T;
+    },
+  };
+  const browser = {
+    async newPage() {
+      actions.push('newPage');
+      return page;
+    },
+    async close(): Promise<void> {
+      actions.push('close');
+    },
+  };
+  const chromium = {
+    async launch() {
+      actions.push('launch');
+      return browser;
+    },
+  };
+  return {
+    loader: async () => ({ chromium }),
+    actions,
+    setUrl: (u: string) => {
+      currentUrl = u;
+    },
+  };
+}
+
+/** A registry with the web+browser family registered over injected mocks. */
+async function registryWith(
+  options: Parameters<typeof registerWebAgentTools>[1],
+): Promise<AgentToolRegistry> {
+  const r = new AgentToolRegistry();
+  registerWebAgentTools(r, options);
+  await r.init({ skipBuiltins: true });
+  return r;
+}
+
+// ===========================================================================
+// Pure helpers — HTML → markdown (AC2)
+// ===========================================================================
+
+describe('htmlToMarkdown (AC2)', () => {
+  it('converts headings, links, lists, emphasis', () => {
+    const html =
+      '<html><head><title>T</title><style>x{}</style></head><body>' +
+      '<h1>Title</h1><p>Hello <strong>world</strong> and <a href="https://x.io">link</a>.</p>' +
+      '<ul><li>one</li><li>two</li></ul>' +
+      '<script>evil()</script></body></html>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('# Title');
+    expect(md).toContain('**world**');
+    expect(md).toContain('[link](https://x.io)');
+    expect(md).toContain('- one');
+    expect(md).toContain('- two');
+    // script/style stripped
+    expect(md).not.toContain('evil');
+    expect(md).not.toContain('x{}');
+  });
+
+  it('renders fenced code from <pre>', () => {
+    const md = htmlToMarkdown('<body><pre>const x = 1;</pre></body>');
+    expect(md).toContain('```');
+    expect(md).toContain('const x = 1;');
+  });
+
+  it('extracts the document title', () => {
+    expect(extractTitle('<html><head><title>My Page</title></head></html>')).toBe('My Page');
+    expect(extractTitle('<html></html>')).toBe('');
+  });
+});
+
+// ===========================================================================
+// Pure helpers — search backends (AC1)
+// ===========================================================================
+
+describe('search-backend parsers (AC1)', () => {
+  it('parses DuckDuckGo HTML results (unwrapping /l/?uddg= targets)', () => {
+    const target = encodeURIComponent('https://example.com/page');
+    const html =
+      `<a class="result__a" href="/l/?uddg=${target}">Example Title</a>` +
+      '<a class="result__snippet" href="#">A snippet here</a>';
+    const hits = parseDuckDuckGoHtml(html, 10);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      title: 'Example Title',
+      url: 'https://example.com/page',
+      snippet: 'A snippet here',
+    });
+  });
+
+  it('parses SearXNG JSON results', () => {
+    const json = {
+      results: [
+        { title: 'A', url: 'https://a.io', content: 'about a' },
+        { title: 'B', url: 'https://b.io' },
+      ],
+    };
+    const hits = parseSearxngJson(json, 10);
+    expect(hits).toEqual([
+      { title: 'A', url: 'https://a.io', snippet: 'about a' },
+      { title: 'B', url: 'https://b.io', snippet: '' },
+    ]);
+  });
+
+  it('searxng backend reports unconfigured when no instance URL', () => {
+    expect(makeSearxngBackend(undefined).isConfigured()).toBe(false);
+    expect(makeSearxngBackend('').isConfigured()).toBe(false);
+    expect(makeSearxngBackend('https://searx.local').isConfigured()).toBe(true);
+  });
+
+  it('resolves only DuckDuckGo in auto mode when searxng is unconfigured', () => {
+    const backends = resolveSearchBackends({ query: 'q' }, undefined);
+    expect(backends.map((b) => b.id)).toEqual(['duckduckgo']);
+  });
+
+  it('a pinned but unconfigured backend resolves to an empty list (→ unavailable)', () => {
+    const backends = resolveSearchBackends({ query: 'q', backend: 'searxng' }, undefined);
+    expect(backends).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// web_search executable (AC1)
+// ===========================================================================
+
+describe('web_search executable (AC1)', () => {
+  it('returns ranked DuckDuckGo results via the injected fetch', async () => {
+    const target = encodeURIComponent('https://result.io');
+    const body = `<a class="result__a" href="/l/?uddg=${target}">Result</a>`;
+    const { http, calls } = mockHttp([{ match: 'duckduckgo', body }]);
+    const r = await registryWith({ http });
+    const exec = r.getExecutable('web_search');
+    if (exec === undefined) throw new Error('web_search missing');
+    const out = (await exec({ query: 'hello' }, undefined as never)) as {
+      results: unknown[];
+      backend: string;
+      unavailable: boolean;
+    };
+    expect(out.unavailable).toBe(false);
+    expect(out.backend).toBe('duckduckgo');
+    expect(out.results).toEqual([{ title: 'Result', url: 'https://result.io', snippet: '' }]);
+    expect(calls[0]).toContain('html.duckduckgo.com');
+  });
+
+  it('degrades gracefully to unavailable when a pinned backend is unconfigured', async () => {
+    const { http } = mockHttp([]);
+    const r = await registryWith({ http });
+    const exec = r.getExecutable('web_search');
+    if (exec === undefined) throw new Error('web_search missing');
+    const out = (await exec({ query: 'q', backend: 'searxng' }, undefined as never)) as {
+      unavailable: boolean;
+      results: unknown[];
+      reason?: string;
+    };
+    expect(out.unavailable).toBe(true);
+    expect(out.results).toEqual([]);
+    expect(out.reason).toBeDefined();
+  });
+
+  it('degrades to unavailable when every backend fails (no real network)', async () => {
+    const http: HttpFetch = async () => {
+      throw new Error('network down');
+    };
+    const r = await registryWith({ http });
+    const exec = r.getExecutable('web_search');
+    if (exec === undefined) throw new Error('web_search missing');
+    const out = (await exec({ query: 'q' }, undefined as never)) as { unavailable: boolean };
+    expect(out.unavailable).toBe(true);
+  });
+
+  it('uses SearXNG first when an instance URL is configured', async () => {
+    const json = JSON.stringify({ results: [{ title: 'S', url: 'https://s.io', content: 'c' }] });
+    const { http, calls } = mockHttp([{ match: 'searx.local', body: json }]);
+    const r = await registryWith({ http, searxngUrl: 'https://searx.local' });
+    const exec = r.getExecutable('web_search');
+    if (exec === undefined) throw new Error('web_search missing');
+    const out = (await exec({ query: 'q' }, undefined as never)) as {
+      backend: string;
+      results: Array<{ title: string }>;
+    };
+    expect(out.backend).toBe('searxng');
+    expect(out.results[0]?.title).toBe('S');
+    expect(calls[0]).toContain('searx.local');
+  });
+});
+
+// ===========================================================================
+// web_extract executable (AC2)
+// ===========================================================================
+
+describe('web_extract executable (AC2)', () => {
+  it('fetches a URL and returns markdown via the injected fetch', async () => {
+    const html =
+      '<html><head><title>Doc</title></head><body><h1>Heading</h1><p>Body.</p></body></html>';
+    const { http } = mockHttp([{ match: 'example.com', body: html }]);
+    const r = await registryWith({ http });
+    const exec = r.getExecutable('web_extract');
+    if (exec === undefined) throw new Error('web_extract missing');
+    const out = (await exec({ url: 'https://example.com/doc' }, undefined as never)) as {
+      title: string;
+      markdown: string;
+      status: number;
+      truncated: boolean;
+    };
+    expect(out.status).toBe(200);
+    expect(out.title).toBe('Doc');
+    expect(out.markdown).toContain('# Heading');
+    expect(out.markdown).toContain('Body.');
+    expect(out.truncated).toBe(false);
+  });
+
+  it('truncates markdown beyond maxChars', async () => {
+    const html = `<body><p>${'x'.repeat(500)}</p></body>`;
+    const { http } = mockHttp([{ match: 'big', body: html }]);
+    const r = await registryWith({ http });
+    const exec = r.getExecutable('web_extract');
+    if (exec === undefined) throw new Error('web_extract missing');
+    const out = (await exec({ url: 'https://big.io', maxChars: 50 }, undefined as never)) as {
+      markdown: string;
+      truncated: boolean;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.markdown.length).toBe(50);
+  });
+});
+
+// ===========================================================================
+// browser_* executables over a MOCKED Playwright (AC3/AC4/AC5/AC7) — AC9
+// ===========================================================================
+
+describe('browser tools over a mocked Playwright (AC3/AC4/AC5/AC7)', () => {
+  async function browserRegistry(): Promise<{
+    r: AgentToolRegistry;
+    actions: string[];
+  }> {
+    const fake = fakePlaywright();
+    const session = new BrowserSession(fake.loader as never);
+    const r = await registryWith({ browser: session });
+    return { r, actions: fake.actions };
+  }
+
+  it('browser_navigate launches the browser lazily and navigates (AC3)', async () => {
+    const { r, actions } = await browserRegistry();
+    const exec = r.getExecutable('browser_navigate');
+    if (exec === undefined) throw new Error('browser_navigate missing');
+    const out = (await exec({ url: 'https://site.io' }, undefined as never)) as {
+      url: string;
+      title: string;
+    };
+    expect(out.url).toBe('https://site.io');
+    expect(out.title).toBe('Mock Page');
+    // Lazy launch happened on first navigation.
+    expect(actions).toContain('launch');
+    expect(actions).toContain('goto:https://site.io');
+  });
+
+  it('browser_click / browser_type / browser_press perform actions (AC4)', async () => {
+    const { r, actions } = await browserRegistry();
+    const click = r.getExecutable('browser_click');
+    const type = r.getExecutable('browser_type');
+    const press = r.getExecutable('browser_press');
+    if (click === undefined || type === undefined || press === undefined) {
+      throw new Error('browser action tools missing');
+    }
+    const clicked = (await click({ selector: '#go' }, undefined as never)) as { action: string };
+    const typed = (await type({ selector: '#q', text: 'hi' }, undefined as never)) as {
+      action: string;
+    };
+    const pressed = (await press({ key: 'Enter', selector: '#q' }, undefined as never)) as {
+      action: string;
+    };
+    expect(clicked.action).toBe('click');
+    expect(typed.action).toBe('type');
+    expect(pressed.action).toBe('press');
+    expect(actions).toContain('click:#go');
+    expect(actions).toContain('fill:#q:hi');
+    expect(actions).toContain('focus:#q');
+    expect(actions).toContain('press:Enter');
+  });
+
+  it('browser_snapshot returns the accessibility tree (AC5)', async () => {
+    const { r, actions } = await browserRegistry();
+    const exec = r.getExecutable('browser_snapshot');
+    if (exec === undefined) throw new Error('browser_snapshot missing');
+    const out = (await exec({}, undefined as never)) as {
+      tree: { role: string; children?: unknown[] } | null;
+    };
+    expect(actions).toContain('snapshot');
+    expect(out.tree?.role).toBe('WebArea');
+    expect(out.tree?.children).toHaveLength(1);
+  });
+
+  it('browser_scroll scrolls up and down (AC7)', async () => {
+    const { r, actions } = await browserRegistry();
+    const exec = r.getExecutable('browser_scroll');
+    if (exec === undefined) throw new Error('browser_scroll missing');
+    const down = (await exec({ direction: 'down' }, undefined as never)) as {
+      direction: string;
+      scrollY: number;
+    };
+    const up = (await exec({ direction: 'up', amountPx: 200 }, undefined as never)) as {
+      direction: string;
+    };
+    expect(down.direction).toBe('down');
+    expect(down.scrollY).toBe(800);
+    expect(up.direction).toBe('up');
+    expect(actions.filter((a) => a === 'evaluate')).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// Registration + availability gating (AC8)
+// ===========================================================================
+
+describe('web + browser tools — registration & availability (AC8)', () => {
+  it('registers every web + browser tool, all surfaced via toOpenAITools', async () => {
+    const r = new AgentToolRegistry();
+    registerBuiltinAgentTools(r);
+    await r.init({ skipBuiltins: true });
+    for (const name of [
+      'web_search',
+      'web_extract',
+      'browser_navigate',
+      'browser_click',
+      'browser_type',
+      'browser_press',
+      'browser_snapshot',
+      'browser_scroll',
+      'browser_vision',
+    ]) {
+      expect(r.get(name), `${name} should be registered`).toBeDefined();
+    }
+    const openai = r.toOpenAITools();
+    expect(openai.find((t) => t.name === 'web_search')?.inputSchema).toMatchObject({
+      type: 'object',
+    });
+    expect(openai.find((t) => t.name === 'browser_vision')).toBeDefined();
+  });
+
+  it('browser tools are hidden when playwright capability is absent (AC8)', async () => {
+    const r = new AgentToolRegistry();
+    registerBuiltinAgentTools(r);
+    await r.init({ skipBuiltins: true });
+    // No playwright capability advertised → browser tools unavailable.
+    const names = r.available({}).map((t) => t.name);
+    expect(names).not.toContain('browser_navigate');
+    expect(names).not.toContain('browser_vision');
+    // web tools (net) are still available (no playwright needed).
+    expect(names).toContain('web_search');
+    expect(names).toContain('web_extract');
+  });
+
+  it('browser tools become available when the playwright capability is present (AC8)', async () => {
+    const r = new AgentToolRegistry();
+    registerBuiltinAgentTools(r);
+    await r.init({ skipBuiltins: true });
+    const names = r.available({ capabilities: { playwright: true } }).map((t) => t.name);
+    expect(names).toContain('browser_navigate');
+    expect(names).toContain('browser_snapshot');
+    expect(names).toContain('browser_vision');
+  });
+
+  it('web tools are hidden when network egress is denied', async () => {
+    const r = new AgentToolRegistry();
+    registerBuiltinAgentTools(r);
+    await r.init({ skipBuiltins: true });
+    const names = r.available({ networkEgressAllowed: false }).map((t) => t.name);
+    expect(names).not.toContain('web_search');
+    expect(names).not.toContain('browser_navigate');
+  });
+
+  it('browser tool descriptions carry the playwright install hint (AC8)', async () => {
+    const r = new AgentToolRegistry();
+    registerBuiltinAgentTools(r);
+    await r.init({ skipBuiltins: true });
+    expect(r.get('browser_navigate')?.description).toContain('playwright');
+  });
+});

--- a/packages/core/src/tools/browser-driver.ts
+++ b/packages/core/src/tools/browser-driver.ts
@@ -1,0 +1,336 @@
+/**
+ * Playwright browser driver — the OPTIONAL, lazily-loaded automation backend
+ * (T1742 · epic T11456 · SG-TOOLS).
+ *
+ * The `browser_*` tools' execution backend. Playwright is an OPTIONAL dependency
+ * (publish-surface discipline · D11136): it is NEVER a hard dependency of
+ * `@cleocode/core`. Like `node-pty` (see {@link ./pty.js}), it is deliberately
+ * NOT declared in `core`'s `dependencies` / `optionalDependencies` and is loaded
+ * ONLY via a dynamic `import()` whose specifier is held in a variable — so
+ * neither the bundler nor TS treats the missing package as a hard,
+ * statically-resolved dependency, the published `@cleocode/core` carries no
+ * Playwright weight, and `core` builds + tests pass with Playwright NOT installed.
+ * An environment that wants the browser tools opts in by installing `playwright`
+ * itself (`pnpm add playwright && pnpm exec playwright install chromium`).
+ *
+ * Import-time side-effect-free: NO top-level `playwright` import; the browser is
+ * launched lazily on the first navigation through a {@link BrowserSession}. When
+ * Playwright is absent, {@link isPlaywrightAvailable} resolves `false` and the
+ * browser tools' availability predicate hides them with an install hint —
+ * nothing throws at import.
+ *
+ * @epic T11456
+ * @task T1742
+ * @see ./pty.js — the analogous optional-native-dep (node-pty) lazy-load pattern
+ */
+
+import type {
+  AccessibilityNode,
+  BrowserNavigateInput,
+  BrowserPageState,
+} from '@cleocode/contracts/tools/web-tools';
+import { getLogger } from '../logger.js';
+
+const log = getLogger('tool-browser');
+
+/**
+ * The npm install hint surfaced to the model when a browser tool is unavailable
+ * because Playwright is not installed. Playwright is an OPTIONAL dep — the
+ * browser tools are registered regardless, but report unavailable until this
+ * runs (AC8).
+ */
+export const PLAYWRIGHT_INSTALL_HINT =
+  'Browser tools require the optional "playwright" package. Install it with ' +
+  '`pnpm add playwright && pnpm exec playwright install chromium`, then retry.';
+
+// ---------------------------------------------------------------------------
+// Minimal structural shapes of the Playwright surface we consume.
+//
+// Declared LOCALLY so this file carries NO type dependency on the optional
+// package — the dynamic import is shape-checked against these, not against
+// `@types/playwright`. Only the members the browser tools actually use are
+// modelled; everything is `readonly` and narrow.
+// ---------------------------------------------------------------------------
+
+/** A keyboard handle (`page.keyboard`). */
+interface PwKeyboard {
+  press(key: string): Promise<void>;
+}
+
+/** A located element handle (`page.locator(...)`). */
+interface PwLocator {
+  click(options?: { timeout?: number }): Promise<void>;
+  fill(value: string, options?: { timeout?: number }): Promise<void>;
+  focus(options?: { timeout?: number }): Promise<void>;
+}
+
+/** The accessibility snapshot surface (`page.accessibility`). */
+interface PwAccessibility {
+  snapshot(): Promise<AccessibilityNode | null>;
+}
+
+/** A Playwright `Page`. */
+interface PwPage {
+  goto(
+    url: string,
+    options?: { waitUntil?: 'load' | 'domcontentloaded' | 'networkidle'; timeout?: number },
+  ): Promise<unknown>;
+  url(): string;
+  title(): Promise<string>;
+  locator(selector: string): PwLocator;
+  readonly keyboard: PwKeyboard;
+  readonly accessibility: PwAccessibility;
+  screenshot(options?: { fullPage?: boolean }): Promise<Buffer | Uint8Array>;
+  evaluate<T>(fn: string): Promise<T>;
+}
+
+/** A Playwright `Browser`. */
+interface PwBrowser {
+  newPage(): Promise<PwPage>;
+  close(): Promise<void>;
+}
+
+/** The `chromium` browser-type launcher. */
+interface PwBrowserType {
+  launch(options?: { headless?: boolean }): Promise<PwBrowser>;
+}
+
+/** The minimal shape of the `playwright` module we depend on. */
+interface PlaywrightModule {
+  readonly chromium: PwBrowserType;
+}
+
+/**
+ * Attempt to lazily load `playwright`. Returns `null` when the optional dep is
+ * not installed or fails to load (any reason), so callers can report the browser
+ * tools as unavailable rather than crashing.
+ *
+ * The import specifier is held in a variable so bundlers / TS do not treat the
+ * missing optional dep as a hard, statically-resolved dependency (same technique
+ * as {@link ./pty.js}'s `node-pty` load).
+ *
+ * @returns The loaded module shape, or `null` when unavailable.
+ */
+async function loadPlaywright(): Promise<PlaywrightModule | null> {
+  const specifier = 'playwright';
+  try {
+    const mod: unknown = await import(specifier);
+    const candidate = (mod as { default?: unknown }).default ?? mod;
+    if (
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      typeof (candidate as { chromium?: unknown }).chromium === 'object'
+    ) {
+      return candidate as PlaywrightModule;
+    }
+    return null;
+  } catch (err) {
+    log.debug({ err }, 'playwright not loadable — browser tools unavailable');
+    return null;
+  }
+}
+
+/**
+ * Whether the optional `playwright` package can be loaded in this process.
+ *
+ * Used by the browser tools' {@link import('./agent-registry.js').AvailabilityCheck}
+ * (via the registry's `capabilities` flag) so they are hidden — with
+ * {@link PLAYWRIGHT_INSTALL_HINT} — when Playwright is absent (AC8). The result is
+ * cached after the first probe so availability checks stay cheap.
+ *
+ * @returns `true` when `playwright` is importable, else `false`.
+ */
+let cachedAvailable: boolean | undefined;
+export async function isPlaywrightAvailable(): Promise<boolean> {
+  if (cachedAvailable !== undefined) return cachedAvailable;
+  cachedAvailable = (await loadPlaywright()) !== null;
+  return cachedAvailable;
+}
+
+/**
+ * Reset the cached Playwright-availability probe.
+ *
+ * EXPORTED FOR TESTS ONLY — lets a unit test toggle the mocked availability of
+ * the optional dep between cases without a fresh module graph.
+ *
+ * @internal
+ */
+export function __resetPlaywrightAvailabilityCache(): void {
+  cachedAvailable = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// BrowserSession — a single lazily-launched browser + page
+// ---------------------------------------------------------------------------
+
+/**
+ * The injectable factory the {@link BrowserSession} uses to obtain a Playwright
+ * module. Defaults to the real lazy {@link loadPlaywright}; unit tests inject a
+ * fake so NO real browser is ever launched (AC9).
+ */
+export type PlaywrightLoader = () => Promise<PlaywrightModule | null>;
+
+/**
+ * A single browser session: lazily launches a headless Chromium on the first
+ * navigation, then reuses the same page for subsequent interactions. Holds no
+ * Playwright reference until {@link BrowserSession.navigate} is first called, so
+ * constructing one is free and import-time side-effect-free.
+ *
+ * The browser tools share ONE session per registry run (created by the browser
+ * tool family at registration). All Playwright access funnels through here so
+ * the lazy-load + teardown live in one place.
+ */
+export class BrowserSession {
+  #browser: PwBrowser | null = null;
+  #page: PwPage | null = null;
+  readonly #load: PlaywrightLoader;
+
+  /**
+   * @param load - Optional Playwright loader (defaults to the real lazy import).
+   *   Tests pass a fake that returns a mock module — no real browser launches.
+   */
+  constructor(load: PlaywrightLoader = loadPlaywright) {
+    this.#load = load;
+  }
+
+  /**
+   * Ensure a page exists, launching the browser on first use. Throws a typed
+   * error when Playwright is unavailable so the tool executable can surface the
+   * install hint (the tool's `available()` predicate normally hides it first).
+   *
+   * @returns The active page.
+   */
+  async #ensurePage(): Promise<PwPage> {
+    if (this.#page !== null) return this.#page;
+    const pw = await this.#load();
+    if (pw === null) {
+      throw new Error(`E_BROWSER_UNAVAILABLE: ${PLAYWRIGHT_INSTALL_HINT}`);
+    }
+    this.#browser = await pw.chromium.launch({ headless: true });
+    this.#page = await this.#browser.newPage();
+    return this.#page;
+  }
+
+  /** The current page state (url + title). */
+  async #state(page: PwPage): Promise<BrowserPageState> {
+    return { url: page.url(), title: await page.title() };
+  }
+
+  /**
+   * Navigate to a URL (launching the browser on first call).
+   *
+   * @param input - {@link BrowserNavigateInput}.
+   * @returns The page state after navigation.
+   */
+  async navigate(input: BrowserNavigateInput): Promise<BrowserPageState> {
+    const page = await this.#ensurePage();
+    await page.goto(input.url, {
+      waitUntil: input.waitUntil ?? 'load',
+      timeout: input.timeoutMs ?? 30000,
+    });
+    return this.#state(page);
+  }
+
+  /**
+   * Click the element matching `selector`.
+   *
+   * @param selector - CSS / Playwright selector.
+   * @param timeoutMs - Per-action timeout.
+   * @returns The page state after the click.
+   */
+  async click(selector: string, timeoutMs = 15000): Promise<BrowserPageState> {
+    const page = await this.#ensurePage();
+    await page.locator(selector).click({ timeout: timeoutMs });
+    return this.#state(page);
+  }
+
+  /**
+   * Type `text` into the element matching `selector`.
+   *
+   * @param selector - CSS / Playwright selector.
+   * @param text - Text to enter (`fill` replaces the field's content).
+   * @param timeoutMs - Per-action timeout.
+   * @returns The page state after typing.
+   */
+  async type(selector: string, text: string, timeoutMs = 15000): Promise<BrowserPageState> {
+    const page = await this.#ensurePage();
+    await page.locator(selector).fill(text, { timeout: timeoutMs });
+    return this.#state(page);
+  }
+
+  /**
+   * Press a key / chord, optionally focusing `selector` first.
+   *
+   * @param key - Playwright key syntax (e.g. `Enter`, `Control+A`).
+   * @param selector - Optional element to focus before pressing.
+   * @param timeoutMs - Per-action timeout (for the focus step).
+   * @returns The page state after the keypress.
+   */
+  async press(key: string, selector?: string, timeoutMs = 15000): Promise<BrowserPageState> {
+    const page = await this.#ensurePage();
+    if (selector !== undefined) {
+      await page.locator(selector).focus({ timeout: timeoutMs });
+    }
+    await page.keyboard.press(key);
+    return this.#state(page);
+  }
+
+  /**
+   * Capture the page's accessibility tree.
+   *
+   * @returns The page state plus the accessibility tree root (or `null`).
+   */
+  async snapshot(): Promise<BrowserPageState & { tree: AccessibilityNode | null }> {
+    const page = await this.#ensurePage();
+    const tree = await page.accessibility.snapshot();
+    return { ...(await this.#state(page)), tree };
+  }
+
+  /**
+   * Scroll the page vertically by `amountPx` in `direction` and report the new
+   * scroll offset.
+   *
+   * @param direction - `up` or `down`.
+   * @param amountPx - Pixels to scroll (defaults to ~one viewport).
+   * @returns The page state plus the post-scroll `scrollY`.
+   */
+  async scroll(
+    direction: 'up' | 'down',
+    amountPx = 800,
+  ): Promise<BrowserPageState & { scrollY: number }> {
+    const page = await this.#ensurePage();
+    const delta = direction === 'down' ? amountPx : -amountPx;
+    // `evaluate(string)` so this file never imports playwright's function-arg
+    // serialization types; the page runs the scroll + returns the new offset.
+    const scrollY = await page.evaluate<number>(
+      `(() => { window.scrollBy(0, ${delta}); return window.scrollY; })()`,
+    );
+    return { ...(await this.#state(page)), scrollY };
+  }
+
+  /**
+   * Capture a screenshot of the current page as base64-encoded PNG bytes.
+   *
+   * @param fullPage - Capture the full scrollable page when `true`.
+   * @returns The page state plus the base64 PNG and the page state.
+   */
+  async screenshot(fullPage = false): Promise<BrowserPageState & { base64Png: string }> {
+    const page = await this.#ensurePage();
+    const buf = await page.screenshot({ fullPage });
+    const base64Png = Buffer.from(buf).toString('base64');
+    return { ...(await this.#state(page)), base64Png };
+  }
+
+  /** Close the browser and release the page (idempotent). */
+  async close(): Promise<void> {
+    if (this.#browser !== null) {
+      try {
+        await this.#browser.close();
+      } catch (err) {
+        log.debug({ err }, 'browser close failed (ignored)');
+      }
+    }
+    this.#browser = null;
+    this.#page = null;
+  }
+}

--- a/packages/core/src/tools/builtin-agent-tools.ts
+++ b/packages/core/src/tools/builtin-agent-tools.ts
@@ -27,6 +27,7 @@ import { z } from 'zod';
 import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
 import { ALWAYS_AVAILABLE } from './agent-registry.js';
 import { registerAgentToolFamilies } from './agent-tool-families.js';
+import { registerWebAgentTools } from './web-agent-tools.js';
 
 /** Available only when the named binary is known on PATH (AC5 example). */
 function binaryAvailable(name: string): AvailabilityCheck {
@@ -137,14 +138,23 @@ export function registerBuiltinAgentTools(registry: AgentToolRegistry): void {
     },
   });
 
-  // Note: `web` (net) and `media` (notebook) primitives are NOT yet implemented
-  // in `core/src/tools/*` (only their contracts exist in atomic.ts). Those
-  // toolsets are intentionally empty until S3+ ships their primitives; the
-  // registry already supports them (AC4) so registration is a one-liner then.
+  // Note: the `media` (notebook) primitives are NOT yet implemented in
+  // `core/src/tools/*` (only their contracts exist in atomic.ts). That toolset is
+  // intentionally empty until a later stage ships its primitives; the registry
+  // already supports it (AC4) so registration is a one-liner then.
 
   // The richer agent-facing tool families (T1741): terminal `run_shell` (PTY +
   // spawn), paginated `read_file_paged`, atomic `write_file_atomic`, fuzzy
   // `apply_patch`, ripgrep `search_files`, and the git family
   // (status/diff/log/commit). All route through the same guarded surface.
   registerAgentToolFamilies(registry);
+
+  // The web + browser family (T1742): `web` toolset — `web_search` (pluggable,
+  // keyless backends), `web_extract` (HTML→markdown), and the Playwright-driven
+  // `browser_*` tools. Playwright is an OPTIONAL, lazily-loaded dependency: the
+  // browser tools register but their availability predicate hides them (with an
+  // install hint) until a context advertises the playwright capability, so core
+  // builds + runs with playwright NOT installed. The web tools' network egress +
+  // the `browser_vision` AI call (via resolveLLMForSystem) use no raw bypass.
+  registerWebAgentTools(registry);
 }

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -113,6 +113,18 @@ export {
   parseRipgrepOutput,
   registerAgentToolFamilies,
 } from './agent-tool-families.js';
+// Web + browser agent tools (T1742 · epic T11456) — the `web` toolset:
+// `web_search` (pluggable keyless backends), `web_extract` (HTML→markdown), and
+// the Playwright-driven `browser_*` family. Playwright is OPTIONAL + lazily
+// loaded; the browser tools register but report unavailable (with an install
+// hint) when it is absent. The `browser_vision` AI call routes through the E9
+// `resolveLLMForSystem` chokepoint + sealed credential — no raw provider call.
+export {
+  BrowserSession,
+  isPlaywrightAvailable,
+  PLAYWRIGHT_INSTALL_HINT,
+  type PlaywrightLoader,
+} from './browser-driver.js';
 export { registerBuiltinAgentTools } from './builtin-agent-tools.js';
 // Subprocess env scrubbing (T11897 · security) — the chokepoint builds a minimal,
 // allowlisted child env so daemon secrets never leak and a Pi-controlled loader
@@ -142,3 +154,18 @@ export { type ZodSchemaTool, zodSchemaToOpenAITool } from './schema-gen.js';
 // Injectable shell executor (E3 · T11406) — threaded into the guard's
 // executeShell/runGit; substitutes the subprocess layer in tests/sandboxes.
 export { defaultShellExecutor, type ShellExecutor } from './shell.js';
+export { registerWebAgentTools, type WebAgentToolOptions } from './web-agent-tools.js';
+export {
+  defaultHttpFetch,
+  duckDuckGoBackend,
+  extractTitle,
+  fetchAndExtract,
+  type HttpFetch,
+  htmlToMarkdown,
+  makeSearxngBackend,
+  parseDuckDuckGoHtml,
+  parseSearxngJson,
+  resolveSearchBackends,
+  runSearch,
+  type WebSearchBackend,
+} from './web-search-backends.js';

--- a/packages/core/src/tools/web-agent-tools.ts
+++ b/packages/core/src/tools/web-agent-tools.ts
@@ -1,0 +1,475 @@
+/**
+ * Web + browser agent-tool FAMILY — registration (T1742 · epic T11456 · SG-TOOLS).
+ *
+ * Registers the `web` toolset into the {@link ./agent-registry.js |
+ * AgentToolRegistry}, on top of the terminal/file/search/git families
+ * ({@link ./agent-tool-families.js}):
+ *
+ *   - **AC1** `web_search` — pluggable, backend-agnostic search
+ *     ({@link ./web-search-backends.js}); graceful `unavailable` result when no
+ *     backend can answer. NO hard paid-API dependency.
+ *   - **AC2** `web_extract` — fetch a URL + convert HTML to markdown.
+ *   - **AC3** `browser_navigate` — Playwright (lazily, optionally loaded).
+ *   - **AC4** `browser_click` / `browser_type` / `browser_press`.
+ *   - **AC5** `browser_snapshot` — accessibility tree.
+ *   - **AC6** `browser_vision` — screenshot + AI analysis routed THROUGH the E9
+ *     `resolveLLMForSystem` chokepoint + sealed-credential handle (never a raw
+ *     provider call).
+ *   - **AC7** `browser_scroll` up / down.
+ *   - **AC8** all registered; the browser tools' `available()` returns `false`
+ *     (with an install hint) when Playwright is absent.
+ *
+ * Browser tools share ONE lazily-launched {@link BrowserSession} per registration
+ * (a closure cell), so the optional Playwright load happens at most once per run.
+ * The web tools' network egress flows through an injectable {@link HttpFetch}; the
+ * vision AI call flows through the single E9 chokepoint — neither bypasses the
+ * resolver / credential layer. Import-time side-effect-free (NO top-level
+ * playwright import).
+ *
+ * @epic T11456
+ * @task T1742
+ * @see ./browser-driver.js — the optional-Playwright lazy-load backend
+ * @see ./web-search-backends.js — the pluggable search backends + HTML→markdown
+ */
+
+import type { TransportMessage } from '@cleocode/contracts/llm/normalized-response.js';
+import type {
+  BrowserVisionResult,
+  WebSearchBackendId,
+  WebSearchInput,
+  WebSearchResult,
+} from '@cleocode/contracts/tools/web-tools';
+import { z } from 'zod';
+import { getLogger } from '../logger.js';
+import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
+import { BrowserSession, PLAYWRIGHT_INSTALL_HINT } from './browser-driver.js';
+import {
+  defaultHttpFetch,
+  fetchAndExtract,
+  type HttpFetch,
+  resolveSearchBackends,
+  runSearch,
+} from './web-search-backends.js';
+
+const log = getLogger('tool-web-agent');
+
+/**
+ * Available only when outbound network egress is permitted. When the context
+ * does not declare egress (`networkEgressAllowed === undefined`) the tool is
+ * permitted — the registry default is permissive; a context that explicitly sets
+ * `false` hides it (AC5/availability).
+ */
+const networkAvailable: AvailabilityCheck = (ctx) => ctx.networkEgressAllowed !== false;
+
+/**
+ * Available only when the optional Playwright capability is present in the
+ * context. The browser tools are ALWAYS registered (AC8), but report unavailable
+ * — surfacing {@link PLAYWRIGHT_INSTALL_HINT} in their description — until a
+ * context advertises `capabilities.playwright === true`. The registration helper
+ * probes Playwright once and stamps that flag, so an absent optional dep simply
+ * leaves the browser tools hidden rather than crashing.
+ */
+const playwrightAvailable: AvailabilityCheck = (ctx) =>
+  ctx.capabilities?.playwright === true && ctx.networkEgressAllowed !== false;
+
+/**
+ * Options for {@link registerWebAgentTools} — all injectable so tests run with
+ * NO real network and NO real browser launch (AC9).
+ */
+export interface WebAgentToolOptions {
+  /** Injected HTTP fetch (defaults to the platform `fetch`). */
+  readonly http?: HttpFetch;
+  /** Injected browser session (defaults to a real lazy-Playwright session). */
+  readonly browser?: BrowserSession;
+  /**
+   * SearXNG instance URL for the `searxng` backend. When omitted, the SearXNG
+   * backend reports unconfigured and only DuckDuckGo answers — preserving the
+   * "graceful when unconfigured" contract (AC1). Read from `SEARXNG_URL` env when
+   * not supplied.
+   */
+  readonly searxngUrl?: string;
+  /**
+   * Project root threaded into the E9 `resolveLLMForSystem` chokepoint for
+   * `browser_vision` (defaults to the resolver's own `process.cwd()` fallback).
+   */
+  readonly projectRoot?: string;
+}
+
+/**
+ * Run the `browser_vision` AI analysis: capture a screenshot, then resolve an
+ * LLM through the SINGLE E9 chokepoint (`resolveLLMForSystem`) and send the
+ * screenshot as a multimodal user turn. The plaintext credential is materialized
+ * from the sealed handle ONLY at the wire (inside `ModelRunner.build`), never
+ * surfaced up the stack — and there is NO raw provider/transport construction
+ * here (Gate-13). Returns `aiUnavailable: true` (with the screenshot still
+ * captured) when no credential resolves — graceful degradation, not an error.
+ *
+ * @param browser - The shared browser session.
+ * @param prompt - The analysis instruction.
+ * @param fullPage - Capture the full page rather than the viewport.
+ * @param projectRoot - Project root for the resolver.
+ * @returns The {@link BrowserVisionResult}.
+ */
+async function runBrowserVision(
+  browser: BrowserSession,
+  prompt: string,
+  fullPage: boolean,
+  projectRoot: string | undefined,
+): Promise<BrowserVisionResult> {
+  const shot = await browser.screenshot(fullPage);
+  const base = { url: shot.url, title: shot.title };
+
+  // E9 resolution chokepoint — the ONLY route to an LLM credential. Never throws.
+  const { resolveLLMForSystem } = await import('../llm/system-resolver.js');
+  const resolved = await resolveLLMForSystem('task-executor', {
+    ...(projectRoot !== undefined ? { projectRoot } : {}),
+  });
+  if (!resolved.sealedCredential) {
+    // No credential reachable — return the screenshot-only result (graceful).
+    return { ...base, analysis: null, aiUnavailable: true };
+  }
+
+  try {
+    // Build the wire surfaces via the single SSoT ModelRunner (Gate-13: no raw
+    // transport / provider construction at this call-site). The descriptor's
+    // token is materialized from the sealed handle inside ModelRunner only.
+    const { ModelRunner } = await import('../llm/model-runner.js');
+    const apiKey = (await resolved.sealedCredential.fetch()).value;
+    const built = await ModelRunner.build({
+      provider: resolved.provider,
+      model: resolved.model,
+      credential: resolved.credential
+        ? {
+            provider: resolved.credential.provider,
+            apiKey,
+            source: resolved.credential.source,
+            authType: resolved.credential.authType,
+          }
+        : null,
+      source: resolved.source,
+      ...(resolved.credentialLabel !== undefined
+        ? { credentialLabel: resolved.credentialLabel }
+        : {}),
+      apiMode: resolved.apiMode,
+      baseUrl: resolved.baseUrl,
+      authType: resolved.authType,
+      ...(resolved.capabilities !== undefined ? { capabilities: resolved.capabilities } : {}),
+    });
+
+    // A single multimodal user turn: the instruction text + the screenshot as a
+    // native image block (transports that cannot do images degrade per imageMode).
+    const messages: TransportMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: prompt },
+          {
+            type: 'image',
+            source: { type: 'base64', data: shot.base64Png, mediaType: 'image/png' },
+          },
+        ],
+      },
+    ];
+    const response = await built.session.send(messages);
+    return {
+      ...base,
+      analysis: response.content,
+      model: resolved.model,
+      aiUnavailable: false,
+    };
+  } catch (err) {
+    log.warn({ err }, 'browser_vision: AI analysis failed — returning screenshot-only result');
+    return { ...base, analysis: null, model: resolved.model, aiUnavailable: true };
+  }
+}
+
+/**
+ * Register the web + browser agent-tool family into `registry`. Pure
+ * registration — no network, no browser launch, no scan; side effects happen
+ * later through the injected {@link HttpFetch} / {@link BrowserSession}.
+ *
+ * The browser tools are registered with a `playwright`-gated availability
+ * predicate (AC8): present in the registry but hidden by `available()` until a
+ * context advertises the optional Playwright capability.
+ *
+ * @param registry - The registry to populate.
+ * @param options - Injectable backends (HTTP fetch, browser session, searxng URL).
+ */
+export function registerWebAgentTools(
+  registry: AgentToolRegistry,
+  options: WebAgentToolOptions = {},
+): void {
+  const http: HttpFetch = options.http ?? defaultHttpFetch;
+  // ONE browser session shared by every browser tool in this registration — the
+  // optional Playwright load happens at most once. Constructing it is free (no
+  // import until the first navigation).
+  const browser = options.browser ?? new BrowserSession();
+  const searxngUrl = options.searxngUrl ?? process.env.SEARXNG_URL;
+  const projectRoot = options.projectRoot;
+
+  // --- AC1: web_search (pluggable backends, graceful when unconfigured) ----
+  registry.register({
+    name: 'web_search',
+    class: 'net',
+    description:
+      'Search the web via a pluggable backend (DuckDuckGo / SearXNG — no API key required). ' +
+      'Returns ranked results, or an `unavailable` result when no backend can answer.',
+    toolset: 'web',
+    stateless: true,
+    available: networkAvailable,
+    parameters: z.object({
+      query: z.string().describe('Free-text search query.'),
+      maxResults: z.number().int().positive().optional().describe('Max results (default 10).'),
+      backend: z
+        .enum(['duckduckgo', 'searxng', 'auto'])
+        .optional()
+        .describe("Preferred backend: 'duckduckgo', 'searxng', or 'auto' (default)."),
+    }),
+    execute: async (rawArgs): Promise<WebSearchResult> => {
+      const backend: WebSearchBackendId | undefined =
+        rawArgs.backend === 'duckduckgo' ||
+        rawArgs.backend === 'searxng' ||
+        rawArgs.backend === 'auto'
+          ? rawArgs.backend
+          : undefined;
+      const input: WebSearchInput = {
+        query: String(rawArgs.query),
+        maxResults: typeof rawArgs.maxResults === 'number' ? rawArgs.maxResults : undefined,
+        backend,
+      };
+      const backends = resolveSearchBackends(input, searxngUrl);
+      if (backends.length === 0) {
+        return {
+          query: input.query,
+          results: [],
+          backend: null,
+          unavailable: true,
+          reason: 'no configured web-search backend',
+        };
+      }
+      const outcome = await runSearch(input, backends, http);
+      if (outcome === null) {
+        return {
+          query: input.query,
+          results: [],
+          backend: null,
+          unavailable: true,
+          reason: 'every web-search backend failed',
+        };
+      }
+      return {
+        query: input.query,
+        results: outcome.results,
+        backend: outcome.backend,
+        unavailable: false,
+      };
+    },
+  });
+
+  // --- AC2: web_extract (URL → markdown) ----------------------------------
+  registry.register({
+    name: 'web_extract',
+    class: 'net',
+    description: 'Fetch a URL and convert its HTML content to markdown.',
+    toolset: 'web',
+    stateless: true,
+    available: networkAvailable,
+    parameters: z.object({
+      url: z.string().describe('Absolute URL to fetch and convert.'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Fetch timeout in ms (default 30000).'),
+      maxChars: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Cap on markdown length in characters (default 100000).'),
+    }),
+    execute: async (rawArgs) => {
+      const url = String(rawArgs.url);
+      return fetchAndExtract(url, http, {
+        timeoutMs: typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined,
+        maxChars: typeof rawArgs.maxChars === 'number' ? rawArgs.maxChars : undefined,
+      });
+    },
+  });
+
+  // --- AC3: browser_navigate ----------------------------------------------
+  registry.register({
+    name: 'browser_navigate',
+    class: 'shell',
+    description: `Navigate a headless browser to a URL (Playwright). ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({
+      url: z.string().describe('Absolute URL to navigate to.'),
+      waitUntil: z
+        .enum(['load', 'domcontentloaded', 'networkidle'])
+        .optional()
+        .describe("When navigation is complete (default 'load')."),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Navigation timeout in ms (default 30000).'),
+    }),
+    execute: async (rawArgs) =>
+      browser.navigate({
+        url: String(rawArgs.url),
+        waitUntil:
+          rawArgs.waitUntil === 'load' ||
+          rawArgs.waitUntil === 'domcontentloaded' ||
+          rawArgs.waitUntil === 'networkidle'
+            ? rawArgs.waitUntil
+            : undefined,
+        timeoutMs: typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined,
+      }),
+  });
+
+  // --- AC4: browser_click / browser_type / browser_press ------------------
+  registry.register({
+    name: 'browser_click',
+    class: 'shell',
+    description: `Click an element by selector in the browser. ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({
+      selector: z.string().describe('CSS / Playwright selector for the element to click.'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Action timeout in ms (default 15000).'),
+    }),
+    execute: async (rawArgs) => {
+      const state = await browser.click(
+        String(rawArgs.selector),
+        typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined,
+      );
+      return { ...state, action: 'click' as const };
+    },
+  });
+
+  registry.register({
+    name: 'browser_type',
+    class: 'shell',
+    description: `Type text into an input element by selector. ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({
+      selector: z.string().describe('CSS / Playwright selector for the input element.'),
+      text: z.string().describe('Text to type into the element.'),
+      clear: z.boolean().optional().describe('Clear the field before typing (default true).'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Action timeout in ms (default 15000).'),
+    }),
+    execute: async (rawArgs) => {
+      const state = await browser.type(
+        String(rawArgs.selector),
+        String(rawArgs.text),
+        typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined,
+      );
+      return { ...state, action: 'type' as const };
+    },
+  });
+
+  registry.register({
+    name: 'browser_press',
+    class: 'shell',
+    description: `Press a key or chord (e.g. Enter, Control+A) in the browser. ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({
+      key: z.string().describe('Key or chord in Playwright syntax (e.g. Enter, Control+A).'),
+      selector: z.string().optional().describe('Optional selector to focus before pressing.'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Focus timeout in ms (default 15000).'),
+    }),
+    execute: async (rawArgs) => {
+      const state = await browser.press(
+        String(rawArgs.key),
+        rawArgs.selector === undefined ? undefined : String(rawArgs.selector),
+        typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined,
+      );
+      return { ...state, action: 'press' as const };
+    },
+  });
+
+  // --- AC5: browser_snapshot (accessibility tree) -------------------------
+  registry.register({
+    name: 'browser_snapshot',
+    class: 'shell',
+    description: `Capture the page's accessibility tree. ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({}),
+    execute: async () => browser.snapshot(),
+  });
+
+  // --- AC7: browser_scroll (up / down) ------------------------------------
+  registry.register({
+    name: 'browser_scroll',
+    class: 'shell',
+    description: `Scroll the page up or down. ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({
+      direction: z.enum(['up', 'down']).describe('Scroll direction.'),
+      amountPx: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Pixels to scroll (default ~one viewport).'),
+    }),
+    execute: async (rawArgs) => {
+      const direction = rawArgs.direction === 'up' ? 'up' : 'down';
+      const state = await browser.scroll(
+        direction,
+        typeof rawArgs.amountPx === 'number' ? rawArgs.amountPx : undefined,
+      );
+      return { ...state, direction };
+    },
+  });
+
+  // --- AC6: browser_vision (screenshot + AI analysis via the E9 chokepoint) -
+  registry.register({
+    name: 'browser_vision',
+    class: 'shell',
+    description:
+      'Screenshot the current page and analyse it with a vision model. ' +
+      `The AI call routes through the resolveLLMForSystem chokepoint. ${PLAYWRIGHT_INSTALL_HINT}`,
+    toolset: 'web',
+    stateless: false,
+    available: playwrightAvailable,
+    parameters: z.object({
+      prompt: z.string().describe('Question / instruction for the vision model about the page.'),
+      fullPage: z
+        .boolean()
+        .optional()
+        .describe('Capture the full scrollable page (default false).'),
+    }),
+    execute: async (rawArgs) =>
+      runBrowserVision(browser, String(rawArgs.prompt), rawArgs.fullPage === true, projectRoot),
+  });
+}

--- a/packages/core/src/tools/web-search-backends.ts
+++ b/packages/core/src/tools/web-search-backends.ts
@@ -1,0 +1,377 @@
+/**
+ * Pluggable `web_search` backends + HTML→markdown extraction (T1742 · epic
+ * T11456 · SG-TOOLS).
+ *
+ * The `web` toolset's network backend. TWO concerns live here, both built over
+ * an INJECTABLE {@link HttpFetch} so unit tests mock the network and CI never
+ * makes a real request (AC9):
+ *
+ *   - **web_search backends** — a {@link WebSearchBackend} interface with two
+ *     keyless builtin implementations ({@link duckDuckGoBackend},
+ *     {@link searxngBackend}). NO hard paid-API dependency: backends are resolved
+ *     at call time and the tool degrades gracefully to an `unavailable` result
+ *     when none answer (AC1). New backends register by satisfying the interface —
+ *     the search tool is backend-agnostic.
+ *   - **web_extract** — {@link htmlToMarkdown}, a dependency-free HTML→markdown
+ *     converter (AC2), plus {@link extractTitle}.
+ *
+ * The pure helpers (parsers, the markdown converter) are exported for direct unit
+ * testing. Import-time side-effect-free.
+ *
+ * @epic T11456
+ * @task T1742
+ */
+
+import type {
+  WebExtractResult,
+  WebSearchBackendId,
+  WebSearchHit,
+  WebSearchInput,
+} from '@cleocode/contracts/tools/web-tools';
+import { getLogger } from '../logger.js';
+
+const log = getLogger('tool-web-search');
+
+/**
+ * A minimal HTTP-fetch surface the web tools depend on by INJECTION. Structurally
+ * a subset of the global `fetch`, declared here so the executables can be driven
+ * by a mock in tests (no real network in CI · AC9) and so a future routing of
+ * web egress through a guarded `net` primitive is a one-line swap.
+ */
+export type HttpFetch = (
+  url: string,
+  init?: { readonly headers?: Record<string, string>; readonly signal?: AbortSignal },
+) => Promise<{
+  readonly status: number;
+  text(): Promise<string>;
+  readonly headers: { get(name: string): string | null };
+}>;
+
+/** The default {@link HttpFetch} — the platform global `fetch`. */
+export const defaultHttpFetch: HttpFetch = (url, init) =>
+  fetch(url, init) as unknown as ReturnType<HttpFetch>;
+
+// ===========================================================================
+// web_search backends
+// ===========================================================================
+
+/**
+ * One pluggable web-search backend. A backend resolves a query into ranked
+ * {@link WebSearchHit}s, or throws (the resolver moves on to the next backend).
+ * `isConfigured()` lets a backend that needs a URL/instance opt OUT of the `auto`
+ * rotation when it has nothing to talk to — keeping the "graceful when
+ * unconfigured" contract (AC1) without a network round-trip.
+ */
+export interface WebSearchBackend {
+  /** Canonical backend id. */
+  readonly id: WebSearchBackendId;
+  /** Whether this backend has everything it needs to run (e.g. an instance URL). */
+  isConfigured(): boolean;
+  /**
+   * Run the search.
+   *
+   * @param query - The search query.
+   * @param maxResults - Cap on returned hits.
+   * @param http - The injected fetch surface.
+   * @returns Ranked hits.
+   */
+  search(query: string, maxResults: number, http: HttpFetch): Promise<WebSearchHit[]>;
+}
+
+/** Decode the most common HTML entities found in result titles/snippets. */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+/** Strip HTML tags from a fragment and collapse whitespace. */
+function stripTags(html: string): string {
+  return decodeEntities(html.replace(/<[^>]*>/g, ''))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Parse DuckDuckGo's keyless HTML endpoint (`html.duckduckgo.com/html/`) into
+ * structured hits. Pure helper (AC9) — exported for direct unit testing against
+ * a captured fixture, so no network is needed.
+ *
+ * @param html - The DuckDuckGo HTML response body.
+ * @param maxResults - Cap on returned hits.
+ * @returns Parsed hits.
+ */
+export function parseDuckDuckGoHtml(html: string, maxResults: number): WebSearchHit[] {
+  const hits: WebSearchHit[] = [];
+  // Each result anchor: <a ... class="result__a" href="URL">TITLE</a>
+  const anchorRe = /<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g;
+  // Optional snippet: <a ... class="result__snippet" ...>SNIPPET</a>
+  const snippetRe = /class="result__snippet"[^>]*>([\s\S]*?)<\/a>/g;
+  const snippets: string[] = [];
+  for (let m = snippetRe.exec(html); m !== null; m = snippetRe.exec(html)) {
+    snippets.push(stripTags(m[1] ?? ''));
+  }
+  let i = 0;
+  for (
+    let m = anchorRe.exec(html);
+    m !== null && hits.length < maxResults;
+    m = anchorRe.exec(html)
+  ) {
+    const rawHref = decodeEntities(m[1] ?? '');
+    // DDG wraps targets as `/l/?uddg=<encoded-url>` — unwrap when present.
+    const uddg = /[?&]uddg=([^&]+)/.exec(rawHref);
+    const url = uddg ? decodeURIComponent(uddg[1] ?? '') : rawHref;
+    const title = stripTags(m[2] ?? '');
+    if (title === '' || url === '') {
+      i++;
+      continue;
+    }
+    hits.push({ title, url, snippet: snippets[i] ?? '' });
+    i++;
+  }
+  return hits;
+}
+
+/**
+ * The DuckDuckGo backend — keyless HTML endpoint, always "configured" (no
+ * instance URL needed). The canonical no-API-key default (AC1).
+ */
+export const duckDuckGoBackend: WebSearchBackend = {
+  id: 'duckduckgo',
+  isConfigured: () => true,
+  async search(query, maxResults, http) {
+    const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+    const res = await http(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; CleoBot/1.0)' },
+    });
+    if (res.status >= 400) {
+      throw new Error(`duckduckgo: HTTP ${res.status}`);
+    }
+    return parseDuckDuckGoHtml(await res.text(), maxResults);
+  },
+};
+
+/**
+ * Parse a SearXNG JSON response (`{ results: [{ title, url, content }] }`) into
+ * hits. Pure helper (AC9).
+ *
+ * @param json - The parsed SearXNG JSON body.
+ * @param maxResults - Cap on returned hits.
+ * @returns Parsed hits.
+ */
+export function parseSearxngJson(json: unknown, maxResults: number): WebSearchHit[] {
+  const results = (json as { results?: unknown }).results;
+  if (!Array.isArray(results)) return [];
+  const hits: WebSearchHit[] = [];
+  for (const r of results) {
+    if (hits.length >= maxResults) break;
+    if (typeof r !== 'object' || r === null) continue;
+    const rec = r as Record<string, unknown>;
+    const title = typeof rec.title === 'string' ? rec.title : '';
+    const url = typeof rec.url === 'string' ? rec.url : '';
+    if (title === '' || url === '') continue;
+    hits.push({ title, url, snippet: typeof rec.content === 'string' ? rec.content : '' });
+  }
+  return hits;
+}
+
+/**
+ * Build a SearXNG backend bound to an instance URL (from `SEARXNG_URL` env or
+ * config). When no instance URL is supplied it reports `isConfigured() === false`
+ * so the `auto` resolver skips it — preserving the "graceful when unconfigured"
+ * contract (AC1) with no paid dependency.
+ *
+ * @param instanceUrl - The SearXNG instance base URL (or `undefined`/empty).
+ * @returns A {@link WebSearchBackend}.
+ */
+export function makeSearxngBackend(instanceUrl: string | undefined): WebSearchBackend {
+  const base = (instanceUrl ?? '').replace(/\/+$/, '');
+  return {
+    id: 'searxng',
+    isConfigured: () => base !== '',
+    async search(query, maxResults, http) {
+      if (base === '') throw new Error('searxng: no instance URL configured');
+      const url = `${base}/search?q=${encodeURIComponent(query)}&format=json`;
+      const res = await http(url, { headers: { Accept: 'application/json' } });
+      if (res.status >= 400) {
+        throw new Error(`searxng: HTTP ${res.status}`);
+      }
+      const json: unknown = JSON.parse(await res.text());
+      return parseSearxngJson(json, maxResults);
+    },
+  };
+}
+
+/**
+ * Resolve the candidate backends for a {@link WebSearchInput}, in priority
+ * order. A SearXNG instance (when configured) ranks before DuckDuckGo; an
+ * explicit `input.backend` pins a single backend. The DuckDuckGo backend is
+ * always present (keyless), so the list is never empty — but a pinned backend
+ * that is not configured yields an empty list, which the executable surfaces as
+ * `unavailable` (AC1).
+ *
+ * @param input - The search input.
+ * @param searxngUrl - Optional SearXNG instance URL (config/env).
+ * @returns The ordered candidate backends.
+ */
+export function resolveSearchBackends(
+  input: WebSearchInput,
+  searxngUrl: string | undefined,
+): WebSearchBackend[] {
+  const searxng = makeSearxngBackend(searxngUrl);
+  const all: WebSearchBackend[] = [searxng, duckDuckGoBackend];
+  const pinned = input.backend;
+  if (pinned !== undefined && pinned !== 'auto') {
+    return all.filter((b) => b.id === pinned && b.isConfigured());
+  }
+  return all.filter((b) => b.isConfigured());
+}
+
+// ===========================================================================
+// web_extract — HTML → markdown
+// ===========================================================================
+
+/** Extract the document `<title>` text, or `''` when absent. Pure (AC9). */
+export function extractTitle(html: string): string {
+  const m = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  return m ? stripTags(m[1] ?? '') : '';
+}
+
+/**
+ * Convert an HTML document to markdown. Dependency-free (AC2) — a focused,
+ * deterministic transform of the structural tags an agent cares about
+ * (headings, links, lists, code, emphasis, paragraphs); `<script>`/`<style>`
+ * and remaining tags are dropped. NOT a full HTML5 parser — a pragmatic
+ * readability-style extraction that keeps `core` free of a heavy DOM dependency.
+ *
+ * Pure function of its input (no I/O), so it is unit-testable in isolation (AC9).
+ *
+ * @param html - The HTML document / fragment.
+ * @returns A markdown rendering of the body content.
+ */
+export function htmlToMarkdown(html: string): string {
+  let s = html;
+  // 1) Drop non-content elements entirely.
+  s = s.replace(/<script[\s\S]*?<\/script>/gi, '');
+  s = s.replace(/<style[\s\S]*?<\/style>/gi, '');
+  s = s.replace(/<noscript[\s\S]*?<\/noscript>/gi, '');
+  s = s.replace(/<!--[\s\S]*?-->/g, '');
+  s = s.replace(/<head[\s\S]*?<\/head>/gi, '');
+  // 2) Headings → #..######.
+  for (let level = 1; level <= 6; level++) {
+    const re = new RegExp(`<h${level}[^>]*>([\\s\\S]*?)<\\/h${level}>`, 'gi');
+    s = s.replace(re, (_m, inner: string) => `\n\n${'#'.repeat(level)} ${stripTags(inner)}\n\n`);
+  }
+  // 3) Links → [text](href). The `(?=[\s>])` after the tag name ensures `<a `
+  //    matches but `<article>` / `<aside>` do not (tag-boundary guard).
+  s = s.replace(
+    /<a(?=[\s>])[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi,
+    (_m, href: string, inner: string) => {
+      const text = stripTags(inner);
+      const url = decodeEntities(href);
+      return text === '' ? '' : `[${text}](${url})`;
+    },
+  );
+  // 4) Inline emphasis / code. Each opening tag is boundary-guarded so a longer
+  //    element (e.g. `<body>` for `<b>`) is never mistaken for the short tag.
+  s = s.replace(
+    /<(?:strong|b)(?=[\s>])[^>]*>([\s\S]*?)<\/(?:strong|b)>/gi,
+    (_m, i: string) => `**${stripTags(i)}**`,
+  );
+  s = s.replace(
+    /<(?:em|i)(?=[\s>])[^>]*>([\s\S]*?)<\/(?:em|i)>/gi,
+    (_m, i: string) => `*${stripTags(i)}*`,
+  );
+  s = s.replace(
+    /<code(?=[\s>])[^>]*>([\s\S]*?)<\/code>/gi,
+    (_m, i: string) => `\`${stripTags(i)}\``,
+  );
+  // 5) Pre blocks → fenced code.
+  s = s.replace(
+    /<pre(?=[\s>])[^>]*>([\s\S]*?)<\/pre>/gi,
+    (_m, i: string) => `\n\n\`\`\`\n${stripTags(i)}\n\`\`\`\n\n`,
+  );
+  // 6) List items → `- `; close lists with a blank line.
+  s = s.replace(/<li(?=[\s>])[^>]*>([\s\S]*?)<\/li>/gi, (_m, i: string) => `\n- ${stripTags(i)}`);
+  s = s.replace(/<\/(?:ul|ol)>/gi, '\n\n');
+  // 7) Block separators → blank line.
+  s = s.replace(/<\/(?:p|div|section|article|tr|table|blockquote)>/gi, '\n\n');
+  s = s.replace(/<br\s*\/?>/gi, '\n');
+  // 8) Drop every remaining tag, decode entities, normalise whitespace.
+  s = stripTagsPreservingNewlines(s);
+  s = s.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n');
+  return s.trim();
+}
+
+/** Like {@link stripTags} but keeps newline structure for block-level markdown. */
+function stripTagsPreservingNewlines(html: string): string {
+  return decodeEntities(html.replace(/<[^>]*>/g, '')).replace(/[ \t]{2,}/g, ' ');
+}
+
+/**
+ * Fetch a URL and convert its HTML body to markdown. The single executable body
+ * for the `web_extract` tool — uses the INJECTED {@link HttpFetch} so CI mocks
+ * the network (AC9).
+ *
+ * @param url - The URL to fetch.
+ * @param http - The injected fetch surface.
+ * @param opts - Timeout + markdown length cap.
+ * @returns The {@link WebExtractResult}.
+ */
+export async function fetchAndExtract(
+  url: string,
+  http: HttpFetch,
+  opts: { timeoutMs?: number; maxChars?: number } = {},
+): Promise<WebExtractResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30000);
+  try {
+    const res = await http(url, { signal: controller.signal });
+    const body = await res.text();
+    const title = extractTitle(body);
+    const full = htmlToMarkdown(body);
+    const maxChars = opts.maxChars ?? 100000;
+    const truncated = full.length > maxChars;
+    return {
+      url,
+      status: res.status,
+      title,
+      markdown: truncated ? full.slice(0, maxChars) : full,
+      truncated,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Run a {@link WebSearchInput} against the resolved backends, first-success-wins.
+ * Returns the hits + the answering backend id, or `null` when no backend could
+ * answer (every candidate failed or the list was empty) — the executable maps
+ * `null` onto a graceful `unavailable` result (AC1).
+ *
+ * @param input - The search input.
+ * @param backends - The ordered candidate backends (from {@link resolveSearchBackends}).
+ * @param http - The injected fetch surface.
+ * @returns The hits + backend, or `null` when none answered.
+ */
+export async function runSearch(
+  input: WebSearchInput,
+  backends: readonly WebSearchBackend[],
+  http: HttpFetch,
+): Promise<{ results: WebSearchHit[]; backend: WebSearchBackendId } | null> {
+  const maxResults = input.maxResults ?? 10;
+  for (const backend of backends) {
+    try {
+      const results = await backend.search(input.query, maxResults, http);
+      return { results, backend: backend.id };
+    } catch (err) {
+      log.debug({ backend: backend.id, err }, 'web_search backend failed — trying next');
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
web_search / web_extract + 7 browser_* tools registered into the AgentToolRegistry (built on #1013 + #1014).

## Tools
- **web_search** — pluggable, keyless backends (DuckDuckGo HTML + SearXNG) behind one `WebSearchBackend` interface; graceful `unavailable` result when no backend is configured/reachable. NO hard paid-API dependency.
- **web_extract** — fetch a URL + dependency-free HTML→markdown conversion.
- **browser_navigate / browser_click / browser_type / browser_press / browser_snapshot (accessibility tree) / browser_scroll** — Playwright-driven.
- **browser_vision** — screenshot + AI analysis routed THROUGH the E9 `resolveLLMForSystem` chokepoint + sealed-credential handle + `ModelRunner` (no raw provider/transport construction — Gate-13 clean); degrades gracefully (`aiUnavailable`, screenshot still captured) when no credential resolves.

## Publish-surface discipline (D11136)
Playwright is an **optional/lazy** dependency — NOT a hard dependency of `@cleocode/core`. Loaded only via a variable-specifier dynamic `import()` guarded by an availability check (same pattern as `node-pty`). The build + the rest of core work with Playwright NOT installed; the browser tools register but their `availability()` returns false with a clear install hint when Playwright is absent. `EXPECTED_PUBLISH_COUNT` unchanged (18); Gate-9 unchanged.

## Boundaries
- Gate-11: tools DEFINED only under `core/src/tools` (+ types in `contracts/src/tools`); registered via the AgentToolRegistry pattern.
- Import-time side-effect-free (NO top-level playwright import — dynamic only).

## Tests
Unit tests MOCK all backends — mocked HTTP fetch + a fake Playwright loader (no real network, no real browser launch in CI); `browser_vision` mocks the resolver + ModelRunner. 46 T1742 tool tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)