### PR TITLE
feat(T11906): port L1 complexity classifier to TS tier-proposer for resolveLLMForSystem

### DIFF
--- a/packages/contracts/src/llm/system-resolver.ts
+++ b/packages/contracts/src/llm/system-resolver.ts
@@ -135,4 +135,20 @@ export interface ResolveLLMForSystemOptions {
    * @internal
    */
   skipCatalogDefault?: boolean;
+
+  /**
+   * Raw prompt used to derive a role from complexity when neither an explicit
+   * tier/role nor a role-mapped system label is available (L1 proposer · T11906).
+   *
+   * When the `system` argument is the flat `'default'` label (which maps to NO
+   * role) and `roleOverride` is unset, the resolver runs the L1 complexity
+   * classifier over this prompt and proposes a {@link RoleName} from the
+   * resulting tier (`low → hygiene`, `mid → consolidation`, `high → judgement`).
+   * This is a COMPLEMENT to the resolver — it only supplies a role when one is
+   * otherwise absent; an explicit label, descriptor, or `roleOverride` always
+   * wins. The classifier returns a TIER only and constructs no LLM client.
+   *
+   * Ignored when the role is already determined by the input or `roleOverride`.
+   */
+  complexityPrompt?: string;
 }

--- a/packages/core/src/llm/__tests__/complexity-classifier.test.ts
+++ b/packages/core/src/llm/__tests__/complexity-classifier.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Unit tests for the L1 complexity classifier (T11906).
+ *
+ * Ports the test corpus of the deleted Rust `cant-router` classifier
+ * (`features.rs` + `classifier.rs`) plus the tier→role wiring (AC2/AC3).
+ *
+ * @task T11906
+ * @epic T11745
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type ComplexityTier,
+  classify,
+  classifyComplexity,
+  complexityTierToRole,
+  escalateTier,
+  extractFeatures,
+  type PromptFeatures,
+  proposeRoleForPrompt,
+  THRESHOLD_HIGH,
+  THRESHOLD_MID,
+} from '../complexity-classifier.js';
+
+// ---------------------------------------------------------------------------
+// Feature extraction (ported from features.rs tests)
+// ---------------------------------------------------------------------------
+
+describe('extractFeatures — five prompt features (ported from features.rs)', () => {
+  it('counts tokens', () => {
+    expect(extractFeatures('hello world this is a test').tokenCount).toBe(6);
+  });
+
+  it('counts tokens for an empty string as 0', () => {
+    expect(extractFeatures('').tokenCount).toBe(0);
+  });
+
+  it('counts tokens for whitespace-only as 0', () => {
+    expect(extractFeatures('   \t  \n ').tokenCount).toBe(0);
+  });
+
+  it('counts reasoning keywords', () => {
+    // why, should, compare, decide = 4
+    const f = extractFeatures('Why should we compare these options and decide?');
+    expect(f.reasoningDepth).toBe(4);
+  });
+
+  it('counts reasoning keywords case-insensitively', () => {
+    // analyze, evaluate, tradeoff = 3
+    const f = extractFeatures('ANALYZE and EVALUATE the tradeoff');
+    expect(f.reasoningDepth).toBe(3);
+  });
+
+  it('counts no reasoning keywords for a plain prompt', () => {
+    expect(extractFeatures('list the files in this directory').reasoningDepth).toBe(0);
+  });
+
+  it('counts file references by slash', () => {
+    // src/main.ts has '/', docs/README.md has '/' — 2 refs
+    const f = extractFeatures('Update src/main.ts and docs/README.md please');
+    expect(f.touchesFilesCount).toBe(2);
+  });
+
+  it('counts file references by extension', () => {
+    const f = extractFeatures('Edit foo.rs bar.ts baz.md config.json');
+    expect(f.touchesFilesCount).toBe(4);
+  });
+
+  it('estimates syntactic complexity as 0 for a flat prompt', () => {
+    expect(extractFeatures('simple flat prompt').syntacticComplexity).toBeCloseTo(0.0, 10);
+  });
+
+  it('estimates syntactic complexity from nested bracket depth', () => {
+    // max depth 3, 3/5 = 0.6
+    expect(extractFeatures('nested ((( three )))').syntacticComplexity).toBeCloseTo(0.6, 10);
+  });
+
+  it('clamps syntactic complexity to 1.0', () => {
+    expect(extractFeatures('deeply (((((((( nested ))))))))').syntacticComplexity).toBeCloseTo(
+      1.0,
+      10,
+    );
+  });
+
+  it('treats mixed bracket kinds as one depth stack', () => {
+    // ( [ { -> depth 3 -> 0.6
+    expect(extractFeatures('a ([{ b }]) c').syntacticComplexity).toBeCloseTo(0.6, 10);
+  });
+
+  it('never drives bracket depth negative on unbalanced closers', () => {
+    // leading closers must not underflow; one '(' -> depth 1 -> 0.2
+    expect(extractFeatures(')))) ( ').syntacticComplexity).toBeCloseTo(0.2, 10);
+  });
+
+  it('estimates domain specificity as 0 for plain english', () => {
+    expect(extractFeatures('plain english prompt').domainSpecificity).toBeCloseTo(0.0, 10);
+  });
+
+  it('estimates domain specificity from CamelCase density', () => {
+    // 2 camel-case tokens / 10 = 0.2
+    const f = extractFeatures('use ModelSelection and RoutingObservation');
+    expect(f.domainSpecificity).toBeCloseTo(0.2, 10);
+  });
+
+  it('does not count a single-capital token as domain-specific', () => {
+    // "Refactor" has only one uppercase letter -> not counted
+    expect(extractFeatures('Refactor the code').domainSpecificity).toBeCloseTo(0.0, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classifier (ported from classifier.rs tests)
+// ---------------------------------------------------------------------------
+
+/** Helper — build a PromptFeatures with explicit fields. */
+function features(
+  tokenCount: number,
+  syntacticComplexity: number,
+  reasoningDepth: number,
+  domainSpecificity: number,
+  touchesFilesCount: number,
+): PromptFeatures {
+  return {
+    tokenCount,
+    syntacticComplexity,
+    reasoningDepth,
+    domainSpecificity,
+    touchesFilesCount,
+  };
+}
+
+describe('classify — linear weighted classifier (ported from classifier.rs)', () => {
+  it('maps a near-zero feature vector to the low tier', () => {
+    const result = classify(features(5, 0.0, 0, 0.0, 0));
+    expect(result.tier).toBe('low');
+    expect(result.score).toBeLessThan(THRESHOLD_MID);
+  });
+
+  it('maps a moderate feature vector to the mid tier', () => {
+    // 0.15*0.8 + 0.25*0.5 + 0.30*0.4 + 0.20*0.5 + 0.10*0.3 = 0.495
+    const result = classify(features(800, 0.5, 4, 0.5, 6));
+    expect(result.tier).toBe('mid');
+    expect(result.score).toBeGreaterThanOrEqual(THRESHOLD_MID);
+    expect(result.score).toBeLessThan(THRESHOLD_HIGH);
+  });
+
+  it('maps a maximally-complex feature vector to the high tier', () => {
+    // Saturates every normalizer: 0.15+0.25+0.30+0.20+0.10 = 1.00
+    const result = classify(features(2000, 1.0, 20, 1.0, 30));
+    expect(result.tier).toBe('high');
+    expect(result.score).toBeGreaterThanOrEqual(THRESHOLD_HIGH);
+  });
+
+  it('lands on mid at exactly the 0.35 boundary', () => {
+    // domain 1.0 (0.20) + reasoning 5 (0.5*0.30 = 0.15) = 0.35 exactly
+    const result = classify(features(0, 0.0, 5, 1.0, 0));
+    expect(result.score).toBeCloseTo(0.35, 9);
+    expect(result.tier).toBe('mid');
+  });
+
+  it('lands on high at exactly the 0.75 boundary', () => {
+    // syntactic 1.0 (0.25) + reasoning 10 (0.30) + domain 1.0 (0.20) = 0.75 exactly
+    const result = classify(features(0, 1.0, 10, 1.0, 0));
+    expect(result.score).toBeCloseTo(0.75, 9);
+    expect(result.tier).toBe('high');
+  });
+
+  it('lands on low just below the 0.35 boundary', () => {
+    // domain 1.0 (0.20) + reasoning 4 (0.4*0.30 = 0.12) = 0.32 < 0.35
+    const result = classify(features(0, 0.0, 4, 1.0, 0));
+    expect(result.score).toBeCloseTo(0.32, 9);
+    expect(result.tier).toBe('low');
+  });
+
+  it('lands on mid just below the 0.75 boundary', () => {
+    // syntactic 1.0 (0.25) + reasoning 10 (0.30) + domain 0.9 (0.18) = 0.73 < 0.75
+    const result = classify(features(0, 1.0, 10, 0.9, 0));
+    expect(result.score).toBeCloseTo(0.73, 9);
+    expect(result.tier).toBe('mid');
+  });
+
+  it('preserves the input feature vector', () => {
+    const result = classify(features(123, 0.5, 4, 0.7, 9));
+    expect(result.features.tokenCount).toBe(123);
+    expect(result.features.reasoningDepth).toBe(4);
+    expect(result.features.touchesFilesCount).toBe(9);
+  });
+
+  it('saturates the score at 1.0 for extreme values', () => {
+    const result = classify(
+      features(
+        Number.MAX_SAFE_INTEGER,
+        999.0,
+        Number.MAX_SAFE_INTEGER,
+        999.0,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    );
+    expect(result.score).toBeLessThanOrEqual(1.0 + Number.EPSILON);
+    expect(result.tier).toBe('high');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end tier boundaries: trivial → simple → moderate → complex → expert
+// ---------------------------------------------------------------------------
+
+describe('classifyComplexity — prompt → tier boundaries', () => {
+  it('classifies a trivial prompt as low', () => {
+    expect(classifyComplexity('hi')).toBe('low');
+  });
+
+  it('classifies a simple prompt as low', () => {
+    expect(classifyComplexity('list the files in src')).toBe('low');
+  });
+
+  it('keeps a SHORT reasoning prompt at low (token normalizer dominates)', () => {
+    // The token-count normalizer divides by 1000, so a short prompt — even one
+    // dense in reasoning keywords and identifiers — scores below 0.35. This
+    // mirrors the Rust normalizers faithfully: complexity needs VOLUME, not just
+    // a couple of keywords.
+    const tier = classifyComplexity(
+      'Why should we compare ModelSelection and RoutingObservation and decide the trade-off?',
+    );
+    expect(tier).toBe('low');
+  });
+
+  it('classifies a moderate-volume reasoning prompt as mid', () => {
+    // ~700 tokens of filler (0.15*0.7 = 0.105) + reasoning keywords (≥5 → 0.15)
+    // + CamelCase identifiers (≥4 → ≥0.08) + a couple files clears 0.35 but not 0.75.
+    const reasoning = 'why should we compare decide evaluate the trade-off';
+    const identifiers = 'ModelSelection RoutingObservation PromptFeatures TierLadder';
+    const files = 'src/a.ts src/b.ts';
+    const filler = 'word '.repeat(700);
+    const tier = classifyComplexity(`${reasoning} ${identifiers} ${files} ${filler}`);
+    expect(tier).toBe('mid');
+  });
+
+  it('classifies a complex multi-signal prompt as high', () => {
+    // Long, bracket-nested, reasoning-heavy, identifier-dense, many files.
+    const brackets = '((((( deeply nested logic )))))';
+    const reasoning =
+      'why should we analyze evaluate consider compare decide explain the tradeoff and trade-off';
+    const identifiers = Array.from({ length: 12 }, (_, i) => `ModelSelection${i}`).join(' ');
+    const files = Array.from({ length: 25 }, (_, i) => `src/mod${i}.ts`).join(' ');
+    const filler = 'word '.repeat(1200);
+    const tier = classifyComplexity(`${brackets} ${reasoning} ${identifiers} ${files} ${filler}`);
+    expect(tier).toBe('high');
+  });
+
+  it('produces a monotonically non-decreasing tier across the complexity ladder', () => {
+    const order: Record<ComplexityTier, number> = { low: 0, mid: 1, high: 2 };
+    const trivial = classifyComplexity('hi');
+    const moderate = classifyComplexity(
+      'Why should we compare ModelSelection and decide src/a.ts vs src/b.ts?',
+    );
+    expect(order[moderate]).toBeGreaterThanOrEqual(order[trivial]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier escalation (ported from types.rs Tier::escalate)
+// ---------------------------------------------------------------------------
+
+describe('escalateTier — ladder escalation (ported from Tier::escalate)', () => {
+  it('escalates low → mid', () => {
+    expect(escalateTier('low')).toBe('mid');
+  });
+
+  it('escalates mid → high', () => {
+    expect(escalateTier('mid')).toBe('high');
+  });
+
+  it('returns null at the top of the ladder', () => {
+    expect(escalateTier('high')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier → role wiring (AC2)
+// ---------------------------------------------------------------------------
+
+describe('complexityTierToRole — tier → RoleName proposer (AC2)', () => {
+  it('maps low → hygiene', () => {
+    expect(complexityTierToRole('low')).toBe('hygiene');
+  });
+
+  it('maps mid → consolidation', () => {
+    expect(complexityTierToRole('mid')).toBe('consolidation');
+  });
+
+  it('maps high → judgement', () => {
+    expect(complexityTierToRole('high')).toBe('judgement');
+  });
+});
+
+describe('proposeRoleForPrompt — prompt → tier → role composition (AC2)', () => {
+  it('proposes the cheap role for a trivial prompt', () => {
+    expect(proposeRoleForPrompt('hi')).toBe('hygiene');
+  });
+
+  it('proposes the most-capable role for a maximally-complex prompt', () => {
+    const brackets = '((((( deeply nested )))))';
+    const reasoning =
+      'why should we analyze evaluate consider compare decide explain the tradeoff and trade-off';
+    const identifiers = Array.from({ length: 12 }, (_, i) => `ModelSelection${i}`).join(' ');
+    const files = Array.from({ length: 25 }, (_, i) => `src/mod${i}.ts`).join(' ');
+    const filler = 'word '.repeat(1200);
+    expect(proposeRoleForPrompt(`${brackets} ${reasoning} ${identifiers} ${files} ${filler}`)).toBe(
+      'judgement',
+    );
+  });
+
+  it('agrees with classifyComplexity + complexityTierToRole', () => {
+    const prompt = 'Why should we compare ModelSelection and decide src/a.ts?';
+    expect(proposeRoleForPrompt(prompt)).toBe(complexityTierToRole(classifyComplexity(prompt)));
+  });
+});

--- a/packages/core/src/llm/__tests__/system-resolver.test.ts
+++ b/packages/core/src/llm/__tests__/system-resolver.test.ts
@@ -223,6 +223,93 @@ describe('resolveLLMForSystem — system-to-role mapping', () => {
 });
 
 // ---------------------------------------------------------------------------
+// L1 complexity classifier wiring (T11906 · AC2)
+// ---------------------------------------------------------------------------
+
+describe('resolveLLMForSystem — L1 complexity proposer wiring (T11906 · AC2)', () => {
+  it('derives a role from complexityPrompt when the label maps to no role', async () => {
+    const { projectRoot } = isolate();
+    // 'default' maps to no role; a trivial prompt → low tier → hygiene role.
+    seedProjectConfig(projectRoot, {
+      roles: { hygiene: { provider: 'anthropic', model: 'cheap-model' } },
+    });
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-complexity-low';
+    const result = await resolveLLMForSystem('default', {
+      projectRoot,
+      complexityPrompt: 'hi',
+      skipCatalogDefault: true,
+    });
+    expect(result.resolvedRole).toBe('hygiene');
+    expect(result.source).toBe('role');
+    expect(result.model).toBe('cheap-model');
+  });
+
+  it('derives the most-capable role for a maximally-complex prompt', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, {
+      roles: { judgement: { provider: 'anthropic', model: 'capable-model' } },
+    });
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-complexity-high';
+    const brackets = '((((( deeply nested )))))';
+    const reasoning =
+      'why should we analyze evaluate consider compare decide explain the tradeoff and trade-off';
+    const identifiers = Array.from({ length: 12 }, (_, i) => `ModelSelection${i}`).join(' ');
+    const files = Array.from({ length: 25 }, (_, i) => `src/mod${i}.ts`).join(' ');
+    const filler = 'word '.repeat(1200);
+    const result = await resolveLLMForSystem('default', {
+      projectRoot,
+      complexityPrompt: `${brackets} ${reasoning} ${identifiers} ${files} ${filler}`,
+      skipCatalogDefault: true,
+    });
+    expect(result.resolvedRole).toBe('judgement');
+    expect(result.model).toBe('capable-model');
+  });
+
+  it('does NOT use complexityPrompt when an explicit roleOverride is given', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, {
+      roles: { extraction: { provider: 'anthropic', model: 'explicit-role-model' } },
+    });
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-explicit-over-complexity';
+    const result = await resolveLLMForSystem('default', {
+      projectRoot,
+      roleOverride: 'extraction',
+      complexityPrompt: 'hi', // would propose hygiene — must be ignored
+      skipCatalogDefault: true,
+    });
+    expect(result.resolvedRole).toBe('extraction');
+    expect(result.model).toBe('explicit-role-model');
+  });
+
+  it('does NOT use complexityPrompt when the label already maps to a role', async () => {
+    const { projectRoot } = isolate();
+    seedProjectConfig(projectRoot, {
+      roles: { extraction: { provider: 'anthropic', model: 'memory-role-model' } },
+    });
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-label-wins';
+    // 'memory' → extraction role; complexityPrompt must be ignored.
+    const result = await resolveLLMForSystem('memory', {
+      projectRoot,
+      complexityPrompt: 'hi',
+      skipCatalogDefault: true,
+    });
+    expect(result.resolvedRole).toBe('extraction');
+    expect(result.model).toBe('memory-role-model');
+  });
+
+  it("falls back to null role (default path) for 'default' with no complexityPrompt", async () => {
+    const { projectRoot } = isolate();
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-no-prompt';
+    const result = await resolveLLMForSystem('default', {
+      projectRoot,
+      skipCatalogDefault: true,
+    });
+    expect(result.resolvedRole).toBeNull();
+    expect(result.source).toBe('implicit-fallback');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Missing profile error path
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/llm/complexity-classifier.ts
+++ b/packages/core/src/llm/complexity-classifier.ts
@@ -1,0 +1,455 @@
+/**
+ * L1 complexity classifier — a prompt-complexity **tier proposer** for the E9
+ * LLM chokepoint.
+ *
+ * ## What this is
+ *
+ * A faithful TypeScript port of the deleted Rust `cant-router` Layer-1
+ * classifier (`crates/cant-router/src/features.rs` + `classifier.rs`, retired
+ * in T11807 / D11137). It converts a raw prompt string into five auditable
+ * heuristic features, scores them with a fixed linear model, and maps the
+ * scalar score to a three-level complexity tier (`low` / `mid` / `high`).
+ *
+ * The classifier is a **proposer** that COMPLEMENTS — never replaces — the E9
+ * resolver {@link resolveLLMForSystem}. The flow is:
+ *
+ * ```text
+ *   classifyComplexity(prompt)  ->  ComplexityTier ('low'|'mid'|'high')
+ *   complexityTierToRole(tier)  ->  RoleName       (cheap → capable ladder)
+ *   resolveLLMForSystem({ kind:'role', id })  ->  model + credential
+ * ```
+ *
+ * So when a caller has NO explicit tier/role, it can derive one from the
+ * prompt's complexity and feed it to the chokepoint.
+ *
+ * ## What this is NOT (Gate-13 LLM Chokepoint Guard — T11783)
+ *
+ * - It NEVER constructs a transport or SDK client.
+ * - It NEVER reads `*_API_KEY` (no credential I/O at all).
+ * - It NEVER hardcodes a model-id literal. The tier→model mapping is the E9
+ *   resolver's job; this module stops at proposing a {@link RoleName}.
+ *
+ * It returns a TIER (and, via the helper, a role). The provider, model, and
+ * credential are resolved exclusively by {@link resolveLLMForSystem}.
+ *
+ * The classifier is a pure, deterministic function with no I/O and no module
+ * side effects — safe to import anywhere in the chokepoint.
+ *
+ * @module llm/complexity-classifier
+ * @task T11906
+ * @epic T11745
+ * @see {@link resolveLLMForSystem} — the E9 chokepoint this proposer feeds.
+ */
+
+import type { RoleName } from '@cleocode/contracts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The three-level complexity ladder proposed by {@link classifyComplexity}.
+ *
+ * Ported verbatim from the Rust `Tier` enum (`low` / `mid` / `high`, in
+ * lowercase serde rename order). It is distinct from the dispatch
+ * `Tier = 0 | 1 | 2` in `@cleocode/contracts`: this ladder describes prompt
+ * complexity, not dispatch privilege.
+ *
+ * - `low`  — fastest, cheapest models. Short, simple prompts.
+ * - `mid`  — balanced cost/latency/capability. The default workhorse.
+ * - `high` — most capable, most expensive models. Complex reasoning.
+ */
+export type ComplexityTier = 'low' | 'mid' | 'high';
+
+/**
+ * The five heuristic features extracted from a prompt — the inputs to the
+ * linear classifier.
+ *
+ * Each field corresponds to one of the five signals defined in the deleted
+ * Rust `PromptFeatures` struct (ULTRAPLAN §11.1). Pure heuristics, no ML
+ * runtime — each extractor is a small, auditable signal.
+ */
+export interface PromptFeatures {
+  /** Raw whitespace-delimited token count of the prompt. */
+  tokenCount: number;
+  /** Syntactic complexity in `[0.0, 1.0]` — proxied by nested bracket depth. */
+  syntacticComplexity: number;
+  /** Count of reasoning keywords (why / should / compare / decide / …). */
+  reasoningDepth: number;
+  /** Domain-specificity in `[0.0, 1.0]` — proxied by CamelCase identifier density. */
+  domainSpecificity: number;
+  /** Number of file references detected in the prompt. */
+  touchesFilesCount: number;
+}
+
+/**
+ * A classification result — the tier recommended for a prompt, plus the raw
+ * score and feature vector that produced it.
+ *
+ * Mirrors the deleted Rust `Classification` struct so downstream consumers can
+ * inspect the signals behind the decision.
+ */
+export interface Classification {
+  /** Scalar complexity score in `[0.0, 1.0]` produced by the weighted sum. */
+  score: number;
+  /** The tier chosen by threshold-mapping `score`. */
+  tier: ComplexityTier;
+  /** The raw feature vector that produced this classification. */
+  features: PromptFeatures;
+}
+
+// ---------------------------------------------------------------------------
+// Classifier weights + thresholds (ULTRAPLAN §11.1 — ported from classifier.rs)
+// ---------------------------------------------------------------------------
+
+/** Weight applied to the normalized `tokenCount` feature. */
+export const WEIGHT_TOKEN_COUNT = 0.15;
+
+/** Weight applied to the normalized `syntacticComplexity` feature. */
+export const WEIGHT_SYNTACTIC_COMPLEXITY = 0.25;
+
+/** Weight applied to the normalized `reasoningDepth` feature. */
+export const WEIGHT_REASONING_DEPTH = 0.3;
+
+/** Weight applied to the normalized `domainSpecificity` feature. */
+export const WEIGHT_DOMAIN_SPECIFICITY = 0.2;
+
+/** Weight applied to the normalized `touchesFilesCount` feature. */
+export const WEIGHT_TOUCHES_FILES_COUNT = 0.1;
+
+/** Score at or above which the classifier returns the `high` tier. */
+export const THRESHOLD_HIGH = 0.75;
+
+/**
+ * Score at or above which the classifier returns the `mid` tier.
+ *
+ * Scores strictly below this threshold are mapped to `low`.
+ */
+export const THRESHOLD_MID = 0.35;
+
+// ---------------------------------------------------------------------------
+// Feature extraction (ported from features.rs — five pure heuristics)
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate syntactic complexity by counting nested bracket depth.
+ *
+ * Walks the string once tracking the running depth of `(`, `{`, `[` (and their
+ * matching closers). The maximum depth observed is divided by 5 and clamped to
+ * `[0.0, 1.0]`, so a prompt with no brackets scores 0 and one with 5+ nested
+ * brackets scores 1.
+ *
+ * @param s - The raw prompt string.
+ * @returns A syntactic-complexity score in `[0.0, 1.0]`.
+ */
+function estimateSyntacticComplexity(s: string): number {
+  let depth = 0;
+  let maxDepth = 0;
+  for (const c of s) {
+    if (c === '(' || c === '{' || c === '[') {
+      depth += 1;
+      if (depth > maxDepth) maxDepth = depth;
+    } else if (c === ')' || c === '}' || c === ']') {
+      depth = Math.max(depth - 1, 0);
+    }
+  }
+  return Math.min(maxDepth / 5.0, 1.0);
+}
+
+/**
+ * Reasoning-signal keywords — terms that correlate with multi-step reasoning.
+ *
+ * Intentionally short and biased; ported verbatim from the Rust `KEYWORDS`
+ * slice in `count_reasoning_keywords`.
+ */
+const REASONING_KEYWORDS: readonly string[] = [
+  'why',
+  'should',
+  'compare',
+  'decide',
+  'explain',
+  'analyze',
+  'evaluate',
+  'consider',
+  'trade-off',
+  'tradeoff',
+];
+
+/**
+ * Count reasoning-signal keyword occurrences in the prompt (case-insensitive,
+ * counting every (possibly overlapping-free) occurrence, matching the Rust
+ * `str::matches` semantics).
+ *
+ * @param s - The raw prompt string.
+ * @returns The total number of reasoning-keyword occurrences.
+ */
+function countReasoningKeywords(s: string): number {
+  const lower = s.toLowerCase();
+  let total = 0;
+  for (const keyword of REASONING_KEYWORDS) {
+    let from = 0;
+    for (;;) {
+      const idx = lower.indexOf(keyword, from);
+      if (idx === -1) break;
+      total += 1;
+      // Rust's `str::matches` advances past each non-overlapping match.
+      from = idx + keyword.length;
+    }
+  }
+  return total;
+}
+
+/**
+ * Count the uppercase characters in a token (used by the CamelCase proxy).
+ *
+ * @param w - A single whitespace-delimited token.
+ * @returns The number of uppercase characters in `w`.
+ */
+function uppercaseCount(w: string): number {
+  let n = 0;
+  for (const c of w) {
+    // An uppercase letter is one that differs from its lowercase form and equals
+    // its own uppercase form (excludes digits/punctuation, mirroring Rust's
+    // `char::is_uppercase`).
+    if (c !== c.toLowerCase() && c === c.toUpperCase()) n += 1;
+  }
+  return n;
+}
+
+/**
+ * Estimate domain specificity via CamelCase identifier density.
+ *
+ * Counts whitespace-delimited tokens containing at least two uppercase letters
+ * (a rough proxy for domain-specific identifiers like `ModelSelection` or
+ * `XDGBaseDir`). The count is divided by 10 and clamped to `[0.0, 1.0]`.
+ *
+ * @param s - The raw prompt string.
+ * @returns A domain-specificity score in `[0.0, 1.0]`.
+ */
+function estimateDomainSpecificity(s: string): number {
+  const camelCaseCount = splitWhitespace(s).filter((w) => uppercaseCount(w) >= 2).length;
+  return Math.min(camelCaseCount / 10.0, 1.0);
+}
+
+/**
+ * Count file references in the prompt.
+ *
+ * A token is a file reference if it contains a `/` or ends in a known
+ * source-file extension (`.rs`, `.ts`, `.md`, `.json`). Punctuation on the
+ * token is left intact for v1 — callers aware of this limitation can pre-clean
+ * their prompts.
+ *
+ * @param s - The raw prompt string.
+ * @returns The number of file-reference tokens.
+ */
+function countFileReferences(s: string): number {
+  return splitWhitespace(s).filter(
+    (w) =>
+      w.includes('/') ||
+      w.endsWith('.rs') ||
+      w.endsWith('.ts') ||
+      w.endsWith('.md') ||
+      w.endsWith('.json'),
+  ).length;
+}
+
+/**
+ * Split a string on Unicode whitespace, dropping empty segments — matching
+ * Rust's `str::split_whitespace` (which never yields empty tokens).
+ *
+ * @param s - The string to split.
+ * @returns The non-empty whitespace-delimited tokens of `s`.
+ */
+function splitWhitespace(s: string): string[] {
+  return s.split(/\s+/).filter((w) => w.length > 0);
+}
+
+/**
+ * Extract a {@link PromptFeatures} vector from a raw prompt string.
+ *
+ * Pure heuristics, no ML runtime — the Layer-1 input stage. Each field is a
+ * small, auditable signal that feeds {@link classify}.
+ *
+ * @param prompt - The raw prompt string.
+ * @returns The five-feature vector for `prompt`.
+ *
+ * @example
+ * ```ts
+ * const f = extractFeatures('Refactor auth.ts to use JWT tokens.');
+ * f.tokenCount; // > 0
+ * ```
+ */
+export function extractFeatures(prompt: string): PromptFeatures {
+  return {
+    tokenCount: splitWhitespace(prompt).length,
+    syntacticComplexity: estimateSyntacticComplexity(prompt),
+    reasoningDepth: countReasoningKeywords(prompt),
+    domainSpecificity: estimateDomainSpecificity(prompt),
+    touchesFilesCount: countFileReferences(prompt),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Linear classifier (ported from classifier.rs)
+// ---------------------------------------------------------------------------
+
+/** Intermediate structure holding features clamped to `[0.0, 1.0]`. */
+interface NormalizedFeatures {
+  tokenCount: number;
+  syntacticComplexity: number;
+  reasoningDepth: number;
+  domainSpecificity: number;
+  touchesFilesCount: number;
+}
+
+/**
+ * Clamp a value to `[lo, hi]` — equivalent to Rust's `f64::clamp`. Returns `lo`
+ * for `NaN`, matching the saturating intent of the original normalizers.
+ */
+function clamp(value: number, lo: number, hi: number): number {
+  if (Number.isNaN(value)) return lo;
+  return Math.min(Math.max(value, lo), hi);
+}
+
+/**
+ * Normalize each feature to `[0.0, 1.0]` for the weighted sum.
+ *
+ * These normalization constants are the heuristic v1 defaults tuned against
+ * the ULTRAPLAN §11.1 example ranges (not a labeled corpus). Ported verbatim
+ * from the Rust `normalize_features`.
+ */
+function normalizeFeatures(f: PromptFeatures): NormalizedFeatures {
+  return {
+    tokenCount: Math.min(f.tokenCount / 1000.0, 1.0),
+    syntacticComplexity: clamp(f.syntacticComplexity, 0.0, 1.0),
+    reasoningDepth: Math.min(f.reasoningDepth / 10.0, 1.0),
+    domainSpecificity: clamp(f.domainSpecificity, 0.0, 1.0),
+    touchesFilesCount: Math.min(f.touchesFilesCount / 20.0, 1.0),
+  };
+}
+
+/**
+ * Classify a feature vector into a {@link Classification} result.
+ *
+ * Applies the linear weighted sum from ULTRAPLAN §11.1 and maps the resulting
+ * score to a tier via {@link THRESHOLD_HIGH} and {@link THRESHOLD_MID}. The
+ * input {@link PromptFeatures} is preserved so downstream consumers can inspect
+ * the raw signals that produced the decision.
+ *
+ * @param features - The five-feature vector to score.
+ * @returns The score, tier, and preserved feature vector.
+ */
+export function classify(features: PromptFeatures): Classification {
+  const normalized = normalizeFeatures(features);
+  const score =
+    WEIGHT_TOKEN_COUNT * normalized.tokenCount +
+    WEIGHT_SYNTACTIC_COMPLEXITY * normalized.syntacticComplexity +
+    WEIGHT_REASONING_DEPTH * normalized.reasoningDepth +
+    WEIGHT_DOMAIN_SPECIFICITY * normalized.domainSpecificity +
+    WEIGHT_TOUCHES_FILES_COUNT * normalized.touchesFilesCount;
+
+  const tier: ComplexityTier =
+    score >= THRESHOLD_HIGH ? 'high' : score >= THRESHOLD_MID ? 'mid' : 'low';
+
+  return { score, tier, features };
+}
+
+// ---------------------------------------------------------------------------
+// Public proposer API
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a raw prompt into a complexity {@link ComplexityTier}.
+ *
+ * The one-call entry point: `extractFeatures` → `classify` → tier. This is the
+ * **proposer** half of the L1 router — it stops at a tier and never touches a
+ * model, transport, or credential (Gate-13 compliant).
+ *
+ * @param prompt - The raw prompt string to classify.
+ * @returns The proposed complexity tier (`low` / `mid` / `high`).
+ *
+ * @example
+ * ```ts
+ * classifyComplexity('list files');                       // 'low'
+ * classifyComplexity('Why should we compare these and decide the trade-off?'); // 'mid'+
+ * ```
+ */
+export function classifyComplexity(prompt: string): ComplexityTier {
+  return classify(extractFeatures(prompt)).tier;
+}
+
+/**
+ * The next tier up for escalation — ported from the Rust `Tier::escalate`.
+ *
+ * Returns `null` when already at `high`, signalling the caller that no further
+ * escalation is possible.
+ *
+ * @param tier - The current complexity tier.
+ * @returns The next tier up, or `null` at the top of the ladder.
+ */
+export function escalateTier(tier: ComplexityTier): ComplexityTier | null {
+  switch (tier) {
+    case 'low':
+      return 'mid';
+    case 'mid':
+      return 'high';
+    case 'high':
+      return null;
+  }
+}
+
+/**
+ * Map a complexity {@link ComplexityTier} to the {@link RoleName} that
+ * {@link resolveLLMForSystem} should resolve when no explicit tier/role was
+ * given.
+ *
+ * This is the wiring contract (AC2) that lets a tier flow into the E9
+ * chokepoint: the classifier proposes a tier, this maps it to a role, and
+ * `resolveLLMForSystem({ kind: 'role', id })` performs the actual model +
+ * credential resolution. The mapping is a cheap → capable ladder over the
+ * canonical {@link RoleName} set — it pins NO model literal of its own.
+ *
+ * - `low`  → `hygiene`      — cheapest single-turn cleanup-class role.
+ * - `mid`  → `consolidation` — the default workhorse role.
+ * - `high` → `judgement`    — the most-capable reasoning role.
+ *
+ * @param tier - The proposed complexity tier.
+ * @returns The {@link RoleName} to feed into the E9 resolver.
+ */
+export function complexityTierToRole(tier: ComplexityTier): RoleName {
+  switch (tier) {
+    case 'low':
+      return 'hygiene';
+    case 'mid':
+      return 'consolidation';
+    case 'high':
+      return 'judgement';
+  }
+}
+
+/**
+ * Propose the {@link RoleName} for a raw prompt by classifying its complexity
+ * and mapping the resulting tier to a role.
+ *
+ * Convenience composition of {@link classifyComplexity} and
+ * {@link complexityTierToRole} — the single call a caller uses to derive a role
+ * for {@link resolveLLMForSystem} when it has no explicit tier/role.
+ *
+ * The returned role is intended to be passed as the structured descriptor:
+ * `resolveLLMForSystem({ kind: 'role', id: proposeRoleForPrompt(prompt) })`.
+ *
+ * @param prompt - The raw prompt string.
+ * @returns The proposed {@link RoleName} for the E9 chokepoint.
+ *
+ * @example
+ * ```ts
+ * import { proposeRoleForPrompt } from './complexity-classifier.js';
+ * import { resolveLLMForSystem } from './system-resolver.js';
+ *
+ * const role = proposeRoleForPrompt(userPrompt);
+ * const llm = await resolveLLMForSystem({ kind: 'role', id: role }, { projectRoot });
+ * ```
+ */
+export function proposeRoleForPrompt(prompt: string): RoleName {
+  return complexityTierToRole(classifyComplexity(prompt));
+}

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -123,6 +123,27 @@ export {
 // the populated singleton without an explicit second import.
 import './credential-seeders/register.js';
 
+// L1 complexity classifier — tier proposer that feeds resolveLLMForSystem (T11906)
+export type {
+  Classification,
+  ComplexityTier,
+  PromptFeatures,
+} from './complexity-classifier.js';
+export {
+  classify,
+  classifyComplexity,
+  complexityTierToRole,
+  escalateTier,
+  extractFeatures,
+  proposeRoleForPrompt,
+  THRESHOLD_HIGH,
+  THRESHOLD_MID,
+  WEIGHT_DOMAIN_SPECIFICITY,
+  WEIGHT_REASONING_DEPTH,
+  WEIGHT_SYNTACTIC_COMPLEXITY,
+  WEIGHT_TOKEN_COUNT,
+  WEIGHT_TOUCHES_FILES_COUNT,
+} from './complexity-classifier.js';
 // Unified credential pool — seed/pick/list singleton (E-CONFIG-AUTH-UNIFY E2a / T9412)
 export type {
   PoolSeedResult,

--- a/packages/core/src/llm/system-resolver.ts
+++ b/packages/core/src/llm/system-resolver.ts
@@ -42,6 +42,7 @@ import type {
 } from '@cleocode/contracts';
 import { SYSTEM_ROLE_MAP } from '@cleocode/contracts';
 import { getLogger } from '../logger.js';
+import { proposeRoleForPrompt } from './complexity-classifier.js';
 import {
   IMPLICIT_FALLBACK_PROVIDER,
   type ResolvedLLM,
@@ -104,10 +105,16 @@ function isRoleSystem(input: SystemResolverInput): input is RoleSystem {
  *   1. `opts.roleOverride` — explicit caller override (both input forms).
  *   2. Structured {@link RoleSystem} descriptor → its `id` IS the role (T11750).
  *   3. {@link SYSTEM_ROLE_MAP} — static default for the flat system label.
+ *   4. L1 complexity proposer (T11906) — when the label maps to NO role AND a
+ *      `complexityPrompt` was supplied, classify it and propose a role from the
+ *      resulting tier. This is the "derive a tier from prompt complexity when no
+ *      explicit tier/role is given" wiring (AC2): it COMPLEMENTS the resolver,
+ *      only filling in a role the input left blank. The classifier returns a
+ *      tier and constructs no LLM client.
  *
- * Returns `null` when a flat label maps to the global default (no role entry).
- * The descriptor form always carries a concrete {@link RoleName}, so it never
- * returns `null`.
+ * Returns `null` when a flat label maps to the global default (no role entry)
+ * and no `complexityPrompt` was supplied. The descriptor form always carries a
+ * concrete {@link RoleName}, so it never returns `null`.
  */
 function deriveRole(
   input: SystemResolverInput,
@@ -115,7 +122,19 @@ function deriveRole(
 ): RoleName | null {
   if (opts?.roleOverride) return opts.roleOverride;
   if (isRoleSystem(input)) return input.id;
-  return SYSTEM_ROLE_MAP[input] ?? null;
+  const mapped = SYSTEM_ROLE_MAP[input] ?? null;
+  if (mapped !== null) return mapped;
+  // No role from the label (e.g. flat `'default'`). If the caller handed us a
+  // prompt, let the L1 complexity classifier propose a tier → role.
+  if (opts?.complexityPrompt !== undefined) {
+    const proposed = proposeRoleForPrompt(opts.complexityPrompt);
+    logger.debug(
+      { system: input, proposedRole: proposed },
+      'system-resolver: derived role from L1 complexity classifier (no explicit tier/role)',
+    );
+    return proposed;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Ports the deleted Rust `cant-router` Layer-1 complexity classifier to TypeScript as a **tier proposer** that feeds the E9 chokepoint `resolveLLMForSystem`. It **complements** the E9 resolver — classify a prompt → propose a tier → propose a role → `resolveLLMForSystem` maps the role to model + credential. It does NOT replace E9 and constructs no LLM client.

**Ported source:** `crates/cant-router/src/features.rs` + `classifier.rs` (+ the `Tier` enum from `types.rs`), retired in `5ac09b139` (T11807 / D11137). Ported from the pre-deletion tree at `5ac09b139^`. The five features, the linear weights (0.15 / 0.25 / 0.30 / 0.20 / 0.10), the normalizers (÷1000, clamp, ÷10, clamp, ÷20), and the thresholds (mid 0.35 / high 0.75) are reproduced verbatim.

## Acceptance criteria

- **AC1** — `classifyComplexity(prompt) -> ComplexityTier` (`'low' | 'mid' | 'high'`) lives in `packages/core/src/llm/complexity-classifier.ts`, **adjacent to `resolveLLMForSystem`** in the Gate-13 LLM chokepoint. Implements the 5 prompt features (`tokenCount`, `syntacticComplexity`, `reasoningDepth`, `domainSpecificity`, `touchesFilesCount`) ported from `features.rs`/`classifier.rs`.
- **AC2** — wiring `classify(prompt) -> tier -> resolveLLMForSystem`: a new optional `complexityPrompt` field on `ResolveLLMForSystemOptions` lets `deriveRole()` propose a role from prompt complexity when no explicit tier/role/label-mapped role is available (`low → hygiene`, `mid → consolidation`, `high → judgement`). Explicit label / `{ kind:'role', id }` descriptor / `roleOverride` always wins.
- **AC3** — unit tests for the 5 features + tier mapping, covering trivial → simple → moderate → complex boundaries (including the exact-0.35 and exact-0.75 boundary cases the Rust original tested), plus tier→role and the resolver wiring path.

## Gate-13 LLM Chokepoint Guard (T11783) compliance

The classifier returns a **TIER only**:
- No transport / SDK-client construction.
- No `*_API_KEY` reads (no credential I/O at all).
- No hardcoded model-id literals — the tier→model mapping is the E9 resolver's job; this module stops at proposing a `RoleName`.

`node scripts/lint-llm-chokepoint.mjs` passes (41 violations vs baseline 53 — zero net-new; the classifier file contributes none).

## Test coverage

- `complexity-classifier.test.ts` — 40 tests: 5-feature extraction (token/whitespace/empty, reasoning keywords case-insensitive, file refs by slash + extension, bracket-depth syntactic complexity incl. clamp + underflow guard, CamelCase domain density), linear classifier (low/mid/high + exact-0.35 + exact-0.75 + just-below boundaries + saturation + feature preservation), tier escalation, tier→role, prompt→role composition.
- `system-resolver.test.ts` — +5 wiring tests: `complexityPrompt` derives a role for the unmapped `'default'` label; high-complexity prompt → `judgement`; `roleOverride` and a role-mapped label both override `complexityPrompt`; null fallback when no prompt.

All 78 llm test files (1189 tests) pass scoped under a 24G memory cap; no regressions.

## Gates run (worktree)

- `pnpm biome check --write` — clean
- `pnpm run build` (full topo) — success
- scoped `vitest run` (llm dir, `--maxWorkers=2`) — 1189 passed
- `lint-llm-chokepoint`, `lint-no-runtime-in-contracts`, `lint-contracts-fan-out`, `lint-cli-package-boundary` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)