### PR TITLE
feat(T10418): tool dispatch engine — Pi loop executes registered agent tools (T1740)

### DIFF
--- a/packages/core/src/llm/pi/__tests__/pi-agent-adapter.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-agent-adapter.test.ts
@@ -19,6 +19,7 @@ import type {
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SkillExecutorAdapter } from '../../../skills/skill-executor-adapter.js';
 import type { Skill } from '../../../skills/types.js';
+import { createAgentToolRegistry } from '../../../tools/agent-registry.js';
 import { createPiSkillRunner, isPiRunnerEnabled, PiAgentAdapter } from '../pi-agent-adapter.js';
 
 // ---------------------------------------------------------------------------
@@ -167,6 +168,29 @@ describe('PiAgentAdapter.run — never throws, contained', () => {
     });
     expect(['success', 'failure']).toContain(result.status);
     // Whatever the outcome, output is an object and it did not throw.
+    expect(typeof result.output).toBe('object');
+  });
+
+  it('accepts a tool registry (AC6) and still returns a contained result, never a throw', async () => {
+    // With a registry wired, the adapter builds the dispatch engine + projects
+    // executable AgentTools onto the loop context. With no credential resolvable
+    // the loop still terminates as a contained result (the tool path is reachable
+    // but the model never gets to emit a call). This proves the registry wiring
+    // does not break the never-throws contract.
+    process.env['CLEO_SESSION_ID'] = 'sess-tools-1';
+    const registry = await createAgentToolRegistry();
+    const adapter = new PiAgentAdapter({
+      system: 'task-executor',
+      registry,
+      budget: { maxCalls: 10, perCallTimeoutMs: 5_000 },
+    });
+    const result = await adapter.run('List the files', fakeTools(), {
+      system: 'task-executor',
+      sessionId: 'sess-tools-1',
+      agentId: null,
+      parentSessionId: null,
+    });
+    expect(['success', 'failure']).toContain(result.status);
     expect(typeof result.output).toBe('object');
   });
 

--- a/packages/core/src/llm/pi/__tests__/pi-tool-bridge.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-tool-bridge.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Pi ↔ dispatch-engine bridge tests (T1740 · AC6 · AC7 · epic T11456).
+ *
+ * Proves the CLOSED tool-call loop for the in-process Pi runner: when the model
+ * emits a tool call, the `AgentTool.execute` the bridge built routes the call
+ * THROUGH the T1740 dispatch engine, runs the real registered tool over the
+ * guarded surface, and returns the formatted result the loop feeds back. This is
+ * the deterministic proof of AC6 that needs no live LLM credential — it simulates
+ * exactly what `pi-agent-core`'s loop does when it invokes a tool the model named.
+ *
+ * @task T1740
+ * @epic T11456
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAgentToolRegistry } from '../../../tools/agent-registry.js';
+import { ToolCallBudget, ToolDispatchEngine } from '../../../tools/dispatch.js';
+import { createToolGuard } from '../../../tools/guard.js';
+import { buildPiAgentTools } from '../pi-tool-bridge.js';
+
+let workspace: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), 'cleo-pi-bridge-'));
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+/** Build the engine + projected AgentTools exactly as PiAgentAdapter does. */
+async function buildBridge(budget?: ToolCallBudget) {
+  const registry = await createAgentToolRegistry();
+  const tools = createToolGuard({ allowedRoots: [workspace], mode: 'enforce' });
+  const engine = new ToolDispatchEngine({ registry, tools, ...(budget ? { budget } : {}) });
+  const agentTools = buildPiAgentTools(engine, registry);
+  return { engine, agentTools };
+}
+
+describe('buildPiAgentTools — closes the tool-call loop (AC6)', () => {
+  it('projects every registry tool into an executable AgentTool with a JSON-schema', async () => {
+    const { agentTools } = await buildBridge();
+    expect(agentTools.length).toBeGreaterThan(0);
+    const readPaged = agentTools.find((t) => t.name === 'read_file_paged');
+    expect(readPaged).toBeDefined();
+    expect(readPaged?.label).toBe('read_file_paged');
+    // The schema is a plain JSON-Schema object (Gate-10 — no typebox).
+    expect(readPaged?.parameters).toMatchObject({ type: 'object' });
+    expect(typeof readPaged?.execute).toBe('function');
+  });
+
+  it('a model tool-call (execute) actually RUNS the registered tool through the guard', async () => {
+    const file = join(workspace, 'doc.txt');
+    await writeFile(file, 'alpha\nbeta\ngamma\n', 'utf8');
+    const { agentTools } = await buildBridge();
+    const readPaged = agentTools.find((t) => t.name === 'read_file_paged');
+    if (!readPaged) throw new Error('read_file_paged missing');
+
+    // Simulate exactly what the Pi loop does: invoke execute with the toolCallId
+    // + the model-validated params object.
+    const result = await readPaged.execute('call-1', { path: file, offset: 0, limit: 2 });
+
+    expect(result.content[0]?.type).toBe('text');
+    expect(result.content[0]?.text).toContain('alpha');
+    expect(result.content[0]?.text).toContain('beta');
+    expect(result.details.ok).toBe(true);
+  });
+
+  it('feeds back a classified, redacted error when the tool call is denied (never throws)', async () => {
+    const { agentTools } = await buildBridge();
+    const readPaged = agentTools.find((t) => t.name === 'read_file_paged');
+    if (!readPaged) throw new Error('read_file_paged missing');
+    // Path OUTSIDE the workspace → the guard denies it during execution.
+    const result = await readPaged.execute('call-2', { path: '/etc/hostname' });
+    expect(result.details.ok).toBe(false);
+    if (result.details.ok) throw new Error('expected failure detail');
+    expect(result.details.kind).toBe('execution-error');
+    // The content carries the classified code for the model.
+    expect(result.content[0]?.text).toContain('E_TOOL_EXECUTION_ERROR');
+  });
+
+  it('reports invalid-args back to the model with the field path', async () => {
+    const { agentTools } = await buildBridge();
+    const readPaged = agentTools.find((t) => t.name === 'read_file_paged');
+    if (!readPaged) throw new Error('read_file_paged missing');
+    // Missing required `path`.
+    const result = await readPaged.execute('call-3', {});
+    expect(result.details.ok).toBe(false);
+    if (result.details.ok) throw new Error('expected failure');
+    expect(result.details.kind).toBe('invalid-args');
+    expect(result.content[0]?.text).toContain('path');
+  });
+
+  it('shares ONE run-scoped budget across all projected tools (AC5)', async () => {
+    const file = join(workspace, 'b.txt');
+    await writeFile(file, 'x\n', 'utf8');
+    const budget = new ToolCallBudget({ maxCalls: 1 });
+    const { engine, agentTools } = await buildBridge(budget);
+    const readPaged = agentTools.find((t) => t.name === 'read_file_paged');
+    const readFile = agentTools.find((t) => t.name === 'read_file');
+    if (!readPaged || !readFile) throw new Error('tools missing');
+
+    const r1 = await readPaged.execute('c1', { path: file });
+    // Second call (a DIFFERENT tool) is denied — the budget is shared, not per-tool.
+    const r2 = await readFile.execute('c2', { path: file });
+    expect(r1.details.ok).toBe(true);
+    expect(r2.details.ok).toBe(false);
+    if (r2.details.ok) throw new Error('expected denial');
+    expect(r2.details.kind).toBe('guard-denied');
+    expect(engine.budgetSnapshot().callsRemaining).toBe(0);
+  });
+});

--- a/packages/core/src/llm/pi/pi-agent-adapter.ts
+++ b/packages/core/src/llm/pi/pi-agent-adapter.ts
@@ -33,7 +33,12 @@ import type {
   SkillExecuteInput,
   SkillExecuteResult,
 } from '@cleocode/contracts/tools/skill-executor';
-import type { AgentEvent, AgentLoopConfig, AgentMessage } from '@earendil-works/pi-agent-core';
+import type {
+  AgentContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+} from '@earendil-works/pi-agent-core';
 import { InMemorySessionRepo, runAgentLoop } from '@earendil-works/pi-agent-core';
 import type { Model } from '@earendil-works/pi-ai';
 import { getLogger } from '../../logger.js';
@@ -44,8 +49,11 @@ import {
 } from '../../sessions/session-id.js';
 import type { SkillRunner } from '../../skills/skill-executor-adapter.js';
 import type { Skill } from '../../skills/types.js';
+import type { AgentToolRegistry } from '../../tools/agent-registry.js';
+import { type ToolBudgetLimits, ToolCallBudget, ToolDispatchEngine } from '../../tools/dispatch.js';
 import { PiContainmentError, wrapPiCall } from './pi-errors.js';
 import { createPiStreamFn } from './pi-stream-fn.js';
+import { buildPiAgentTools } from './pi-tool-bridge.js';
 import type { PiAgentResult, PiAgentRunContext } from './pi-types.js';
 
 const logger = getLogger('pi-agent-adapter');
@@ -76,6 +84,21 @@ export interface PiAgentAdapterDeps {
    * `process.cwd()` inside `resolveLLMForSystem`.
    */
   readonly projectRoot?: string;
+  /**
+   * The frozen {@link AgentToolRegistry} whose tools the loop may CALL (T1740 ·
+   * AC6). When supplied, {@link run} builds a {@link ToolDispatchEngine} over it
+   * + the injected guarded surface and projects executable `AgentTool`s onto the
+   * loop, so a model tool-call actually runs through the dispatch engine. When
+   * omitted the loop is text-only (no tools offered for execution) — the prior
+   * behaviour, preserved so existing callers are unchanged.
+   */
+  readonly registry?: AgentToolRegistry;
+  /**
+   * Optional per-run tool-call budget limits (T1740 · AC5) applied to the
+   * dispatch engine: max call count, per-call timeout, total time. Omitted →
+   * unbounded.
+   */
+  readonly budget?: ToolBudgetLimits;
 }
 
 /**
@@ -126,10 +149,6 @@ export class PiAgentAdapter {
     tools: GuardedToolSurface,
     ctx: PiAgentRunContext,
   ): Promise<PiAgentResult> {
-    // `tools` is threaded for S3+ ExecutionEnv wiring; on the v0 read/stream path
-    // the binding is asserted so the seam is real (no ambient tool access).
-    void tools;
-
     // Merge construction defaults UNDER the per-call ctx — a field the caller
     // supplied on `ctx` always wins; deps fill the `projectRoot` gap.
     const runCtx: PiAgentRunContext =
@@ -160,9 +179,17 @@ export class PiAgentAdapter {
         const emit = (event: AgentEvent): void => {
           events.push(event);
         };
+        // AC6 — close the tool-call loop. When a registry is wired, build the
+        // T1740 dispatch engine over it + the injected guarded surface, project
+        // executable `AgentTool`s onto the loop context, and (separately) advertise
+        // the same schemas to the model on the wire (Context.tools is read by the
+        // streamFn). When NO registry is supplied the loop is text-only — the
+        // guarded surface is still asserted so the seam is never ambient.
+        void tools;
+        const agentContext = this.#buildAgentContext(tools);
         const result = await runAgentLoop(
           [userMessage(prompt)],
-          { systemPrompt: '', messages: [] },
+          agentContext,
           config,
           emit,
           signal,
@@ -199,6 +226,42 @@ export class PiAgentAdapter {
       convertToLlm: (messages: AgentMessage[]) => messages as never,
     };
   }
+
+  /**
+   * Build the loop's {@link AgentContext}, wiring the executable tools when a
+   * registry is configured (T1740 · AC6).
+   *
+   * With a registry: a {@link ToolDispatchEngine} is constructed over it + the
+   * injected guarded surface + the optional run-scoped budget, and {@link
+   * buildPiAgentTools} projects executable `AgentTool`s onto `context.tools`. The
+   * loop reads those `execute` bodies when the model emits a tool-call, so the
+   * call runs through the dispatch engine (lookup → validate → availability →
+   * budget → guarded side effect → formatted result) and the result is fed back.
+   * Without a registry the context is text-only — the prior behaviour.
+   *
+   * @param tools - The injected guarded tool surface every executable runs through.
+   * @returns The loop context (`systemPrompt` + empty transcript + optional tools).
+   */
+  #buildAgentContext(tools: GuardedToolSurface): AgentContext {
+    if (!this.#deps.registry) {
+      return { systemPrompt: '', messages: [] };
+    }
+    const engine = new ToolDispatchEngine({
+      registry: this.#deps.registry,
+      tools,
+      ...(this.#deps.budget !== undefined ? { budget: new ToolCallBudget(this.#deps.budget) } : {}),
+    });
+    const agentTools = buildPiAgentTools(engine, this.#deps.registry);
+    // `buildPiAgentTools` returns the structural `AgentTool` subset the loop
+    // reads (name/description/parameters/label/execute); the cast bridges to
+    // `pi-agent-core`'s generic `AgentTool<TSchema, TDetails>` without importing
+    // its TypeBox-parameterized type into the bridge (Gate-10 quarantine).
+    return {
+      systemPrompt: '',
+      messages: [],
+      tools: agentTools as unknown as AgentContext['tools'],
+    };
+  }
 }
 
 /**
@@ -222,6 +285,8 @@ export class PiAgentAdapter {
  * @returns A `SkillRunner` that runs the Pi loop in-process.
  */
 export function createPiSkillRunner(deps: PiAgentAdapterDeps = {}): SkillRunner {
+  // The adapter receives the full deps (incl. the optional tool registry + budget
+  // for AC6 tool-call dispatch).
   const adapter = new PiAgentAdapter(deps);
   return async (skill, input): Promise<SkillExecuteResult> => {
     const sessionId = resolveSessionIdFromEnv();

--- a/packages/core/src/llm/pi/pi-tool-bridge.ts
+++ b/packages/core/src/llm/pi/pi-tool-bridge.ts
@@ -1,0 +1,172 @@
+/**
+ * Pi ↔ dispatch-engine bridge (T1740 · AC6 · epic T11456).
+ *
+ * Closes the agent tool-call loop for the in-process Pi runner. Pi's agent loop
+ * executes a tool the model emits by calling the `execute(toolCallId, params,
+ * signal)` method of the matching `AgentTool` it finds on `AgentContext.tools`.
+ * Before T1740 the Pi adapter advertised the registry's tool SCHEMAS to the
+ * model (`pi-stream-fn.ts` → `SendOptions.tools`) but supplied NO executables —
+ * so a model tool-call had nothing to run and the loop could only stream text.
+ *
+ * {@link buildPiAgentTools} projects the {@link AgentToolRegistry} into the
+ * `AgentTool[]` the loop needs, binding each tool's `execute` body to the T1740
+ * {@link ToolDispatchEngine}. When the model emits a tool call, Pi invokes the
+ * bound `execute`, which runs the call THROUGH the dispatch engine — lookup +
+ * Zod-validate + availability + budget + guarded execution + LLM-safe
+ * formatting — and returns the classified result as an `AgentToolResult` Pi
+ * feeds back to the model as a `tool_result`. That is the closed loop:
+ *
+ *   model tool-call → Pi AgentTool.execute → ToolDispatchEngine.dispatch →
+ *   GuardedToolSurface side effect → formatted result → back to the model.
+ *
+ * ## Boundary cleanliness
+ *
+ * - **Gate-11** — this module defines NO atomic tool primitive; it CONSUMES the
+ *   frozen registry (`toOpenAITools`-shaped schemas) and the dispatch engine.
+ * - **Gate-13** — no LLM resolution / transport / client construction here; the
+ *   only LLM route stays in {@link createPiStreamFn}. Tool execution is pure
+ *   side-effect dispatch through the guard.
+ * - **Gate-10** — the Pi `AgentTool.parameters` is a TypeBox `TSchema`; the
+ *   registry carries Zod. We convert via the shared {@link zodSchemaToOpenAITool}
+ *   generator (Zod v4 native `z.toJSONSchema`) and pass the resulting JSON-Schema
+ *   object through as the (structurally-compatible) `parameters` WITHOUT a
+ *   typebox value-import, matching `pi-stream-fn.ts`'s quarantine.
+ *
+ * @task T1740
+ * @epic T11456
+ * @see ../../tools/dispatch.js — the dispatch engine this binds the loop to
+ * @see ./pi-stream-fn.js — the sibling that advertises the same tools' schemas
+ */
+
+import { getLogger } from '../../logger.js';
+import type { AgentToolRegistry } from '../../tools/agent-registry.js';
+import type { ToolCall, ToolDispatchEngine, ToolDispatchResult } from '../../tools/dispatch.js';
+import { zodSchemaToOpenAITool } from '../../tools/schema-gen.js';
+
+const logger = getLogger('pi-tool-bridge');
+
+/**
+ * The minimal `AgentTool` shape `pi-agent-core` requires on
+ * `AgentContext.tools`. Declared structurally here (NOT a type-only import of
+ * `@earendil-works/pi-agent-core`'s `AgentTool`) so the bridge stays decoupled
+ * from the loop package's generic `TSchema`/`TDetails` parameterization and so a
+ * `pi-agent-core` minor cannot silently widen the contract we satisfy. The
+ * fields mirror `AgentTool` member-for-member; the loop reads exactly these.
+ */
+export interface PiBridgeAgentTool {
+  /** Model-visible tool name. */
+  readonly name: string;
+  /** Human-readable description shown to the model. */
+  readonly description: string;
+  /** JSON-Schema (TypeBox-structural) parameter schema for the model. */
+  readonly parameters: Record<string, unknown>;
+  /** UI label (Pi requires it; we reuse the name). */
+  readonly label: string;
+  /**
+   * Execute the tool call. Pi calls this when the model emits a matching
+   * tool-call; it routes THROUGH the dispatch engine and returns the formatted
+   * result content. Never throws — a dispatch failure becomes an error-flagged
+   * `AgentToolResult` so the loop can feed it back and continue.
+   */
+  execute(toolCallId: string, params: unknown, signal?: AbortSignal): Promise<PiBridgeToolResult>;
+}
+
+/**
+ * The `AgentToolResult` subset the loop reads back from {@link
+ * PiBridgeAgentTool.execute}. `content` is the model-facing `tool_result` body;
+ * `details` carries the structured {@link ToolDispatchResult} for logs/UI; a
+ * dispatch failure is reported via the content + the `isError`-style detail.
+ */
+export interface PiBridgeToolResult {
+  /** Text content blocks fed back to the model (one text block in v0). */
+  readonly content: readonly { readonly type: 'text'; readonly text: string }[];
+  /** Structured dispatch result for logs / UI rendering. */
+  readonly details: ToolDispatchResult;
+}
+
+/**
+ * Project an {@link AgentToolRegistry} into the `AgentTool[]` the Pi loop
+ * executes, binding every tool's `execute` to the shared {@link
+ * ToolDispatchEngine} (AC6).
+ *
+ * One {@link ToolDispatchEngine} instance is shared across all returned tools so
+ * the run-scoped budget (call count / time ceilings) is enforced ACROSS the
+ * whole turn, not per tool. Each `execute`:
+ *   1. wraps Pi's `(toolCallId, params)` into a {@link ToolCall};
+ *   2. dispatches it through the engine (validate → availability → budget →
+ *      guarded execution → format);
+ *   3. returns the formatted content as an `AgentToolResult` Pi feeds back.
+ *
+ * @param engine - The dispatch engine (carries registry + guard + budget).
+ * @returns The `AgentTool[]` to assign to `AgentContext.tools`.
+ */
+export function buildPiAgentTools(
+  engine: ToolDispatchEngine,
+  registry: AgentToolRegistry,
+): PiBridgeAgentTool[] {
+  return registry.list().map((descriptor) => {
+    // Reuse the SINGLE shared schema generator so the bridge's advertised schema
+    // is byte-identical to what `pi-stream-fn.ts` puts on the wire (DRY, Gate-10
+    // — Zod → JSON-Schema, no typebox value-import).
+    const { inputSchema } = zodSchemaToOpenAITool({
+      name: descriptor.name,
+      description: descriptor.description,
+      parameters: descriptor.parameters,
+    });
+    return {
+      name: descriptor.name,
+      description: descriptor.description,
+      parameters: inputSchema,
+      label: descriptor.name,
+      async execute(
+        toolCallId: string,
+        params: unknown,
+        signal?: AbortSignal,
+      ): Promise<PiBridgeToolResult> {
+        const call: ToolCall = {
+          id: toolCallId,
+          name: descriptor.name,
+          // Pi passes the schema-validated params object; normalize a non-object
+          // to an empty record so the engine's own re-validation runs cleanly.
+          arguments: isRecord(params) ? params : {},
+        };
+        const result = await engine.dispatch(call, signal);
+        if (!result.ok) {
+          logger.debug(
+            { tool: descriptor.name, kind: result.kind, code: result.code },
+            'pi tool dispatch failed (contained)',
+          );
+        }
+        return toAgentToolResult(result);
+      },
+    };
+  });
+}
+
+/**
+ * Convert a {@link ToolDispatchResult} into the {@link PiBridgeToolResult} the
+ * loop reads. Success → the `display` body; failure → the redacted, classified
+ * `[CODE] message` body. Either way it is a normal (non-throwing) result so the
+ * loop continues — Pi's contract is that a tool encodes failure in its result,
+ * not by throwing.
+ *
+ * @param result - The dispatch outcome.
+ * @returns The Pi-shaped tool result.
+ */
+function toAgentToolResult(result: ToolDispatchResult): PiBridgeToolResult {
+  const text = result.ok
+    ? result.display
+    : `[${result.code}] ${result.message}${formatIssues(result)}`;
+  return { content: [{ type: 'text', text }], details: result };
+}
+
+/** Append flattened arg-validation issues to a failure body, when present. */
+function formatIssues(result: Extract<ToolDispatchResult, { ok: false }>): string {
+  if (!result.issues || result.issues.length === 0) return '';
+  return `\n${result.issues.map((i) => `- ${i.path ? `${i.path}: ` : ''}${i.message}`).join('\n')}`;
+}
+
+/** Narrow an unknown to a plain record (Pi may hand a non-object on edge cases). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/tools/__tests__/dispatch.test.ts
+++ b/packages/core/src/tools/__tests__/dispatch.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for the agent tool-call dispatch engine (T1740 · AC7 · epic T11456).
+ *
+ * Covers the full pipeline against a REAL registered tool (`read_file_paged`
+ * over a temp dir through the deny-first guard) plus every error class, the
+ * sync/async handler support, the budget caps (count + per-call timeout), and
+ * the LLM-safe result formatting + redaction.
+ *
+ * @task T1740
+ * @epic T11456
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { AgentToolRegistry, createAgentToolRegistry } from '../agent-registry.js';
+import {
+  flattenZodIssues,
+  formatToolResultForLlm,
+  formatToolValueForLlm,
+  MAX_TOOL_RESULT_CHARS,
+  redactErrorMessage,
+  ToolCallBudget,
+  ToolDispatchEngine,
+} from '../dispatch.js';
+import { createToolGuard } from '../guard.js';
+
+// ---------------------------------------------------------------------------
+// Temp workspace + registry helpers
+// ---------------------------------------------------------------------------
+
+let workspace: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), 'cleo-dispatch-'));
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+/** A registry with the built-ins + a couple of synthetic tools for edge cases. */
+async function buildRegistry(): Promise<AgentToolRegistry> {
+  const registry = new AgentToolRegistry();
+  // A synchronous (non-async) handler returning a plain value (AC2).
+  registry.register({
+    name: 'echo_sync',
+    class: 'search',
+    description: 'Echo the message back synchronously.',
+    toolset: 'agent',
+    stateless: true,
+    parameters: z.object({ message: z.string() }),
+    // NOTE: not declared async — returns a plain value, not a promise.
+    execute: ((args: Record<string, unknown>) => ({ echoed: args.message })) as never,
+  });
+  // A handler that throws a raw error carrying a secret-looking token (AC3 redaction).
+  registry.register({
+    name: 'boom',
+    class: 'search',
+    description: 'Always throws.',
+    toolset: 'agent',
+    stateless: true,
+    parameters: z.object({}),
+    execute: async () => {
+      throw new Error('exploded with key sk-ABCDEF1234567890SECRET trailing');
+    },
+  });
+  // A slow async handler to exercise the per-call timeout (AC5).
+  registry.register({
+    name: 'slow',
+    class: 'search',
+    description: 'Sleeps.',
+    toolset: 'agent',
+    stateless: true,
+    parameters: z.object({ ms: z.number() }),
+    execute: async (args) =>
+      new Promise((resolve) => setTimeout(() => resolve({ slept: args.ms }), Number(args.ms))),
+  });
+  // An availability-gated tool (AC5 — registry availability).
+  registry.register({
+    name: 'net_only',
+    class: 'net',
+    description: 'Only available with network egress.',
+    toolset: 'web',
+    stateless: true,
+    available: (ctx) => ctx.networkEgressAllowed === true,
+    parameters: z.object({}),
+    execute: async () => ({ ok: true }),
+  });
+  await registry.init(); // also registers the real built-ins (read_file_paged, …)
+  return registry;
+}
+
+/** Build an engine over the registry + an enforce-mode guard scoped to `workspace`. */
+function buildEngine(registry: AgentToolRegistry, budget?: ToolCallBudget): ToolDispatchEngine {
+  const tools = createToolGuard({ allowedRoots: [workspace], mode: 'enforce' });
+  return new ToolDispatchEngine({ registry, tools, ...(budget ? { budget } : {}) });
+}
+
+// ---------------------------------------------------------------------------
+// AC1 + AC2 + AC4 — dispatch a real registered tool
+// ---------------------------------------------------------------------------
+
+describe('ToolDispatchEngine.dispatch — real tool over a temp dir', () => {
+  it('runs read_file_paged through the guard and formats the result for the LLM', async () => {
+    const file = join(workspace, 'note.txt');
+    await writeFile(file, 'line1\nline2\nline3\n', 'utf8');
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+
+    const result = await engine.dispatch({
+      id: 'c1',
+      name: 'read_file_paged',
+      arguments: { path: file, offset: 0, limit: 2 },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected success');
+    expect(result.name).toBe('read_file_paged');
+    // The display is the JSON-rendered paginated result — contains the read lines.
+    expect(result.display).toContain('line1');
+    expect(result.display).toContain('line2');
+    expect(result.display).not.toContain('line3'); // limit honoured
+  });
+
+  it('supports a synchronous (non-async) handler returning a plain value (AC2)', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+    const result = await engine.dispatch({
+      id: 'c2',
+      name: 'echo_sync',
+      arguments: { message: 'hi there' },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected success');
+    expect(result.display).toContain('hi there');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3 — error classification (never throws; typed kinds)
+// ---------------------------------------------------------------------------
+
+describe('ToolDispatchEngine.dispatch — error classification', () => {
+  it('classifies an unknown tool as tool-not-found', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+    const result = await engine.dispatch({ id: 'x', name: 'no_such_tool', arguments: {} });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.kind).toBe('tool-not-found');
+    expect(result.code).toBe('E_TOOL_NOT_FOUND');
+  });
+
+  it('classifies bad arguments as invalid-args with flattened issues', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+    // read_file_paged requires `path: string`; omit it.
+    const result = await engine.dispatch({ id: 'x', name: 'read_file_paged', arguments: {} });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.kind).toBe('invalid-args');
+    expect(result.code).toBe('E_TOOL_INVALID_ARGS');
+    expect(result.issues?.length).toBeGreaterThan(0);
+    expect(result.issues?.[0]?.path).toBe('path');
+  });
+
+  it('classifies an unavailable tool as guard-denied', async () => {
+    const registry = await buildRegistry();
+    // No network egress in the availability context → net_only is hidden.
+    const tools = createToolGuard({ allowedRoots: [workspace], mode: 'enforce' });
+    const engine = new ToolDispatchEngine({
+      registry,
+      tools,
+      availability: { networkEgressAllowed: false },
+    });
+    const result = await engine.dispatch({ id: 'x', name: 'net_only', arguments: {} });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.kind).toBe('guard-denied');
+  });
+
+  it('classifies a thrown executable as execution-error and REDACTS secrets (no leak)', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+    const result = await engine.dispatch({ id: 'x', name: 'boom', arguments: {} });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.kind).toBe('execution-error');
+    expect(result.code).toBe('E_TOOL_EXECUTION_ERROR');
+    // The raw error embedded a key-shaped token — it must be masked.
+    expect(result.message).not.toContain('sk-ABCDEF1234567890SECRET');
+    expect(result.message).toContain('[redacted]');
+  });
+
+  it('denies a guard violation DURING execution (path escape) as execution-error', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry); // guard scoped to `workspace`
+    // read_file_paged a path OUTSIDE the allowed root → the guard throws inside execution.
+    const result = await engine.dispatch({
+      id: 'x',
+      name: 'read_file_paged',
+      arguments: { path: '/etc/hostname' },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.kind).toBe('execution-error');
+    expect(result.message).toMatch(/allowed roots|denied|outside/i);
+  });
+
+  it('never throws — every failure mode is a returned result', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+    await expect(
+      engine.dispatch({ id: 'x', name: 'no_such_tool', arguments: {} }),
+    ).resolves.toBeDefined();
+    await expect(engine.dispatch({ id: 'x', name: 'boom', arguments: {} })).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5 — budget tracking (count + per-call timeout)
+// ---------------------------------------------------------------------------
+
+describe('ToolCallBudget — call-count + timeout caps (AC5)', () => {
+  it('denies a call once the maxCalls ceiling is reached', async () => {
+    const registry = await buildRegistry();
+    const budget = new ToolCallBudget({ maxCalls: 2 });
+    const engine = buildEngine(registry, budget);
+    const call = { id: 'c', name: 'echo_sync', arguments: { message: 'x' } };
+
+    const r1 = await engine.dispatch(call);
+    const r2 = await engine.dispatch(call);
+    const r3 = await engine.dispatch(call);
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    expect(r3.ok).toBe(false);
+    if (r3.ok) throw new Error('expected denial');
+    expect(r3.kind).toBe('guard-denied');
+    expect(r3.message).toMatch(/budget exhausted/i);
+
+    const snap = engine.budgetSnapshot();
+    expect(snap.callsUsed).toBe(2); // the denied 3rd call was NOT charged
+    expect(snap.callsRemaining).toBe(0);
+  });
+
+  it('yields a timeout result when a call exceeds the per-call ceiling', async () => {
+    const registry = await buildRegistry();
+    const budget = new ToolCallBudget({ perCallTimeoutMs: 20 });
+    const engine = buildEngine(registry, budget);
+    const result = await engine.dispatch({ id: 't', name: 'slow', arguments: { ms: 200 } });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected timeout');
+    expect(result.kind).toBe('timeout');
+    expect(result.code).toBe('E_TOOL_TIMEOUT');
+  });
+
+  it('reports remaining headroom in the snapshot', async () => {
+    const registry = await buildRegistry();
+    const budget = new ToolCallBudget({ maxCalls: 5 });
+    const engine = buildEngine(registry, budget);
+    await engine.dispatch({ id: 'c', name: 'echo_sync', arguments: { message: 'x' } });
+    const snap = engine.budgetSnapshot();
+    expect(snap.callsUsed).toBe(1);
+    expect(snap.callsRemaining).toBe(4);
+    expect(snap.timeRemainingMs).toBe(Number.POSITIVE_INFINITY); // no time cap set
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4 — result formatting + AC3 redaction helpers
+// ---------------------------------------------------------------------------
+
+describe('result formatting + redaction helpers', () => {
+  it('formats a string value verbatim and an object as JSON', () => {
+    expect(formatToolValueForLlm('hello')).toBe('hello');
+    expect(formatToolValueForLlm({ a: 1 })).toContain('"a": 1');
+    expect(formatToolValueForLlm(undefined)).toBe('');
+  });
+
+  it('truncates an oversized value with a marker', () => {
+    const big = 'x'.repeat(MAX_TOOL_RESULT_CHARS + 100);
+    const out = formatToolValueForLlm(big);
+    expect(out.length).toBeLessThan(big.length);
+    expect(out).toContain('truncated');
+  });
+
+  it('degrades a circular value instead of throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => formatToolValueForLlm(circular)).not.toThrow();
+  });
+
+  it('projects a success result onto the tool_result payload (AC4)', async () => {
+    const payload = formatToolResultForLlm(
+      { id: 'c1' },
+      { ok: true, name: 'echo_sync', value: { x: 1 }, display: '{"x":1}' },
+    );
+    expect(payload).toEqual({
+      toolCallId: 'c1',
+      toolName: 'echo_sync',
+      content: '{"x":1}',
+      isError: false,
+    });
+  });
+
+  it('projects a failure result onto an error-flagged payload with the code', () => {
+    const payload = formatToolResultForLlm(
+      { id: 'c1' },
+      {
+        ok: false,
+        name: 'read_file_paged',
+        kind: 'invalid-args',
+        code: 'E_TOOL_INVALID_ARGS',
+        message: 'arguments failed validation',
+        issues: [{ path: 'path', message: 'Required' }],
+      },
+    );
+    expect(payload.isError).toBe(true);
+    expect(payload.content).toContain('E_TOOL_INVALID_ARGS');
+    expect(payload.content).toContain('path: Required');
+  });
+
+  it('redactErrorMessage strips secrets, stacks, and non-Error throws', () => {
+    expect(redactErrorMessage(new Error('leak sk-1234567890ABCDEF here'))).toContain('[redacted]');
+    expect(redactErrorMessage(new Error('Bearer abcdefghijkl1234 token'))).toContain(
+      'Bearer [redacted]',
+    );
+    // Only the first line survives (no stack lines).
+    expect(redactErrorMessage(new Error('one\ntwo\nthree'))).toBe('one');
+    expect(redactErrorMessage(42)).toBe('tool execution failed');
+  });
+
+  it('flattenZodIssues produces path + message tuples', () => {
+    const schema = z.object({ path: z.string(), n: z.number() });
+    const parsed = schema.safeParse({ n: 'not-a-number' });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error('expected parse failure');
+    const issues = flattenZodIssues(parsed.error);
+    const paths = issues.map((i) => i.path);
+    expect(paths).toContain('path');
+    expect(paths).toContain('n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Convenience factory parity
+// ---------------------------------------------------------------------------
+
+describe('createAgentToolRegistry parity', () => {
+  it('dispatches against a registry built via the convenience factory', async () => {
+    const file = join(workspace, 'f.txt');
+    await writeFile(file, 'abc\n', 'utf8');
+    const registry = await createAgentToolRegistry();
+    const tools = createToolGuard({ allowedRoots: [workspace], mode: 'enforce' });
+    const engine = new ToolDispatchEngine({ registry, tools });
+    const result = await engine.dispatch({ id: 'c', name: 'read_file', arguments: { path: file } });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/core/src/tools/__tests__/dispatch.test.ts
+++ b/packages/core/src/tools/__tests__/dispatch.test.ts
@@ -270,6 +270,91 @@ describe('ToolCallBudget — call-count + timeout caps (AC5)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Abort handling — signal honoured on EVERY path, incl. the default no-budget
+// production config (regression: the listener used to be wired only inside the
+// timeout-only branch, so an abort was silently ignored when no per-call
+// timeout was set — i.e. always, by default).
+// ---------------------------------------------------------------------------
+
+describe('ToolDispatchEngine.dispatch — abort signal', () => {
+  it('short-circuits a PRE-ABORTED signal with NO budget (default production path)', async () => {
+    const registry = await buildRegistry();
+    // No budget → perCallTimeoutMs is undefined: this is the default path where
+    // the abort was previously ignored entirely.
+    const engine = buildEngine(registry);
+    const controller = new AbortController();
+    controller.abort();
+
+    const startedAt = Date.now();
+    const result = await engine.dispatch(
+      { id: 'a', name: 'slow', arguments: { ms: 200 } },
+      controller.signal,
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected abort failure');
+    // Cancellation classifies as execution-error (the call did not complete).
+    expect(result.kind).toBe('execution-error');
+    expect(result.message).toMatch(/aborted/i);
+    // It must NOT have waited the full 200ms sleep — the abort short-circuited.
+    expect(elapsed).toBeLessThan(150);
+  });
+
+  it('honours an IN-FLIGHT abort with NO per-call timeout configured', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry); // no budget → no per-call timeout
+    const controller = new AbortController();
+    // Fire the abort shortly after dispatch starts, while `slow` is still sleeping.
+    setTimeout(() => controller.abort(), 20);
+
+    const startedAt = Date.now();
+    const result = await engine.dispatch(
+      { id: 'a', name: 'slow', arguments: { ms: 500 } },
+      controller.signal,
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected abort failure');
+    expect(result.kind).toBe('execution-error');
+    expect(result.message).toMatch(/aborted/i);
+    expect(elapsed).toBeLessThan(450); // returned well before the 500ms sleep
+  });
+
+  it('still completes normally when the signal is never aborted (no regression on the fast path)', async () => {
+    const registry = await buildRegistry();
+    const engine = buildEngine(registry);
+    const controller = new AbortController(); // never aborted
+    const result = await engine.dispatch(
+      { id: 'a', name: 'echo_sync', arguments: { message: 'ok' } },
+      controller.signal,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected success');
+    expect(result.display).toContain('ok');
+  });
+
+  it('honours an abort even WITH a per-call timeout set (abort wins the race as execution-error)', async () => {
+    const registry = await buildRegistry();
+    const budget = new ToolCallBudget({ perCallTimeoutMs: 10_000 }); // long enough not to fire
+    const engine = buildEngine(registry, budget);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+
+    const result = await engine.dispatch(
+      { id: 'a', name: 'slow', arguments: { ms: 500 } },
+      controller.signal,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected abort failure');
+    // Abort, not timeout — the call was cancelled, not slow.
+    expect(result.kind).toBe('execution-error');
+    expect(result.message).toMatch(/aborted/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC4 — result formatting + AC3 redaction helpers
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/tools/dispatch.ts
+++ b/packages/core/src/tools/dispatch.ts
@@ -1,0 +1,659 @@
+/**
+ * Agent tool-call dispatch engine (T1740 · epic T11456 · SG-TOOLS).
+ *
+ * The SINGLE chokepoint that turns a model-emitted tool-call `{ name, args }`
+ * into an executed, LLM-safe result. It is the SDK-side dispatch path the T1738
+ * architecture (D11141) names: **core DISPATCHES, cleo-os DRIVES**. Given a tool
+ * call from the agent loop, it:
+ *
+ *  1. **Looks up** the tool in the injected {@link AgentToolRegistry} (the
+ *     name→descriptor catalog). An unknown name is a typed
+ *     `tool-not-found` result — never a throw.
+ *  2. **Validates** the model-supplied arguments against the tool's Zod schema
+ *     (defense in depth: the wire layer advertised the JSON-schema, but the
+ *     model's emitted args are re-validated here before any side effect). A
+ *     schema failure is a typed `invalid-args` result carrying the FLATTENED
+ *     issue list — not the raw Zod error (no internals leak).
+ *  3. **Checks availability** for the current {@link ToolAvailabilityContext}
+ *     (network egress, binaries on PATH, capability flags). An unavailable tool
+ *     is a typed `guard-denied` result — the model is told the tool is not
+ *     offered right now, with no precondition internals.
+ *  4. **Charges the budget** ({@link ToolCallBudget}) — per-call count / wall-time
+ *     ceilings. An exhausted budget short-circuits with a typed `guard-denied`
+ *     result BEFORE the tool runs; a per-call timeout races the execution and
+ *     yields a typed `timeout` result.
+ *  5. **Executes** the bound {@link AgentToolExecutable} over the injected
+ *     {@link GuardedToolSurface} — the deny-first chokepoint
+ *     ({@link ./guard.js}). Every fs/shell side effect therefore still funnels
+ *     through the guard's path allowlist + command denylist + env scrub; there
+ *     is NO raw-primitive bypass.
+ *  6. **Formats** the outcome for LLM consumption ({@link formatToolResultForLlm})
+ *     — a `tool_result`-shaped payload the Pi loop feeds back to the model. On
+ *     ANY error the message is a redacted, classified summary; a raw secret,
+ *     stack trace, or guard internal NEVER reaches the model-facing string.
+ *
+ * ## Sync + async handlers (AC2)
+ *
+ * A registered {@link AgentToolExecutable} returns a `Promise<unknown>`, but a
+ * synchronous handler that returns a plain value is equally supported: the
+ * engine `await`s the call so a non-thenable return is normalized to a resolved
+ * value, and a synchronous throw is caught the same as a rejected promise.
+ *
+ * ## Why it lives in `core/src/tools` (Gate-11)
+ *
+ * The dispatch engine is a CORE-SDK concern, built entirely against the frozen
+ * {@link AgentToolRegistry} + {@link GuardedToolSurface} contracts. It defines
+ * NO new atomic tool primitive (Gate-11 Tools-vs-Skills boundary) and makes NO
+ * LLM call (Gate-13): result-formatting is pure serialization. The harness
+ * (`cleo-os`) and the in-process Pi adapter merely SUPPLY the registry, the
+ * guard, and the workspace context, then read the {@link ToolDispatchResult}.
+ *
+ * @task T1740
+ * @epic T11456
+ * @see ./agent-registry.js — the name→descriptor catalog + availability checks
+ * @see ./guard.js — the deny-first surface every executable routes side effects through
+ * @see ../llm/pi/pi-tool-bridge.js — the AC6 consumer wiring this into the Pi loop
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import type { z } from 'zod';
+import { getLogger } from '../logger.js';
+import type {
+  AgentToolDescriptor,
+  AgentToolRegistry,
+  ToolAvailabilityContext,
+} from './agent-registry.js';
+import { ALWAYS_AVAILABLE } from './agent-registry.js';
+
+const log = getLogger('tool-dispatch');
+
+// ---------------------------------------------------------------------------
+// Error classification (AC3)
+// ---------------------------------------------------------------------------
+
+/**
+ * The typed failure classes a dispatch can produce (AC3). Each maps a distinct
+ * failure mode to a stable, model-safe category so the loop (and any UI) can
+ * branch on the KIND without parsing a free-text message:
+ *
+ *  - `tool-not-found` — the model named a tool not in the registry.
+ *  - `invalid-args`   — arguments failed the tool's Zod schema.
+ *  - `guard-denied`   — the tool is unavailable for this context, or the
+ *                       per-call budget was exhausted before it ran.
+ *  - `execution-error`— the tool ran but threw (incl. a `GuardDeniedError`
+ *                       from the deny-first surface during the side effect).
+ *  - `timeout`        — the tool exceeded the per-call wall-time ceiling.
+ */
+export type ToolDispatchErrorKind =
+  | 'tool-not-found'
+  | 'invalid-args'
+  | 'guard-denied'
+  | 'execution-error'
+  | 'timeout';
+
+/**
+ * Stable machine-readable error codes, one per {@link ToolDispatchErrorKind}.
+ * Surfaced on the failure envelope so a programmatic caller never string-matches
+ * the human message.
+ */
+export const TOOL_DISPATCH_ERROR_CODE: Readonly<Record<ToolDispatchErrorKind, string>> = {
+  'tool-not-found': 'E_TOOL_NOT_FOUND',
+  'invalid-args': 'E_TOOL_INVALID_ARGS',
+  'guard-denied': 'E_TOOL_GUARD_DENIED',
+  'execution-error': 'E_TOOL_EXECUTION_ERROR',
+  timeout: 'E_TOOL_TIMEOUT',
+};
+
+// ---------------------------------------------------------------------------
+// Dispatch I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * A single tool call as the model emits it — the dispatch engine's input. The
+ * `name` is the model-visible tool name; `arguments` is the JSON-parsed argument
+ * object (the engine never sees the raw JSON string — parsing is the loop's job,
+ * the engine validates the parsed shape).
+ */
+export interface ToolCall {
+  /** Stable id correlating the call to its `tool_result` (loop-supplied). */
+  readonly id: string;
+  /** Model-visible tool name to dispatch. */
+  readonly name: string;
+  /** JSON-parsed argument object the model supplied. */
+  readonly arguments: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * The successful outcome of a dispatch (AC4). `value` is the tool's raw return
+ * (opaque to the engine); `display` is the LLM-facing string the loop feeds back
+ * in the `tool_result` message.
+ */
+export interface ToolDispatchSuccess {
+  /** Discriminant. */
+  readonly ok: true;
+  /** The dispatched tool's name (echoed for correlation). */
+  readonly name: string;
+  /** The raw tool return value (for structured logging / details). */
+  readonly value: unknown;
+  /** The LLM-facing rendering of `value` (the `tool_result` body). */
+  readonly display: string;
+}
+
+/**
+ * The failed outcome of a dispatch (AC3 + AC4). Carries the typed
+ * {@link ToolDispatchErrorKind}, a stable code, and a REDACTED, model-safe
+ * `message` — a raw secret / stack / guard internal is never placed here.
+ */
+export interface ToolDispatchFailure {
+  /** Discriminant. */
+  readonly ok: false;
+  /** The dispatched tool's name (echoed for correlation). */
+  readonly name: string;
+  /** The typed failure class (AC3). */
+  readonly kind: ToolDispatchErrorKind;
+  /** Stable machine-readable code ({@link TOOL_DISPATCH_ERROR_CODE}). */
+  readonly code: string;
+  /** Redacted, model-safe failure summary (the `tool_result` body). */
+  readonly message: string;
+  /**
+   * For `invalid-args`, the flattened schema issues (path + reason) — safe to
+   * show the model so it can correct its call. Absent for other kinds.
+   */
+  readonly issues?: readonly ToolArgIssue[];
+}
+
+/** A flattened Zod issue: the field path and the human-readable reason. */
+export interface ToolArgIssue {
+  /** Dotted field path, e.g. `path` or `args.0`. Empty for a root issue. */
+  readonly path: string;
+  /** Human-readable validation reason. */
+  readonly message: string;
+}
+
+/** The terminal result of a single dispatch — success or a classified failure. */
+export type ToolDispatchResult = ToolDispatchSuccess | ToolDispatchFailure;
+
+// ---------------------------------------------------------------------------
+// Budget tracking (AC5)
+// ---------------------------------------------------------------------------
+
+/** Caps for {@link ToolCallBudget}. A cap of `undefined` means "unbounded". */
+export interface ToolBudgetLimits {
+  /** Max number of tool calls this budget admits. */
+  readonly maxCalls?: number;
+  /** Per-call wall-time ceiling in milliseconds (a slower call → `timeout`). */
+  readonly perCallTimeoutMs?: number;
+  /** Cumulative wall-time ceiling across all calls in milliseconds. */
+  readonly totalTimeBudgetMs?: number;
+}
+
+/**
+ * A snapshot of a {@link ToolCallBudget}'s consumption — surfaced so a consumer
+ * (the Pi loop / a UI) can report remaining headroom (AC5).
+ */
+export interface ToolBudgetSnapshot {
+  /** Calls charged so far. */
+  readonly callsUsed: number;
+  /** Calls remaining (`Infinity` when uncapped). */
+  readonly callsRemaining: number;
+  /** Cumulative wall-time charged so far, in ms. */
+  readonly timeUsedMs: number;
+  /** Cumulative wall-time remaining, in ms (`Infinity` when uncapped). */
+  readonly timeRemainingMs: number;
+}
+
+/**
+ * Per-run tool-call budget (AC5). Tracks call count + cumulative wall-time
+ * against the configured {@link ToolBudgetLimits}. The engine consults
+ * {@link admit} BEFORE running a tool (rejecting once a ceiling is hit) and
+ * {@link charge}s the elapsed time AFTER. A single budget instance is threaded
+ * across all calls of one run, so the count/time caps are run-scoped.
+ */
+export class ToolCallBudget {
+  readonly #limits: ToolBudgetLimits;
+  #callsUsed = 0;
+  #timeUsedMs = 0;
+
+  /**
+   * @param limits - The ceilings this budget enforces (each optional → uncapped).
+   */
+  constructor(limits: ToolBudgetLimits = {}) {
+    this.#limits = limits;
+  }
+
+  /** The per-call timeout ceiling in ms, or `undefined` when uncapped. */
+  get perCallTimeoutMs(): number | undefined {
+    return this.#limits.perCallTimeoutMs;
+  }
+
+  /**
+   * Whether another call is admitted right now. Returns a typed denial reason
+   * (or `null` when admitted) so the engine can map it onto the precise
+   * `guard-denied` message WITHOUT exposing the limit internals to the model.
+   *
+   * @returns `null` when a call is admitted; otherwise the human-readable reason.
+   */
+  admit(): string | null {
+    if (this.#limits.maxCalls !== undefined && this.#callsUsed >= this.#limits.maxCalls) {
+      return `tool-call budget exhausted (max ${this.#limits.maxCalls} calls)`;
+    }
+    if (
+      this.#limits.totalTimeBudgetMs !== undefined &&
+      this.#timeUsedMs >= this.#limits.totalTimeBudgetMs
+    ) {
+      return `tool-call time budget exhausted (max ${this.#limits.totalTimeBudgetMs}ms)`;
+    }
+    return null;
+  }
+
+  /**
+   * Charge one completed call against the budget.
+   *
+   * @param elapsedMs - The call's measured wall-time in milliseconds.
+   */
+  charge(elapsedMs: number): void {
+    this.#callsUsed += 1;
+    this.#timeUsedMs += Math.max(0, elapsedMs);
+  }
+
+  /** A read-only snapshot of current consumption (AC5). */
+  snapshot(): ToolBudgetSnapshot {
+    const callsRemaining =
+      this.#limits.maxCalls === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, this.#limits.maxCalls - this.#callsUsed);
+    const timeRemainingMs =
+      this.#limits.totalTimeBudgetMs === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, this.#limits.totalTimeBudgetMs - this.#timeUsedMs);
+    return {
+      callsUsed: this.#callsUsed,
+      callsRemaining,
+      timeUsedMs: this.#timeUsedMs,
+      timeRemainingMs,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/** Maximum length of a formatted `tool_result` body before truncation (AC4). */
+export const MAX_TOOL_RESULT_CHARS = 16_000;
+
+/**
+ * Construction dependencies for {@link ToolDispatchEngine}.
+ */
+export interface ToolDispatchEngineDeps {
+  /** The frozen tool catalog the engine dispatches against (name→descriptor). */
+  readonly registry: AgentToolRegistry;
+  /**
+   * The deny-first guarded surface every executable performs side effects
+   * through. Injected — the engine never constructs a guard (Gate-11).
+   */
+  readonly tools: GuardedToolSurface;
+  /**
+   * Availability context (AC5 of the registry): a tool whose
+   * {@link AgentToolDescriptor.available} predicate is false for this context is
+   * `guard-denied` before it runs. Defaults to `{}` (everything available).
+   */
+  readonly availability?: ToolAvailabilityContext;
+  /**
+   * Optional run-scoped budget (AC5). When omitted an unbounded budget is used,
+   * so a call count / time ceiling is opt-in. Threaded across all
+   * {@link ToolDispatchEngine.dispatch} calls of one run.
+   */
+  readonly budget?: ToolCallBudget;
+}
+
+/**
+ * The agent tool-call dispatch engine (AC1).
+ *
+ * One instance per agent run: it holds the frozen registry, the guarded surface,
+ * the availability context, and the run-scoped budget, and dispatches each
+ * model-emitted {@link ToolCall} to a classified {@link ToolDispatchResult}.
+ * {@link dispatch} NEVER throws — every failure mode is encoded as a typed
+ * {@link ToolDispatchFailure} (AC3), so the agent loop can always feed a
+ * `tool_result` back and continue.
+ *
+ * @example
+ * ```ts
+ * const registry = await createAgentToolRegistry();
+ * const tools = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+ * const engine = new ToolDispatchEngine({
+ *   registry,
+ *   tools,
+ *   budget: new ToolCallBudget({ maxCalls: 50, perCallTimeoutMs: 30_000 }),
+ * });
+ * const result = await engine.dispatch({ id: 'c1', name: 'read_file_paged', arguments: { path } });
+ * // result.ok ? feed result.display : feed the classified result.message
+ * ```
+ */
+export class ToolDispatchEngine {
+  readonly #registry: AgentToolRegistry;
+  readonly #tools: GuardedToolSurface;
+  readonly #availability: ToolAvailabilityContext;
+  readonly #budget: ToolCallBudget;
+
+  /**
+   * @param deps - The registry, guarded surface, availability context, and
+   *   optional run-scoped budget.
+   */
+  constructor(deps: ToolDispatchEngineDeps) {
+    this.#registry = deps.registry;
+    this.#tools = deps.tools;
+    this.#availability = deps.availability ?? {};
+    this.#budget = deps.budget ?? new ToolCallBudget();
+  }
+
+  /** A read-only snapshot of the run's budget consumption (AC5). */
+  budgetSnapshot(): ToolBudgetSnapshot {
+    return this.#budget.snapshot();
+  }
+
+  /**
+   * Dispatch a single model-emitted tool call to a classified result (AC1–AC5).
+   *
+   * The full pipeline — lookup → validate → availability → budget admit →
+   * (timed) execute → charge → format — runs here. It NEVER throws: a thrown
+   * executable (incl. a deny-first `GuardDeniedError` during the side effect)
+   * becomes an `execution-error`, a slow executable a `timeout`, an unknown name
+   * a `tool-not-found`, bad args an `invalid-args`, and an unavailable tool /
+   * exhausted budget a `guard-denied`. A `signal` (when supplied) aborts the
+   * underlying call cooperatively.
+   *
+   * @param call - The model-emitted tool call (`{ id, name, arguments }`).
+   * @param signal - Optional abort signal threaded into the per-call race.
+   * @returns The terminal {@link ToolDispatchResult}.
+   */
+  async dispatch(call: ToolCall, signal?: AbortSignal): Promise<ToolDispatchResult> {
+    // 1. Lookup (AC1).
+    const descriptor = this.#registry.get(call.name);
+    if (!descriptor) {
+      return this.#fail(call.name, 'tool-not-found', `unknown tool "${call.name}"`);
+    }
+
+    // 2. Validate arguments against the tool's Zod schema (AC3 — defense in depth).
+    const parsed = descriptor.parameters.safeParse(call.arguments);
+    if (!parsed.success) {
+      const issues = flattenZodIssues(parsed.error);
+      return this.#fail(
+        call.name,
+        'invalid-args',
+        `arguments for "${call.name}" failed validation`,
+        issues,
+      );
+    }
+
+    // 3. Availability check (AC5 — registry availability predicates).
+    const available = (descriptor.available ?? ALWAYS_AVAILABLE)(this.#availability);
+    if (!available) {
+      return this.#fail(
+        call.name,
+        'guard-denied',
+        `tool "${call.name}" is not available in the current context`,
+      );
+    }
+
+    // 4. Budget admit (AC5 — count/time ceilings BEFORE running).
+    const denial = this.#budget.admit();
+    if (denial !== null) {
+      return this.#fail(call.name, 'guard-denied', denial);
+    }
+
+    // 5. Timed execution through the guarded surface (AC2 sync/async + AC5 timeout).
+    // `parsed.data` is the schema-validated argument object; a tool's `parameters`
+    // is always a Zod object schema, so the validated value is a record. Coerce to
+    // the executable's input shape (the generic `z.ZodType` infers `unknown`).
+    const validatedArgs: Readonly<Record<string, unknown>> = isRecord(parsed.data)
+      ? parsed.data
+      : {};
+    const startedAt = Date.now();
+    try {
+      const value = await this.#runWithTimeout(descriptor, validatedArgs, signal);
+      this.#budget.charge(Date.now() - startedAt);
+      // 6. Format the success for LLM consumption (AC4).
+      return { ok: true, name: call.name, value, display: formatToolValueForLlm(value) };
+    } catch (err) {
+      // Charge the elapsed time even on failure so a long-running failed call
+      // still counts against the time budget (AC5).
+      this.#budget.charge(Date.now() - startedAt);
+      if (err instanceof ToolTimeoutError) {
+        return this.#fail(call.name, 'timeout', err.message);
+      }
+      // Any thrown executable error (incl. a deny-first GuardDeniedError raised
+      // DURING the side effect) is an execution-error. The message is REDACTED
+      // (AC3) — no raw secret/stack reaches the model-facing result.
+      const redacted = redactErrorMessage(err);
+      log.debug({ tool: call.name, kind: 'execution-error' }, 'tool dispatch execution failed');
+      return this.#fail(call.name, 'execution-error', redacted);
+    }
+  }
+
+  /**
+   * Run the executable, racing it against the per-call timeout when one is set.
+   *
+   * Both a synchronous return value and a `Promise` are handled: `await`ing a
+   * non-thenable normalizes it to a resolved value, and a synchronous throw is
+   * caught by {@link dispatch}'s surrounding `try` exactly like a rejection
+   * (AC2). The timeout rejects with a {@link ToolTimeoutError} the caller maps
+   * to a `timeout` result.
+   */
+  async #runWithTimeout(
+    descriptor: AgentToolDescriptor,
+    args: Readonly<Record<string, unknown>>,
+    signal: AbortSignal | undefined,
+  ): Promise<unknown> {
+    const timeoutMs = this.#budget.perCallTimeoutMs;
+    // `Promise.resolve(...)` normalizes a synchronous (non-thenable) return into
+    // a resolved promise; a synchronous throw inside `execute` rejects it.
+    const run = Promise.resolve(descriptor.execute(args, this.#tools));
+    if (timeoutMs === undefined) return run;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new ToolTimeoutError(
+              `tool "${descriptor.name}" exceeded the per-call timeout of ${timeoutMs}ms`,
+            ),
+          ),
+        timeoutMs,
+      );
+      // Abort short-circuits the race the same as a timeout would — but as an
+      // execution-error (the call was cancelled, not slow). A pre-aborted signal
+      // rejects immediately.
+      if (signal) {
+        if (signal.aborted) {
+          reject(new Error('tool call aborted'));
+        } else {
+          signal.addEventListener('abort', () => reject(new Error('tool call aborted')), {
+            once: true,
+          });
+        }
+      }
+    });
+    try {
+      return await Promise.race([run, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Build a classified {@link ToolDispatchFailure}. */
+  #fail(
+    name: string,
+    kind: ToolDispatchErrorKind,
+    message: string,
+    issues?: readonly ToolArgIssue[],
+  ): ToolDispatchFailure {
+    return {
+      ok: false,
+      name,
+      kind,
+      code: TOOL_DISPATCH_ERROR_CODE[kind],
+      message,
+      ...(issues !== undefined ? { issues } : {}),
+    };
+  }
+}
+
+/** Thrown internally when a tool call exceeds its per-call timeout (AC5). */
+export class ToolTimeoutError extends Error {
+  /** Machine-readable code. */
+  readonly code = 'E_TOOL_TIMEOUT';
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolTimeoutError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result formatting (AC4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a tool's raw return value into the LLM-facing `tool_result` body (AC4).
+ *
+ * A string passes through; everything else is JSON-serialized (pretty, stable).
+ * A circular / non-serializable value degrades to its `String(...)` form rather
+ * than throwing. The result is hard-capped at {@link MAX_TOOL_RESULT_CHARS} with
+ * a truncation marker so one tool call cannot blow the model's context window.
+ *
+ * @param value - The raw tool return.
+ * @returns The model-safe `tool_result` string.
+ */
+export function formatToolValueForLlm(value: unknown): string {
+  let rendered: string;
+  if (typeof value === 'string') {
+    rendered = value;
+  } else if (value === undefined) {
+    rendered = '';
+  } else {
+    try {
+      rendered = JSON.stringify(value, null, 2) ?? String(value);
+    } catch {
+      // Circular / BigInt / non-serializable — degrade rather than throw.
+      rendered = String(value);
+    }
+  }
+  return truncateForLlm(rendered);
+}
+
+/**
+ * Project a terminal {@link ToolDispatchResult} onto the `tool_result` message
+ * shape the agent loop feeds back to the model (AC4).
+ *
+ * The `content` is `result.display` on success or the redacted, classified
+ * `result.message` on failure (with the flattened arg issues appended when
+ * present). `isError` lets the loop / transport mark the turn so the model knows
+ * the call did not succeed.
+ *
+ * @param result - The dispatch outcome.
+ * @returns A `{ toolCallId, toolName, content, isError }` envelope.
+ */
+export function formatToolResultForLlm(
+  call: Pick<ToolCall, 'id'>,
+  result: ToolDispatchResult,
+): ToolResultPayload {
+  if (result.ok) {
+    return { toolCallId: call.id, toolName: result.name, content: result.display, isError: false };
+  }
+  const issuesText =
+    result.issues && result.issues.length > 0
+      ? `\n${result.issues.map((i) => `- ${i.path ? `${i.path}: ` : ''}${i.message}`).join('\n')}`
+      : '';
+  return {
+    toolCallId: call.id,
+    toolName: result.name,
+    content: `[${result.code}] ${result.message}${issuesText}`,
+    isError: true,
+  };
+}
+
+/**
+ * The LLM-facing `tool_result` payload shape (AC4) — the minimal subset the loop
+ * needs to build a provider `tool_result` / `toolResult` message. Structurally a
+ * subset of `pi-ai`'s `ToolResultMessage`, so the Pi bridge maps it 1:1.
+ */
+export interface ToolResultPayload {
+  /** Correlates back to the originating {@link ToolCall.id}. */
+  readonly toolCallId: string;
+  /** The tool's name (echoed for the provider message). */
+  readonly toolName: string;
+  /** The model-facing result body (display on success, redacted summary on error). */
+  readonly content: string;
+  /** Whether the turn is an error result. */
+  readonly isError: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Redaction + helpers
+// ---------------------------------------------------------------------------
+
+/** Truncate a rendered result to {@link MAX_TOOL_RESULT_CHARS} with a marker. */
+function truncateForLlm(text: string): string {
+  if (text.length <= MAX_TOOL_RESULT_CHARS) return text;
+  const head = text.slice(0, MAX_TOOL_RESULT_CHARS);
+  const omitted = text.length - MAX_TOOL_RESULT_CHARS;
+  return `${head}\n…[truncated ${omitted} chars]`;
+}
+
+/**
+ * Produce a REDACTED, model-safe message from a thrown executable error (AC3).
+ *
+ * Only the error's single-line `message` is kept — never the stack trace (which
+ * can leak absolute paths / internal module structure) and never an attached
+ * `cause`. The message itself is scrubbed for obvious secret-looking tokens so a
+ * tool that interpolates a credential into its error string cannot leak it to
+ * the model. A non-`Error` throw degrades to a fixed, generic summary.
+ *
+ * @param err - The thrown value.
+ * @returns A single-line, secret-scrubbed message safe for the model.
+ */
+export function redactErrorMessage(err: unknown): string {
+  const raw =
+    err instanceof Error ? err.message : typeof err === 'string' ? err : 'tool execution failed';
+  // Keep a single line (drop any embedded newlines/stack-like content) and cap
+  // the length so a runaway message cannot dominate the context window.
+  const firstLine = raw.split('\n', 1)[0] ?? 'tool execution failed';
+  return scrubSecrets(firstLine).slice(0, 500);
+}
+
+/**
+ * Best-effort secret scrub for a model-facing string. Masks the high-signal
+ * secret shapes (provider key prefixes, bearer tokens, long base64-ish blobs)
+ * so a leaked credential cannot reach the LLM-facing result. This is a
+ * defense-in-depth net on TOP of the architecture's rule that no plaintext key
+ * is ever in scope here — not a substitute for it.
+ *
+ * @param text - The candidate message.
+ * @returns The message with secret-looking tokens masked.
+ */
+function scrubSecrets(text: string): string {
+  return text
+    .replace(/\b(sk|pk|rk|ghp|gho|ghs|xoxb|xoxp|AKIA)[-_a-zA-Z0-9]{12,}\b/g, '[redacted]')
+    .replace(/\bBearer\s+[A-Za-z0-9._-]{12,}\b/gi, 'Bearer [redacted]')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '[redacted-jwt]');
+}
+
+/**
+ * Flatten a {@link z.ZodError} into the minimal, model-safe
+ * {@link ToolArgIssue}[] — path + reason only, no raw Zod internals.
+ *
+ * @param error - The Zod validation error.
+ * @returns The flattened issues.
+ */
+export function flattenZodIssues(error: z.ZodError): readonly ToolArgIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.map(String).join('.'),
+    message: issue.message,
+  }));
+}
+
+/** Narrow an unknown to a plain (non-array) record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/tools/dispatch.ts
+++ b/packages/core/src/tools/dispatch.ts
@@ -81,7 +81,9 @@ const log = getLogger('tool-dispatch');
  *  - `guard-denied`   — the tool is unavailable for this context, or the
  *                       per-call budget was exhausted before it ran.
  *  - `execution-error`— the tool ran but threw (incl. a `GuardDeniedError`
- *                       from the deny-first surface during the side effect).
+ *                       from the deny-first surface during the side effect), OR
+ *                       the call was cancelled via its abort signal before it
+ *                       completed (the run was cancelled out from under it).
  *  - `timeout`        — the tool exceeded the per-call wall-time ceiling.
  */
 export type ToolDispatchErrorKind =
@@ -358,13 +360,27 @@ export class ToolDispatchEngine {
    * The full pipeline — lookup → validate → availability → budget admit →
    * (timed) execute → charge → format — runs here. It NEVER throws: a thrown
    * executable (incl. a deny-first `GuardDeniedError` during the side effect)
-   * becomes an `execution-error`, a slow executable a `timeout`, an unknown name
-   * a `tool-not-found`, bad args an `invalid-args`, and an unavailable tool /
-   * exhausted budget a `guard-denied`. A `signal` (when supplied) aborts the
-   * underlying call cooperatively.
+   * becomes an `execution-error`, a slow executable a `timeout`, a cancelled call
+   * an `execution-error`, an unknown name a `tool-not-found`, bad args an
+   * `invalid-args`, and an unavailable tool / exhausted budget a `guard-denied`.
+   *
+   * ## Abort handling (honest contract)
+   *
+   * A `signal` (when supplied) is honoured REGARDLESS of whether a per-call
+   * timeout is configured — including the default no-budget production path: an
+   * already-aborted signal short-circuits before the executable is awaited, and
+   * an abort RACED in flight rejects with an `execution-error`. BUT this is
+   * abandon-the-promise cancellation, NOT preemptive kill: the frozen
+   * {@link AgentToolExecutable}/{@link GuardedToolSurface} contracts expose no
+   * signal channel, so a tool that already spawned an OS process keeps that
+   * process running until the tool's own internal bound fires. The engine
+   * returns promptly; the side effect may still be settling. See
+   * {@link ToolDispatchEngine.#runWithTimeout} for the full rationale.
    *
    * @param call - The model-emitted tool call (`{ id, name, arguments }`).
-   * @param signal - Optional abort signal threaded into the per-call race.
+   * @param signal - Optional abort signal honoured on every path (timeout or
+   *   not); aborting yields an `execution-error` but cannot preemptively kill an
+   *   in-flight OS process (frozen-contract limitation).
    * @returns The terminal {@link ToolDispatchResult}.
    */
   async dispatch(call: ToolCall, signal?: AbortSignal): Promise<ToolDispatchResult> {
@@ -422,6 +438,12 @@ export class ToolDispatchEngine {
       if (err instanceof ToolTimeoutError) {
         return this.#fail(call.name, 'timeout', err.message);
       }
+      if (err instanceof ToolAbortError) {
+        // Cancellation is an execution-error (the call did not complete). The
+        // engine-authored abort message carries no secret, so it is safe verbatim.
+        log.debug({ tool: call.name, kind: 'execution-error' }, 'tool dispatch aborted');
+        return this.#fail(call.name, 'execution-error', err.message);
+      }
       // Any thrown executable error (incl. a deny-first GuardDeniedError raised
       // DURING the side effect) is an execution-error. The message is REDACTED
       // (AC3) — no raw secret/stack reaches the model-facing result.
@@ -432,13 +454,38 @@ export class ToolDispatchEngine {
   }
 
   /**
-   * Run the executable, racing it against the per-call timeout when one is set.
+   * Run the executable, racing it against the per-call timeout AND the abort
+   * signal whenever EITHER is present.
    *
    * Both a synchronous return value and a `Promise` are handled: `await`ing a
    * non-thenable normalizes it to a resolved value, and a synchronous throw is
    * caught by {@link dispatch}'s surrounding `try` exactly like a rejection
    * (AC2). The timeout rejects with a {@link ToolTimeoutError} the caller maps
-   * to a `timeout` result.
+   * to a `timeout` result; an abort rejects with a {@link ToolAbortError} the
+   * caller maps to an `execution-error` (the call was cancelled, not slow).
+   *
+   * ## Fast path
+   *
+   * When NO timeout is configured AND no `signal` is supplied there is nothing
+   * to race, so the executable promise is returned directly — the engine adds no
+   * overhead to the common bounded-by-the-loop case.
+   *
+   * ## Cancellation is cooperative-or-abandon, NOT preemptive
+   *
+   * Winning the race (timeout or abort) only ABANDONS the executable promise —
+   * it does NOT cancel the running tool. The frozen {@link AgentToolExecutable}
+   * signature (`(args, tools) => Promise<unknown>`) and the frozen
+   * {@link GuardedToolSurface} (whose `executeShell`/`executePty`/`runGit` carry
+   * no `AbortSignal` parameter) expose NO cancellation channel, so a tool that
+   * spawned a real OS process keeps that process running in the background until
+   * the tool's OWN internal bound (its per-call `timeoutMs`, when the model
+   * supplied one) fires. The engine therefore returns a `timeout`/`execution-error`
+   * result to the model PROMPTLY while the underlying side effect may still be
+   * settling. This is the honest contract: the dispatch-level cap bounds how long
+   * the LOOP waits, not how long the OS process lives. Wiring a real signal
+   * through to the surface requires evolving the frozen registry +
+   * `GuardedToolSurface` contracts (out of T1740's scope — tracked for the
+   * contract owner of #1013).
    */
   async #runWithTimeout(
     descriptor: AgentToolDescriptor,
@@ -449,36 +496,45 @@ export class ToolDispatchEngine {
     // `Promise.resolve(...)` normalizes a synchronous (non-thenable) return into
     // a resolved promise; a synchronous throw inside `execute` rejects it.
     const run = Promise.resolve(descriptor.execute(args, this.#tools));
-    if (timeoutMs === undefined) return run;
+    // Fast path: nothing to race against → return the executable directly.
+    if (timeoutMs === undefined && signal === undefined) return run;
+
+    // A pre-aborted signal short-circuits BEFORE awaiting the run — the abort was
+    // already requested, so the engine must not wait for (nor charge a full
+    // timeout for) the in-flight call. This is the default-production path the
+    // no-budget config exercises: the signal is honoured even with no timeout.
+    if (signal?.aborted) {
+      throw new ToolAbortError(`tool "${descriptor.name}" call aborted`);
+    }
 
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(
-        () =>
-          reject(
-            new ToolTimeoutError(
-              `tool "${descriptor.name}" exceeded the per-call timeout of ${timeoutMs}ms`,
+    let onAbort: (() => void) | undefined;
+    const interrupt = new Promise<never>((_resolve, reject) => {
+      // Wire the per-call timeout only when one is configured.
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(
+          () =>
+            reject(
+              new ToolTimeoutError(
+                `tool "${descriptor.name}" exceeded the per-call timeout of ${timeoutMs}ms`,
+              ),
             ),
-          ),
-        timeoutMs,
-      );
-      // Abort short-circuits the race the same as a timeout would — but as an
-      // execution-error (the call was cancelled, not slow). A pre-aborted signal
-      // rejects immediately.
+          timeoutMs,
+        );
+      }
+      // Wire the abort listener whenever a (not-yet-aborted) signal is present —
+      // independent of whether a timeout is set, so the default no-budget path
+      // still honours containment-managed cancellation.
       if (signal) {
-        if (signal.aborted) {
-          reject(new Error('tool call aborted'));
-        } else {
-          signal.addEventListener('abort', () => reject(new Error('tool call aborted')), {
-            once: true,
-          });
-        }
+        onAbort = () => reject(new ToolAbortError(`tool "${descriptor.name}" call aborted`));
+        signal.addEventListener('abort', onAbort, { once: true });
       }
     });
     try {
-      return await Promise.race([run, timeout]);
+      return await Promise.race([run, interrupt]);
     } finally {
       if (timer) clearTimeout(timer);
+      if (signal && onAbort) signal.removeEventListener('abort', onAbort);
     }
   }
 
@@ -507,6 +563,27 @@ export class ToolTimeoutError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'ToolTimeoutError';
+  }
+}
+
+/**
+ * Thrown internally when a tool call is cancelled via its {@link AbortSignal}
+ * (containment-managed run cancel / OOM-guard / budget kill). Distinct from
+ * {@link ToolTimeoutError}: a timeout means "the call was too slow", an abort
+ * means "the run was cancelled out from under the call". The engine maps it to a
+ * typed `execution-error` result (the call did not complete).
+ *
+ * @remarks Winning the abort race only ABANDONS the executable promise — it does
+ *   NOT preemptively kill a tool that already spawned an OS process, because the
+ *   frozen {@link AgentToolExecutable}/{@link GuardedToolSurface} contracts carry
+ *   no signal channel (see {@link ToolDispatchEngine.dispatch}).
+ */
+export class ToolAbortError extends Error {
+  /** Machine-readable code. */
+  readonly code = 'E_TOOL_ABORTED';
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolAbortError';
   }
 }
 

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -126,6 +126,33 @@ export {
   type PlaywrightLoader,
 } from './browser-driver.js';
 export { registerBuiltinAgentTools } from './builtin-agent-tools.js';
+// Agent tool-call dispatch engine (T1740 · epic T11456) — the SDK chokepoint that
+// turns a model-emitted tool-call into an executed, LLM-safe result: registry
+// lookup → Zod-validate → availability → run-scoped budget → guarded execution →
+// classified result + LLM-facing formatting. Pure dispatch; defines NO new tool
+// primitive (Gate-11) and makes NO LLM call (Gate-13). The Pi adapter binds the
+// loop's tool execution to this engine (AC6 — see core/src/llm/pi/pi-tool-bridge).
+export {
+  flattenZodIssues,
+  formatToolResultForLlm,
+  formatToolValueForLlm,
+  MAX_TOOL_RESULT_CHARS,
+  redactErrorMessage,
+  TOOL_DISPATCH_ERROR_CODE,
+  type ToolArgIssue,
+  type ToolBudgetLimits,
+  type ToolBudgetSnapshot,
+  type ToolCall,
+  ToolCallBudget,
+  ToolDispatchEngine,
+  type ToolDispatchEngineDeps,
+  type ToolDispatchErrorKind,
+  type ToolDispatchFailure,
+  type ToolDispatchResult,
+  type ToolDispatchSuccess,
+  type ToolResultPayload,
+  ToolTimeoutError,
+} from './dispatch.js';
 // Subprocess env scrubbing (T11897 · security) — the chokepoint builds a minimal,
 // allowlisted child env so daemon secrets never leak and a Pi-controlled loader
 // hook / PATH can never reach a spawned process.


### PR DESCRIPTION
core/src/tools/dispatch.ts closes the tool-calling loop — model tool-call -> registry lookup -> guarded execution -> typed result -> back to the Pi loop; sync+async, typed error classification, per-call budget caps, Gate-11/13 clean. Per the T1738 architecture (core DISPATCHES, cleo-os DRIVES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)