### PR TITLE
feat(T11599): Gondolin micro-VM ExecutionEnv backend + resolveExecutionEnv selector (T11888)

### DIFF
--- a/packages/core/src/llm/pi/__tests__/gondolin-loader.test.ts
+++ b/packages/core/src/llm/pi/__tests__/gondolin-loader.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the Gondolin optional-dep loader + availability probe
+ * (T11908 · T11888-A).
+ *
+ * Mirrors the merged T1742 Playwright-optional pattern: the dynamic `import()` and
+ * the host probes (`/dev/kvm`, QEMU) are injected via `__setGondolinTestHooks` so
+ * EVERY case is deterministic — NO real `@earendil-works/gondolin` is required and
+ * NO real QEMU VM is ever launched. A real-VM exercise is a separate opt-in
+ * integration test gated on `/dev/kvm`+QEMU (out of scope here).
+ *
+ * @task T11908
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __resetGondolinAvailabilityCache,
+  __setGondolinTestHooks,
+  GONDOLIN_INSTALL_HINT,
+  type GondolinModule,
+  isGondolinAvailable,
+  loadGondolin,
+} from '../gondolin-loader.js';
+
+/**
+ * A structurally-valid mock of the consumed Gondolin surface — enough to pass the
+ * loader's shape-check. No method is ever invoked here (the loader only inspects
+ * `typeof`), so no VM boots.
+ */
+const validMockModule = {
+  VM: { create: async () => ({}) },
+  RealFSProvider: class {},
+  createHttpHooks: () => ({ __httpHooks: true }),
+} as const;
+
+afterEach(() => {
+  // Restore the real importer + probes and clear the cache between cases.
+  __setGondolinTestHooks();
+});
+
+describe('loadGondolin', () => {
+  it('returns null when the package is absent (import() rejects)', async () => {
+    __setGondolinTestHooks({
+      importer: () => Promise.reject(new Error("Cannot find module '@earendil-works/gondolin'")),
+    });
+    await expect(loadGondolin()).resolves.toBeNull();
+  });
+
+  it('never throws — a rejected import resolves to null, not an exception', async () => {
+    __setGondolinTestHooks({
+      importer: () => {
+        throw new Error('synchronous import explosion');
+      },
+    });
+    await expect(loadGondolin()).resolves.toBeNull();
+  });
+
+  it('returns the typed module when the package loads with the expected surface', async () => {
+    __setGondolinTestHooks({ importer: () => Promise.resolve(validMockModule) });
+    const mod = await loadGondolin();
+    expect(mod).not.toBeNull();
+    expect(typeof (mod as GondolinModule).VM.create).toBe('function');
+    expect(typeof (mod as GondolinModule).createHttpHooks).toBe('function');
+  });
+
+  it('unwraps an ESM default export', async () => {
+    __setGondolinTestHooks({ importer: () => Promise.resolve({ default: validMockModule }) });
+    await expect(loadGondolin()).resolves.not.toBeNull();
+  });
+
+  it('returns null when the loaded module is missing a required export (shape-check)', async () => {
+    __setGondolinTestHooks({
+      // Missing `createHttpHooks` → shape-check fails → unavailable, not a crash.
+      importer: () =>
+        Promise.resolve({ VM: { create: async () => ({}) }, RealFSProvider: class {} }),
+    });
+    await expect(loadGondolin()).resolves.toBeNull();
+  });
+
+  it('returns null when VM lacks a create() factory', async () => {
+    __setGondolinTestHooks({
+      importer: () =>
+        Promise.resolve({
+          VM: {},
+          RealFSProvider: class {},
+          createHttpHooks: () => ({}),
+        }),
+    });
+    await expect(loadGondolin()).resolves.toBeNull();
+  });
+});
+
+describe('isGondolinAvailable — AND-gates package + /dev/kvm + QEMU', () => {
+  it('is false when the package is absent (even with kvm + qemu present)', async () => {
+    __setGondolinTestHooks({
+      importer: () => Promise.reject(new Error('not installed')),
+      hasKvm: () => true,
+      hasQemu: () => true,
+    });
+    await expect(isGondolinAvailable()).resolves.toBe(false);
+  });
+
+  it('is false when /dev/kvm is absent (package + qemu present)', async () => {
+    __setGondolinTestHooks({
+      importer: () => Promise.resolve(validMockModule),
+      hasKvm: () => false,
+      hasQemu: () => true,
+    });
+    await expect(isGondolinAvailable()).resolves.toBe(false);
+  });
+
+  it('is false when QEMU is absent (package + kvm present)', async () => {
+    __setGondolinTestHooks({
+      importer: () => Promise.resolve(validMockModule),
+      hasKvm: () => true,
+      hasQemu: () => false,
+    });
+    await expect(isGondolinAvailable()).resolves.toBe(false);
+  });
+
+  it('is true ONLY when package + /dev/kvm + QEMU are all present', async () => {
+    __setGondolinTestHooks({
+      importer: () => Promise.resolve(validMockModule),
+      hasKvm: () => true,
+      hasQemu: () => true,
+    });
+    await expect(isGondolinAvailable()).resolves.toBe(true);
+  });
+
+  it('caches the result so a later probe-mutation is ignored until __resetGondolinAvailabilityCache', async () => {
+    // Use a MUTABLE kvm flag so we can flip the probe WITHOUT calling
+    // __setGondolinTestHooks (which itself resets the cache).
+    let kvmPresent = true;
+    __setGondolinTestHooks({
+      importer: () => Promise.resolve(validMockModule),
+      hasKvm: () => kvmPresent,
+      hasQemu: () => true,
+    });
+
+    // First probe: everything present → true (and cached).
+    await expect(isGondolinAvailable()).resolves.toBe(true);
+
+    // Flip the underlying probe to "no kvm" — but the cached `true` must STAND
+    // because the cache short-circuits before re-probing.
+    kvmPresent = false;
+    await expect(isGondolinAvailable()).resolves.toBe(true);
+
+    // Manual reset clears the cache → the next probe reflects the new value.
+    __resetGondolinAvailabilityCache();
+    await expect(isGondolinAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('GONDOLIN_INSTALL_HINT', () => {
+  it('names the package and the QEMU/KVM host requirement', () => {
+    expect(GONDOLIN_INSTALL_HINT).toContain('@earendil-works/gondolin');
+    expect(GONDOLIN_INSTALL_HINT).toMatch(/QEMU|KVM|kvm|qemu/);
+  });
+});

--- a/packages/core/src/llm/pi/__tests__/pi-gondolin-env.integration.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-gondolin-env.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * OPT-IN real-VM integration test for the Gondolin selector (T11910 · T11888-C).
+ *
+ * This is the ONE test that may boot a REAL micro-VM. It is GATED on the host
+ * actually having the sandbox infra — the optional `@earendil-works/gondolin`
+ * package loads AND `/dev/kvm` exists AND a working `qemu-system-x86_64` is on
+ * `PATH` (the same AND-gate as {@link isGondolinAvailable}) — AND the explicit
+ * opt-in env flag `CLEO_GONDOLIN_INTEGRATION=1`. When ANY of those is absent the
+ * suite is SKIPPED (never failed), so CI — gondolin uninstalled, no `/dev/kvm`,
+ * no QEMU — stays green with zero VM infra. The unit matrix
+ * ({@link ./resolve-execution-env.test.js}) mocks the VM and is the always-run
+ * coverage; this file only adds value on a real KVM-capable box.
+ *
+ * Run it deliberately, cgroup-wrapped (the MEMORY.md OOM cap), e.g.:
+ *   systemd-run --user --scope -p MemoryMax=32G -p MemorySwapMax=0 -- \
+ *     env CLEO_GONDOLIN_INTEGRATION=1 \
+ *     pnpm --filter @cleocode/core test -- --maxWorkers=1 resolve-execution-env
+ *
+ * @epic T11599
+ * @task T11910
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createToolGuard } from '../../../tools/guard.js';
+import { isGondolinAvailable } from '../gondolin-loader.js';
+import type { PiExecutionEnv } from '../pi-execution-env.js';
+import { resolveExecutionEnv } from '../resolve-execution-env.js';
+
+/**
+ * Whether the real-VM exercise should run: the explicit opt-in flag AND the host
+ * sandbox infra (package + `/dev/kvm` + QEMU) are both present. Awaited in
+ * `beforeAll` so an unavailable host skips every case rather than throwing at
+ * VM-boot time.
+ */
+async function shouldRunRealVm(): Promise<boolean> {
+  if (process.env.CLEO_GONDOLIN_INTEGRATION !== '1') return false;
+  return isGondolinAvailable();
+}
+
+describe('resolveExecutionEnv — REAL VM integration (opt-in, gated on /dev/kvm + QEMU)', () => {
+  let enabled = false;
+  let root: string;
+  let seededCopyDir: string;
+  let env: PiExecutionEnv | undefined;
+
+  beforeAll(async () => {
+    enabled = await shouldRunRealVm();
+    if (!enabled) return;
+    root = mkdtempSync(join(tmpdir(), 'gondolin-int-'));
+    // The VM's single RW mount: a disposable seeded copy (NEVER a live DB dir).
+    seededCopyDir = mkdtempSync(join(tmpdir(), 'gondolin-seed-'));
+  });
+
+  afterAll(async () => {
+    if (env !== undefined) await env.cleanup();
+    if (enabled) {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(seededCopyDir, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.env.CLEO_GONDOLIN_INTEGRATION === '1')(
+    'boots a real VM when requested AND available, then runs a guest command',
+    async () => {
+      if (!enabled) {
+        // Infra absent even though the opt-in flag was set — skip without failing.
+        return;
+      }
+      const guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+      env = await resolveExecutionEnv({
+        backend: 'gondolin',
+        guard,
+        workspaceRoot: root,
+        seededCopyDir,
+        // Egress stays deny-by-default (the factory passes allowedHosts: []).
+      });
+      // The VM-backed env reports the guest workspace root, not the host root.
+      expect(env.cwd()).toBe('/workspace');
+      // A trivial guest command round-trips through the real VM.
+      const res = await env.exec('echo gondolin-ok');
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.value.stdout).toContain('gondolin-ok');
+        expect(res.value.exitCode).toBe(0);
+      }
+    },
+  );
+});

--- a/packages/core/src/llm/pi/__tests__/pi-gondolin-env.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-gondolin-env.test.ts
@@ -1,0 +1,572 @@
+/**
+ * Unit tests for the Gondolin micro-VM Pi `ExecutionEnv` (T11909 · T11888-B).
+ *
+ * The VM is FULLY MOCKED — NO `@earendil-works/gondolin` package, NO QEMU, NO
+ * `/dev/kvm` is required and NO real VM is ever launched. A `MockVm` records the
+ * `vm.fs.*` / `vm.exec` calls so each test asserts the method→VM mapping, the
+ * deny-first path/command guard, the seeded-copy-only mount set, and the
+ * egress-deny-by-default footgun guard. A real-VM exercise is a separate opt-in
+ * integration test gated on `/dev/kvm`+QEMU (out of scope here).
+ *
+ * @epic T11599
+ * @task T11909
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  CreateHttpHooksOptions,
+  ExecOptions,
+  ExecResult,
+  GondolinModule,
+  HttpHooks,
+  RealFSProviderInstance,
+  VM,
+  VmFs,
+  VmStat,
+} from '../gondolin-loader.js';
+import {
+  createGondolinExecutionEnv,
+  GONDOLIN_WORKSPACE_ROOT,
+  GondolinUnavailableError,
+} from '../pi-gondolin-env.js';
+
+// ---------------------------------------------------------------------------
+// Mock gondolin surface
+// ---------------------------------------------------------------------------
+
+/** A recorded `vm.exec` invocation. */
+interface ExecCall {
+  readonly command: string | readonly string[];
+  readonly options?: ExecOptions;
+}
+
+/** A recorded `vm.fs.*` invocation. */
+interface FsCall {
+  readonly method: string;
+  readonly path: string;
+  readonly args: readonly unknown[];
+}
+
+/** Controls what the mock VM returns / throws, per test. */
+interface MockVmConfig {
+  /** Seed file contents (guest path → utf-8 text). */
+  readonly files?: Record<string, string>;
+  /** Binary seed contents (guest path → bytes). */
+  readonly binary?: Record<string, Uint8Array>;
+  /** Directory listings (guest path → entries). */
+  readonly dirs?: Record<string, string[]>;
+  /** Paths that `stat`/`access` resolve as a directory. */
+  readonly directories?: readonly string[];
+  /** Paths that exist (for `access`). When omitted, `files`/`dirs` keys exist. */
+  readonly existing?: readonly string[];
+  /** Per-command exec result override (keyed by JSON of the command). */
+  readonly execResult?: (command: string | readonly string[], options?: ExecOptions) => ExecResult;
+}
+
+/** A mock `VM` recording every fs/exec call; never boots QEMU. */
+class MockVm implements VM {
+  readonly fsCalls: FsCall[] = [];
+  readonly execCalls: ExecCall[] = [];
+  closeCount = 0;
+  readonly fs: VmFs;
+
+  constructor(private readonly cfg: MockVmConfig = {}) {
+    const record = (method: string, path: string, ...args: unknown[]): void => {
+      this.fsCalls.push({ method, path, args });
+    };
+    const isDir = (p: string): boolean => (this.cfg.directories ?? []).includes(p);
+    const stat = (p: string): VmStat => ({ isFile: () => !isDir(p), isDirectory: () => isDir(p) });
+    const exists = (p: string): boolean => {
+      if (this.cfg.existing !== undefined) return this.cfg.existing.includes(p);
+      return (
+        p in (this.cfg.files ?? {}) ||
+        p in (this.cfg.dirs ?? {}) ||
+        p in (this.cfg.binary ?? {}) ||
+        isDir(p)
+      );
+    };
+    // The VmFs surface is intentionally narrow; the mock implements exactly the
+    // overloaded `readFile` plus the consumed mutators.
+    this.fs = {
+      readFile: (async (p: string, options?: { encoding: 'utf-8' }) => {
+        record('readFile', p, options);
+        if (options?.encoding === 'utf-8') {
+          const text = this.cfg.files?.[p];
+          if (text === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+          return text;
+        }
+        const bytes = this.cfg.binary?.[p];
+        if (bytes === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return bytes;
+      }) as VmFs['readFile'],
+      writeFile: async (p: string, content: string) => {
+        record('writeFile', p, content);
+      },
+      stat: async (p: string) => {
+        record('stat', p);
+        if (!exists(p)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return stat(p);
+      },
+      listDir: async (p: string) => {
+        record('listDir', p);
+        const entries = this.cfg.dirs?.[p];
+        if (entries === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return entries;
+      },
+      access: async (p: string) => {
+        record('access', p);
+        if (!exists(p)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+      mkdir: async (p: string, options: { recursive: boolean }) => {
+        record('mkdir', p, options);
+      },
+      deleteFile: async (p: string, options: { recursive: boolean; force: boolean }) => {
+        record('deleteFile', p, options);
+      },
+    };
+  }
+
+  exec(command: string | readonly string[], options?: ExecOptions): PromiseLike<ExecResult> {
+    this.execCalls.push({ command, options });
+    const result: ExecResult = this.cfg.execResult?.(command, options) ?? {
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+    };
+    return Promise.resolve(result);
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+/** Records the args passed to the mock `createHttpHooks` + `RealFSProvider`. */
+interface MockModuleProbe {
+  hooksOptions?: CreateHttpHooksOptions;
+  realFsRoots: string[];
+  vmOptionsSeen?: unknown;
+  readonly vm: MockVm;
+}
+
+/**
+ * Build a mock {@link GondolinModule} whose `VM.create` returns the supplied
+ * {@link MockVm} (recording the `VMOptions`), plus a probe capturing the hooks /
+ * mount construction. NO real package, NO QEMU.
+ */
+function mockModule(vm: MockVm): { module: GondolinModule; probe: MockModuleProbe } {
+  const probe: MockModuleProbe = { realFsRoots: [], vm };
+  const httpHooks: HttpHooks = { __httpHooks: true };
+  const module: GondolinModule = {
+    VM: {
+      create: async (options) => {
+        probe.vmOptionsSeen = options;
+        return vm;
+      },
+    },
+    RealFSProvider: class implements RealFSProviderInstance {
+      readonly __realFsProvider = true as const;
+      constructor(root: string) {
+        probe.realFsRoots.push(root);
+      }
+    },
+    createHttpHooks: (options) => {
+      probe.hooksOptions = options;
+      return httpHooks;
+    },
+  };
+  return { module, probe };
+}
+
+/** Construct an env over a fresh mock VM (no QEMU), returning env + handles. */
+async function gondolinEnv(cfg: MockVmConfig = {}, seededCopyDir = '/tmp/seed-copy') {
+  const vm = new MockVm(cfg);
+  const { module, probe } = mockModule(vm);
+  const env = await createGondolinExecutionEnv({ seededCopyDir, load: async () => module });
+  return { env, vm, probe };
+}
+
+const WS = GONDOLIN_WORKSPACE_ROOT;
+
+// ---------------------------------------------------------------------------
+// Factory: VM boot wiring (zero authority, seeded-copy-only, deny-by-default)
+// ---------------------------------------------------------------------------
+
+describe('createGondolinExecutionEnv — VM boot wiring', () => {
+  it('throws GondolinUnavailableError when the loader returns null (package absent)', async () => {
+    await expect(
+      createGondolinExecutionEnv({ seededCopyDir: '/tmp/seed', load: async () => null }),
+    ).rejects.toBeInstanceOf(GondolinUnavailableError);
+  });
+
+  it('mounts ONLY the disposable seeded copy at /workspace (no live DB ever mounted)', async () => {
+    const { probe } = await gondolinEnv({}, '/tmp/disposable-seed');
+    // Exactly one RealFSProvider, rooted at the seeded copy dir.
+    expect(probe.realFsRoots).toEqual(['/tmp/disposable-seed']);
+    const opts = probe.vmOptionsSeen as {
+      vfs?: { mounts?: Record<string, unknown> };
+    };
+    const mounts = opts.vfs?.mounts ?? {};
+    expect(Object.keys(mounts)).toEqual([WS]);
+  });
+
+  it('NEVER mounts a live tasks.db / brain.db path — the mount set is the seeded copy only', async () => {
+    // Even when the host has live DBs, the factory mounts ONLY seededCopyDir; a
+    // live `.cleo` path is structurally absent from the mount set + roots.
+    const { probe } = await gondolinEnv({}, '/home/u/project/.cleo/snapshot-disposable');
+    expect(probe.realFsRoots).toEqual(['/home/u/project/.cleo/snapshot-disposable']);
+    const json = JSON.stringify(probe.vmOptionsSeen);
+    expect(json).not.toContain('tasks.db');
+    expect(json).not.toContain('brain.db');
+  });
+
+  it('boots egress DENY-BY-DEFAULT — allowedHosts is PRESENT-and-empty (the footgun guard)', async () => {
+    const { probe } = await gondolinEnv();
+    expect(probe.hooksOptions).toBeDefined();
+    // The field must be present (not undefined) AND empty — omitting it = allow-all.
+    expect(probe.hooksOptions?.allowedHosts).toEqual([]);
+    expect(probe.hooksOptions?.allowedHosts).not.toBeUndefined();
+  });
+
+  it('forwards explicit allowedHosts + vault secret placeholders to the hooks', async () => {
+    const vm = new MockVm();
+    const { module, probe } = mockModule(vm);
+    await createGondolinExecutionEnv({
+      seededCopyDir: '/tmp/seed',
+      allowedHosts: ['api.example.com'],
+      vaultSecrets: {
+        API_KEY: { hosts: ['api.example.com'], value: 'REAL-SECRET', placeholder: '<<API_KEY>>' },
+      },
+      load: async () => module,
+    });
+    expect(probe.hooksOptions?.allowedHosts).toEqual(['api.example.com']);
+    // The guest only ever sees the placeholder — but the factory faithfully
+    // passes the secret def through to the HOST-side hooks.
+    expect(probe.hooksOptions?.secrets?.API_KEY?.placeholder).toBe('<<API_KEY>>');
+  });
+
+  it('passes ZERO authority into the guest — env is opts.env only (no host process.env)', async () => {
+    const { probe } = await gondolinEnv();
+    const opts = probe.vmOptionsSeen as { env?: Record<string, string>; memory?: string };
+    // Default env is the empty map — host process.env is never inherited.
+    expect(opts.env).toEqual({});
+    // Memory is set EXPLICITLY (never relies on the gondolin default).
+    expect(opts.memory).toBe('1G');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileSystem method → vm.fs mapping (incl. S1's filled v0 denials)
+// ---------------------------------------------------------------------------
+
+describe('pure path arithmetic (no VM round-trip)', () => {
+  it('cwd is the guest /workspace root', async () => {
+    const { env } = await gondolinEnv();
+    expect(env.cwd()).toBe(WS);
+  });
+
+  it('joinPath / absolutePath anchor at /workspace (POSIX)', async () => {
+    const { env } = await gondolinEnv();
+    expect(env.joinPath('a', 'b')).toBe(`${WS}/a/b`);
+    expect(env.absolutePath('rel.txt')).toBe(`${WS}/rel.txt`);
+    expect(env.absolutePath(`${WS}/x`)).toBe(`${WS}/x`);
+  });
+});
+
+describe('file reads map to vm.fs.readFile', () => {
+  it('readTextFile → vm.fs.readFile(p, {encoding:utf-8})', async () => {
+    const { env, vm } = await gondolinEnv({ files: { [`${WS}/a.txt`]: 'hi' } });
+    const r = await env.readTextFile(`${WS}/a.txt`);
+    expect(r).toEqual({ ok: true, value: 'hi' });
+    expect(vm.fsCalls[0]).toMatchObject({ method: 'readFile', path: `${WS}/a.txt` });
+    expect(vm.fsCalls[0]?.args[0]).toEqual({ encoding: 'utf-8' });
+  });
+
+  it('readTextLines splits the read content', async () => {
+    const { env } = await gondolinEnv({ files: { [`${WS}/l.txt`]: 'a\nb\nc' } });
+    const r = await env.readTextLines(`${WS}/l.txt`);
+    expect(r).toEqual({ ok: true, value: ['a', 'b', 'c'] });
+  });
+
+  it('readBinaryFile → vm.fs.readFile(p) — FILLS S1 v0 denial (returns Uint8Array)', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const { env, vm } = await gondolinEnv({ binary: { [`${WS}/blob.bin`]: bytes } });
+    const r = await env.readBinaryFile(`${WS}/blob.bin`);
+    expect(r).toEqual({ ok: true, value: bytes });
+    // The binary read passes NO encoding option (the Buffer overload).
+    expect(vm.fsCalls.at(-1)).toMatchObject({ method: 'readFile', path: `${WS}/blob.bin` });
+    expect(vm.fsCalls.at(-1)?.args[0]).toBeUndefined();
+  });
+});
+
+describe('file writes map to vm.fs.writeFile', () => {
+  it('writeFile → vm.fs.writeFile', async () => {
+    const { env, vm } = await gondolinEnv();
+    const r = await env.writeFile(`${WS}/out.txt`, 'data');
+    expect(r).toEqual({ ok: true, value: undefined });
+    expect(vm.fsCalls.at(-1)).toMatchObject({ method: 'writeFile', path: `${WS}/out.txt` });
+    expect(vm.fsCalls.at(-1)?.args[0]).toBe('data');
+  });
+
+  it('appendFile concatenates onto existing content', async () => {
+    const { env, vm } = await gondolinEnv({ files: { [`${WS}/log.txt`]: 'one' } });
+    const r = await env.appendFile(`${WS}/log.txt`, '-two');
+    expect(r).toEqual({ ok: true, value: undefined });
+    const write = vm.fsCalls.find((c) => c.method === 'writeFile');
+    expect(write?.args[0]).toBe('one-two');
+  });
+
+  it('appendFile treats a missing file as empty (append-creates)', async () => {
+    const { env, vm } = await gondolinEnv();
+    const r = await env.appendFile(`${WS}/fresh.txt`, 'first');
+    expect(r).toEqual({ ok: true, value: undefined });
+    const write = vm.fsCalls.find((c) => c.method === 'writeFile');
+    expect(write?.args[0]).toBe('first');
+  });
+});
+
+describe('metadata maps to vm.fs.stat / access', () => {
+  it('fileInfo → vm.fs.stat → {isFile,isDirectory}', async () => {
+    const { env } = await gondolinEnv({
+      files: { [`${WS}/f.txt`]: 'x' },
+      directories: [`${WS}/d`],
+      existing: [`${WS}/f.txt`, `${WS}/d`],
+    });
+    expect(await env.fileInfo(`${WS}/f.txt`)).toEqual({
+      ok: true,
+      value: { isFile: true, isDirectory: false },
+    });
+    expect(await env.fileInfo(`${WS}/d`)).toEqual({
+      ok: true,
+      value: { isFile: false, isDirectory: true },
+    });
+  });
+
+  it('exists → vm.fs.access resolve→true / reject→false (a missing path is ok(false), not err)', async () => {
+    const { env } = await gondolinEnv({ existing: [`${WS}/here`] });
+    expect(await env.exists(`${WS}/here`)).toEqual({ ok: true, value: true });
+    expect(await env.exists(`${WS}/gone`)).toEqual({ ok: true, value: false });
+  });
+
+  it('canonicalPath runs /bin/realpath in ARRAY form (no $PATH expansion)', async () => {
+    const { env, vm } = await gondolinEnv({
+      execResult: () => ({ stdout: `${WS}/real`, stderr: '', exitCode: 0 }),
+    });
+    const r = await env.canonicalPath(`${WS}/link`);
+    expect(r).toEqual({ ok: true, value: `${WS}/real` });
+    expect(vm.execCalls[0]?.command).toEqual(['/bin/realpath', `${WS}/link`]);
+  });
+});
+
+describe('FILLS S1 v0 denials: listDir / createDir / remove / createTempDir / createTempFile', () => {
+  it('listDir → vm.fs.listDir', async () => {
+    const { env, vm } = await gondolinEnv({ dirs: { [`${WS}/d`]: ['a', 'b'] } });
+    expect(await env.listDir(`${WS}/d`)).toEqual({ ok: true, value: ['a', 'b'] });
+    expect(vm.fsCalls.at(-1)).toMatchObject({ method: 'listDir', path: `${WS}/d` });
+  });
+
+  it('createDir → vm.fs.mkdir(p, {recursive:true})', async () => {
+    const { env, vm } = await gondolinEnv();
+    expect(await env.createDir(`${WS}/new/deep`)).toEqual({ ok: true, value: undefined });
+    expect(vm.fsCalls.at(-1)).toMatchObject({ method: 'mkdir', path: `${WS}/new/deep` });
+    expect(vm.fsCalls.at(-1)?.args[0]).toEqual({ recursive: true });
+  });
+
+  it('remove → vm.fs.deleteFile(p, {recursive:true,force:true})', async () => {
+    const { env, vm } = await gondolinEnv();
+    expect(await env.remove(`${WS}/junk`)).toEqual({ ok: true, value: undefined });
+    expect(vm.fsCalls.at(-1)).toMatchObject({ method: 'deleteFile', path: `${WS}/junk` });
+    expect(vm.fsCalls.at(-1)?.args[0]).toEqual({ recursive: true, force: true });
+  });
+
+  it('createTempDir → mktemp -d under /workspace/.tmp (ARRAY form)', async () => {
+    const { env, vm } = await gondolinEnv({
+      execResult: () => ({ stdout: `${WS}/.tmp/pi-AbC123`, stderr: '', exitCode: 0 }),
+    });
+    const r = await env.createTempDir('job-');
+    expect(r).toEqual({ ok: true, value: `${WS}/.tmp/pi-AbC123` });
+    const exec = vm.execCalls.at(-1)?.command as string[];
+    expect(exec[0]).toBe('/bin/mktemp');
+    expect(exec).toContain('-d');
+    expect(exec.at(-1)).toBe(`${WS}/.tmp/job-XXXXXX`);
+  });
+
+  it('createTempFile → mktemp (no -d) under /workspace/.tmp', async () => {
+    const { env, vm } = await gondolinEnv({
+      execResult: () => ({ stdout: `${WS}/.tmp/pi-Xy9`, stderr: '', exitCode: 0 }),
+    });
+    const r = await env.createTempFile();
+    expect(r).toEqual({ ok: true, value: `${WS}/.tmp/pi-Xy9` });
+    const exec = vm.execCalls.at(-1)?.command as string[];
+    expect(exec[0]).toBe('/bin/mktemp');
+    expect(exec).not.toContain('-d');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deny-first path confinement
+// ---------------------------------------------------------------------------
+
+describe('deny-first: paths outside /workspace are rejected BEFORE touching vm.fs', () => {
+  const escapes = ['/etc/passwd', '../secrets', `${WS}/../etc/shadow`, '/'];
+  for (const bad of escapes) {
+    it(`readTextFile("${bad}") → E_PI_FS_DENIED, no vm.fs call`, async () => {
+      const { env, vm } = await gondolinEnv();
+      const r = await env.readTextFile(bad);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.code).toBe('E_PI_FS_DENIED');
+      expect(vm.fsCalls).toHaveLength(0);
+    });
+  }
+
+  it('writeFile outside /workspace is denied (no write reaches the VM)', async () => {
+    const { env, vm } = await gondolinEnv();
+    const r = await env.writeFile('/etc/cron.d/evil', 'x');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('E_PI_FS_DENIED');
+    expect(vm.fsCalls).toHaveLength(0);
+  });
+
+  it('createDir / remove / listDir outside /workspace are denied', async () => {
+    const { env, vm } = await gondolinEnv();
+    expect((await env.createDir('/opt/x')).ok).toBe(false);
+    expect((await env.remove('/var/lib')).ok).toBe(false);
+    expect((await env.listDir('/root')).ok).toBe(false);
+    expect(vm.fsCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shell: command denylist + cwd confinement + exitCode mapping
+// ---------------------------------------------------------------------------
+
+describe('exec: real-egress verbs are DENIED before reaching vm.exec', () => {
+  const denied = [
+    'gh pr create',
+    'git push origin main',
+    'npm publish --tag latest',
+    'cleo release plan',
+    'git remote add origin url',
+    '/usr/bin/gh auth login',
+  ];
+  for (const cmd of denied) {
+    it(`denies "${cmd}"`, async () => {
+      const { env, vm } = await gondolinEnv();
+      const r = await env.exec(cmd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.code).toBe('E_PI_EXEC_DENIED');
+      // The denied command NEVER reaches the VM.
+      expect(vm.execCalls).toHaveLength(0);
+    });
+  }
+
+  it('ALLOWS patch-producing git verbs (git diff / git status / git apply)', async () => {
+    const { env, vm } = await gondolinEnv({
+      execResult: () => ({ stdout: 'diff', stderr: '', exitCode: 0 }),
+    });
+    const r = await env.exec('git diff HEAD');
+    expect(r.ok).toBe(true);
+    expect(vm.execCalls).toHaveLength(1);
+  });
+});
+
+describe('exec: cwd confinement + options + exitCode mapping', () => {
+  it('rejects a cwd outside /workspace', async () => {
+    const { env, vm } = await gondolinEnv();
+    const r = await env.exec('ls', { cwd: '/etc' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('E_PI_EXEC_DENIED');
+    expect(vm.execCalls).toHaveLength(0);
+  });
+
+  it('forwards command + cwd/env/timeout to vm.exec and returns stdout/stderr/exitCode', async () => {
+    const { env, vm } = await gondolinEnv({
+      execResult: () => ({ stdout: 'out', stderr: 'err', exitCode: 0 }),
+    });
+    const r = await env.exec('echo hi', {
+      cwd: `${WS}/sub`,
+      env: { FOO: 'bar' },
+      timeout: 1234,
+    });
+    expect(r).toEqual({ ok: true, value: { stdout: 'out', stderr: 'err', exitCode: 0 } });
+    const call = vm.execCalls[0];
+    expect(call?.command).toBe('echo hi');
+    expect(call?.options).toMatchObject({ cwd: `${WS}/sub`, env: { FOO: 'bar' }, timeout: 1234 });
+  });
+
+  it('maps a SIGNAL-killed process to exitCode null (not the raw number)', async () => {
+    const { env } = await gondolinEnv({
+      execResult: () => ({ stdout: '', stderr: 'killed', exitCode: 137, signal: 9 }),
+    });
+    const r = await env.exec('sleep 999');
+    expect(r).toEqual({ ok: true, value: { stdout: '', stderr: 'killed', exitCode: null } });
+  });
+
+  it('a normal non-zero exit passes the number through (no signal → exitCode stays)', async () => {
+    const { env } = await gondolinEnv({
+      execResult: () => ({ stdout: '', stderr: 'boom', exitCode: 2 }),
+    });
+    const r = await env.exec('false');
+    expect(r).toEqual({ ok: true, value: { stdout: '', stderr: 'boom', exitCode: 2 } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Never-throw discipline + cleanup
+// ---------------------------------------------------------------------------
+
+describe('never-throws → PiResult.err', () => {
+  it('a thrown vm.fs error becomes a PiResult.err (not an exception)', async () => {
+    const vm = new MockVm();
+    // Force writeFile to throw a coded error.
+    vm.fs.writeFile = async () => {
+      throw Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+    };
+    const { module } = mockModule(vm);
+    const env = await createGondolinExecutionEnv({
+      seededCopyDir: '/tmp/s',
+      load: async () => module,
+    });
+    const r = await env.writeFile(`${WS}/x`, 'data');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe('ENOSPC');
+      expect(r.error.message).toContain('disk full');
+    }
+  });
+
+  it('a thrown vm.exec error becomes a PiResult.err with E_PI_EXEC_FAILED', async () => {
+    const vm = new MockVm();
+    vm.exec = () => Promise.reject(new Error('vm exploded'));
+    const { module } = mockModule(vm);
+    const env = await createGondolinExecutionEnv({
+      seededCopyDir: '/tmp/s',
+      load: async () => module,
+    });
+    const r = await env.exec('ls');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('E_PI_EXEC_FAILED');
+  });
+});
+
+describe('cleanup() releases the VM (idempotent)', () => {
+  it('cleanup → vm.close() exactly once even when called twice', async () => {
+    const { env, vm } = await gondolinEnv();
+    await env.cleanup();
+    await env.cleanup();
+    expect(vm.closeCount).toBe(1);
+  });
+
+  it('a close() failure is swallowed (cleanup never throws)', async () => {
+    const vm = new MockVm();
+    vm.close = async () => {
+      throw new Error('close failed');
+    };
+    const { module } = mockModule(vm);
+    const env = await createGondolinExecutionEnv({
+      seededCopyDir: '/tmp/s',
+      load: async () => module,
+    });
+    await expect(env.cleanup()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/llm/pi/__tests__/resolve-execution-env.test.ts
+++ b/packages/core/src/llm/pi/__tests__/resolve-execution-env.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Selector matrix tests for {@link resolveExecutionEnv} (T11910 · T11888-C).
+ *
+ * The VM is FULLY MOCKED via the `seams` parameter — NO `@earendil-works/gondolin`
+ * package, NO QEMU, NO `/dev/kvm` is required and NO real VM is ever launched. The
+ * matrix asserts:
+ *   - `backend:'gondolin'` + available → the VM factory is called (VM-backed env);
+ *   - `backend:'gondolin'` + UNAVAILABLE → silent degrade to `GuardedExecutionEnv`;
+ *   - `backend:'in-process'` → `GuardedExecutionEnv` WITHOUT probing the host.
+ *
+ * The in-process fallback is exercised with a REAL enforce-mode {@link ToolGuard}
+ * (the same construction S1's tests use), so the returned env is the genuine
+ * guarded backend, not a stub. A real-VM exercise is a separate opt-in integration
+ * test gated on `/dev/kvm`+QEMU (`pi-gondolin-env.integration.test.ts`).
+ *
+ * @epic T11599
+ * @task T11910
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createToolGuard, type ToolGuard } from '../../../tools/guard.js';
+import { GuardedExecutionEnv, type PiExecutionEnv } from '../pi-execution-env.js';
+import {
+  type CreateGondolinExecutionEnvOptions,
+  GONDOLIN_WORKSPACE_ROOT,
+} from '../pi-gondolin-env.js';
+import { ExecutionEnvConfigError, resolveExecutionEnv } from '../resolve-execution-env.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures: a real enforce-mode ToolGuard for the fallback + a fake VM env that
+// records the options it was booted with (NO real QEMU).
+// ---------------------------------------------------------------------------
+
+let root: string;
+let guard: ToolGuard;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'resolve-env-'));
+  guard = createToolGuard({ allowedRoots: [root], mode: 'enforce' });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** A sentinel env the mocked VM factory returns; identity-checked by the matrix. */
+const VM_ENV_MARKER = '__vm_env_marker__' as const;
+
+/** A fake `PiExecutionEnv` standing in for a booted VM — never touches QEMU. */
+function fakeVmEnv(): PiExecutionEnv & { readonly marker: typeof VM_ENV_MARKER } {
+  return {
+    marker: VM_ENV_MARKER,
+    cwd: () => GONDOLIN_WORKSPACE_ROOT,
+    absolutePath: (p) => p,
+    joinPath: (...s) => s.join('/'),
+    readTextFile: async () => ({ ok: true, value: '' }),
+    readTextLines: async () => ({ ok: true, value: [] }),
+    readBinaryFile: async () => ({ ok: true, value: new Uint8Array() }),
+    writeFile: async () => ({ ok: true, value: undefined }),
+    appendFile: async () => ({ ok: true, value: undefined }),
+    fileInfo: async () => ({ ok: true, value: { isFile: true, isDirectory: false } }),
+    listDir: async () => ({ ok: true, value: [] }),
+    canonicalPath: async () => ({ ok: true, value: GONDOLIN_WORKSPACE_ROOT }),
+    exists: async () => ({ ok: true, value: true }),
+    createDir: async () => ({ ok: true, value: undefined }),
+    remove: async () => ({ ok: true, value: undefined }),
+    createTempDir: async () => ({ ok: true, value: GONDOLIN_WORKSPACE_ROOT }),
+    createTempFile: async () => ({ ok: true, value: GONDOLIN_WORKSPACE_ROOT }),
+    exec: async () => ({ ok: true, value: { stdout: '', stderr: '', exitCode: 0 } }),
+    cleanup: async () => {},
+  };
+}
+
+/** Build the test seams: a fixed availability + a recording VM factory. */
+function seamsFor(available: boolean) {
+  const calls: CreateGondolinExecutionEnvOptions[] = [];
+  const seams = {
+    isAvailable: async () => available,
+    createGondolin: async (opts: CreateGondolinExecutionEnvOptions): Promise<PiExecutionEnv> => {
+      calls.push(opts);
+      return fakeVmEnv();
+    },
+  };
+  return { seams, calls };
+}
+
+// ---------------------------------------------------------------------------
+// The selection matrix
+// ---------------------------------------------------------------------------
+
+describe('resolveExecutionEnv — selector matrix', () => {
+  it('VM REQUESTED + AVAILABLE → boots the gondolin VM (createGondolin called)', async () => {
+    const { seams, calls } = seamsFor(true);
+    const env = await resolveExecutionEnv(
+      {
+        backend: 'gondolin',
+        guard,
+        workspaceRoot: root,
+        seededCopyDir: '/tmp/disposable-seed',
+        allowedHosts: ['api.example.com'],
+        memory: '2G',
+        env: { CI: 'false' },
+      },
+      seams,
+    );
+    // The VM-backed env was returned (the sentinel marker), NOT the guarded env.
+    expect((env as { marker?: string }).marker).toBe(VM_ENV_MARKER);
+    expect(env).not.toBeInstanceOf(GuardedExecutionEnv);
+    // The VM factory received exactly the VM-only options (mount + egress + bounds).
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      seededCopyDir: '/tmp/disposable-seed',
+      allowedHosts: ['api.example.com'],
+      memory: '2G',
+      env: { CI: 'false' },
+    });
+  });
+
+  it('VM REQUESTED + UNAVAILABLE → SILENTLY DEGRADES to GuardedExecutionEnv (no throw, no VM)', async () => {
+    const { seams, calls } = seamsFor(false);
+    const env = await resolveExecutionEnv(
+      {
+        backend: 'gondolin',
+        guard,
+        workspaceRoot: root,
+        seededCopyDir: '/tmp/disposable-seed',
+      },
+      seams,
+    );
+    // Fell back to the in-process guarded backend — the VM factory was never called.
+    expect(env).toBeInstanceOf(GuardedExecutionEnv);
+    expect(calls).toHaveLength(0);
+    // The guarded fallback is anchored at the workspace root, not /workspace.
+    expect(env.cwd()).toBe(root);
+  });
+
+  it('backend:in-process → GuardedExecutionEnv WITHOUT probing availability', async () => {
+    let probed = false;
+    const seams = {
+      isAvailable: async () => {
+        probed = true;
+        return true;
+      },
+      createGondolin: async (): Promise<PiExecutionEnv> => {
+        throw new Error('createGondolin must NOT be called for backend:in-process');
+      },
+    };
+    const env = await resolveExecutionEnv(
+      { backend: 'in-process', guard, workspaceRoot: root },
+      seams,
+    );
+    expect(env).toBeInstanceOf(GuardedExecutionEnv);
+    // An in-process request must NOT touch the host availability probe at all.
+    expect(probed).toBe(false);
+    expect(env.cwd()).toBe(root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Misconfiguration vs degradation
+// ---------------------------------------------------------------------------
+
+describe('resolveExecutionEnv — misconfiguration is NOT silently degraded', () => {
+  it('VM requested + available but NO seededCopyDir → ExecutionEnvConfigError (caller bug)', async () => {
+    const { seams, calls } = seamsFor(true);
+    await expect(
+      resolveExecutionEnv({ backend: 'gondolin', guard, workspaceRoot: root }, seams),
+    ).rejects.toBeInstanceOf(ExecutionEnvConfigError);
+    // It is NOT a silent fallback: the VM factory was never reached either.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('VM requested + UNAVAILABLE + no seededCopyDir → degrades cleanly (config error never fires)', async () => {
+    const { seams } = seamsFor(false);
+    // When the VM is unavailable the seededCopyDir is irrelevant — the fallback
+    // does not need it, so the absence is NOT a misconfiguration here.
+    const env = await resolveExecutionEnv(
+      { backend: 'gondolin', guard, workspaceRoot: root },
+      seams,
+    );
+    expect(env).toBeInstanceOf(GuardedExecutionEnv);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The fallback is the REAL guarded backend (functional, not a stub)
+// ---------------------------------------------------------------------------
+
+describe('resolveExecutionEnv — the degraded env is a fully-functional GuardedExecutionEnv', () => {
+  it('the fallback env confines reads to the workspace root (deny-first still holds)', async () => {
+    const { seams } = seamsFor(false);
+    const env = await resolveExecutionEnv(
+      { backend: 'gondolin', guard, workspaceRoot: root },
+      seams,
+    );
+    // A path that climbs out of the workspace is denied by the guarded backend.
+    const r = await env.readTextFile('/etc/passwd');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('E_PI_FS_DENIED');
+  });
+});

--- a/packages/core/src/llm/pi/gondolin-loader.ts
+++ b/packages/core/src/llm/pi/gondolin-loader.ts
@@ -1,0 +1,391 @@
+/**
+ * Gondolin micro-VM sandbox — the OPTIONAL, lazily-loaded execution backend
+ * (T11908 · T11888-A · P5 Gondolin · epic T11599).
+ *
+ * The {@link import('./pi-execution-env.js').PiExecutionEnv} seam gains a SECOND
+ * implementation (`GondolinExecutionEnv`, T11888-B) whose confinement is a real
+ * micro-VM boundary instead of the in-process deny-first guard. The VM backend is
+ * powered by `@earendil-works/gondolin`, which is an OPTIONAL dependency
+ * (dependency-discipline · D11142): it is NEVER a hard dependency of
+ * `@cleocode/core`. Exactly like `playwright` (see {@link ../../tools/browser-driver.js})
+ * and `node-pty` (see {@link ../../tools/pty.js}), it is deliberately NOT declared
+ * in `core`'s `dependencies` / `optionalDependencies` and is loaded ONLY via a
+ * dynamic `import()` whose specifier is held in a variable — so neither the
+ * bundler nor TS treats the missing package as a hard, statically-resolved
+ * dependency, the published `@cleocode/core` carries no Gondolin / QEMU weight,
+ * and `core` builds + non-sandbox tests pass with Gondolin NOT installed.
+ *
+ * An environment that wants the sandbox opts in by installing the package itself
+ * (`pnpm add @earendil-works/gondolin`) AND providing the host infra (QEMU +
+ * `/dev/kvm`). Availability is the AND of all three — package present, `/dev/kvm`
+ * present, and a working `qemu-system-x86_64` — so a box with the package but no
+ * KVM still reports UNAVAILABLE and the selector ({@link ./resolve-execution-env.js},
+ * T11888-C) silently degrades to the in-process `GuardedExecutionEnv` rather than
+ * erroring.
+ *
+ * Import-time side-effect-free: NO top-level `@earendil-works/gondolin` import; the
+ * VM is booted lazily on the first `resolveExecutionEnv`. When Gondolin is absent,
+ * {@link loadGondolin} resolves `null` and {@link isGondolinAvailable} resolves
+ * `false` — nothing throws at import.
+ *
+ * The structural shapes of the consumed Gondolin surface are declared LOCALLY in
+ * this file (`VM`, `VMOptions`, `VmFs`, `ExecResult`, `RealFSProvider`,
+ * `createHttpHooks`); there is NO `import type` from the optional package, so the
+ * type-check passes with the package uninstalled.
+ *
+ * @epic T11599
+ * @task T11908
+ * @see ../../tools/browser-driver.js — the analogous optional-dep (Playwright) lazy-load pattern
+ * @see ./pi-execution-env.js — the `PiExecutionEnv` seam this backend implements
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { getLogger } from '../../logger.js';
+
+const log = getLogger('pi-gondolin');
+
+/**
+ * The npm install hint surfaced to the model / caller when the sandbox backend is
+ * unavailable because `@earendil-works/gondolin` (or its QEMU/KVM host infra) is
+ * not present. Gondolin is an OPTIONAL dep — the selector degrades to the
+ * in-process `GuardedExecutionEnv` regardless, but reports the sandbox
+ * UNAVAILABLE until this is satisfied.
+ */
+export const GONDOLIN_INSTALL_HINT =
+  'Sandbox execution requires the optional "@earendil-works/gondolin" package + QEMU/KVM. ' +
+  'Install with `pnpm add @earendil-works/gondolin` (boots a ~200MB Alpine guest on first run), ' +
+  'and ensure `/dev/kvm` plus a working `qemu-system-x86_64` are available on the host.';
+
+// ---------------------------------------------------------------------------
+// Minimal structural shapes of the Gondolin surface we consume.
+//
+// Declared LOCALLY so this file carries NO type dependency on the optional
+// package — the dynamic import is shape-checked against these, not against the
+// package's own `.d.ts`. Only the members the sandbox backend (T11888-B) actually
+// uses are modelled; everything is `readonly` and narrow. There is NO
+// `import type` from `@earendil-works/gondolin` anywhere in `core`.
+// ---------------------------------------------------------------------------
+
+/**
+ * A buffered result of `vm.exec` (gondolin `exec.d.ts` `ExecResult`).
+ *
+ * `exitCode` is NON-nullable here (a `number`); a SEPARATE optional `signal`
+ * field is set when the process was killed by a signal. The Pi adapter
+ * (T11888-B) maps this to Pi's `exitCode: number | null` by emitting `null`
+ * whenever `signal` is present.
+ */
+export interface ExecResult {
+  /** Captured standard output. */
+  readonly stdout: string;
+  /** Captured standard error. */
+  readonly stderr: string;
+  /** Process exit code (always a number; `signal` distinguishes signal-kills). */
+  readonly exitCode: number;
+  /** The terminating signal number, when the process was killed by a signal. */
+  readonly signal?: number;
+}
+
+/** Options for a single `vm.exec` invocation. */
+export interface ExecOptions {
+  /** Working directory inside the guest. */
+  readonly cwd?: string;
+  /** Extra guest environment variables. */
+  readonly env?: Readonly<Record<string, string>>;
+  /** Host abort signal — cancels the in-flight guest process. */
+  readonly signal?: AbortSignal;
+  /** Hard timeout in milliseconds. */
+  readonly timeout?: number;
+}
+
+/** Metadata returned by `vm.fs.stat`. */
+export interface VmStat {
+  /** Whether the entry is a regular file. */
+  isFile(): boolean;
+  /** Whether the entry is a directory. */
+  isDirectory(): boolean;
+}
+
+/**
+ * The guest filesystem surface (`vm.fs`). Only the members the sandbox backend
+ * consumes are modelled. All paths are guest-absolute under the single
+ * `/workspace` RW mount.
+ */
+export interface VmFs {
+  readFile(path: string, options: { readonly encoding: 'utf-8' }): Promise<string>;
+  readFile(path: string): Promise<Uint8Array>;
+  writeFile(path: string, content: string): Promise<void>;
+  stat(path: string): Promise<VmStat>;
+  listDir(path: string): Promise<string[]>;
+  access(path: string): Promise<void>;
+  mkdir(path: string, options: { readonly recursive: boolean }): Promise<void>;
+  deleteFile(
+    path: string,
+    options: { readonly recursive: boolean; readonly force: boolean },
+  ): Promise<void>;
+}
+
+/**
+ * A running micro-VM handle (gondolin `vm.d.ts` `VM`). The sandbox backend owns
+ * exactly one of these per run and releases it in `cleanup()` via `close()`.
+ */
+export interface VM {
+  /** The guest filesystem surface. */
+  readonly fs: VmFs;
+  /**
+   * Run a command in the guest. STRING form runs via `/bin/sh -lc`; ARRAY form
+   * runs the argv directly with no `$PATH` / shell expansion. The returned value
+   * `implements PromiseLike<ExecResult>`, so `await vm.exec(...)` resolves the
+   * buffered result.
+   */
+  exec(command: string | readonly string[], options?: ExecOptions): PromiseLike<ExecResult>;
+  /** Tear down the VM and release its host resources (idempotent host-side guard recommended). */
+  close(): Promise<void>;
+}
+
+/**
+ * A single readable+writable secret the egress proxy injects HOST-side. The guest
+ * only ever sees `placeholder` — never the real `value` bytes.
+ */
+export interface SecretDefinition {
+  /** Hosts the secret may be sent to. */
+  readonly hosts: readonly string[];
+  /** The real secret bytes — injected host-side, NEVER visible to the guest. */
+  readonly value: string;
+  /** The opaque token the guest sees in place of `value`. */
+  readonly placeholder: string;
+}
+
+/**
+ * Options for {@link CreateHttpHooks}. Per the gondolin docs, `allowedHosts`
+ * OMITTED = allow-all; `allowedHosts: []` (present-and-empty) = deny-all. The
+ * backend MUST pass it present-and-empty by default (the egress-deny footgun).
+ */
+export interface CreateHttpHooksOptions {
+  /** Outbound host allowlist. Present-and-empty `[]` = deny all; omitted = allow all. */
+  readonly allowedHosts: readonly string[];
+  /** Host-side secret injection (guest sees only `placeholder`). */
+  readonly secrets?: Readonly<Record<string, SecretDefinition>>;
+}
+
+/** Opaque HTTP-hook handle wired into a VM's network namespace via {@link VMOptions}. */
+export interface HttpHooks {
+  readonly __httpHooks: true;
+}
+
+/** The `createHttpHooks` factory — allowlists egress + injects credential placeholders. */
+export type CreateHttpHooks = (options: CreateHttpHooksOptions) => HttpHooks;
+
+/**
+ * A read/write filesystem provider rooted at a host directory, mounted into the
+ * guest VFS (gondolin `fs/real.d.ts` `RealFSProvider`). The sandbox backend
+ * mounts ONLY a disposable seeded-copy directory at `/workspace`; live
+ * `tasks.db`/`brain.db` are NEVER in the mount set.
+ */
+export interface RealFSProviderInstance {
+  readonly __realFsProvider: true;
+}
+
+/** The `RealFSProvider` constructor surface. */
+export interface RealFSProvider {
+  new (hostRootDir: string): RealFSProviderInstance;
+}
+
+/**
+ * Options for {@link VMConstructor.create}. The guest's environment is ONLY
+ * `env` (host `process.env` is NEVER inherited — that isolation is structural);
+ * `memory` bounds the guest in-process (default `"1G"`, set explicitly).
+ */
+export interface VMOptions {
+  /** Guest memory bound (e.g. `"1G"`). Set explicitly — never rely on the default. */
+  readonly memory?: string;
+  /** Guest environment — the ONLY env the guest sees (no host `process.env` inheritance). */
+  readonly env?: Readonly<Record<string, string>>;
+  /** VFS mount set — guest path → host FS provider. Live DBs never appear here. */
+  readonly vfs?: {
+    readonly mounts: Readonly<Record<string, RealFSProviderInstance>>;
+  };
+  /** Network egress hooks (allowlist + credential injection). */
+  readonly httpHooks?: HttpHooks;
+}
+
+/** The `VM` constructor / factory surface (`VM.create`). */
+export interface VMConstructor {
+  create(options?: VMOptions): Promise<VM>;
+}
+
+/**
+ * The minimal shape of the `@earendil-works/gondolin` module we depend on. Only
+ * the three named exports the sandbox backend consumes are modelled.
+ */
+export interface GondolinModule {
+  readonly VM: VMConstructor;
+  readonly RealFSProvider: RealFSProvider;
+  readonly createHttpHooks: CreateHttpHooks;
+}
+
+// ---------------------------------------------------------------------------
+// Injectable seams — overridable ONLY by the unit tests so a mocked import() /
+// host probe can deterministically simulate "package absent" and "no /dev/kvm"
+// WITHOUT touching the module graph or launching a real QEMU VM. In production
+// these resolve to the real dynamic import + host probes.
+// ---------------------------------------------------------------------------
+
+/** The npm specifier — held in a VARIABLE so it is never statically resolved. */
+const GONDOLIN_SPECIFIER = '@earendil-works/gondolin';
+
+/** A pluggable dynamic-importer (test seam). Defaults to the real `import()`. */
+type DynamicImporter = (specifier: string) => Promise<unknown>;
+
+/** A pluggable host probe (test seam) for `/dev/kvm` presence + a working QEMU. */
+interface GondolinHostProbes {
+  /** Whether `/dev/kvm` exists on the host. */
+  readonly hasKvm: () => boolean;
+  /** Whether a working `qemu-system-x86_64` is on `PATH`. */
+  readonly hasQemu: () => boolean;
+}
+
+/**
+ * The real dynamic importer. The specifier is passed as an argument (held in a
+ * variable at the call site) so the bundler / TS never treats the optional
+ * package as a hard dependency.
+ */
+const realImporter: DynamicImporter = (specifier) => import(specifier);
+
+/** `true` when `/dev/kvm` exists — KVM acceleration is available on the host. */
+function realHasKvm(): boolean {
+  try {
+    return existsSync('/dev/kvm');
+  } catch {
+    return false;
+  }
+}
+
+/** `true` when `qemu-system-x86_64 --version` runs successfully (cheap probe). */
+function realHasQemu(): boolean {
+  try {
+    execFileSync('qemu-system-x86_64', ['--version'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The active importer (swapped only by {@link __setGondolinTestHooks}). */
+let importer: DynamicImporter = realImporter;
+/** The active host probes (swapped only by {@link __setGondolinTestHooks}). */
+let hostProbes: GondolinHostProbes = { hasKvm: realHasKvm, hasQemu: realHasQemu };
+
+/**
+ * Structurally validate a dynamically-imported candidate against the three
+ * Gondolin exports the backend consumes. Returns the typed module on a match,
+ * else `null` — so a shape-incompatible package version reports unavailable
+ * rather than crashing later at VM-boot time.
+ */
+function shapeCheck(candidate: unknown): GondolinModule | null {
+  if (candidate === null || typeof candidate !== 'object') return null;
+  const mod = candidate as {
+    VM?: unknown;
+    RealFSProvider?: unknown;
+    createHttpHooks?: unknown;
+  };
+  const vmOk =
+    typeof mod.VM === 'object' &&
+    mod.VM !== null &&
+    typeof (mod.VM as { create?: unknown }).create === 'function';
+  const realFsOk = typeof mod.RealFSProvider === 'function';
+  const hooksOk = typeof mod.createHttpHooks === 'function';
+  if (vmOk && realFsOk && hooksOk) {
+    return candidate as GondolinModule;
+  }
+  return null;
+}
+
+/**
+ * Attempt to lazily load `@earendil-works/gondolin`. Returns `null` when the
+ * optional dep is not installed, fails to load, OR does not expose the expected
+ * `VM` / `RealFSProvider` / `createHttpHooks` surface — so callers can report the
+ * sandbox unavailable rather than crashing. NEVER throws.
+ *
+ * The import specifier is held in a variable (passed to the {@link importer}
+ * seam) so bundlers / TS do not treat the missing optional dep as a hard,
+ * statically-resolved dependency (same technique as
+ * {@link ../../tools/browser-driver.js}'s Playwright load).
+ *
+ * @returns The shape-checked module, or `null` when unavailable.
+ */
+export async function loadGondolin(): Promise<GondolinModule | null> {
+  try {
+    const mod: unknown = await importer(GONDOLIN_SPECIFIER);
+    const candidate = (mod as { default?: unknown }).default ?? mod;
+    return shapeCheck(candidate);
+  } catch (err) {
+    log.debug({ err }, 'gondolin not loadable — sandbox execution unavailable');
+    return null;
+  }
+}
+
+/**
+ * Whether the Gondolin sandbox backend can run in this process. The AND of three
+ * conditions:
+ *
+ * 1. the `@earendil-works/gondolin` package loads ({@link loadGondolin} is non-`null`),
+ * 2. `/dev/kvm` exists (KVM acceleration is present),
+ * 3. a working `qemu-system-x86_64` is on `PATH`.
+ *
+ * A box with the package but no KVM still reports `false` so the selector
+ * ({@link ./resolve-execution-env.js}) degrades to the in-process
+ * `GuardedExecutionEnv` — it NEVER errors. The result is cached after the first
+ * probe so availability checks stay cheap; {@link __resetGondolinAvailabilityCache}
+ * clears it (tests only).
+ *
+ * @returns `true` only when package + `/dev/kvm` + QEMU are all present.
+ */
+let cachedAvailable: boolean | undefined;
+export async function isGondolinAvailable(): Promise<boolean> {
+  if (cachedAvailable !== undefined) return cachedAvailable;
+  const pkgPresent = (await loadGondolin()) !== null;
+  cachedAvailable = pkgPresent && hostProbes.hasKvm() && hostProbes.hasQemu();
+  return cachedAvailable;
+}
+
+/**
+ * Reset the cached Gondolin-availability probe.
+ *
+ * EXPORTED FOR TESTS ONLY — lets a unit test toggle the mocked availability of
+ * the optional dep + host probes between cases without a fresh module graph.
+ *
+ * @internal
+ */
+export function __resetGondolinAvailabilityCache(): void {
+  cachedAvailable = undefined;
+}
+
+/**
+ * Override the dynamic-importer and/or host probes, and reset the availability
+ * cache.
+ *
+ * EXPORTED FOR TESTS ONLY — lets a unit test simulate "package absent" (importer
+ * rejects), "package present" (importer resolves a mock module), and "no
+ * `/dev/kvm`" / "no QEMU" deterministically, WITHOUT touching the module graph or
+ * launching a real QEMU VM. Pass `undefined` for a field to leave it at the real
+ * default; call with no arguments to restore the real importer + probes.
+ *
+ * @param hooks - Partial overrides for the importer and host probes.
+ * @internal
+ */
+export function __setGondolinTestHooks(hooks?: {
+  importer?: DynamicImporter;
+  hasKvm?: () => boolean;
+  hasQemu?: () => boolean;
+}): void {
+  importer = hooks?.importer ?? realImporter;
+  hostProbes = {
+    hasKvm: hooks?.hasKvm ?? realHasKvm,
+    hasQemu: hooks?.hasQemu ?? realHasQemu,
+  };
+  cachedAvailable = undefined;
+}

--- a/packages/core/src/llm/pi/pi-gondolin-env.ts
+++ b/packages/core/src/llm/pi/pi-gondolin-env.ts
@@ -1,0 +1,640 @@
+/**
+ * Gondolin micro-VM Pi `ExecutionEnv` — the SECOND backend of the
+ * {@link PiExecutionEnv} seam (T11909 · T11888-B · P5 Gondolin · epic T11599).
+ *
+ * Where the in-process {@link import('./pi-execution-env.js').GuardedExecutionEnv}
+ * (S1 · T11761 · T11897) confines Pi with a deny-first `ToolGuard` + workspace
+ * boundary INSIDE the host process, this backend's confinement is the
+ * **micro-VM boundary itself**. Guest code runs with:
+ *
+ * - **ZERO host authority** — no `cleo.db` handle, no writer-lease IPC socket, no
+ *   host `process.env` secrets, no host filesystem outside the single RW
+ *   `/workspace` mount. The guest is a different kernel; it cannot reach the
+ *   daemon, the lease arbiter, or BRAIN even if Pi-driven code tries.
+ * - **Egress only via the credential-injection proxy** — `createHttpHooks` is
+ *   constructed with `allowedHosts: []` (present-and-empty = DENY ALL per the
+ *   gondolin docs; OMITTING it = allow-all — the egress footgun this guards) and
+ *   host-side secret PLACEHOLDERS, so the guest only ever sees the `placeholder`
+ *   bytes, never the real token. The loop appends specific hosts per run.
+ * - **Live DBs NEVER mounted** — `.cleo/tasks.db` / `.cleo/brain.db` are NOT in
+ *   the VFS mount set. A replay operates on a DISPOSABLE seeded copy
+ *   (`VACUUM INTO` snapshot), so the T5158 data-loss vector (git overwrites the
+ *   live WAL-backed DB) is structurally impossible: there is no live handle
+ *   inside the VM to corrupt.
+ *
+ * This is strictly stronger than S1's env-scrub: S1 protects against an in-process
+ * Pi escape via the guard allowlist; Gondolin protects via kernel + VFS + network
+ * namespace separation. A thin in-guest deny layer (lexical `/workspace`
+ * confinement + a command denylist for real egress verbs) is kept as DEFENSE IN
+ * DEPTH — the boundary is the VM, but a Pi escape that runs a binary still cannot
+ * do damage that survives the run.
+ *
+ * Optional-dep discipline (D11142): `@earendil-works/gondolin` is loaded ONLY via
+ * the {@link import('./gondolin-loader.js').loadGondolin} dynamic import — it is
+ * in NEITHER `dependencies` NOR `optionalDependencies`, and this module declares
+ * NO `import type` from the package (the consumed structural shapes come from the
+ * loader's LOCAL types). `core` builds + all non-gondolin tests pass with gondolin
+ * ABSENT, and this module is import-time side-effect-free (no top-level VM boot).
+ *
+ * Never-throw discipline: every `vm.fs.*` / `vm.exec` call is wrapped exactly as
+ * S1's `#toFsErr` / `execErr` — a thrown gondolin/guest error becomes a
+ * {@link PiResult} `err` with `E_PI_FS_*` / `E_PI_EXEC_*` codes. The
+ * `PiResult<T, E>` contract is byte-for-byte identical to S1, so the Pi loop
+ * cannot tell the two backends apart.
+ *
+ * @epic T11599
+ * @task T11909
+ * @see ./pi-execution-env.js — the S1 `GuardedExecutionEnv` this mirrors over a VM
+ * @see ./gondolin-loader.js — the optional-dep loader supplying the structural types
+ */
+
+import { isAbsolute as posixIsAbsolute, join as posixJoin } from 'node:path/posix';
+import { getLogger } from '../../logger.js';
+import {
+  type CreateHttpHooks,
+  type ExecOptions as GondolinExecOptions,
+  type ExecResult as GondolinExecResult,
+  type GondolinModule,
+  loadGondolin,
+  type RealFSProviderInstance,
+  type SecretDefinition,
+  type VM,
+} from './gondolin-loader.js';
+import type {
+  PiExecOptions,
+  PiExecResult,
+  PiExecutionEnv,
+  PiExecutionError,
+  PiFileError,
+  PiFileInfo,
+  PiResult,
+} from './pi-execution-env.js';
+
+const log = getLogger('pi-gondolin-env');
+
+/** The single RW mount point inside the guest — the ONLY writable location. */
+export const GONDOLIN_WORKSPACE_ROOT = '/workspace' as const;
+
+/** Where in-guest temp dirs/files are created (under the workspace mount). */
+const GONDOLIN_TMP_DIR = `${GONDOLIN_WORKSPACE_ROOT}/.tmp`;
+
+/** Default guest memory bound — set explicitly so we never rely on gondolin's default. */
+const DEFAULT_GUEST_MEMORY = '1G' as const;
+
+// ---------------------------------------------------------------------------
+// Result constructors (byte-for-byte identical to S1's, so the Pi loop cannot
+// tell the backends apart).
+// ---------------------------------------------------------------------------
+
+/** Build a successful {@link PiResult}. */
+function ok<T>(value: T): PiResult<T, never> {
+  return { ok: true, value };
+}
+
+/** Build a failed {@link PiResult} with a {@link PiFileError}. */
+function fsErr(code: string, message: string, path?: string): PiResult<never, PiFileError> {
+  return { ok: false, error: { code, message, ...(path !== undefined ? { path } : {}) } };
+}
+
+/** Build a failed {@link PiResult} with a {@link PiExecutionError}. */
+function execErr(code: string, message: string): PiResult<never, PiExecutionError> {
+  return { ok: false, error: { code, message } };
+}
+
+/**
+ * The real egress verbs the guest is NEVER allowed to run. Sandbox output is a
+ * DRAFT PR opened HOST-side by the loop's egress step (never from inside the
+ * guest). The guest may run `git diff`/`git apply`/`git status` to PRODUCE a
+ * patch, but pushing/publishing is a host-only, budget-gated action. `cleo` is
+ * denied for completeness (no daemon is reachable from the guest anyway).
+ *
+ * Each entry is matched against the command's argv-0 basename, plus the
+ * two-token forms `git push` / `git remote` so a `git`-rooted egress is caught
+ * even though `git`'s OWN basename is allowed (for `git diff` etc.).
+ */
+const DENIED_EXEC_PREFIXES: readonly string[] = [
+  'gh',
+  'npm publish',
+  'cleo',
+  'git push',
+  'git remote',
+];
+
+/**
+ * Whether `command` (string or argv) is a denied real-egress verb. Deny-first:
+ * checked BEFORE the command ever reaches `vm.exec`. Comparison is on the
+ * normalized leading tokens (argv-0 basename + a possible second subcommand
+ * token), so `git push origin main`, `/usr/bin/gh pr create`, and
+ * `npm publish --tag x` are all rejected, while `git diff` / `git status` pass.
+ *
+ * @param command - The string command or argv array the env received.
+ * @returns The matched denied prefix, or `null` when the command is allowed.
+ */
+function deniedEgressVerb(command: string | readonly string[]): string | null {
+  const tokens = Array.isArray(command)
+    ? [...command]
+    : String(command)
+        .trim()
+        .split(/\s+/)
+        .filter((t) => t.length > 0);
+  if (tokens.length === 0) return null;
+  const base0 = basenameOf(tokens[0] ?? '');
+  const base1 = tokens.length > 1 ? basenameOf(tokens[1] ?? '') : '';
+  const one = base0;
+  const two = base1 ? `${base0} ${base1}` : '';
+  for (const denied of DENIED_EXEC_PREFIXES) {
+    if (denied === one) return denied;
+    if (two !== '' && denied === two) return denied;
+  }
+  return null;
+}
+
+/** POSIX basename of a token (strips any path prefix, e.g. `/usr/bin/gh` → `gh`). */
+function basenameOf(token: string): string {
+  const slash = token.lastIndexOf('/');
+  return slash === -1 ? token : token.slice(slash + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Loader injection seam (mirrors browser-driver's PlaywrightLoader)
+// ---------------------------------------------------------------------------
+
+/**
+ * The injectable factory the {@link createGondolinExecutionEnv} uses to obtain
+ * the gondolin module. Defaults to the real lazy {@link loadGondolin}; unit
+ * tests inject a fake that returns a MOCK module so NO real QEMU VM is launched.
+ */
+export type GondolinLoader = () => Promise<GondolinModule | null>;
+
+// ---------------------------------------------------------------------------
+// Factory options
+// ---------------------------------------------------------------------------
+
+/** Construction options for {@link createGondolinExecutionEnv}. */
+export interface CreateGondolinExecutionEnvOptions {
+  /**
+   * The host directory mounted RW at `/workspace` inside the guest. This MUST be
+   * a DISPOSABLE seeded copy (e.g. a `VACUUM INTO` snapshot dir) — NEVER a path
+   * containing the live `.cleo/tasks.db` / `.cleo/brain.db`. The factory mounts
+   * ONLY this directory; live DBs are structurally absent from the guest VFS.
+   */
+  readonly seededCopyDir: string;
+  /**
+   * Outbound host allowlist. Defaults to `[]` (DENY ALL) when omitted — the
+   * egress footgun guard. The loop appends ONLY the specific hosts it needs
+   * (e.g. the model endpoint via the Vault proxy) per run.
+   */
+  readonly allowedHosts?: readonly string[];
+  /**
+   * Host-side secret injections. The guest only ever sees each entry's
+   * `placeholder`; the real `value` bytes never enter the VM.
+   */
+  readonly vaultSecrets?: Readonly<Record<string, SecretDefinition>>;
+  /** Guest memory bound (e.g. `"1G"`). Defaults to {@link DEFAULT_GUEST_MEMORY}. */
+  readonly memory?: string;
+  /**
+   * Guest environment — the ONLY env the guest sees (host `process.env` is NEVER
+   * inherited; that isolation is structural). Defaults to an empty map.
+   */
+  readonly env?: Readonly<Record<string, string>>;
+  /**
+   * Optional loader override (tests inject a fake → a MOCK VM, no QEMU). Defaults
+   * to the real {@link loadGondolin}.
+   */
+  readonly load?: GondolinLoader;
+}
+
+// ---------------------------------------------------------------------------
+// GondolinExecutionEnv
+// ---------------------------------------------------------------------------
+
+/**
+ * A {@link PiExecutionEnv} whose confinement is a gondolin micro-VM. Owns exactly
+ * ONE {@link VM} and releases it in {@link cleanup} via `vm.close()`.
+ *
+ * Every fs op maps to `vm.fs.*`; `exec` maps to `vm.exec`. Each call is wrapped
+ * try/catch → {@link PiResult} `err`, so no method ever throws. A thin in-guest
+ * deny layer (lexical `/workspace` confinement + the {@link DENIED_EXEC_PREFIXES}
+ * command denylist) is the defense-in-depth net BEHIND the VM boundary.
+ *
+ * Unlike the stateless {@link import('./pi-execution-env.js').GuardedExecutionEnv}
+ * (whose `cleanup()` is a no-op), this env OWNS the VM and MUST release it.
+ * `cleanup()` is idempotent (guarded by a `#closed` flag).
+ */
+export class GondolinExecutionEnv implements PiExecutionEnv {
+  readonly #vm: VM;
+  #closed = false;
+
+  /**
+   * @param vm - The booted gondolin VM this env owns. Construct via
+   *   {@link createGondolinExecutionEnv}, not directly — the factory wires the
+   *   deny-by-default egress hooks + seeded-copy-only mount set.
+   */
+  constructor(vm: VM) {
+    this.#vm = vm;
+  }
+
+  // --- pure path arithmetic (no VM round-trip) -----------------------------
+
+  /** The guest workspace root — the in-VM Pi run's working directory. */
+  cwd(): string {
+    return GONDOLIN_WORKSPACE_ROOT;
+  }
+
+  /** Resolve `path` to a guest-absolute path anchored at `/workspace`. */
+  absolutePath(path: string): string {
+    return posixIsAbsolute(path) ? posixJoin(path) : posixJoin(GONDOLIN_WORKSPACE_ROOT, path);
+  }
+
+  /** Join path segments (pure POSIX) anchored at the guest workspace root. */
+  joinPath(...segments: string[]): string {
+    return posixJoin(GONDOLIN_WORKSPACE_ROOT, ...segments);
+  }
+
+  /**
+   * Lexically confine a (possibly relative) guest path under `/workspace`. The
+   * guest cannot see host paths at all (separate VFS), so there is no
+   * symlink-to-host vector to resolve — a lexical check is sufficient here. A
+   * `../` climb or an absolute path outside `/workspace` returns `null`.
+   *
+   * @returns the normalized guest-absolute path, or `null` on an escape.
+   */
+  #confine(path: string): string | null {
+    const abs = posixIsAbsolute(path) ? posixJoin(path) : posixJoin(GONDOLIN_WORKSPACE_ROOT, path);
+    if (abs === GONDOLIN_WORKSPACE_ROOT || abs.startsWith(`${GONDOLIN_WORKSPACE_ROOT}/`)) {
+      return abs;
+    }
+    return null;
+  }
+
+  // --- file reads ----------------------------------------------------------
+
+  /** Read a file's text from the guest workspace. */
+  async readTextFile(path: string): Promise<PiResult<string, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const content = await this.#vm.fs.readFile(abs, { encoding: 'utf-8' });
+      return ok(content);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Read a file's text as an array of lines. */
+  async readTextLines(path: string): Promise<PiResult<string[], PiFileError>> {
+    const res = await this.readTextFile(path);
+    return res.ok ? ok(res.value.split(/\r?\n/)) : res;
+  }
+
+  /**
+   * Binary read — FILLS S1's v0 denial. The guest VFS supports binary reads
+   * directly via `vm.fs.readFile(p)` (returns a `Uint8Array`).
+   */
+  async readBinaryFile(path: string): Promise<PiResult<Uint8Array, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const bytes = await this.#vm.fs.readFile(abs);
+      return ok(bytes);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  // --- file writes ---------------------------------------------------------
+
+  /** Write a file to the guest workspace. */
+  async writeFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      await this.#vm.fs.writeFile(abs, content);
+      return ok(undefined);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /**
+   * Append to a file. The guest fs surface offers only whole-file writes, so this
+   * reads-then-writes the concatenation (still confined). A missing file is
+   * treated as empty (append-creates).
+   */
+  async appendFile(path: string, content: string): Promise<PiResult<void, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    let prefix = '';
+    try {
+      prefix = await this.#vm.fs.readFile(abs, { encoding: 'utf-8' });
+    } catch (err) {
+      // A missing file is the only non-fatal case (append-creates). Any other
+      // failure (permission, …) propagates as the Pi error.
+      if (!isMissingFileError(err)) return this.#toFsErr(err, abs);
+    }
+    try {
+      await this.#vm.fs.writeFile(abs, prefix + content);
+      return ok(undefined);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  // --- metadata ------------------------------------------------------------
+
+  /** Report whether a guest path is a file or directory. */
+  async fileInfo(path: string): Promise<PiResult<PiFileInfo, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const stat = await this.#vm.fs.stat(abs);
+      return ok({ isFile: stat.isFile(), isDirectory: stat.isDirectory() });
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Whether a guest path exists. */
+  async exists(path: string): Promise<PiResult<boolean, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      await this.#vm.fs.access(abs);
+      return ok(true);
+    } catch {
+      // `access` rejects for a missing path — that is a definitive "does not
+      // exist", NOT an error to surface. (A denied path was already rejected
+      // above by `#confine`.)
+      return ok(false);
+    }
+  }
+
+  /**
+   * Canonicalize a guest path via `realpath` inside the guest. Runs the binary in
+   * ARRAY form (no `$PATH` / shell expansion) so the path argument cannot be
+   * reinterpreted as shell.
+   */
+  async canonicalPath(path: string): Promise<PiResult<string, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const res = await this.#vm.exec(['/bin/realpath', abs]);
+      const resolved = res.stdout.trim();
+      if (res.exitCode !== 0 || resolved === '') {
+        return fsErr('E_PI_FS_FAILED', res.stderr.trim() || 'realpath failed', abs);
+      }
+      return ok(resolved);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  // --- fs-mutating / listing ops (FILL S1's v0 denials) --------------------
+
+  /** List a guest directory — FILLS S1's v0 denial. */
+  async listDir(path: string): Promise<PiResult<string[], PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      const entries = await this.#vm.fs.listDir(abs);
+      return ok(entries);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Create a guest directory (recursive) — FILLS S1's v0 denial. */
+  async createDir(path: string): Promise<PiResult<void, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      await this.#vm.fs.mkdir(abs, { recursive: true });
+      return ok(undefined);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /** Remove a guest path (recursive, force) — FILLS S1's v0 denial. */
+  async remove(path: string): Promise<PiResult<void, PiFileError>> {
+    const abs = this.#confine(path);
+    if (abs === null) return fsErr('E_PI_FS_DENIED', 'path escapes workspace boundary', path);
+    try {
+      await this.#vm.fs.deleteFile(abs, { recursive: true, force: true });
+      return ok(undefined);
+    } catch (err) {
+      return this.#toFsErr(err, abs);
+    }
+  }
+
+  /**
+   * Create a temp directory under `/workspace/.tmp` — FILLS S1's v0 denial. Runs
+   * `mktemp -d` in ARRAY form (no `$PATH` / shell expansion).
+   */
+  async createTempDir(prefix?: string): Promise<PiResult<string, PiFileError>> {
+    return this.#mktemp(['-d'], prefix);
+  }
+
+  /**
+   * Create a temp file under `/workspace/.tmp` — FILLS S1's v0 denial. Runs
+   * `mktemp` in ARRAY form (no `$PATH` / shell expansion).
+   */
+  async createTempFile(prefix?: string): Promise<PiResult<string, PiFileError>> {
+    return this.#mktemp([], prefix);
+  }
+
+  /**
+   * Shared `mktemp` helper for {@link createTempDir} / {@link createTempFile}.
+   * The template lives UNDER the `/workspace` mount, so the created path is
+   * inside the only writable location and is confined by construction.
+   */
+  async #mktemp(flags: readonly string[], prefix?: string): Promise<PiResult<string, PiFileError>> {
+    const safePrefix = (prefix ?? 'pi-').replace(/[^A-Za-z0-9._-]/g, '');
+    const template = `${GONDOLIN_TMP_DIR}/${safePrefix}XXXXXX`;
+    try {
+      // Ensure the parent .tmp dir exists (idempotent) before mktemp runs.
+      await this.#vm.fs.mkdir(GONDOLIN_TMP_DIR, { recursive: true });
+      const res = await this.#vm.exec(['/bin/mktemp', ...flags, template]);
+      const created = res.stdout.trim();
+      if (res.exitCode !== 0 || created === '') {
+        return fsErr('E_PI_FS_FAILED', res.stderr.trim() || 'mktemp failed', template);
+      }
+      return ok(created);
+    } catch (err) {
+      return this.#toFsErr(err, template);
+    }
+  }
+
+  // --- shell ---------------------------------------------------------------
+
+  /**
+   * Execute a command in the guest via `vm.exec`. Deny-first: a real-egress verb
+   * ({@link DENIED_EXEC_PREFIXES} — `gh` / `git push` / `npm publish` / `cleo` /
+   * `git remote`) is rejected BEFORE reaching the VM, even though the VM itself
+   * has no egress (the network namespace is deny-by-default). `cwd` is confined
+   * to the workspace; the host `AbortSignal` is forwarded only when supplied.
+   *
+   * ## exitCode mapping
+   *
+   * gondolin's `ExecResult.exitCode` is `number` (NON-nullable) with a SEPARATE
+   * optional `signal` field; Pi's `PiExecResult.exitCode` is `number | null`
+   * ("null when killed by signal"). So a signal-kill is mapped to `null`, NOT
+   * the raw `exitCode`.
+   */
+  async exec(
+    command: string,
+    options?: PiExecOptions,
+  ): Promise<PiResult<PiExecResult, PiExecutionError>> {
+    const denied = deniedEgressVerb(command);
+    if (denied !== null) {
+      return execErr('E_PI_EXEC_DENIED', `egress verb "${denied}" is denied inside the sandbox`);
+    }
+    const cwd = options?.cwd !== undefined ? this.#confine(options.cwd) : GONDOLIN_WORKSPACE_ROOT;
+    if (cwd === null) {
+      return execErr('E_PI_EXEC_DENIED', 'cwd escapes workspace boundary');
+    }
+    const execOptions: GondolinExecOptions = {
+      cwd,
+      ...(options?.env !== undefined ? { env: options.env } : {}),
+      ...(options?.timeout !== undefined ? { timeout: options.timeout } : {}),
+    };
+    try {
+      const res: GondolinExecResult = await this.#vm.exec(command, execOptions);
+      const exitCode = res.signal !== undefined ? null : res.exitCode;
+      return ok({ stdout: res.stdout, stderr: res.stderr, exitCode });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return execErr('E_PI_EXEC_FAILED', message);
+    }
+  }
+
+  // --- cleanup (idempotent — owns the VM) ----------------------------------
+
+  /**
+   * Tear down the owned VM (`vm.close()`). Idempotent: a second call is a no-op.
+   * Best-effort and never throws (a close failure is logged, not propagated) so
+   * the Pi contract — `cleanup()` must not throw — holds.
+   */
+  async cleanup(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    try {
+      await this.#vm.close();
+    } catch (err) {
+      log.debug({ err }, 'gondolin VM close failed during cleanup (ignored)');
+    }
+  }
+
+  // --- error mapping -------------------------------------------------------
+
+  /** Convert a thrown error from a `vm.fs.*` call into a Pi `Result.err`. */
+  #toFsErr(err: unknown, path: string): PiResult<never, PiFileError> {
+    const code =
+      typeof err === 'object' && err !== null && 'code' in err
+        ? String((err as { code?: unknown }).code)
+        : 'E_PI_FS_FAILED';
+    const message = err instanceof Error ? err.message : String(err);
+    return fsErr(code, message, path);
+  }
+}
+
+/**
+ * Whether `err` is a "file does not exist" failure (`ENOENT`). Used by
+ * {@link GondolinExecutionEnv.appendFile} to treat append-to-missing as
+ * append-creates while still propagating every OTHER failure.
+ */
+function isMissingFileError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === 'ENOENT'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by {@link createGondolinExecutionEnv} when the optional
+ * `@earendil-works/gondolin` package (or its QEMU/KVM host infra) is not
+ * available, so a VM cannot be booted. Callers that want graceful degradation
+ * should check `isGondolinAvailable()` first (the selector
+ * {@link import('./resolve-execution-env.js')} does this) and fall back to the
+ * in-process {@link import('./pi-execution-env.js').GuardedExecutionEnv}.
+ */
+export class GondolinUnavailableError extends Error {
+  /** Machine-readable code. */
+  readonly code = 'E_GONDOLIN_UNAVAILABLE';
+  constructor(message: string) {
+    super(message);
+    this.name = 'GondolinUnavailableError';
+  }
+}
+
+/**
+ * Boot a gondolin micro-VM and wrap it in a {@link GondolinExecutionEnv}.
+ *
+ * The VM is configured for ZERO host authority:
+ * - **mount set** = ONLY `{ '/workspace': new RealFSProvider(seededCopyDir) }`.
+ *   The disposable seeded copy is the single RW mount; live `tasks.db`/`brain.db`
+ *   are structurally absent from the guest VFS (T5158 impossible in-VM).
+ * - **egress** = `createHttpHooks({ allowedHosts, secrets })` with `allowedHosts`
+ *   defaulting to `[]` (DENY ALL — the footgun guard) and host-side secret
+ *   PLACEHOLDERS (the guest never sees real token bytes).
+ * - **env** = ONLY `opts.env` (host `process.env` is NEVER inherited).
+ * - **memory** = `opts.memory` (default `"1G"`), set EXPLICITLY.
+ *
+ * Import-time side-effect-free: the gondolin module is loaded lazily HERE (not at
+ * module top-level) via the injectable {@link GondolinLoader} (tests pass a fake
+ * → a MOCK VM, so NO real QEMU boots).
+ *
+ * @param opts - The seeded-copy mount dir + egress allowlist/secrets + guest env.
+ * @returns A {@link PiExecutionEnv} backed by the booted VM.
+ * @throws {GondolinUnavailableError} When the optional package cannot be loaded.
+ *
+ * @example
+ * ```ts
+ * const env = await createGondolinExecutionEnv({ seededCopyDir: snapshotDir });
+ * // ... drive Pi's loop over `env` ...
+ * await env.cleanup(); // releases the VM
+ * ```
+ */
+export async function createGondolinExecutionEnv(
+  opts: CreateGondolinExecutionEnvOptions,
+): Promise<PiExecutionEnv> {
+  const load = opts.load ?? loadGondolin;
+  const mod = await load();
+  if (mod === null) {
+    throw new GondolinUnavailableError(
+      'gondolin is not available (package absent or host infra missing); ' +
+        'check isGondolinAvailable() and fall back to the in-process GuardedExecutionEnv',
+    );
+  }
+
+  // The ONLY RW mount is the disposable seeded copy at /workspace. Live DBs are
+  // structurally absent — there is no live handle inside the VM to corrupt.
+  const mounts: Record<string, RealFSProviderInstance> = {
+    [GONDOLIN_WORKSPACE_ROOT]: new mod.RealFSProvider(opts.seededCopyDir),
+  };
+
+  // Egress deny-by-default: `allowedHosts` MUST be PRESENT-and-empty `[]` (the
+  // footgun — OMITTING it = allow-all per the gondolin docs). The loop appends
+  // specific hosts per run; secret bytes are injected host-side (guest sees only
+  // each `placeholder`).
+  const createHooks: CreateHttpHooks = mod.createHttpHooks;
+  const httpHooks = createHooks({
+    allowedHosts: opts.allowedHosts ?? [],
+    ...(opts.vaultSecrets !== undefined ? { secrets: opts.vaultSecrets } : {}),
+  });
+
+  const vm = await mod.VM.create({
+    memory: opts.memory ?? DEFAULT_GUEST_MEMORY,
+    env: opts.env ?? {},
+    vfs: { mounts },
+    httpHooks,
+  });
+
+  return new GondolinExecutionEnv(vm);
+}

--- a/packages/core/src/llm/pi/resolve-execution-env.ts
+++ b/packages/core/src/llm/pi/resolve-execution-env.ts
@@ -1,0 +1,234 @@
+/**
+ * Per-run {@link PiExecutionEnv} selector + CI process-isolation fallback
+ * (T11910 · T11888-C · P5 Gondolin · epic T11599).
+ *
+ * The self-improvement loop wants ONE swap point that picks the strongest
+ * available confinement backend for a run and SILENTLY DEGRADES when the stronger
+ * one is unavailable — never erroring, never coupling the caller to whether a VM
+ * booted. That is this module:
+ *
+ * - When `backend: 'gondolin'` is requested AND the Gondolin sandbox is available
+ *   (the optional `@earendil-works/gondolin` package loads AND `/dev/kvm` exists
+ *   AND a working `qemu-system-x86_64` is on `PATH` — the AND-gate of
+ *   {@link import('./gondolin-loader.js').isGondolinAvailable}), the selector boots
+ *   a micro-VM-backed {@link import('./pi-gondolin-env.js').GondolinExecutionEnv}
+ *   (confinement = the VM boundary itself; guest has ZERO host authority).
+ * - OTHERWISE — `backend: 'in-process'`, OR `'gondolin'` requested on a box where
+ *   the package / `/dev/kvm` / QEMU is absent (the CI + most-developer-machines
+ *   case) — it returns the always-available in-process deny-first
+ *   {@link import('./pi-execution-env.js').GuardedExecutionEnv} (`ToolGuard` +
+ *   workspace boundary). The loop runs IDENTICALLY over either backend (the
+ *   `PiExecutionEnv` contract is byte-for-byte identical), just without VM
+ *   isolation in the fallback.
+ *
+ * So in CI — gondolin uninstalled AND `/dev/kvm`/QEMU usually absent —
+ * `isGondolinAvailable()` is `false`, the selector returns the in-process env, and
+ * the suite stays green with ZERO VM infra. The degradation is structural: a box
+ * that requested the VM but lacks the infra gets the guarded fallback, not an
+ * error.
+ *
+ * Optional-dep discipline (D11142): this module imports ONLY sibling Pi modules
+ * (`./gondolin-loader.js`, `./pi-gondolin-env.js`, `./pi-execution-env.js`). It has
+ * NO `import type` from `@earendil-works/gondolin` — the gondolin package is loaded
+ * lazily (and ONLY when chosen) inside `createGondolinExecutionEnv`. `core` builds
+ * + all non-gondolin tests pass with gondolin ABSENT, and this module is
+ * import-time side-effect-free (no top-level VM boot, no host probe).
+ *
+ * Scope (T11888-C): this is the SELECTOR ONLY. It does NOT wire the
+ * `pi-agent-adapter.ts` env seam (a separate follow-up) — it is the single
+ * function the loop calls to obtain a per-run env.
+ *
+ * @epic T11599
+ * @task T11910
+ * @see ./gondolin-loader.js — the optional-dep availability probe (`isGondolinAvailable`)
+ * @see ./pi-gondolin-env.js — the VM-backed backend booted when available
+ * @see ./pi-execution-env.js — the in-process `GuardedExecutionEnv` fallback
+ */
+
+import type { ToolGuard } from '../../tools/guard.js';
+import { isGondolinAvailable as realIsGondolinAvailable } from './gondolin-loader.js';
+import { createGuardedExecutionEnv, type PiExecutionEnv } from './pi-execution-env.js';
+import {
+  type CreateGondolinExecutionEnvOptions,
+  createGondolinExecutionEnv as realCreateGondolinExecutionEnv,
+} from './pi-gondolin-env.js';
+
+/**
+ * Which confinement backend a run REQUESTS. `'gondolin'` is a PREFERENCE, not a
+ * guarantee — when the VM infra is absent the selector degrades to `'in-process'`
+ * (the guarded fallback). `'in-process'` always resolves to the in-process
+ * {@link import('./pi-execution-env.js').GuardedExecutionEnv} (no VM probe at all).
+ */
+export type ExecutionEnvBackend = 'gondolin' | 'in-process';
+
+/**
+ * Options for {@link resolveExecutionEnv}. The `guard` + `workspaceRoot` pair is
+ * ALWAYS required because they back the in-process fallback (the guarded env that
+ * runs when the VM is unavailable or not requested). The VM-only fields
+ * (`seededCopyDir`, `allowedHosts`, `vaultSecrets`, `memory`, `env`) are consumed
+ * ONLY when a Gondolin VM is actually booted.
+ */
+export interface ResolveExecutionEnvOptions {
+  /**
+   * The confinement backend this run PREFERS. `'gondolin'` boots a micro-VM when
+   * available and degrades to the guarded env otherwise; `'in-process'` always
+   * resolves to the guarded env.
+   */
+  readonly backend: ExecutionEnvBackend;
+  /**
+   * The deny-first guard surface backing the in-process fallback. REQUIRED even
+   * when `backend: 'gondolin'` — it is what the selector returns when the VM is
+   * unavailable. Must be an `enforce`-mode guard (the fallback factory asserts it).
+   */
+  readonly guard: ToolGuard;
+  /**
+   * The absolute workspace root the in-process fallback confines every fs path
+   * under. Used ONLY by the guarded fallback (the VM confines to its own
+   * `/workspace` mount).
+   */
+  readonly workspaceRoot: string;
+  /**
+   * The disposable seeded-copy host directory mounted RW at `/workspace` inside
+   * the guest. REQUIRED when a VM is actually booted (`backend: 'gondolin'` AND
+   * available); MUST be a `VACUUM INTO` snapshot dir, NEVER a path containing the
+   * live `.cleo/tasks.db` / `.cleo/brain.db`. Ignored by the fallback.
+   */
+  readonly seededCopyDir?: string;
+  /**
+   * Outbound host allowlist forwarded to the VM's egress hooks. Defaults to `[]`
+   * (DENY ALL) inside the VM factory when omitted. Ignored by the fallback.
+   */
+  readonly allowedHosts?: readonly string[];
+  /**
+   * Host-side secret injections for the VM's egress proxy (the guest only ever
+   * sees each entry's `placeholder`). Ignored by the fallback.
+   */
+  readonly vaultSecrets?: CreateGondolinExecutionEnvOptions['vaultSecrets'];
+  /**
+   * Guest memory bound (e.g. `"1G"`) for a booted VM. Defaults inside the VM
+   * factory. Ignored by the fallback.
+   */
+  readonly memory?: string;
+  /**
+   * Guest environment — the ONLY env a booted VM's guest sees (host `process.env`
+   * is NEVER inherited). Ignored by the fallback.
+   */
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Injectable seams for {@link resolveExecutionEnv}.
+ *
+ * EXPORTED FOR TESTS ONLY — lets the selector matrix test simulate
+ * "VM requested + available" (a mocked `isAvailable` returning `true` + a mocked
+ * `createGondolin` returning a fake env) and "VM requested + unavailable"
+ * (`isAvailable` returning `false`) WITHOUT touching the module graph or launching
+ * a real QEMU VM. In production both default to the real loader probe + the real
+ * VM factory.
+ *
+ * @internal
+ */
+export interface ResolveExecutionEnvSeams {
+  /**
+   * The availability probe. Defaults to the real
+   * {@link import('./gondolin-loader.js').isGondolinAvailable} (package + `/dev/kvm`
+   * + QEMU AND-gate).
+   */
+  readonly isAvailable?: () => Promise<boolean>;
+  /**
+   * The VM-backed env factory. Defaults to the real
+   * {@link import('./pi-gondolin-env.js').createGondolinExecutionEnv}.
+   */
+  readonly createGondolin?: (opts: CreateGondolinExecutionEnvOptions) => Promise<PiExecutionEnv>;
+}
+
+/**
+ * Thrown by {@link resolveExecutionEnv} when `backend: 'gondolin'` is requested,
+ * the VM is reported available, but no {@link ResolveExecutionEnvOptions.seededCopyDir}
+ * was supplied — a VM cannot boot without a disposable seeded-copy mount, and
+ * silently degrading to the in-process fallback here would HIDE a caller bug
+ * (the caller asked for the VM and the infra IS present). This is the ONE
+ * non-degrading failure: it signals a misconfiguration, not missing infra.
+ */
+export class ExecutionEnvConfigError extends Error {
+  /** Machine-readable code. */
+  readonly code = 'E_EXECUTION_ENV_CONFIG';
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExecutionEnvConfigError';
+  }
+}
+
+/**
+ * Resolve the {@link PiExecutionEnv} a single self-improvement run should use,
+ * preferring the Gondolin micro-VM when requested AND available and SILENTLY
+ * DEGRADING to the in-process {@link import('./pi-execution-env.js').GuardedExecutionEnv}
+ * otherwise.
+ *
+ * Selection matrix:
+ *
+ * | `backend`      | VM available? | Result                                  |
+ * |----------------|---------------|-----------------------------------------|
+ * | `'gondolin'`   | yes           | `createGondolinExecutionEnv` (micro-VM) |
+ * | `'gondolin'`   | no            | `createGuardedExecutionEnv` (degrade)   |
+ * | `'in-process'` | (not probed)  | `createGuardedExecutionEnv`             |
+ *
+ * The availability check (`package + /dev/kvm + QEMU`) is performed ONLY when
+ * `backend === 'gondolin'`, so an `'in-process'` request never probes the host or
+ * touches the optional package. Degradation NEVER throws — the one exception is a
+ * misconfiguration (`gondolin` requested + available but no `seededCopyDir`), which
+ * is a caller bug surfaced as {@link ExecutionEnvConfigError} rather than a hidden
+ * fallback.
+ *
+ * @param opts - The backend preference + the always-required guard/workspaceRoot
+ *   fallback inputs + the VM-only mount/egress inputs.
+ * @param seams - Test-only overrides for the availability probe + VM factory
+ *   (defaults are the real loader probe + the real VM factory). Production callers
+ *   pass nothing.
+ * @returns A {@link PiExecutionEnv} — VM-backed when the sandbox booted, in-process
+ *   guarded otherwise. The loop cannot tell the backends apart.
+ * @throws {ExecutionEnvConfigError} When the VM is requested AND available but no
+ *   `seededCopyDir` was supplied.
+ *
+ * @example
+ * ```ts
+ * // Prefer the VM; degrades to the guarded env in CI (no /dev/kvm / QEMU).
+ * const env = await resolveExecutionEnv({
+ *   backend: 'gondolin',
+ *   guard,                       // enforce-mode ToolGuard (the fallback)
+ *   workspaceRoot: projectRoot,  // the fallback's confinement root
+ *   seededCopyDir: snapshotDir,  // the VM's only RW mount (disposable copy)
+ * });
+ * // ... drive Pi's loop over `env` ...
+ * await env.cleanup();
+ * ```
+ */
+export async function resolveExecutionEnv(
+  opts: ResolveExecutionEnvOptions,
+  seams: ResolveExecutionEnvSeams = {},
+): Promise<PiExecutionEnv> {
+  const isAvailable = seams.isAvailable ?? realIsGondolinAvailable;
+  const createGondolin = seams.createGondolin ?? realCreateGondolinExecutionEnv;
+
+  if (opts.backend === 'gondolin' && (await isAvailable())) {
+    if (opts.seededCopyDir === undefined) {
+      throw new ExecutionEnvConfigError(
+        'backend "gondolin" is available but no seededCopyDir was supplied; ' +
+          'a VM requires a disposable seeded-copy mount (VACUUM INTO snapshot) — ' +
+          'live tasks.db/brain.db are NEVER mounted',
+      );
+    }
+    return createGondolin({
+      seededCopyDir: opts.seededCopyDir,
+      ...(opts.allowedHosts !== undefined ? { allowedHosts: opts.allowedHosts } : {}),
+      ...(opts.vaultSecrets !== undefined ? { vaultSecrets: opts.vaultSecrets } : {}),
+      ...(opts.memory !== undefined ? { memory: opts.memory } : {}),
+      ...(opts.env !== undefined ? { env: opts.env } : {}),
+    });
+  }
+
+  // Degrade (or honour `'in-process'`): the always-available in-process env. This
+  // is the CI / most-developer-machines path — no VM probe touched the host when
+  // backend was `'in-process'`; when it was `'gondolin'` the probe returned false.
+  return createGuardedExecutionEnv({ guard: opts.guard, workspaceRoot: opts.workspaceRoot });
+}


### PR DESCRIPTION
## Summary

`GondolinExecutionEnv` implements the Pi `ExecutionEnv` over `@earendil-works/gondolin` (dynamic-import-only, D11142; CI degrades to the S1 `GuardedExecutionEnv`); guest ZERO authority, live DBs never mounted, deny-first; the sandbox the self-improvement loop runs in.

### What ships (3 commits, 7 new files, +2290 LOC, purely additive)

- **T11888-A — `gondolin-loader.ts`**: optional-dep loader + availability probe. `@earendil-works/gondolin` loaded ONLY via a dynamic `import()` whose specifier is held in a variable — in NEITHER `dependencies` NOR `optionalDependencies`, with local structural types (NO `import type` from the package). `isGondolinAvailable()` is the AND-gate of (package loads) ∧ (`/dev/kvm` present) ∧ (working `qemu-system-x86_64`); import-time side-effect-free; never throws.
- **T11888-B — `pi-gondolin-env.ts`**: the second `PiExecutionEnv` backend over the micro-VM. Confinement IS the VM boundary. Guest has ZERO host authority — no `cleo.db` handle, no lease socket, no host `process.env`; the ONLY RW mount is a disposable seeded-copy at `/workspace`; egress hooks default to `allowedHosts: []` (present-and-empty = DENY ALL, the gondolin footgun guard) with host-side credential PLACEHOLDERS. A thin in-guest deny-first layer (lexical `/workspace` confinement + a `gh`/`git push`/`git remote`/`npm publish`/`cleo` denylist) is defense-in-depth. Every `vm.fs.*`/`vm.exec` is wrapped → `PiResult.err` (never throws; Pi `process.exit` never in-process).
- **T11888-C — `resolve-execution-env.ts`**: the per-run selector. `backend: 'gondolin'` boots a VM when available, SILENTLY DEGRADES to the in-process `GuardedExecutionEnv` otherwise (the CI + most-dev-machines path); `backend: 'in-process'` never probes the host. The one non-degrading failure is a caller misconfig (`gondolin` available but no `seededCopyDir`).

### Sandbox safety (the whole point)

Live `.cleo/tasks.db`/`.cleo/brain.db` are NEVER in the VFS mount set — only a disposable `VACUUM INTO` seeded copy — so the T5158 data-loss vector is structurally impossible inside the VM (no live handle to corrupt). Guest sees no real secret bytes (placeholders only). Real `gh`/`git push`/`npm publish` are denied; sandbox output is a DRAFT PR opened host-side by the loop's egress step.

### Tests

- Unit suites MOCK the VM — 61 tests pass (`gondolin-loader`, `pi-gondolin-env`, `resolve-execution-env`); NO real QEMU/gondolin VM is launched.
- The real-VM exercise is an OPT-IN integration test gated on `CLEO_GONDOLIN_INTEGRATION=1` ∧ host KVM/QEMU; it SKIPS in CI (gondolin uninstalled, no `/dev/kvm`).

### Gates

biome clean · build success · 61 gondolin unit tests pass (integration skips) · `lint-publish-surface` (Gate 9 unchanged, 18) · `lint-tools-vs-skills-boundary` · `lint-llm-chokepoint` (41 < 53 baseline) · `lint-no-runtime-in-contracts --strict` · `cleo check arch` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)