### PR TITLE
feat(T11889): self-improvement foundation — selfimprove_dhq table + scenario-replay/envelope-diff (T11911/T11912)

### DIFF
--- a/packages/core/migrations/drizzle-cleo-global/20260608020000_t11889-selfimprove-dhq/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260608020000_t11889-selfimprove-dhq/migration.sql
@@ -1,0 +1,64 @@
+-- T11889 (T11889-A · T11911) — the self-improvement-loop DHQ sink (`selfimprove_dhq`).
+--
+-- One row per Dogfood-Harness-Question raised by `cleo selfimprove run`: the loop
+-- replays a canned scenario, diffs the LAFS envelopes against a golden, and on
+-- regression UPSERTs exactly ONE row here via the leased Gate-3 accessor
+-- (selfimprove-dhq-store.ts). On green it writes nothing.
+--
+-- Co-located inside EACH scope's consolidated cleo.db (this file is byte-identical
+-- in drizzle-cleo-project and drizzle-cleo-global so the two lineages produce the
+-- SAME migration hash — the consolidated single-file journal converges across both
+-- under the CONSOLIDATED_JOURNAL_LINEAGES cross-lineage guard, T11829). Pure runtime
+-- infrastructure (like `_writer_leases` from T11627 and `pi_session_*` from T11899)
+-- — NOT part of the exodus target shape under `schema/cleo-project/`.
+--
+-- ## Idempotency invariant (partial UNIQUE index)
+--
+-- At most ONE row per `question_hash` may carry `status = 'open'`, so a repeated
+-- regression UPSERTs the same open row instead of spamming duplicates. drizzle-orm
+-- cannot model a partial WHERE unique index, so it is emitted here as raw SQL (the
+-- established repo pattern — cf. `_writer_leases.active`, T11627 ·
+-- `project_agent_refs.enabled`). The drizzle schema (selfimprove-dhq-schema.ts)
+-- declares ONLY the full-column table plus the two non-partial indexes drizzle CAN
+-- emit; the runtime bootstrap asserts this partial index exists
+-- (assertSelfimproveDhqOpenIndexPresent).
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-project) which already creates dozens of tables, so `selfimprove_dhq` is
+-- NEVER the first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables. No journal pre-create is required
+-- (the lease cold-open path pre-creates `__drizzle_migrations` before any first
+-- table, so the precondition holds even on a freshly cold-opened DB).
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op. Each
+-- statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11889
+-- @task T11911
+-- @epic T11889
+
+CREATE TABLE IF NOT EXISTS `selfimprove_dhq` (
+  `id` INTEGER PRIMARY KEY,
+  `dhq_id` TEXT NOT NULL,
+  `scenario` TEXT NOT NULL,
+  `question_hash` TEXT NOT NULL,
+  `title` TEXT NOT NULL,
+  `regression_json` TEXT NOT NULL,
+  `status` TEXT NOT NULL DEFAULT 'open',
+  `severity` TEXT,
+  `pr_url` TEXT,
+  `run_id` TEXT NOT NULL,
+  `created_at` INTEGER NOT NULL,
+  `updated_at` INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ix_selfimprove_dhq_status` ON `selfimprove_dhq` (`status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ix_selfimprove_dhq_scenario` ON `selfimprove_dhq` (`scenario`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_selfimprove_dhq_open` ON `selfimprove_dhq` (`question_hash`) WHERE `status` = 'open';

--- a/packages/core/migrations/drizzle-cleo-project/20260608020000_t11889-selfimprove-dhq/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260608020000_t11889-selfimprove-dhq/migration.sql
@@ -1,0 +1,64 @@
+-- T11889 (T11889-A · T11911) — the self-improvement-loop DHQ sink (`selfimprove_dhq`).
+--
+-- One row per Dogfood-Harness-Question raised by `cleo selfimprove run`: the loop
+-- replays a canned scenario, diffs the LAFS envelopes against a golden, and on
+-- regression UPSERTs exactly ONE row here via the leased Gate-3 accessor
+-- (selfimprove-dhq-store.ts). On green it writes nothing.
+--
+-- Co-located inside EACH scope's consolidated cleo.db (this file is byte-identical
+-- in drizzle-cleo-project and drizzle-cleo-global so the two lineages produce the
+-- SAME migration hash — the consolidated single-file journal converges across both
+-- under the CONSOLIDATED_JOURNAL_LINEAGES cross-lineage guard, T11829). Pure runtime
+-- infrastructure (like `_writer_leases` from T11627 and `pi_session_*` from T11899)
+-- — NOT part of the exodus target shape under `schema/cleo-project/`.
+--
+-- ## Idempotency invariant (partial UNIQUE index)
+--
+-- At most ONE row per `question_hash` may carry `status = 'open'`, so a repeated
+-- regression UPSERTs the same open row instead of spamming duplicates. drizzle-orm
+-- cannot model a partial WHERE unique index, so it is emitted here as raw SQL (the
+-- established repo pattern — cf. `_writer_leases.active`, T11627 ·
+-- `project_agent_refs.enabled`). The drizzle schema (selfimprove-dhq-schema.ts)
+-- declares ONLY the full-column table plus the two non-partial indexes drizzle CAN
+-- emit; the runtime bootstrap asserts this partial index exists
+-- (assertSelfimproveDhqOpenIndexPresent).
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-project) which already creates dozens of tables, so `selfimprove_dhq` is
+-- NEVER the first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables. No journal pre-create is required
+-- (the lease cold-open path pre-creates `__drizzle_migrations` before any first
+-- table, so the precondition holds even on a freshly cold-opened DB).
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op. Each
+-- statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11889
+-- @task T11911
+-- @epic T11889
+
+CREATE TABLE IF NOT EXISTS `selfimprove_dhq` (
+  `id` INTEGER PRIMARY KEY,
+  `dhq_id` TEXT NOT NULL,
+  `scenario` TEXT NOT NULL,
+  `question_hash` TEXT NOT NULL,
+  `title` TEXT NOT NULL,
+  `regression_json` TEXT NOT NULL,
+  `status` TEXT NOT NULL DEFAULT 'open',
+  `severity` TEXT,
+  `pr_url` TEXT,
+  `run_id` TEXT NOT NULL,
+  `created_at` INTEGER NOT NULL,
+  `updated_at` INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ix_selfimprove_dhq_status` ON `selfimprove_dhq` (`status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ix_selfimprove_dhq_scenario` ON `selfimprove_dhq` (`scenario`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_selfimprove_dhq_open` ON `selfimprove_dhq` (`question_hash`) WHERE `status` = 'open';

--- a/packages/core/src/selfimprove/__tests__/envelope-diff.test.ts
+++ b/packages/core/src/selfimprove/__tests__/envelope-diff.test.ts
@@ -38,6 +38,44 @@ function replayed(taskId: string): DispatchResponse {
   };
 }
 
+/**
+ * A LIVE-shaped envelope as the real `Dispatcher` stamps it — carries the
+ * per-run session-lineage UUIDs AND the deterministic-but-golden-absent infra
+ * meta keys. This is the wiring-time shape the hand-trimmed mock omits; the
+ * normalizer + subset compare MUST treat it as a non-regression vs the golden.
+ *
+ * @param taskId - The task id in the envelope body.
+ * @param sid - The (per-run, non-deterministic) session-lineage UUID seed.
+ */
+function liveEnvelope(taskId: string, sid: string): DispatchResponse {
+  return {
+    meta: {
+      gateway: 'query',
+      domain: 'tasks',
+      operation: 'find',
+      // Volatile timing/trace.
+      timestamp: '2026-06-08T00:00:00.000Z',
+      duration_ms: 42,
+      requestId: `req-${sid}`,
+      source: 'rpc',
+      // Per-run session lineage (randomUUID() in the real Dispatcher).
+      sessionId: `sess-${sid}`,
+      originSessionId: `origin-${sid}`,
+      executionSessionId: `exec-${sid}`,
+      // Deterministic-but-golden-absent infra keys (createGatewayMeta / legacy).
+      specVersion: '1.2.3',
+      schemaVersion: '2026.2.1',
+      transport: 'sdk',
+      strict: true,
+      mvi: 'minimal',
+      contextVersion: 1,
+      'x-cleo-transport': 'stdio',
+    } as DispatchResponse['meta'],
+    success: true,
+    data: { tasks: [{ id: taskId, title: 'T' }], count: 1 },
+  };
+}
+
 /** The golden — already normalized (no volatile meta fields). */
 function goldenEntry(taskId: string): GoldenEntry {
   return {
@@ -64,6 +102,23 @@ describe('normalizeEnvelope', () => {
     normalizeEnvelope(env);
     expect(env.meta.timestamp).toBe('2026-06-08T00:00:00.000Z');
     expect(env.meta.duration_ms).toBe(42);
+  });
+
+  it('strips the per-run session-lineage UUIDs (sessionId/originSessionId/executionSessionId)', () => {
+    const norm = normalizeEnvelope(liveEnvelope('T1', 'aaa'));
+    const meta = norm.meta as Record<string, unknown>;
+    expect(meta.sessionId).toBeUndefined();
+    expect(meta.originSessionId).toBeUndefined();
+    expect(meta.executionSessionId).toBeUndefined();
+  });
+
+  it('preserves deterministic infra meta keys (not stripped — tolerated by subset compare)', () => {
+    const norm = normalizeEnvelope(liveEnvelope('T1', 'aaa'));
+    const meta = norm.meta as Record<string, unknown>;
+    // The strip set is exactly the volatile fields — nothing semantic/stable.
+    expect(meta.specVersion).toBe('1.2.3');
+    expect(meta.transport).toBe('sdk');
+    expect(meta.gateway).toBe('query');
   });
 });
 
@@ -97,6 +152,30 @@ describe('diffEnvelopes', () => {
     const result = diffEnvelopes(ops, [replayed('T1'), replayed('T1')], [goldenEntry('T1')]);
     expect(result.regressions.some((r) => r.path === 'envelopes/length')).toBe(true);
   });
+
+  it('treats a LIVE envelope (lineage UUIDs + infra meta) as NOT a regression', () => {
+    // The real Dispatcher stamps non-deterministic *SessionId UUIDs and stable
+    // infra meta keys the hand-authored golden never declares. Without the
+    // lineage strip + subset meta compare this would be a permanent phantom DHQ.
+    const result = diffEnvelopes(ops, [liveEnvelope('T1', 'run-1')], [goldenEntry('T1')]);
+    expect(result.regressions).toEqual([]);
+  });
+
+  it('two live envelopes with DIFFERENT lineage UUIDs both match the golden', () => {
+    const a = diffEnvelopes(ops, [liveEnvelope('T1', 'run-aaa')], [goldenEntry('T1')]);
+    const b = diffEnvelopes(ops, [liveEnvelope('T1', 'run-zzz')], [goldenEntry('T1')]);
+    expect(a.regressions).toEqual([]);
+    expect(b.regressions).toEqual([]);
+  });
+
+  it('still flags a real meta divergence on a golden-DECLARED key', () => {
+    // Subset compare ignores EXTRA actual keys, but a golden-declared key that
+    // diverges IS a regression (the `source` here flips rpc → cli).
+    const live = liveEnvelope('T1', 'run-1');
+    (live.meta as Record<string, unknown>).source = 'cli';
+    const result = diffEnvelopes(ops, [live], [goldenEntry('T1')]);
+    expect(result.regressions.some((r) => r.path === 'meta/source')).toBe(true);
+  });
 });
 
 describe('computeQuestionHash', () => {
@@ -118,6 +197,15 @@ describe('computeQuestionHash', () => {
     const green = diffEnvelopes(ops, [replayed('T1')], [goldenEntry('T1')]);
     const red = diffEnvelopes(ops, [replayed('T2')], [goldenEntry('T1')]);
     expect(computeQuestionHash(green)).not.toBe(computeQuestionHash(red));
+  });
+
+  it('a clean LIVE replay hashes to the green signature — no permanent phantom DHQ', () => {
+    // Regression guard for the wiring-time false positive: a live envelope (per-run
+    // UUIDs + infra meta) matching the golden body must hash identically to the
+    // trimmed-mock green, NOT to a stable red.
+    const liveGreen = diffEnvelopes(ops, [liveEnvelope('T1', 'run-1')], [goldenEntry('T1')]);
+    const mockGreen = diffEnvelopes(ops, [replayed('T1')], [goldenEntry('T1')]);
+    expect(computeQuestionHash(liveGreen)).toBe(computeQuestionHash(mockGreen));
   });
 });
 

--- a/packages/core/src/selfimprove/__tests__/envelope-diff.test.ts
+++ b/packages/core/src/selfimprove/__tests__/envelope-diff.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for envelope normalization + structural diff (T11889-B).
+ *
+ * PURE — no DB. Asserts volatile-meta stripping, zero regressions on a golden
+ * match, N regressions on injected divergence, stable `question_hash`, and the
+ * reused LAFS targeted-field extractor.
+ *
+ * @epic T11889
+ * @task T11912
+ */
+
+import type { DispatchResponse } from '@cleocode/contracts/gateway';
+import { describe, expect, it } from 'vitest';
+import {
+  computeQuestionHash,
+  diffEnvelopes,
+  extractTargetedField,
+  normalizeEnvelope,
+} from '../envelope-diff.js';
+import type { GoldenEntry, ScenarioOp } from '../scenario.js';
+
+const ops: ScenarioOp[] = [{ gateway: 'query', domain: 'tasks', operation: 'find' }];
+
+/** A replayed envelope with volatile meta fields populated. */
+function replayed(taskId: string): DispatchResponse {
+  return {
+    meta: {
+      gateway: 'query',
+      domain: 'tasks',
+      operation: 'find',
+      timestamp: '2026-06-08T00:00:00.000Z',
+      duration_ms: 42,
+      source: 'rpc',
+      requestId: 'req-abc',
+    },
+    success: true,
+    data: { tasks: [{ id: taskId, title: 'T' }], count: 1 },
+  };
+}
+
+/** The golden — already normalized (no volatile meta fields). */
+function goldenEntry(taskId: string): GoldenEntry {
+  return {
+    success: true,
+    meta: { gateway: 'query', domain: 'tasks', operation: 'find', source: 'rpc' },
+    data: { tasks: [{ id: taskId, title: 'T' }], count: 1 },
+  };
+}
+
+describe('normalizeEnvelope', () => {
+  it('strips volatile meta fields (timestamp/requestId/duration_ms)', () => {
+    const norm = normalizeEnvelope(replayed('T1'));
+    const meta = norm.meta as Record<string, unknown>;
+    expect(meta.timestamp).toBeUndefined();
+    expect(meta.requestId).toBeUndefined();
+    expect(meta.duration_ms).toBeUndefined();
+    // Stable fields preserved.
+    expect(meta.gateway).toBe('query');
+    expect(meta.operation).toBe('find');
+  });
+
+  it('does not mutate the input envelope', () => {
+    const env = replayed('T1');
+    normalizeEnvelope(env);
+    expect(env.meta.timestamp).toBe('2026-06-08T00:00:00.000Z');
+    expect(env.meta.duration_ms).toBe(42);
+  });
+});
+
+describe('diffEnvelopes', () => {
+  it('reports ZERO regressions when the replay matches the golden', () => {
+    const result = diffEnvelopes(ops, [replayed('T1')], [goldenEntry('T1')]);
+    expect(result.regressions).toEqual([]);
+  });
+
+  it('ignores volatile meta divergence (normalization removes it)', () => {
+    // Two replays differ ONLY in volatile fields; both match the same golden.
+    const a = replayed('T1');
+    const b = replayed('T1');
+    b.meta.requestId = 'req-different';
+    b.meta.duration_ms = 9999;
+    expect(diffEnvelopes(ops, [a], [goldenEntry('T1')]).regressions).toEqual([]);
+    expect(diffEnvelopes(ops, [b], [goldenEntry('T1')]).regressions).toEqual([]);
+  });
+
+  it('reports a regression on structural (data) divergence', () => {
+    const result = diffEnvelopes(ops, [replayed('T2')], [goldenEntry('T1')]);
+    expect(result.regressions.length).toBeGreaterThan(0);
+    const r = result.regressions[0];
+    expect(r?.opCoord).toBe('tasks.find');
+    expect(r?.path).toContain('data/tasks/0/id');
+    expect(r?.actual).toBe('T2');
+    expect(r?.expected).toBe('T1');
+  });
+
+  it('reports a count mismatch when replay/golden lengths differ', () => {
+    const result = diffEnvelopes(ops, [replayed('T1'), replayed('T1')], [goldenEntry('T1')]);
+    expect(result.regressions.some((r) => r.path === 'envelopes/length')).toBe(true);
+  });
+});
+
+describe('computeQuestionHash', () => {
+  it('is stable for the same regression signature', () => {
+    const r1 = diffEnvelopes(ops, [replayed('T2')], [goldenEntry('T1')]);
+    const r2 = diffEnvelopes(ops, [replayed('T2')], [goldenEntry('T1')]);
+    expect(computeQuestionHash(r1)).toBe(computeQuestionHash(r2));
+    expect(computeQuestionHash(r1)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('ignores actual/expected VALUE noise — same paths ⇒ same hash', () => {
+    // T2 vs T1 and T3 vs T1 diverge at the SAME path; signature (op+path) is identical.
+    const r2 = diffEnvelopes(ops, [replayed('T2')], [goldenEntry('T1')]);
+    const r3 = diffEnvelopes(ops, [replayed('T3')], [goldenEntry('T1')]);
+    expect(computeQuestionHash(r2)).toBe(computeQuestionHash(r3));
+  });
+
+  it('differs for the no-regression (green) signature', () => {
+    const green = diffEnvelopes(ops, [replayed('T1')], [goldenEntry('T1')]);
+    const red = diffEnvelopes(ops, [replayed('T2')], [goldenEntry('T1')]);
+    expect(computeQuestionHash(green)).not.toBe(computeQuestionHash(red));
+  });
+});
+
+describe('extractTargetedField (reuses LAFS fieldExtraction)', () => {
+  it('extracts a nested field from the normalized data payload', () => {
+    const norm = normalizeEnvelope(replayed('T9'));
+    // data.tasks[0].id — wrapper-array shape handled by the LAFS extractor.
+    expect(extractTargetedField(norm, 'id')).toBe('T9');
+    expect(extractTargetedField(norm, 'count')).toBe(1);
+  });
+
+  it('returns undefined for an absent field', () => {
+    const norm = normalizeEnvelope(replayed('T9'));
+    expect(extractTargetedField(norm, 'nonexistent')).toBeUndefined();
+  });
+});

--- a/packages/core/src/selfimprove/__tests__/replay.test.ts
+++ b/packages/core/src/selfimprove/__tests__/replay.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for self-improvement scenario replay (T11889-B).
+ *
+ * PURE — no DB. The {@link ReplayDispatch} port is MOCKED; no real dispatcher is
+ * constructed. Asserts envelope capture order, param threading, and the
+ * read-only mutate guard.
+ *
+ * @epic T11889
+ * @task T11912
+ */
+
+import type { DispatchResponse } from '@cleocode/contracts/gateway';
+import { describe, expect, it, vi } from 'vitest';
+import { MutateInFallbackError, type ReplayDispatch, replayScenario } from '../replay.js';
+import type { Scenario } from '../scenario.js';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+/** Build a minimal valid {@link DispatchResponse} for a mocked op. */
+function fakeEnvelope(operation: string): DispatchResponse {
+  return {
+    meta: {
+      gateway: 'query',
+      domain: 'tasks',
+      operation,
+      timestamp: new Date().toISOString(),
+      duration_ms: 7,
+      source: 'rpc',
+      requestId: `req-${operation}`,
+    },
+    success: true,
+    data: { operation },
+  };
+}
+
+const queryScenario: Scenario = {
+  name: 'two-query',
+  description: 'two read-only ops',
+  ops: [
+    { gateway: 'query', domain: 'tasks', operation: 'find', params: { query: 'x' } },
+    { gateway: 'query', domain: 'tasks', operation: 'show', params: { id: 'T1' } },
+  ],
+};
+
+describe('replayScenario — capture (mocked dispatch)', () => {
+  it('captures one envelope per op, in order', async () => {
+    const calls: { gateway: string; domain: string; operation: string }[] = [];
+    const dispatch: ReplayDispatch = vi.fn(async (op) => {
+      calls.push({ gateway: op.gateway, domain: op.domain, operation: op.operation });
+      return fakeEnvelope(op.operation);
+    });
+
+    const envelopes = await replayScenario(queryScenario, dispatch);
+
+    expect(envelopes).toHaveLength(2);
+    expect(calls.map((c) => c.operation)).toEqual(['find', 'show']);
+    expect(envelopes.every((e) => e.success)).toBe(true);
+  });
+
+  it('threads op params into the dispatch port', async () => {
+    const seen: (Record<string, unknown> | undefined)[] = [];
+    const dispatch: ReplayDispatch = vi.fn(async (op) => {
+      seen.push(op.params);
+      return fakeEnvelope(op.operation);
+    });
+
+    await replayScenario(queryScenario, dispatch);
+
+    expect(seen[0]).toEqual({ query: 'x' });
+    expect(seen[1]).toEqual({ id: 'T1' });
+  });
+});
+
+describe('replayScenario — read-only mutate guard', () => {
+  const mutateScenario: Scenario = {
+    name: 'has-mutate',
+    description: 'contains a mutate op',
+    ops: [
+      { gateway: 'query', domain: 'tasks', operation: 'find' },
+      { gateway: 'mutate', domain: 'tasks', operation: 'add', params: { title: 'x' } },
+    ],
+  };
+
+  it('hard-rejects a mutate op in fallback mode (no allowMutate)', async () => {
+    const dispatch: ReplayDispatch = vi.fn(async (op) => fakeEnvelope(op.operation));
+
+    await expect(replayScenario(mutateScenario, dispatch)).rejects.toBeInstanceOf(
+      MutateInFallbackError,
+    );
+    await expect(replayScenario(mutateScenario, dispatch)).rejects.toMatchObject({
+      code: 'E_SELFIMPROVE_MUTATE_IN_FALLBACK',
+      opCoord: 'tasks.add',
+    });
+  });
+
+  it('does NOT dispatch the mutate op (rejects before the costed call)', async () => {
+    const dispatch = vi.fn(async (op: { operation: string }) => fakeEnvelope(op.operation));
+
+    await expect(
+      replayScenario(mutateScenario, dispatch as unknown as ReplayDispatch),
+    ).rejects.toBeInstanceOf(MutateInFallbackError);
+
+    // Only the leading query op may have dispatched; the mutate op must not.
+    const dispatchedOps = dispatch.mock.calls.map((c) => c[0].operation);
+    expect(dispatchedOps).not.toContain('add');
+  });
+
+  it('permits a mutate op when allowMutate is explicitly set (VM path)', async () => {
+    const dispatch: ReplayDispatch = vi.fn(async (op) => fakeEnvelope(op.operation));
+
+    const envelopes = await replayScenario(mutateScenario, dispatch, { allowMutate: true });
+    expect(envelopes).toHaveLength(2);
+  });
+});

--- a/packages/core/src/selfimprove/__tests__/scenario.test.ts
+++ b/packages/core/src/selfimprove/__tests__/scenario.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for self-improvement scenario + golden loading/validation (T11889-B).
+ *
+ * PURE — no DB. Exercises the bundled canned `dhq-replay-find` fixture plus the
+ * Zod-validation and invariant-enforcement paths of {@link loadScenario}.
+ *
+ * @epic T11889
+ * @task T11912
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { GoldenSchema, loadScenario, ScenarioLoadError, ScenarioSchema } from '../scenario.js';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('scenario schema validation', () => {
+  it('accepts a well-formed query-only scenario', () => {
+    const parsed = ScenarioSchema.safeParse({
+      name: 'x',
+      description: 'd',
+      ops: [{ gateway: 'query', domain: 'tasks', operation: 'find' }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an empty ops array', () => {
+    const parsed = ScenarioSchema.safeParse({ name: 'x', description: 'd', ops: [] });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an unknown gateway', () => {
+    const parsed = ScenarioSchema.safeParse({
+      name: 'x',
+      description: 'd',
+      ops: [{ gateway: 'delete', domain: 'tasks', operation: 'find' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects unknown top-level keys (strict)', () => {
+    const parsed = ScenarioSchema.safeParse({
+      name: 'x',
+      description: 'd',
+      ops: [{ gateway: 'query', domain: 'tasks', operation: 'find' }],
+      extra: true,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('validates a golden envelope set', () => {
+    const parsed = GoldenSchema.safeParse({
+      name: 'x',
+      envelopes: [{ success: true, data: {} }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('loadScenario — canned fixture', () => {
+  it('loads and validates the dhq-replay-find scenario + golden', async () => {
+    const { scenario, golden } = await loadScenario('dhq-replay-find');
+    expect(scenario.name).toBe('dhq-replay-find');
+    expect(scenario.ops.length).toBeGreaterThan(0);
+    expect(golden.name).toBe('dhq-replay-find');
+    // Invariant: one golden envelope per op.
+    expect(golden.envelopes.length).toBe(scenario.ops.length);
+    // The canned scenario is query-only (read-only replay guarantee).
+    for (const op of scenario.ops) {
+      expect(op.gateway).toBe('query');
+    }
+  });
+});
+
+describe('loadScenario — error paths', () => {
+  it('rejects a path-traversal name before touching the filesystem', async () => {
+    await expect(loadScenario('../../etc')).rejects.toBeInstanceOf(ScenarioLoadError);
+  });
+
+  it('rejects an unknown scenario name with a typed error', async () => {
+    await expect(loadScenario('does-not-exist')).rejects.toMatchObject({
+      code: 'E_SELFIMPROVE_SCENARIO_INVALID',
+    });
+  });
+});

--- a/packages/core/src/selfimprove/envelope-diff.ts
+++ b/packages/core/src/selfimprove/envelope-diff.ts
@@ -1,0 +1,296 @@
+/**
+ * Envelope normalization + structural diff vs a golden (T11889-B).
+ *
+ * The self-improvement loop replays a scenario (see {@link "./replay.js"}) and
+ * diffs each captured envelope against the golden expected envelope. This module:
+ *
+ *   1. {@link normalizeEnvelope} — strips the VOLATILE `meta` fields
+ *      (`timestamp`, `requestId`, `duration_ms` / `durationMs`) so only
+ *      deterministic structure is compared. (The runtime field is `meta` with
+ *      snake_case `duration_ms`; the spec wording uses `_meta`/`durationMs`, so
+ *      both spellings and both container keys are stripped defensively.)
+ *   2. {@link diffEnvelopes} — structurally compares the normalized envelope set
+ *      against the golden, producing `{ regressions: DiffEntry[] }`. Zero
+ *      regressions on a golden match; N on injected divergence.
+ *   3. {@link computeQuestionHash} — sha256 of the normalized regression
+ *      signature (op coordinates + diff path set) so the SAME regression maps to
+ *      the SAME open DHQ row (the idempotency partial-UNIQUE index in T11889-A).
+ *
+ * `extractFieldFromResult` from `@cleocode/lafs` is reused for targeted-field
+ * asserts where a full structural compare would be too brittle.
+ *
+ * This module is PURE — no DB, no native handle, no `cleo` mutation.
+ * Import-time side-effect-free.
+ *
+ * @module @cleocode/core/selfimprove/envelope-diff
+ * @epic T11889
+ * @task T11912
+ */
+
+import { createHash } from 'node:crypto';
+import { extractFieldFromResult } from '@cleocode/lafs';
+import type { ReplayEnvelope } from './replay.js';
+import type { GoldenEntry, ScenarioOp } from './scenario.js';
+
+/**
+ * Volatile envelope-meta field names stripped before diffing.
+ *
+ * The runtime canonical name is `duration_ms` (snake_case); `durationMs` (the
+ * spec wording) is also stripped so a golden authored either way normalizes
+ * identically.
+ */
+const VOLATILE_META_FIELDS = ['timestamp', 'requestId', 'duration_ms', 'durationMs'] as const;
+
+/**
+ * Meta container keys whose volatile fields are stripped.
+ *
+ * Runtime envelopes use `meta`; `_meta` is stripped too for defensive parity with
+ * the gateway envelope shape.
+ */
+const META_CONTAINER_KEYS = ['meta', '_meta'] as const;
+
+/**
+ * A normalized envelope: the replayed envelope with volatile `meta` fields removed.
+ *
+ * Structurally identical to {@link ReplayEnvelope} except every volatile
+ * meta field is absent. Stored as a plain JSON-serializable record so it can be
+ * compared deeply and hashed deterministically.
+ */
+export type NormalizedEnvelope = Record<string, unknown>;
+
+/**
+ * A single structural difference between a normalized envelope and its golden.
+ */
+export interface DiffEntry {
+  /** Zero-based index of the op in the scenario whose envelope diverged. */
+  opIndex: number;
+  /** The op coordinate (`domain.operation`) for the diverging op. */
+  opCoord: string;
+  /** JSON-pointer-ish path to the diverging value (e.g. `data/tasks/0/id`). */
+  path: string;
+  /** The value found in the replayed (actual) normalized envelope. */
+  actual: unknown;
+  /** The value found in the golden (expected) envelope. */
+  expected: unknown;
+}
+
+/** The result of diffing a replayed envelope set against a golden. */
+export interface EnvelopeDiffResult {
+  /** All structural regressions; empty ⇒ the replay matched the golden. */
+  regressions: DiffEntry[];
+}
+
+/**
+ * Deep-clone a JSON-serializable value via structured round-trip.
+ *
+ * Replay envelopes are JSON-shaped (they round-trip through transports), so a
+ * JSON clone is safe and avoids mutating the caller's object during normalization.
+ *
+ * @param value - The value to clone.
+ * @returns A deep copy.
+ */
+function jsonClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Strip the volatile `meta`/`_meta` fields from an envelope.
+ *
+ * Returns a NEW object; the input is not mutated. Only the volatile timing/trace
+ * fields are removed — the stable meta remnant (`gateway`, `domain`, `operation`,
+ * `source`, …) is preserved so structural identity (which operation produced the
+ * envelope) still compares.
+ *
+ * @param envelope - The replayed envelope to normalize.
+ * @returns The normalized envelope with volatile meta fields removed.
+ *
+ * @example
+ * ```ts
+ * const norm = normalizeEnvelope(envelope);
+ * // norm.meta has no timestamp / requestId / duration_ms
+ * ```
+ */
+export function normalizeEnvelope(envelope: ReplayEnvelope): NormalizedEnvelope {
+  const cloned = jsonClone(envelope) as Record<string, unknown>;
+  for (const containerKey of META_CONTAINER_KEYS) {
+    const container = cloned[containerKey];
+    if (container !== null && typeof container === 'object' && !Array.isArray(container)) {
+      const meta = container as Record<string, unknown>;
+      for (const field of VOLATILE_META_FIELDS) {
+        delete meta[field];
+      }
+    }
+  }
+  return cloned;
+}
+
+/**
+ * Recursively collect structural differences between two JSON values.
+ *
+ * Walks both trees in parallel, recording a `{ path, actual, expected }` for each
+ * leaf-level divergence. Object key sets and array lengths are compared; the path
+ * uses `/`-delimited segments.
+ *
+ * @param actual - The actual (normalized replay) value.
+ * @param expected - The expected (golden) value.
+ * @param path - Accumulated path prefix.
+ * @param out - Mutable accumulator of `{ path, actual, expected }` tuples.
+ */
+function collectStructuralDiffs(
+  actual: unknown,
+  expected: unknown,
+  path: string,
+  out: { path: string; actual: unknown; expected: unknown }[],
+): void {
+  if (actual === expected) return;
+
+  const bothObjects =
+    actual !== null &&
+    expected !== null &&
+    typeof actual === 'object' &&
+    typeof expected === 'object' &&
+    Array.isArray(actual) === Array.isArray(expected);
+
+  if (!bothObjects) {
+    out.push({ path, actual, expected });
+    return;
+  }
+
+  const actualRec = actual as Record<string, unknown>;
+  const expectedRec = expected as Record<string, unknown>;
+  const keys = new Set<string>([...Object.keys(actualRec), ...Object.keys(expectedRec)]);
+  for (const key of keys) {
+    const childPath = path === '' ? key : `${path}/${key}`;
+    collectStructuralDiffs(actualRec[key], expectedRec[key], childPath, out);
+  }
+}
+
+/**
+ * Diff a set of replayed envelopes against the golden envelope set.
+ *
+ * Normalizes each replayed envelope (volatile meta stripped) and structurally
+ * compares it against the positionally-aligned golden entry. The op coordinate
+ * for each `DiffEntry` is taken from `ops[opIndex]`. Callers MUST pass aligned
+ * arrays (`ops.length === replayed.length === golden.length`); the function
+ * diffs up to the shortest length and reports an extra regression for any length
+ * mismatch.
+ *
+ * @param ops - The scenario ops (for op-coordinate labelling).
+ * @param replayed - The captured envelopes, one per op (replay order).
+ * @param golden - The golden expected entries, positionally aligned with `ops`.
+ * @returns `{ regressions }` — empty when the replay matches the golden.
+ *
+ * @example
+ * ```ts
+ * const { regressions } = diffEnvelopes(scenario.ops, replayed, golden.envelopes);
+ * if (regressions.length === 0) { /* happy path — no DHQ, no PR *\/ }
+ * ```
+ */
+export function diffEnvelopes(
+  ops: ScenarioOp[],
+  replayed: ReplayEnvelope[],
+  golden: GoldenEntry[],
+): EnvelopeDiffResult {
+  const regressions: DiffEntry[] = [];
+  const n = Math.min(ops.length, replayed.length, golden.length);
+
+  for (let i = 0; i < n; i++) {
+    const op = ops[i];
+    const replayEnvelope = replayed[i];
+    const goldenEntry = golden[i];
+    if (op === undefined || replayEnvelope === undefined || goldenEntry === undefined) continue;
+
+    const opCoord = `${op.domain}.${op.operation}`;
+    const normalized = normalizeEnvelope(replayEnvelope);
+
+    const leafDiffs: { path: string; actual: unknown; expected: unknown }[] = [];
+    collectStructuralDiffs(normalized, goldenEntry as Record<string, unknown>, '', leafDiffs);
+    for (const d of leafDiffs) {
+      regressions.push({
+        opIndex: i,
+        opCoord,
+        path: d.path,
+        actual: d.actual,
+        expected: d.expected,
+      });
+    }
+  }
+
+  if (replayed.length !== golden.length) {
+    regressions.push({
+      opIndex: -1,
+      opCoord: '<count>',
+      path: 'envelopes/length',
+      actual: replayed.length,
+      expected: golden.length,
+    });
+  }
+
+  return { regressions };
+}
+
+/**
+ * Extract a targeted field from a normalized envelope's `data` payload.
+ *
+ * Reuses the LAFS `--field` extractor (`extractFieldFromResult`) for cases where
+ * a full structural diff is too brittle and only a specific field's value matters
+ * (e.g. assert `data.tasks[0].id` without comparing the whole envelope).
+ *
+ * @param normalized - A normalized envelope (from {@link normalizeEnvelope}).
+ * @param field - The field name to extract from the envelope's `data` payload.
+ * @returns The extracted value, or `undefined` when absent.
+ *
+ * @example
+ * ```ts
+ * const id = extractTargetedField(normalizeEnvelope(env), 'id');
+ * ```
+ */
+export function extractTargetedField(normalized: NormalizedEnvelope, field: string): unknown {
+  const data = normalized.data;
+  if (data === undefined || data === null) return undefined;
+  // The LAFS extractor operates on a result value (object | array | null); the
+  // dispatch envelope's `data` is the equivalent payload.
+  if (typeof data !== 'object') return undefined;
+  return extractFieldFromResult(data as Record<string, unknown> | Record<string, unknown>[], field);
+}
+
+/**
+ * Build the deterministic regression signature for a diff result.
+ *
+ * The signature is the SORTED set of `{ opCoord, path }` pairs from the
+ * regressions — NOT the values. Two runs that diverge at the same op coordinates
+ * on the same paths produce the same signature (and thus the same
+ * {@link computeQuestionHash}), so a repeated regression maps to ONE open DHQ row
+ * rather than spamming duplicates. Actual/expected values are intentionally
+ * excluded so transient value noise does not fork the hash.
+ *
+ * @param regressions - The diff regressions.
+ * @returns A stable, sorted signature string.
+ */
+function regressionSignature(regressions: DiffEntry[]): string {
+  const pairs = regressions.map((r) => `${r.opCoord}@${r.path}`);
+  pairs.sort();
+  return pairs.join('\n');
+}
+
+/**
+ * Compute the sha256 `question_hash` of a diff result's normalized signature.
+ *
+ * The hash is over the {@link regressionSignature} (op coordinates + diff path
+ * set), so it is stable across runs of the SAME regression and feeds the
+ * idempotency partial-UNIQUE index (`ux_selfimprove_dhq_open`, T11889-A): one
+ * open DHQ row per `question_hash`. An empty regression set hashes the empty
+ * signature deterministically (callers should not persist on the happy path).
+ *
+ * @param result - The diff result whose regressions are hashed.
+ * @returns The lowercase hex sha256 of the regression signature.
+ *
+ * @example
+ * ```ts
+ * const hash = computeQuestionHash(diffEnvelopes(ops, replayed, golden));
+ * ```
+ */
+export function computeQuestionHash(result: EnvelopeDiffResult): string {
+  const signature = regressionSignature(result.regressions);
+  return createHash('sha256').update(signature, 'utf-8').digest('hex');
+}

--- a/packages/core/src/selfimprove/envelope-diff.ts
+++ b/packages/core/src/selfimprove/envelope-diff.ts
@@ -4,14 +4,28 @@
  * The self-improvement loop replays a scenario (see {@link "./replay.js"}) and
  * diffs each captured envelope against the golden expected envelope. This module:
  *
- *   1. {@link normalizeEnvelope} — strips the VOLATILE `meta` fields
- *      (`timestamp`, `requestId`, `duration_ms` / `durationMs`) so only
- *      deterministic structure is compared. (The runtime field is `meta` with
- *      snake_case `duration_ms`; the spec wording uses `_meta`/`durationMs`, so
- *      both spellings and both container keys are stripped defensively.)
+ *   1. {@link normalizeEnvelope} — strips the VOLATILE `meta` fields so only
+ *      deterministic structure is compared. Two classes are stripped:
+ *      timing/trace fields (`timestamp`, `requestId`, `duration_ms` /
+ *      `durationMs`) AND the per-run session-lineage UUIDs (`sessionId`,
+ *      `originSessionId`, `executionSessionId`). The latter are non-deterministic:
+ *      the live `Dispatcher` defaults `executionSessionId`/`originSessionId` to a
+ *      fresh `randomUUID()` per request
+ *      (`ensureRequestSessionLineage`), then stamps all three onto `response.meta`
+ *      — so a real envelope carries UUIDs the hand-authored golden cannot know.
+ *      Stripping them prevents a permanent phantom DHQ that self-fires on every
+ *      clean run. (The runtime field is `meta` with snake_case `duration_ms`; the
+ *      spec wording uses `_meta`/`durationMs`, so both spellings and both
+ *      container keys are stripped defensively.)
  *   2. {@link diffEnvelopes} — structurally compares the normalized envelope set
  *      against the golden, producing `{ regressions: DiffEntry[] }`. Zero
- *      regressions on a golden match; N on injected divergence.
+ *      regressions on a golden match; N on injected divergence. The `meta`
+ *      container is compared as a SUBSET (only golden-declared meta keys are
+ *      asserted) so deterministic-but-golden-absent infra keys
+ *      (`specVersion`, `schemaVersion`, `transport`, `mvi`, `contextVersion`,
+ *      `strict`, `x-cleo-transport`, …) stamped by the runtime are NOT phantom
+ *      regressions. The semantic payload (`data`/`error`) is still compared by
+ *      full key-union — a missing or extra payload key IS a regression.
  *   3. {@link computeQuestionHash} — sha256 of the normalized regression
  *      signature (op coordinates + diff path set) so the SAME regression maps to
  *      the SAME open DHQ row (the idempotency partial-UNIQUE index in T11889-A).
@@ -35,19 +49,51 @@ import type { GoldenEntry, ScenarioOp } from './scenario.js';
 /**
  * Volatile envelope-meta field names stripped before diffing.
  *
- * The runtime canonical name is `duration_ms` (snake_case); `durationMs` (the
- * spec wording) is also stripped so a golden authored either way normalizes
- * identically.
+ * Two classes, both non-deterministic per run:
+ *
+ *   - Timing / trace: `timestamp`, `requestId`, `duration_ms` (the runtime
+ *     canonical, snake_case) and `durationMs` (the spec wording — stripped so a
+ *     golden authored either way normalizes identically).
+ *   - Session lineage: `sessionId`, `originSessionId`, `executionSessionId`. The
+ *     live `Dispatcher` stamps these onto `response.meta`
+ *     after defaulting `executionSessionId`/`originSessionId` to a fresh
+ *     `randomUUID()` per request (`ensureRequestSessionLineage`). They are
+ *     per-run UUIDs the hand-authored golden cannot encode; leaving them in would
+ *     make every clean replay emit a phantom regression at
+ *     `meta/executionSessionId` and `meta/originSessionId`, and because the
+ *     regression signature hashes only `opCoord@path` (constant), the resulting
+ *     `question_hash` would be STABLE — a permanent self-firing DHQ. Stripping
+ *     them keeps an identical-but-for-lineage envelope a non-regression.
  */
-const VOLATILE_META_FIELDS = ['timestamp', 'requestId', 'duration_ms', 'durationMs'] as const;
+const VOLATILE_META_FIELDS = [
+  'timestamp',
+  'requestId',
+  'duration_ms',
+  'durationMs',
+  'sessionId',
+  'originSessionId',
+  'executionSessionId',
+] as const;
 
 /**
- * Meta container keys whose volatile fields are stripped.
+ * Meta container keys whose volatile fields are stripped, and whose remaining
+ * keys are compared as a SUBSET (see {@link diffEnvelopes}).
  *
  * Runtime envelopes use `meta`; `_meta` is stripped too for defensive parity with
  * the gateway envelope shape.
  */
 const META_CONTAINER_KEYS = ['meta', '_meta'] as const;
+
+/**
+ * Top-level envelope keys whose value is a meta container.
+ *
+ * The structural diff treats these containers as a SUBSET compare (golden-declared
+ * keys only) so deterministic-but-golden-absent infra keys the runtime stamps
+ * (`specVersion`, `schemaVersion`, `transport`, `mvi`, `contextVersion`, `strict`,
+ * `x-cleo-transport`, …) are not phantom regressions. Everything else (`data`,
+ * `error`, …) keeps a full key-union compare.
+ */
+const SUBSET_COMPARE_KEYS = new Set<string>(META_CONTAINER_KEYS);
 
 /**
  * A normalized envelope: the replayed envelope with volatile `meta` fields removed.
@@ -96,10 +142,16 @@ function jsonClone<T>(value: T): T {
 /**
  * Strip the volatile `meta`/`_meta` fields from an envelope.
  *
- * Returns a NEW object; the input is not mutated. Only the volatile timing/trace
- * fields are removed — the stable meta remnant (`gateway`, `domain`, `operation`,
- * `source`, …) is preserved so structural identity (which operation produced the
- * envelope) still compares.
+ * Returns a NEW object; the input is not mutated. The volatile timing/trace fields
+ * AND the per-run session-lineage UUIDs (`sessionId`, `originSessionId`,
+ * `executionSessionId`) are removed — see {@link VOLATILE_META_FIELDS}. The stable
+ * meta remnant (`gateway`, `domain`, `operation`, `source`, …) is preserved so
+ * structural identity (which operation produced the envelope) still compares.
+ *
+ * Note: deterministic-but-golden-absent infra meta keys (`specVersion`,
+ * `transport`, …) are NOT stripped here — they are tolerated by the SUBSET compare
+ * in {@link diffEnvelopes} instead, so the strip set stays exactly the volatile
+ * fields and nothing semantic.
  *
  * @param envelope - The replayed envelope to normalize.
  * @returns The normalized envelope with volatile meta fields removed.
@@ -107,7 +159,7 @@ function jsonClone<T>(value: T): T {
  * @example
  * ```ts
  * const norm = normalizeEnvelope(envelope);
- * // norm.meta has no timestamp / requestId / duration_ms
+ * // norm.meta has no timestamp / requestId / duration_ms / *SessionId
  * ```
  */
 export function normalizeEnvelope(envelope: ReplayEnvelope): NormalizedEnvelope {
@@ -131,16 +183,31 @@ export function normalizeEnvelope(envelope: ReplayEnvelope): NormalizedEnvelope 
  * leaf-level divergence. Object key sets and array lengths are compared; the path
  * uses `/`-delimited segments.
  *
+ * Key-set semantics depend on the container:
+ *   - **Subset** (`subset === true`): only the EXPECTED (golden) object's keys are
+ *     compared. Extra keys present in `actual` but absent from the golden are
+ *     ignored. Applied to the `meta` container (see {@link SUBSET_COMPARE_KEYS}) so
+ *     deterministic infra meta keys the runtime stamps but the golden omits are not
+ *     phantom regressions.
+ *   - **Full union** (`subset === false`, the default): keys from BOTH objects are
+ *     compared, so an extra OR missing key is a regression. Applied to the semantic
+ *     payload (`data`/`error`).
+ *
+ * A child whose top-level key is in {@link SUBSET_COMPARE_KEYS} (i.e. `meta`)
+ * switches its subtree into subset mode.
+ *
  * @param actual - The actual (normalized replay) value.
  * @param expected - The expected (golden) value.
  * @param path - Accumulated path prefix.
  * @param out - Mutable accumulator of `{ path, actual, expected }` tuples.
+ * @param subset - When `true`, compare only the golden-declared keys at this node.
  */
 function collectStructuralDiffs(
   actual: unknown,
   expected: unknown,
   path: string,
   out: { path: string; actual: unknown; expected: unknown }[],
+  subset = false,
 ): void {
   if (actual === expected) return;
 
@@ -158,10 +225,18 @@ function collectStructuralDiffs(
 
   const actualRec = actual as Record<string, unknown>;
   const expectedRec = expected as Record<string, unknown>;
-  const keys = new Set<string>([...Object.keys(actualRec), ...Object.keys(expectedRec)]);
+  // Subset mode (meta container): compare ONLY the golden's keys, so extra
+  // deterministic runtime meta keys are not regressions. Full mode: union both
+  // key sets, so an extra OR missing payload key IS a regression.
+  const keys = subset
+    ? new Set<string>(Object.keys(expectedRec))
+    : new Set<string>([...Object.keys(actualRec), ...Object.keys(expectedRec)]);
   for (const key of keys) {
     const childPath = path === '' ? key : `${path}/${key}`;
-    collectStructuralDiffs(actualRec[key], expectedRec[key], childPath, out);
+    // A `meta`/`_meta` container's subtree is compared as a subset; never widen
+    // back to full-union once inside a subset container.
+    const childSubset = subset || SUBSET_COMPARE_KEYS.has(key);
+    collectStructuralDiffs(actualRec[key], expectedRec[key], childPath, out, childSubset);
   }
 }
 
@@ -174,6 +249,14 @@ function collectStructuralDiffs(
  * arrays (`ops.length === replayed.length === golden.length`); the function
  * diffs up to the shortest length and reports an extra regression for any length
  * mismatch.
+ *
+ * The `meta` container is compared as a SUBSET (only golden-declared meta keys are
+ * asserted) so deterministic-but-golden-absent infra keys the runtime stamps
+ * (`specVersion`, `transport`, …) are not phantom regressions; the semantic
+ * payload (`data`/`error`) keeps a full key-union compare where an extra or
+ * missing key IS a regression. Together with the volatile-lineage strip in
+ * {@link normalizeEnvelope}, a real live envelope that matches the golden body
+ * yields ZERO regressions.
  *
  * @param ops - The scenario ops (for op-coordinate labelling).
  * @param replayed - The captured envelopes, one per op (replay order).

--- a/packages/core/src/selfimprove/replay.ts
+++ b/packages/core/src/selfimprove/replay.ts
@@ -1,0 +1,184 @@
+/**
+ * Self-improvement scenario replay via an injected dispatch port (T11889-B).
+ *
+ * `replayScenario` replays a scenario's ordered ops through an injected
+ * {@link ReplayDispatch} port — it captures ONE LAFS envelope per op. CORE owns
+ * the PORT TYPE only; the real adapter (a thin closure over the cleo-resident
+ * `Dispatcher`) is supplied by `packages/cleo` at the call site (dependency
+ * inversion — `core` MUST NOT import the cleo dispatcher, and `dispatchFromCore`
+ * does not exist; see the P5 self-improvement spec §B.0.1).
+ *
+ * This module is PURE — no DB, no native handle, no `cleo` mutation. Tests inject
+ * a mocked `ReplayDispatch`. Import-time side-effect-free: the logger is resolved
+ * lazily on first use.
+ *
+ * Read-only guarantee: in the in-process fallback (no VM isolation) a `mutate` op
+ * could touch a live handle, so {@link replayScenario} HARD-REJECTS any
+ * `gateway:'mutate'` op when `allowMutate` is not explicitly set, throwing
+ * {@link MutateInFallbackError} (code `E_SELFIMPROVE_MUTATE_IN_FALLBACK`). The
+ * canned dogfood scenario is `query`-only, so the default replay never mutates.
+ *
+ * @module @cleocode/core/selfimprove/replay
+ * @epic T11889
+ * @task T11912
+ */
+
+import type { DispatchResponse } from '@cleocode/contracts/gateway';
+import type { Logger } from 'pino';
+import type { Scenario, ScenarioOp } from './scenario.js';
+
+/**
+ * The captured envelope shape per replayed op.
+ *
+ * This is the canonical {@link DispatchResponse} the cleo-side `Dispatcher`
+ * returns (a `meta` block + `success` + optional `data`/`error`/`page`/`partial`).
+ * The diff layer (see {@link "./envelope-diff.js"}) normalizes this by stripping
+ * the volatile `meta` fields before comparing against the golden.
+ */
+export type ReplayEnvelope = DispatchResponse;
+
+/**
+ * Narrow dispatch port the replay engine calls — CORE owns this TYPE, NOT the impl.
+ *
+ * The cleo dispatch handler supplies the concrete adapter by closing over its
+ * already-instantiated `Dispatcher` (`dispatcher.dispatch({ gateway, domain,
+ * operation, params, source, requestId })`, where `source` is a valid
+ * `GatewaySource` — e.g. `'rpc'`) and returning the resulting envelope. Injecting
+ * the port keeps the engine + diff + budget logic
+ * in `core` while the dispatcher binding lives in `cleo` (CORE-first, no
+ * package-boundary inversion).
+ */
+export interface ReplayDispatch {
+  /**
+   * Dispatch a single op and return its captured envelope.
+   *
+   * @param op - The dispatch coordinate (gateway, domain, operation, params).
+   * @returns The captured {@link ReplayEnvelope}.
+   */
+  (op: {
+    /** CQRS gateway. */
+    gateway: ScenarioOp['gateway'];
+    /** Registered domain handler key (plural, e.g. `'tasks'`). */
+    domain: string;
+    /** Operation name within the domain. */
+    operation: string;
+    /** Optional operation parameters. */
+    params?: Record<string, unknown>;
+  }): Promise<ReplayEnvelope>;
+}
+
+/** Options controlling a replay run. */
+export interface ReplayOptions {
+  /**
+   * When `true`, permit `gateway:'mutate'` ops (VM-isolated execution path).
+   *
+   * Defaults to `false`: in the in-process fallback there is no VM boundary, so a
+   * mutate op is HARD-REJECTED with {@link MutateInFallbackError}. The canned
+   * dogfood scenario is `query`-only and never sets this.
+   *
+   * @defaultValue false
+   */
+  allowMutate?: boolean;
+}
+
+/**
+ * Thrown when a `gateway:'mutate'` op is replayed without `allowMutate`.
+ *
+ * In the in-process fallback the replay runs in the host process, which DOES hold
+ * live-DB handles; a mutate op there could corrupt a live `tasks.db`/`brain.db`
+ * (the T5158 vector). The hard guard ensures no mutate path can fire without an
+ * explicit VM-isolation opt-in.
+ */
+export class MutateInFallbackError extends Error {
+  /** Stable machine-readable error code. */
+  public readonly code = 'E_SELFIMPROVE_MUTATE_IN_FALLBACK' as const;
+
+  /** The op coordinate (`domain.operation`) that was rejected. */
+  public readonly opCoord: string;
+
+  /**
+   * @param op - The rejected mutate op.
+   */
+  constructor(op: ScenarioOp) {
+    const opCoord = `${op.domain}.${op.operation}`;
+    super(
+      `Refusing to replay mutate op '${opCoord}' without VM isolation ` +
+        '(set allowMutate only when running in a sandbox VM)',
+    );
+    this.name = 'MutateInFallbackError';
+    this.opCoord = opCoord;
+  }
+}
+
+/**
+ * Lazily-resolved module logger.
+ *
+ * Resolved on first use rather than at import time so importing this module never
+ * triggers logger initialization. The cached instance is reused across calls.
+ */
+let cachedLogger: Logger | undefined;
+
+/**
+ * Resolve the module logger, initializing it lazily on first call.
+ *
+ * @returns The `selfimprove-replay` subsystem logger.
+ */
+async function getModuleLogger(): Promise<Logger> {
+  if (cachedLogger === undefined) {
+    const { getLogger } = await import('../logger.js');
+    cachedLogger = getLogger('selfimprove-replay');
+  }
+  return cachedLogger;
+}
+
+/**
+ * Replay a scenario's ordered ops through the injected dispatch port.
+ *
+ * Captures ONE envelope per op, in op order. Read-only by default: every
+ * `gateway:'mutate'` op is HARD-REJECTED with {@link MutateInFallbackError}
+ * unless `options.allowMutate` is set (the VM-isolation path).
+ *
+ * PURE — no DB, no mutation. The `dispatch` port is the only external dependency;
+ * tests inject a mock.
+ *
+ * @param scenario - The validated scenario whose ops are replayed.
+ * @param dispatch - The injected dispatch port (cleo supplies the real adapter).
+ * @param options - Replay options; see {@link ReplayOptions}.
+ * @returns The captured envelopes, one per op, in scenario order.
+ * @throws {@link MutateInFallbackError} On a `mutate` op without `allowMutate`.
+ *
+ * @example
+ * ```ts
+ * const envelopes = await replayScenario(scenario, dispatch);
+ * // envelopes.length === scenario.ops.length
+ * ```
+ */
+export async function replayScenario(
+  scenario: Scenario,
+  dispatch: ReplayDispatch,
+  options: ReplayOptions = {},
+): Promise<ReplayEnvelope[]> {
+  const allowMutate = options.allowMutate ?? false;
+  const logger = await getModuleLogger();
+
+  const captured: ReplayEnvelope[] = [];
+  for (const op of scenario.ops) {
+    if (op.gateway === 'mutate' && !allowMutate) {
+      throw new MutateInFallbackError(op);
+    }
+    const envelope = await dispatch({
+      gateway: op.gateway,
+      domain: op.domain,
+      operation: op.operation,
+      ...(op.params !== undefined ? { params: op.params } : {}),
+    });
+    captured.push(envelope);
+  }
+
+  logger.debug(
+    { scenario: scenario.name, captured: captured.length },
+    'replayed self-improvement scenario',
+  );
+
+  return captured;
+}

--- a/packages/core/src/selfimprove/replay.ts
+++ b/packages/core/src/selfimprove/replay.ts
@@ -48,24 +48,27 @@ export type ReplayEnvelope = DispatchResponse;
  * in `core` while the dispatcher binding lives in `cleo` (CORE-first, no
  * package-boundary inversion).
  */
-export interface ReplayDispatch {
-  /**
-   * Dispatch a single op and return its captured envelope.
-   *
-   * @param op - The dispatch coordinate (gateway, domain, operation, params).
-   * @returns The captured {@link ReplayEnvelope}.
-   */
-  (op: {
-    /** CQRS gateway. */
-    gateway: ScenarioOp['gateway'];
-    /** Registered domain handler key (plural, e.g. `'tasks'`). */
-    domain: string;
-    /** Operation name within the domain. */
-    operation: string;
-    /** Optional operation parameters. */
-    params?: Record<string, unknown>;
-  }): Promise<ReplayEnvelope>;
+/**
+ * The dispatch coordinate handed to a {@link ReplayDispatch} port for one op.
+ */
+export interface ReplayDispatchOp {
+  /** CQRS gateway. */
+  gateway: ScenarioOp['gateway'];
+  /** Registered domain handler key (plural, e.g. `'tasks'`). */
+  domain: string;
+  /** Operation name within the domain. */
+  operation: string;
+  /** Optional operation parameters. */
+  params?: Record<string, unknown>;
 }
+
+/**
+ * Dispatch a single op and return its captured envelope.
+ *
+ * @param op - The dispatch coordinate (gateway, domain, operation, params).
+ * @returns The captured {@link ReplayEnvelope}.
+ */
+export type ReplayDispatch = (op: ReplayDispatchOp) => Promise<ReplayEnvelope>;
 
 /** Options controlling a replay run. */
 export interface ReplayOptions {

--- a/packages/core/src/selfimprove/scenario.ts
+++ b/packages/core/src/selfimprove/scenario.ts
@@ -1,0 +1,306 @@
+/**
+ * Self-improvement scenario + golden fixture loading and validation (T11889-B).
+ *
+ * A *scenario* is a deterministic, ordered sequence of READ-ONLY dispatch ops
+ * (the GRADE-playbook shape — see `docs/specs/GRADE-SCENARIO-PLAYBOOK.md`) paired
+ * with a *golden* envelope set: the known-good, already-normalized response for
+ * each op. The self-improvement loop replays the ops (see {@link "./replay.js"})
+ * and diffs the captured envelopes against the golden (see
+ * {@link "./envelope-diff.js"}); any deviation is a regression.
+ *
+ * This module is PURE — no DB, no native handle, no `cleo` mutation. Scenario and
+ * golden fixtures are stored under
+ * `packages/core/src/selfimprove/scenarios/<name>/{scenario,golden}.json` and loaded
+ * by {@link loadScenario}, which Zod-validates both files before returning.
+ *
+ * Import-time side-effect-free: the logger is resolved lazily on first use.
+ *
+ * @module @cleocode/core/selfimprove/scenario
+ * @epic T11889
+ * @task T11912
+ */
+
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Gateway } from '@cleocode/contracts';
+import type { Logger } from 'pino';
+import { z } from 'zod';
+
+/**
+ * The set of dispatch gateways a scenario op may target.
+ *
+ * Mirrors the contracts {@link Gateway} union (`'query' | 'mutate'`). Declared as
+ * a tuple constant so the Zod enum and the static type stay in lockstep with
+ * `@cleocode/contracts`.
+ */
+const SCENARIO_GATEWAYS = ['query', 'mutate'] as const satisfies readonly Gateway[];
+
+/**
+ * Lazily-resolved module logger.
+ *
+ * Resolved on first use rather than at import time so that importing this module
+ * never triggers logger initialization (a side effect). The cached instance is
+ * reused across calls.
+ */
+let cachedLogger: Logger | undefined;
+
+/**
+ * Resolve the module logger, initializing it lazily on first call.
+ *
+ * @returns The `selfimprove-scenario` subsystem logger.
+ */
+async function getModuleLogger(): Promise<Logger> {
+  if (cachedLogger === undefined) {
+    const { getLogger } = await import('../logger.js');
+    cachedLogger = getLogger('selfimprove-scenario');
+  }
+  return cachedLogger;
+}
+
+/**
+ * Zod schema for a single scenario op.
+ *
+ * An op is a dispatch coordinate: the CQRS `gateway`, the REGISTERED handler
+ * `domain` key (e.g. `'tasks'`, plural — NOT the singular CLI noun), the
+ * `operation` name, and optional `params`. The skeleton's canned scenario is
+ * `query`-only, so replaying it performs zero mutations.
+ */
+export const ScenarioOpSchema = z
+  .object({
+    /** CQRS gateway the op targets (`'query'` for read-only replay). */
+    gateway: z.enum(SCENARIO_GATEWAYS),
+    /** Registered domain handler key (plural, e.g. `'tasks'`). */
+    domain: z.string().min(1),
+    /** Operation name within the domain (e.g. `'find'`, `'show'`). */
+    operation: z.string().min(1),
+    /** Optional operation parameters. */
+    params: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+/** A single ordered, replayable scenario op. */
+export type ScenarioOp = z.infer<typeof ScenarioOpSchema>;
+
+/**
+ * Zod schema for a scenario file (`scenario.json`).
+ *
+ * A scenario is a named, described, ordered op sequence. `ops` must be non-empty
+ * so a scenario always replays at least one op.
+ */
+export const ScenarioSchema = z
+  .object({
+    /** Scenario name — MUST match the containing directory name. */
+    name: z.string().min(1),
+    /** Human-readable description of what the scenario exercises. */
+    description: z.string().min(1),
+    /** Ordered ops replayed left-to-right. */
+    ops: z.array(ScenarioOpSchema).min(1),
+  })
+  .strict();
+
+/** A validated scenario: a named, ordered, read-only op sequence. */
+export type Scenario = z.infer<typeof ScenarioSchema>;
+
+/**
+ * Zod schema for one entry in a golden file.
+ *
+ * A golden entry is the already-normalized expected envelope for the op at the
+ * same index in the scenario's `ops`. Stored as a structural shape (volatile
+ * `meta` fields already stripped); validated loosely here because the structural
+ * comparison happens in {@link "./envelope-diff.js"}, not at load time.
+ */
+export const GoldenEntrySchema = z
+  .object({
+    /** Expected `success` discriminant of the normalized envelope. */
+    success: z.boolean(),
+    /** Expected normalized envelope data payload (volatile `meta` already stripped). */
+    data: z.unknown().optional(),
+    /** Expected normalized error payload, when the golden op is an error. */
+    error: z.unknown().optional(),
+    /**
+     * Expected stable `meta` remnant after volatile-field stripping
+     * (e.g. `gateway`, `domain`, `operation`, `source`). Optional because a
+     * golden may assert only the body.
+     */
+    meta: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+/** A validated golden entry — the expected normalized envelope for one op. */
+export type GoldenEntry = z.infer<typeof GoldenEntrySchema>;
+
+/**
+ * Zod schema for a golden file (`golden.json`).
+ *
+ * The golden is the ordered set of expected normalized envelopes, ONE per
+ * scenario op. {@link loadScenario} enforces that `golden.length === scenario.ops.length`.
+ */
+export const GoldenSchema = z
+  .object({
+    /** Scenario name the golden belongs to — MUST match `scenario.name`. */
+    name: z.string().min(1),
+    /** Expected normalized envelopes, positionally aligned with `scenario.ops`. */
+    envelopes: z.array(GoldenEntrySchema),
+  })
+  .strict();
+
+/** A validated golden envelope set. */
+export type Golden = z.infer<typeof GoldenSchema>;
+
+/**
+ * A loaded scenario together with its golden envelope set.
+ *
+ * Returned by {@link loadScenario}. Guarantees: both files Zod-valid, the golden
+ * name matches the scenario name, and the golden envelope count equals the
+ * scenario op count.
+ */
+export interface LoadedScenario {
+  /** The validated scenario (ordered ops). */
+  scenario: Scenario;
+  /** The validated golden envelope set (positionally aligned with `scenario.ops`). */
+  golden: Golden;
+}
+
+/** Thrown when a scenario name is malformed or a fixture is missing / invalid. */
+export class ScenarioLoadError extends Error {
+  /** Stable machine-readable error code. */
+  public readonly code = 'E_SELFIMPROVE_SCENARIO_INVALID' as const;
+
+  /**
+   * @param message - Human-readable failure description.
+   * @param options - Optional `cause` for error chaining.
+   */
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'ScenarioLoadError';
+  }
+}
+
+/**
+ * Pattern a scenario name must match: kebab/alphanumeric, no path separators.
+ *
+ * Defends `loadScenario` against path traversal: a name like `../../etc` is
+ * rejected before it is ever joined to the scenarios directory.
+ */
+const SCENARIO_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Resolve the candidate scenario directories for a given name.
+ *
+ * Mirrors the established core asset-resolution convention (see
+ * `agent-resolver.ts`): walk up from `import.meta.url` and cover both the
+ * workspace `src/` layout (where vitest runs) and the compiled `dist/` layout.
+ *
+ * @param name - Validated scenario name.
+ * @returns Ordered candidate absolute directory paths.
+ */
+function scenarioDirCandidates(name: string): string[] {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // `here` is `.../selfimprove` (src/selfimprove or dist/selfimprove); the
+  // scenarios live directly beneath it.
+  return [resolve(here, 'scenarios', name)];
+}
+
+/**
+ * Read and parse a JSON fixture file, surfacing a typed error on any failure.
+ *
+ * @param filePath - Absolute path to the JSON file.
+ * @param label - Human label for error messages (e.g. `'scenario'`).
+ * @returns The parsed JSON value.
+ * @throws {@link ScenarioLoadError} When the file is missing or not valid JSON.
+ */
+async function readJsonFixture(filePath: string, label: string): Promise<unknown> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch (cause) {
+    throw new ScenarioLoadError(`Cannot read ${label} fixture at ${filePath}`, { cause });
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (cause) {
+    throw new ScenarioLoadError(`${label} fixture at ${filePath} is not valid JSON`, { cause });
+  }
+}
+
+/**
+ * Load and validate a scenario and its golden fixture by name.
+ *
+ * Reads `scenarios/<name>/scenario.json` and `scenarios/<name>/golden.json`,
+ * Zod-validates both, and cross-checks the invariants:
+ *   - the scenario name matches the requested `name`;
+ *   - the golden name matches the scenario name;
+ *   - the golden envelope count equals the scenario op count.
+ *
+ * PURE — no DB, no mutation. Read-only filesystem access to the bundled fixtures.
+ *
+ * @param name - Scenario name (also the fixture directory name). Must match
+ *   {@link SCENARIO_NAME_PATTERN}.
+ * @returns The validated {@link LoadedScenario}.
+ * @throws {@link ScenarioLoadError} When the name is malformed, a fixture is
+ *   missing/invalid, or an invariant is violated.
+ *
+ * @example
+ * ```ts
+ * const { scenario, golden } = await loadScenario('dhq-replay-find');
+ * // scenario.ops.length === golden.envelopes.length
+ * ```
+ */
+export async function loadScenario(name: string): Promise<LoadedScenario> {
+  if (!SCENARIO_NAME_PATTERN.test(name)) {
+    throw new ScenarioLoadError(
+      `Invalid scenario name '${name}': must match ${SCENARIO_NAME_PATTERN.source}`,
+    );
+  }
+
+  const dir = scenarioDirCandidates(name)[0];
+  if (dir === undefined) {
+    throw new ScenarioLoadError(`Cannot resolve scenario directory for '${name}'`);
+  }
+
+  const scenarioRaw = await readJsonFixture(resolve(dir, 'scenario.json'), 'scenario');
+  const goldenRaw = await readJsonFixture(resolve(dir, 'golden.json'), 'golden');
+
+  const scenarioParsed = ScenarioSchema.safeParse(scenarioRaw);
+  if (!scenarioParsed.success) {
+    throw new ScenarioLoadError(
+      `scenario.json for '${name}' failed validation: ${scenarioParsed.error.message}`,
+      { cause: scenarioParsed.error },
+    );
+  }
+  const goldenParsed = GoldenSchema.safeParse(goldenRaw);
+  if (!goldenParsed.success) {
+    throw new ScenarioLoadError(
+      `golden.json for '${name}' failed validation: ${goldenParsed.error.message}`,
+      { cause: goldenParsed.error },
+    );
+  }
+
+  const scenario = scenarioParsed.data;
+  const golden = goldenParsed.data;
+
+  if (scenario.name !== name) {
+    throw new ScenarioLoadError(
+      `scenario.json name '${scenario.name}' does not match directory '${name}'`,
+    );
+  }
+  if (golden.name !== scenario.name) {
+    throw new ScenarioLoadError(
+      `golden.json name '${golden.name}' does not match scenario name '${scenario.name}'`,
+    );
+  }
+  if (golden.envelopes.length !== scenario.ops.length) {
+    throw new ScenarioLoadError(
+      `golden envelope count (${golden.envelopes.length}) does not match scenario op count (${scenario.ops.length}) for '${name}'`,
+    );
+  }
+
+  const logger = await getModuleLogger();
+  logger.debug(
+    { scenario: name, ops: scenario.ops.length },
+    'loaded self-improvement scenario + golden',
+  );
+
+  return { scenario, golden };
+}

--- a/packages/core/src/selfimprove/scenarios/dhq-replay-find/golden.json
+++ b/packages/core/src/selfimprove/scenarios/dhq-replay-find/golden.json
@@ -1,0 +1,32 @@
+{
+  "name": "dhq-replay-find",
+  "envelopes": [
+    {
+      "success": true,
+      "meta": {
+        "gateway": "query",
+        "domain": "tasks",
+        "operation": "find",
+        "source": "rpc"
+      },
+      "data": {
+        "tasks": [
+          { "id": "T11889", "title": "Self-improvement loop foundation", "status": "active" }
+        ],
+        "count": 1
+      }
+    },
+    {
+      "success": true,
+      "meta": {
+        "gateway": "query",
+        "domain": "tasks",
+        "operation": "show",
+        "source": "rpc"
+      },
+      "data": {
+        "task": { "id": "T11889", "title": "Self-improvement loop foundation", "status": "active" }
+      }
+    }
+  ]
+}

--- a/packages/core/src/selfimprove/scenarios/dhq-replay-find/scenario.json
+++ b/packages/core/src/selfimprove/scenarios/dhq-replay-find/scenario.json
@@ -1,0 +1,18 @@
+{
+  "name": "dhq-replay-find",
+  "description": "Canonical read-only dogfood discovery sequence: find then show. The golden is the known-good normalized envelope set; any structural deviation is a regression.",
+  "ops": [
+    {
+      "gateway": "query",
+      "domain": "tasks",
+      "operation": "find",
+      "params": { "query": "selfimprove" }
+    },
+    {
+      "gateway": "query",
+      "domain": "tasks",
+      "operation": "show",
+      "params": { "id": "T11889" }
+    }
+  ]
+}

--- a/packages/core/src/store/__tests__/selfimprove-dhq-store.test.ts
+++ b/packages/core/src/store/__tests__/selfimprove-dhq-store.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the self-improvement DHQ table + Gate-3 accessor (T11889-A · T11911).
+ *
+ * Required proofs (AC4):
+ *  1. **migration round-trip** — open a TEMP-DIR project `cleo.db` (real migrations
+ *     applied), assert the `selfimprove_dhq` table and all THREE indexes
+ *     (`ix_selfimprove_dhq_status`, `ix_selfimprove_dhq_scenario`,
+ *     `ux_selfimprove_dhq_open`) are present, and round-trip one row.
+ *  2. **partial-unique-open enforcement** — two `status='open'` rows for the SAME
+ *     `question_hash` are rejected (the second raw INSERT throws); a SECOND row for
+ *     the same hash with a NON-open status IS allowed (the partial index only keys
+ *     on `WHERE status='open'`); and the adapter UPSERT path refreshes the single
+ *     open row instead of inserting a duplicate.
+ *  3. **bootstrap assertion** — `assertSelfimproveDhqOpenIndexPresent` returns when
+ *     the index exists and THROWS `E_SELFIMPROVE_DHQ_INDEX_MISSING` once it is
+ *     dropped (proving the migration is the sole enforcer of the invariant).
+ *
+ * The accessor opens via `openDualScopeDbAtPath` (the dual-scope chokepoint) and
+ * extracts `$client` — it NEVER calls `new DatabaseSync` (Gate 3).
+ *
+ * @epic T11889
+ * @task T11889
+ * @task T11911
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from '../dual-scope-db.js';
+import {
+  assertSelfimproveDhqOpenIndexPresent,
+  SELFIMPROVE_DHQ_OPEN_INDEX,
+  SELFIMPROVE_DHQ_TABLE,
+} from '../selfimprove-dhq-schema.js';
+import {
+  readOpenSelfimproveDhq,
+  readSelfimproveDhqByScenario,
+  setSelfimproveDhqPrUrl,
+  updateSelfimproveDhqStatus,
+  upsertOpenSelfimproveDhq,
+} from '../selfimprove-dhq-store.js';
+
+let testRoot: string;
+let native: DatabaseSync;
+
+beforeEach(async () => {
+  testRoot = join(tmpdir(), `selfimprove-dhq-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const cleoDir = join(testRoot, 'project', '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  const dbPath = join(cleoDir, 'cleo.db');
+  // Real migrations applied (the t11889 migration creates selfimprove_dhq + indexes).
+  const handle = await openDualScopeDbAtPath('project', dbPath);
+  native = (handle.db as unknown as { $client: DatabaseSync }).$client;
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+/** Count rows in `selfimprove_dhq`. */
+function rowCount(): number {
+  const row = native.prepare(`SELECT COUNT(*) AS n FROM ${SELFIMPROVE_DHQ_TABLE}`).get() as {
+    n: number;
+  };
+  return Number(row.n);
+}
+
+describe('selfimprove_dhq migration + Gate-3 accessor (T11911)', () => {
+  it('migrates the table and all three indexes (round-trip)', () => {
+    const tbl = native
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(SELFIMPROVE_DHQ_TABLE) as { name: string } | undefined;
+    expect(tbl?.name).toBe(SELFIMPROVE_DHQ_TABLE);
+
+    const indexes = native
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ? ORDER BY name`)
+      .all(SELFIMPROVE_DHQ_TABLE)
+      .map((r) => String((r as { name: unknown }).name));
+    expect(indexes).toContain('ix_selfimprove_dhq_status');
+    expect(indexes).toContain('ix_selfimprove_dhq_scenario');
+    expect(indexes).toContain(SELFIMPROVE_DHQ_OPEN_INDEX);
+
+    // Insert/select round-trip via the accessor.
+    upsertOpenSelfimproveDhq(native, {
+      dhqId: 'DHQ-101',
+      scenario: 'dhq-replay-find',
+      questionHash: 'hash-a',
+      title: 'find drift',
+      regressionJson: '{"regressions":[{"path":"/data/total"}]}',
+      severity: 'P1',
+      runId: 'run-1',
+      now: 1000,
+    });
+
+    const open = readOpenSelfimproveDhq(native, 'hash-a');
+    expect(open).not.toBeNull();
+    expect(open?.dhqId).toBe('DHQ-101');
+    expect(open?.scenario).toBe('dhq-replay-find');
+    expect(open?.status).toBe('open');
+    expect(open?.severity).toBe('P1');
+    expect(open?.prUrl).toBeNull();
+    expect(open?.runId).toBe('run-1');
+    expect(open?.createdAt).toBe(1000);
+
+    const byScenario = readSelfimproveDhqByScenario(native, 'dhq-replay-find');
+    expect(byScenario).toHaveLength(1);
+    expect(byScenario[0]?.questionHash).toBe('hash-a');
+  });
+
+  it('rejects a second open row for the same question_hash (raw INSERT)', () => {
+    const rawInsert = (hash: string, status: string): void => {
+      native
+        .prepare(
+          `INSERT INTO ${SELFIMPROVE_DHQ_TABLE} ` +
+            `(dhq_id, scenario, question_hash, title, regression_json, status, severity, ` +
+            `pr_url, run_id, created_at, updated_at) ` +
+            `VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
+        )
+        .run('DHQ-1', 'scen', hash, 't', '{}', status, 'run', 1, 1);
+    };
+
+    rawInsert('dup-hash', 'open');
+    // Second OPEN row for the same hash violates the partial-UNIQUE index.
+    expect(() => rawInsert('dup-hash', 'open')).toThrow(/UNIQUE|constraint/i);
+    expect(rowCount()).toBe(1);
+
+    // A second row for the SAME hash with a NON-open status IS allowed — the partial
+    // index only keys on `WHERE status = 'open'`.
+    expect(() => rawInsert('dup-hash', 'fixed')).not.toThrow();
+    expect(rowCount()).toBe(2);
+  });
+
+  it('UPSERT refreshes the single open row instead of inserting a duplicate', () => {
+    upsertOpenSelfimproveDhq(native, {
+      dhqId: 'DHQ-201',
+      scenario: 'scen',
+      questionHash: 'idem',
+      title: 'first',
+      regressionJson: '{"v":1}',
+      severity: null,
+      runId: 'run-a',
+      now: 100,
+    });
+    upsertOpenSelfimproveDhq(native, {
+      dhqId: 'DHQ-999-IGNORED',
+      scenario: 'scen',
+      questionHash: 'idem',
+      title: 'second-ignored',
+      regressionJson: '{"v":2}',
+      severity: 'P2',
+      runId: 'run-b',
+      now: 200,
+    });
+
+    expect(rowCount()).toBe(1);
+    const open = readOpenSelfimproveDhq(native, 'idem');
+    expect(open?.dhqId).toBe('DHQ-201'); // first insert wins identity
+    expect(open?.regressionJson).toBe('{"v":2}'); // refreshed
+    expect(open?.severity).toBe('P2'); // refreshed
+    expect(open?.runId).toBe('run-b'); // refreshed
+    expect(open?.updatedAt).toBe(200); // refreshed
+
+    // Terminal transition frees the slot; a new regression of the same hash opens a
+    // fresh row.
+    const changed = updateSelfimproveDhqStatus(native, 'idem', 'fixed', 300);
+    expect(changed).toBe(1);
+    expect(readOpenSelfimproveDhq(native, 'idem')).toBeNull();
+
+    upsertOpenSelfimproveDhq(native, {
+      dhqId: 'DHQ-202',
+      scenario: 'scen',
+      questionHash: 'idem',
+      title: 'reopened',
+      regressionJson: '{"v":3}',
+      severity: null,
+      runId: 'run-c',
+      now: 400,
+    });
+    expect(rowCount()).toBe(2);
+    expect(readOpenSelfimproveDhq(native, 'idem')?.dhqId).toBe('DHQ-202');
+  });
+
+  it('records the draft PR URL on the open row', () => {
+    upsertOpenSelfimproveDhq(native, {
+      dhqId: 'DHQ-301',
+      scenario: 'scen',
+      questionHash: 'pr-hash',
+      title: 'pr',
+      regressionJson: '{}',
+      severity: null,
+      runId: 'run-1',
+      now: 100,
+    });
+    const changed = setSelfimproveDhqPrUrl(native, 'pr-hash', 'https://github.com/o/r/pull/1', 150);
+    expect(changed).toBe(1);
+    expect(readOpenSelfimproveDhq(native, 'pr-hash')?.prUrl).toBe('https://github.com/o/r/pull/1');
+  });
+
+  it('assertSelfimproveDhqOpenIndexPresent passes when present, throws when dropped', () => {
+    expect(() => assertSelfimproveDhqOpenIndexPresent(native)).not.toThrow();
+
+    native.prepare(`DROP INDEX ${SELFIMPROVE_DHQ_OPEN_INDEX}`).run();
+    expect(() => assertSelfimproveDhqOpenIndexPresent(native)).toThrow(
+      /E_SELFIMPROVE_DHQ_INDEX_MISSING/,
+    );
+  });
+});

--- a/packages/core/src/store/selfimprove-dhq-schema.ts
+++ b/packages/core/src/store/selfimprove-dhq-schema.ts
@@ -1,0 +1,139 @@
+/**
+ * Drizzle ORM schema for the **self-improvement DHQ** table (`selfimprove_dhq`),
+ * the durable sink for the P5 self-improvement loop (T11889 · T11889-A · T11911).
+ *
+ * One row per Dogfood-Harness-Question (DHQ) emitted by `cleo selfimprove run`:
+ * the loop replays a canned dogfood scenario, diffs the resulting LAFS envelopes
+ * against a golden, and — on regression — UPSERTs exactly ONE row here through the
+ * leased Gate-3 accessor ({@link ./selfimprove-dhq-store.ts}). On green it writes
+ * nothing. The table is dual-scope: co-located inside EACH scope's consolidated
+ * `cleo.db` (project + global) via the `drizzle-cleo-project` / `drizzle-cleo-global`
+ * migration sets, exactly like the `_writer_leases` (T11627) and `pi_session_*`
+ * (T11899) runtime-infrastructure tables. It is NOT part of the exodus target shape
+ * under `schema/cleo-project/`.
+ *
+ * ## Idempotency invariant — at most ONE open DHQ per `question_hash`
+ *
+ * A repeated regression must UPSERT the SAME open row rather than spam N duplicates.
+ * This is enforced by the **partial UNIQUE index**
+ * `ux_selfimprove_dhq_open ON selfimprove_dhq (question_hash) WHERE status = 'open'`.
+ * drizzle-orm does **not** surface partial-`WHERE` indexes in its typed schema API
+ * (cf. `writer-lease-schema.ts` `_writer_leases.active`, `conduit-schema.ts`
+ * `project_agent_refs.enabled`), so the partial index is emitted as **raw SQL in the
+ * baseline migration** — this module declares only the full-column table plus the two
+ * non-partial indexes drizzle CAN model. The runtime bootstrap asserts the partial
+ * index exists via {@link assertSelfimproveDhqOpenIndexPresent} so a missing index
+ * (a migration that never ran, or a dropped index) fails loudly instead of silently
+ * permitting two open rows for the same `question_hash`.
+ *
+ * @module
+ * @task T11911
+ * @task T11889
+ * @epic T11889
+ * @see ./selfimprove-dhq-store.ts — the Gate-3 accessor over these tables
+ * @see ./writer-lease-schema.ts — the partial-UNIQUE-index-via-raw-SQL precedent
+ * @see ../../migrations/drizzle-cleo-project — project migration (raw partial index)
+ * @see ../../migrations/drizzle-cleo-global — global migration (raw partial index)
+ */
+
+import type { DatabaseSync } from 'node:sqlite';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * The physical name of the self-improvement DHQ table. Exported so the engine, the
+ * store accessor, the bootstrap assertion, and tests all reference one source of
+ * truth.
+ */
+export const SELFIMPROVE_DHQ_TABLE = 'selfimprove_dhq' as const;
+
+/**
+ * The physical name of the partial-UNIQUE active-row index (`WHERE status = 'open'`).
+ * Asserted present at bootstrap because drizzle cannot emit it — it lives as raw SQL
+ * in the baseline migration.
+ */
+export const SELFIMPROVE_DHQ_OPEN_INDEX = 'ux_selfimprove_dhq_open' as const;
+
+/**
+ * `selfimprove_dhq` — one row per self-improvement-loop DHQ.
+ *
+ * The at-most-one-open-per-`question_hash` invariant is enforced by the raw-SQL
+ * partial-UNIQUE index `ux_selfimprove_dhq_open ON selfimprove_dhq (question_hash)
+ * WHERE status = 'open'` (emitted in the baseline migration — drizzle cannot model
+ * partial `WHERE`). This declaration intentionally carries only the full-column
+ * table plus the two non-partial indexes; do NOT add a `.unique()` on
+ * `question_hash` here (it would emit a NON-partial unique that wrongly forbids a
+ * second non-open row for the same hash).
+ */
+export const selfimproveDhq = sqliteTable(
+  SELFIMPROVE_DHQ_TABLE,
+  {
+    /** Surrogate primary key (autoincrement via INTEGER PRIMARY KEY rowid alias). */
+    id: integer('id').primaryKey(),
+    /** Stable `'DHQ-###'` handle for the question. */
+    dhqId: text('dhq_id').notNull(),
+    /** The scenario name replayed when this DHQ was raised. */
+    scenario: text('scenario').notNull(),
+    /** sha256 of the normalized regression signature — the idempotency key. */
+    questionHash: text('question_hash').notNull(),
+    /** Human-readable DHQ title. */
+    title: text('title').notNull(),
+    /** The envelope-diff payload (the evidence) as serialized JSON. */
+    regressionJson: text('regression_json').notNull(),
+    /**
+     * Lifecycle status — `open` while the regression is live; advanced to a terminal
+     * value as the DHQ is worked. The partial-UNIQUE index keys on `status = 'open'`.
+     */
+    status: text('status').notNull().default('open'),
+    /** Severity classification (nullable until triaged), e.g. `P0`..`P3`. */
+    severity: text('severity'),
+    /** The draft PR URL once egress fires (nullable until a PR is opened). */
+    prUrl: text('pr_url'),
+    /** Ties the row to ONE loop run. */
+    runId: text('run_id').notNull(),
+    /** Creation timestamp (epoch ms). */
+    createdAt: integer('created_at').notNull(),
+    /** Last-update timestamp (epoch ms). */
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('ix_selfimprove_dhq_status').on(table.status),
+    index('ix_selfimprove_dhq_scenario').on(table.scenario),
+  ],
+);
+
+/**
+ * Assert that the raw-SQL partial-UNIQUE open-row index is physically present on the
+ * given native `cleo.db` handle.
+ *
+ * Because drizzle cannot emit a partial-`WHERE` index, the at-most-one-open-DHQ
+ * invariant depends entirely on the hand-written baseline migration having run. This
+ * check makes a missing index a loud, immediate failure at bootstrap rather than a
+ * silent loss of the idempotency guarantee (which would let the loop spam duplicate
+ * open rows).
+ *
+ * @param nativeDb - The native `DatabaseSync` handle for a scope's `cleo.db`.
+ * @throws {Error} `E_SELFIMPROVE_DHQ_INDEX_MISSING` if `ux_selfimprove_dhq_open` is
+ *   absent (the migration did not run, or the partial index was dropped).
+ *
+ * @example
+ * ```ts
+ * const nativeDb = (handle.db as { $client: DatabaseSync }).$client;
+ * assertSelfimproveDhqOpenIndexPresent(nativeDb); // throws if the index is missing
+ * ```
+ *
+ * @task T11911
+ */
+export function assertSelfimproveDhqOpenIndexPresent(nativeDb: DatabaseSync): void {
+  const row = nativeDb
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`)
+    .get(SELFIMPROVE_DHQ_OPEN_INDEX) as { name: string } | undefined;
+  if (!row) {
+    throw new Error(
+      `E_SELFIMPROVE_DHQ_INDEX_MISSING: partial-unique open-row index ` +
+        `"${SELFIMPROVE_DHQ_OPEN_INDEX}" is absent from this cleo.db. The DHQ ` +
+        `baseline migration (drizzle-cleo-{project,global}/…_t11889-selfimprove-dhq) ` +
+        `did not run, so the at-most-one-open-DHQ-per-question_hash invariant is ` +
+        `unenforced.`,
+    );
+  }
+}

--- a/packages/core/src/store/selfimprove-dhq-store.ts
+++ b/packages/core/src/store/selfimprove-dhq-store.ts
@@ -1,0 +1,300 @@
+/**
+ * Store-layer accessor for the self-improvement DHQ table (`selfimprove_dhq`) —
+ * T11889 · T11889-A · T11911.
+ *
+ * This module is the ONLY place that touches the native `cleo.db` handle for the
+ * self-improvement loop's DHQ persistence. It lives INSIDE the store chokepoint
+ * (`packages/core/src/store/**`), the Gate-3 allowlist, so it may extract the native
+ * `DatabaseSync` that {@link openDualScopeDb} already holds (via drizzle's `$client`)
+ * and run prepared statements over it — exactly the established `pi-session-store.ts`
+ * pattern. It NEVER calls `new DatabaseSync(` itself.
+ *
+ * The durable adapter (`packages/core/src/selfimprove/dhq-adapter.ts`, T11889-C)
+ * sits OUTSIDE the chokepoint, so it must NOT open a raw handle; it calls these
+ * accessors and wraps every WRITE in `withWriterLease('project', 'bulk', …)` so the
+ * write is serialized against any other writer on the `(project, bulk)` lane. The
+ * lease SERIALIZES the write; the "only ever writes `selfimprove_dhq`, never a live
+ * `tasks`/`brain` row" guarantee comes from this accessor's prepared statements
+ * targeting ONLY `selfimprove_dhq` — adapter discipline, not the lease.
+ *
+ * Physical model (see the `t11889-selfimprove-dhq` migration):
+ *  - `selfimprove_dhq(id, dhq_id, scenario, question_hash, title, regression_json,
+ *    status, severity, pr_url, run_id, created_at, updated_at)` — one row per DHQ.
+ *  - Idempotency: a raw-SQL partial-UNIQUE index `ux_selfimprove_dhq_open` keys on
+ *    `question_hash WHERE status = 'open'`, so at most one open row per hash.
+ *
+ * @module
+ * @task T11911
+ * @task T11889
+ * @epic T11889
+ */
+
+import type { DatabaseSync as DatabaseSyncType } from 'node:sqlite';
+import { openDualScopeDb } from './dual-scope-db.js';
+import {
+  assertSelfimproveDhqOpenIndexPresent,
+  SELFIMPROVE_DHQ_TABLE,
+} from './selfimprove-dhq-schema.js';
+
+export {
+  assertSelfimproveDhqOpenIndexPresent,
+  SELFIMPROVE_DHQ_OPEN_INDEX,
+  SELFIMPROVE_DHQ_TABLE,
+} from './selfimprove-dhq-schema.js';
+
+/** A persisted DHQ row, decoded from `selfimprove_dhq`. */
+export interface SelfimproveDhqRow {
+  /** Stable `'DHQ-###'` handle for the question. */
+  readonly dhqId: string;
+  /** The scenario name replayed when this DHQ was raised. */
+  readonly scenario: string;
+  /** sha256 of the normalized regression signature — the idempotency key. */
+  readonly questionHash: string;
+  /** Human-readable DHQ title. */
+  readonly title: string;
+  /** The envelope-diff payload (the evidence) as serialized JSON. */
+  readonly regressionJson: string;
+  /** Lifecycle status — `'open'` while the regression is live. */
+  readonly status: string;
+  /** Severity classification, or `null` until triaged. */
+  readonly severity: string | null;
+  /** The draft PR URL once egress fires, or `null`. */
+  readonly prUrl: string | null;
+  /** Ties the row to ONE loop run. */
+  readonly runId: string;
+  /** Creation timestamp (epoch ms). */
+  readonly createdAt: number;
+  /** Last-update timestamp (epoch ms). */
+  readonly updatedAt: number;
+}
+
+/**
+ * Fields required to UPSERT one open DHQ. `status` is fixed to `'open'` by the
+ * accessor (the partial-UNIQUE index keys on it); terminal-status transitions go
+ * through {@link updateSelfimproveDhqStatus} instead.
+ */
+export interface SelfimproveDhqUpsert {
+  /** Stable `'DHQ-###'` handle (used only on first insert for a hash). */
+  readonly dhqId: string;
+  /** The scenario name replayed. */
+  readonly scenario: string;
+  /** sha256 of the normalized regression signature — the idempotency key. */
+  readonly questionHash: string;
+  /** Human-readable DHQ title. */
+  readonly title: string;
+  /** The envelope-diff payload (the evidence) as serialized JSON. */
+  readonly regressionJson: string;
+  /** Severity classification, or `null` until triaged. */
+  readonly severity: string | null;
+  /** Ties the row to ONE loop run. */
+  readonly runId: string;
+  /** The timestamp to stamp on insert/update (epoch ms). */
+  readonly now: number;
+}
+
+/** Narrow shape of the native handle methods this accessor uses. */
+type NativeRunResult = { changes: number | bigint; lastInsertRowid: number | bigint };
+interface NativeStatement {
+  run(...params: ReadonlyArray<string | number | null>): NativeRunResult;
+  get(...params: ReadonlyArray<string | number | null>): Record<string, unknown> | undefined;
+  all(...params: ReadonlyArray<string | number | null>): Array<Record<string, unknown>>;
+}
+interface NativeHandle {
+  prepare(sql: string): NativeStatement;
+}
+
+/**
+ * Extract the native `DatabaseSync` handle for the PROJECT-scope `cleo.db`.
+ *
+ * Routes through {@link openDualScopeDb} (the dual-scope chokepoint) — which applies
+ * the pragma SSoT, runs the consolidated migrations (creating `selfimprove_dhq`),
+ * and manages the singleton cache — then extracts the native handle drizzle holds on
+ * `$client`. NEVER opens a raw connection (Gate 3): it reuses the handle the
+ * chokepoint already owns.
+ *
+ * @param cwd - Working directory for project resolution (defaults to `cwd`).
+ * @returns The live native handle.
+ * @throws When the chokepoint returns a handle without `$client`.
+ */
+export async function getSelfimproveDhqNativeDb(cwd?: string): Promise<NativeHandle> {
+  const handle = await openDualScopeDb('project', cwd);
+  const native = (handle.db as unknown as { $client?: DatabaseSyncType }).$client;
+  if (!native) {
+    throw new Error(
+      'T11911: openDualScopeDb returned a project handle without $client — ' +
+        'cannot extract DatabaseSync for selfimprove_dhq persistence.',
+    );
+  }
+  // The node:sqlite surface is wider than NativeHandle; narrow to what we use.
+  return native as unknown as NativeHandle;
+}
+
+/** Decode a raw SQLite row into a typed {@link SelfimproveDhqRow}. */
+function decodeRow(row: Record<string, unknown>): SelfimproveDhqRow {
+  return {
+    dhqId: String(row.dhq_id),
+    scenario: String(row.scenario),
+    questionHash: String(row.question_hash),
+    title: String(row.title),
+    regressionJson: String(row.regression_json),
+    status: String(row.status),
+    severity: row.severity === null || row.severity === undefined ? null : String(row.severity),
+    prUrl: row.pr_url === null || row.pr_url === undefined ? null : String(row.pr_url),
+    runId: String(row.run_id),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+// ── Reads (no lease — readers operate on the shared handle) ────────────────────
+
+/**
+ * Return the open DHQ row for a `question_hash`, or `null` when none is open.
+ *
+ * @param native - The native project `cleo.db` handle.
+ * @param questionHash - The regression-signature hash.
+ * @returns The open row or `null`.
+ */
+export function readOpenSelfimproveDhq(
+  native: NativeHandle,
+  questionHash: string,
+): SelfimproveDhqRow | null {
+  const row = native
+    .prepare(
+      `SELECT id, dhq_id, scenario, question_hash, title, regression_json, status, ` +
+        `severity, pr_url, run_id, created_at, updated_at ` +
+        `FROM ${SELFIMPROVE_DHQ_TABLE} WHERE question_hash = ? AND status = 'open'`,
+    )
+    .get(questionHash);
+  return row === undefined ? null : decodeRow(row);
+}
+
+/**
+ * Return all DHQ rows for a scenario in stable creation order (`created_at ASC`).
+ *
+ * @param native - The native project `cleo.db` handle.
+ * @param scenario - The scenario name.
+ * @returns The ordered rows (empty when the scenario has none).
+ */
+export function readSelfimproveDhqByScenario(
+  native: NativeHandle,
+  scenario: string,
+): SelfimproveDhqRow[] {
+  const rows = native
+    .prepare(
+      `SELECT id, dhq_id, scenario, question_hash, title, regression_json, status, ` +
+        `severity, pr_url, run_id, created_at, updated_at ` +
+        `FROM ${SELFIMPROVE_DHQ_TABLE} WHERE scenario = ? ORDER BY created_at ASC, id ASC`,
+    )
+    .all(scenario);
+  return rows.map(decodeRow);
+}
+
+// ── Writes (caller MUST hold the writer lease — see dhq-adapter.ts) ────────────
+
+/**
+ * Insert (or, on a repeated open regression, refresh) exactly ONE open DHQ row for a
+ * `question_hash`.
+ *
+ * The partial-UNIQUE index `ux_selfimprove_dhq_open (question_hash) WHERE status =
+ * 'open'` makes this idempotent: a second open regression for the same hash updates
+ * the existing open row's `updated_at` / `run_id` / `severity` instead of inserting a
+ * duplicate. The caller MUST already hold the PROJECT/`bulk` writer lease — this
+ * accessor performs the raw write and does NOT acquire the lease itself (the lease
+ * boundary lives in `dhq-adapter.ts`, outside the chokepoint).
+ *
+ * @param native - The native project `cleo.db` handle (leased section).
+ * @param row - The DHQ to upsert.
+ */
+export function upsertOpenSelfimproveDhq(native: NativeHandle, row: SelfimproveDhqUpsert): void {
+  native
+    .prepare(
+      `INSERT INTO ${SELFIMPROVE_DHQ_TABLE} ` +
+        `(dhq_id, scenario, question_hash, title, regression_json, status, severity, ` +
+        `pr_url, run_id, created_at, updated_at) ` +
+        `VALUES (?, ?, ?, ?, ?, 'open', ?, NULL, ?, ?, ?) ` +
+        `ON CONFLICT(question_hash) WHERE status = 'open' DO UPDATE SET ` +
+        `regression_json = excluded.regression_json, severity = excluded.severity, ` +
+        `run_id = excluded.run_id, updated_at = excluded.updated_at`,
+    )
+    .run(
+      row.dhqId,
+      row.scenario,
+      row.questionHash,
+      row.title,
+      row.regressionJson,
+      row.severity,
+      row.runId,
+      row.now,
+      row.now,
+    );
+}
+
+/**
+ * Advance an open DHQ to a terminal status (e.g. `'fixed'` / `'dismissed'`) for a
+ * `question_hash`. Frees the partial-UNIQUE slot so a future regression of the same
+ * hash can open a new row.
+ *
+ * The caller MUST hold the writer lease.
+ *
+ * @param native - The native project `cleo.db` handle (leased section).
+ * @param questionHash - The regression-signature hash whose open row to advance.
+ * @param status - The new (non-open) status.
+ * @param now - The update timestamp (epoch ms).
+ * @returns The number of rows updated (0 when no open row exists).
+ */
+export function updateSelfimproveDhqStatus(
+  native: NativeHandle,
+  questionHash: string,
+  status: string,
+  now: number,
+): number {
+  const result = native
+    .prepare(
+      `UPDATE ${SELFIMPROVE_DHQ_TABLE} SET status = ?, updated_at = ? ` +
+        `WHERE question_hash = ? AND status = 'open'`,
+    )
+    .run(status, now, questionHash);
+  return Number(result.changes);
+}
+
+/**
+ * Record the draft PR URL on the open DHQ row for a `question_hash`.
+ *
+ * The caller MUST hold the writer lease.
+ *
+ * @param native - The native project `cleo.db` handle (leased section).
+ * @param questionHash - The regression-signature hash whose open row to annotate.
+ * @param prUrl - The draft PR URL.
+ * @param now - The update timestamp (epoch ms).
+ * @returns The number of rows updated (0 when no open row exists).
+ */
+export function setSelfimproveDhqPrUrl(
+  native: NativeHandle,
+  questionHash: string,
+  prUrl: string,
+  now: number,
+): number {
+  const result = native
+    .prepare(
+      `UPDATE ${SELFIMPROVE_DHQ_TABLE} SET pr_url = ?, updated_at = ? ` +
+        `WHERE question_hash = ? AND status = 'open'`,
+    )
+    .run(prUrl, now, questionHash);
+  return Number(result.changes);
+}
+
+/**
+ * Bootstrap check: open the project `cleo.db` (running migrations) and assert the
+ * partial-UNIQUE open-row index is physically present.
+ *
+ * Convenience wrapper over {@link getSelfimproveDhqNativeDb} +
+ * {@link assertSelfimproveDhqOpenIndexPresent} for callers that only have a `cwd`.
+ *
+ * @param cwd - Working directory for project resolution.
+ * @throws `E_SELFIMPROVE_DHQ_INDEX_MISSING` if the index is absent.
+ */
+export async function assertSelfimproveDhqReady(cwd?: string): Promise<void> {
+  const native = await getSelfimproveDhqNativeDb(cwd);
+  assertSelfimproveDhqOpenIndexPresent(native as unknown as DatabaseSyncType);
+}


### PR DESCRIPTION
## Summary

The DHQ-burn engine foundation — a dual-scope `selfimprove_dhq` table (lease-gated, partial-unique-open) + read-only scenario replay + deterministic envelope-diff vs golden. This is the storage + measurement substrate the self-improvement loop (`cleo selfimprove run`) builds on: replay a canned scenario, diff the LAFS envelopes against a golden, and on regression UPSERT exactly ONE open row per question.

## What ships (additive only — 2139 insertions, 0 deletions)

### T11911 — `selfimprove_dhq` storage (Gate-3 clean)
- **Byte-identical migration pair** under `drizzle-cleo-project` + `drizzle-cleo-global` (`20260608020000_t11889-selfimprove-dhq`, same SHA so the consolidated single-file journal converges across both lineages under `CONSOLIDATED_JOURNAL_LINEAGES`, T11829).
- `--> statement-breakpoint` between **every** statement (node:sqlite `prepare()` truncates multi-statement files otherwise).
- **Partial-UNIQUE active-row index** `ux_selfimprove_dhq_open ... WHERE status = 'open'` emitted as **raw SQL** (drizzle cannot model a partial WHERE) — at most one open row per `question_hash`, so a repeated regression UPSERTs instead of spamming duplicates. Runtime asserts the index via `assertSelfimproveDhqOpenIndexPresent`.
- **Page-2 invariant:** the migration runs AFTER the consolidation baseline, so `selfimprove_dhq` is never the first CREATE on a fresh DB.
- **Gate-3:** the accessor routes through `openDualScopeDb` and extracts `$client` — it NEVER calls `new DatabaseSync`. `scripts/lint-no-direct-db-open.mjs --strict` is green.

### T11912 — scenario replay + envelope-diff (pure, no DB)
- **Read-only scenario replay** — no prod mutation in the dogfood replay; `gateway:'mutate'` ops are gated behind an explicit VM-isolated opt-in.
- **Deterministic envelope-diff vs golden** — normalization strips the volatile `_meta` fields (timestamp / requestId / durationMs) plus session-lineage UUIDs before diffing; subset-compares meta. Module B is pure (no DB).

## Verification
- `pnpm biome check .` — clean (exit 0)
- `pnpm run build` — full monorepo build success; `@cleocode/core` tsc clean
- cgroup-wrapped core tests — all 35 selfimprove + dhq-store tests pass; 44 migration smoke / cross-lineage-convergence / schema-parity tests pass (new migration converges + maintains parity)
- `scripts/lint-no-direct-db-open.mjs --strict` — STRICT OK, zero violations
- `cleo check arch` — 5/5 gates pass

GENERATED-WITH Claude Code