### PR TITLE
feat(T11919): /v1 REST facade + wire HTTP gateway into cleo daemon serve (M5/AC4+AC5)

### DIFF
--- a/packages/cleo/src/cli/commands/daemon.ts
+++ b/packages/cleo/src/cli/commands/daemon.ts
@@ -39,9 +39,38 @@ import {
   getSentientDaemonStatus,
 } from '@cleocode/core/sentient';
 import { resolveLegacyCleoDir } from '@cleocode/paths';
+import { type ServeGatewayHandle, serveGateway } from '@cleocode/runtime/gateway';
 import { defineCommand } from 'citty';
+import { createCliGatewayHandler } from '../../dispatch/adapters/cli.js';
 import { isSubCommandDispatch } from '../lib/subcommand-guard.js';
 import { cliError, cliOutput } from '../renderers/index.js';
+
+/**
+ * Default loopback TCP port for the `cleo daemon serve` HTTP gateway.
+ *
+ * Bound to `127.0.0.1` by default (loopback only) — the gateway is
+ * local-process-facing and secrets are never serialized onto the wire
+ * (sealed-handle resolution stays server-side). Exposing it on a public
+ * interface is an explicit `--host` decision.
+ */
+const DEFAULT_GATEWAY_HTTP_PORT = 7777;
+
+/**
+ * Block until the process receives a termination signal, then close the gateway
+ * listener. Resolves once the listener is torn down so the caller can exit
+ * cleanly. The HTTP adapter never calls `process.exit` — lifecycle stays here.
+ *
+ * @param handle - The live gateway server handle to close on shutdown.
+ */
+async function blockUntilSignal(handle: ServeGatewayHandle): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const onSignal = (): void => {
+      void handle.close().finally(resolve);
+    };
+    process.once('SIGTERM', onSignal);
+    process.once('SIGINT', onSignal);
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -452,6 +481,95 @@ const uninstallCommand = defineCommand({
   },
 });
 
+/**
+ * cleo daemon serve — start the HTTP gateway listener in the foreground.
+ *
+ * Wires the existing HTTP gateway adapter (`startHttpServer` /
+ * `defineGatewaySubsystem`, T11254) into a runnable call-site (T11919 AC5): it
+ * assembles the in-process CLI gateway handler (full middleware chain) and
+ * starts the HTTP transport over it, serving the versioned `/v1/<domain>/<op>`
+ * REST facade plus `GET /v1/health`.
+ *
+ * Loopback-only by default (`127.0.0.1:7777`) — secrets are never serialized
+ * onto the wire (sealed-handle resolution stays server-side). Per North-Star the
+ * daemon stays OFF by default; this only provides the serve call-site so it CAN
+ * serve when explicitly invoked. The NDJSON IPC / RPC transport is unaffected
+ * and co-listens when separately configured (AC3).
+ *
+ * Runs in the foreground and blocks until SIGTERM/SIGINT, then closes the
+ * listener cleanly. The streaming routes (SSE — T11921, WS — T11922) extend the
+ * same listener; this command owns only the unary HTTP serve call-site.
+ *
+ * @task T11919 (M5 · AC5)
+ */
+const serveCommand = defineCommand({
+  meta: {
+    name: 'serve',
+    description: 'Start the HTTP gateway listener (versioned /v1 REST facade, loopback by default)',
+  },
+  args: {
+    port: {
+      type: 'string',
+      description: `TCP port to bind (default ${DEFAULT_GATEWAY_HTTP_PORT}; 0 = ephemeral)`,
+    },
+    host: {
+      type: 'string',
+      description: 'Host/interface to bind (default 127.0.0.1 — loopback only)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output result as JSON',
+    },
+  },
+  async run({ args }) {
+    try {
+      const portArg = args.port as string | undefined;
+      const port =
+        portArg !== undefined && portArg.length > 0
+          ? Number.parseInt(portArg, 10)
+          : DEFAULT_GATEWAY_HTTP_PORT;
+      if (Number.isNaN(port) || port < 0 || port > 65535) {
+        cliError(
+          `Invalid --port '${portArg}'; expected an integer in [0, 65535]`,
+          'E_INVALID_INPUT',
+          { name: 'E_INVALID_INPUT' },
+          { operation: 'daemon.serve' },
+        );
+        process.exit(2);
+      }
+      const host = (args.host as string | undefined) ?? '127.0.0.1';
+
+      const handle = await serveGateway({ handler: createCliGatewayHandler(), port, host });
+      cliOutput(
+        {
+          pid: process.pid,
+          host: handle.host,
+          port: handle.port,
+          scope: handle.scope,
+          facade: '/v1',
+          message: `HTTP gateway listening on http://${handle.host}:${handle.port}/v1`,
+        },
+        {
+          command: 'daemon',
+          operation: 'daemon.serve',
+          message: `HTTP gateway listening on http://${handle.host}:${handle.port}/v1 (PID ${process.pid})`,
+        },
+      );
+      // Foreground: block until a termination signal, then close cleanly.
+      await blockUntilSignal(handle);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cliError(
+        `Error starting HTTP gateway: ${message}`,
+        'E_INTERNAL',
+        { name: 'E_INTERNAL' },
+        { operation: 'daemon.serve' },
+      );
+      process.exit(1);
+    }
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Root command group
 // ---------------------------------------------------------------------------
@@ -482,6 +600,7 @@ export const daemonCommand = defineCommand({
     start: startCommand,
     stop: stopCommand,
     status: statusCommand,
+    serve: serveCommand,
     install: installCommand,
     uninstall: uninstallCommand,
   },

--- a/packages/cleo/src/dispatch/adapters/cli.ts
+++ b/packages/cleo/src/dispatch/adapters/cli.ts
@@ -21,6 +21,7 @@ import {
   getProjectRoot,
   hooks,
 } from '@cleocode/core/internal';
+import type { GatewayHandler } from '@cleocode/runtime/gateway';
 import { createDispatchSpinner } from '../../cli/animation-bridge.js';
 import { isDescribeMode } from '../../cli/describe-context.js';
 import { getIdempotencyKeyContext } from '../../cli/idempotency-context.js';
@@ -36,7 +37,7 @@ import { createMviRecordProjection } from '../middleware/mvi-record-projection.j
 import { createSanitizer } from '../middleware/sanitizer.js';
 import { createSessionResolver } from '../middleware/session-resolver.js';
 import { createTelemetry } from '../middleware/telemetry.js';
-import type { DispatchResponse, Gateway } from '../types.js';
+import type { DispatchRequest, DispatchResponse, Gateway } from '../types.js';
 
 // Reverse mapping from string error codes to numeric exit codes.
 // Used when dispatch handlers return string error codes without exitCode.
@@ -136,6 +137,32 @@ export function getCliDispatcher(): Dispatcher {
     _dispatcher = createCliDispatcher();
   }
   return _dispatcher;
+}
+
+/**
+ * Build a transport-neutral {@link GatewayHandler} backed by the singleton CLI
+ * dispatcher — the in-process assembly the daemon's HTTP/RPC listeners route
+ * through.
+ *
+ * `cleo daemon serve` (T11919) needs a `GatewayHandler` (the `handle()` surface
+ * `startHttpServer` / `defineGatewaySubsystem` expect) rather than the raw
+ * {@link Dispatcher}. Wrapping the SAME singleton dispatcher reuses the full
+ * configured middleware chain (session-resolver, sanitizer, audit, MVI
+ * projection, …) and the domain-handler map — so an operation routed over the
+ * `/v1` HTTP facade traverses byte-for-byte the same pipeline as the CLI, with
+ * only the request `source` differing (forced to `'http'`/`'rpc'` by the
+ * transport adapter). Secrets are never serialized onto the wire: sealed-handle
+ * resolution happens server-side inside the dispatched handler, exactly as it
+ * does for an in-process CLI call.
+ *
+ * @returns A `GatewayHandler` whose `handle()` dispatches through the CLI pipeline.
+ * @task T11919
+ */
+export function createCliGatewayHandler(): GatewayHandler {
+  const dispatcher = getCliDispatcher();
+  return {
+    handle: (req: DispatchRequest): Promise<DispatchResponse> => dispatcher.dispatch(req),
+  };
 }
 
 /**

--- a/packages/runtime/src/gateway/__tests__/serve.test.ts
+++ b/packages/runtime/src/gateway/__tests__/serve.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `serveGateway` bootstrap tests (T11919 · M5 · AC2+AC4).
+ *
+ * `serveGateway` is the runtime-side call-site `cleo daemon serve` drives: it
+ * assembles one scoped gateway subsystem hosting the HTTP transport over an
+ * injected handler and returns a live handle with the bound port + an idempotent
+ * `close()`. This test boots it on an EPHEMERAL port (in-process, NO subprocess —
+ * tsx is unresolvable in CI), round-trips one operation through the `/v1` facade,
+ * asserts `/v1/health`, and verifies `close()` tears the listener down.
+ *
+ * @task T11919
+ * @epic T11769
+ * @saga T10400
+ */
+
+import { request } from 'node:http';
+import type { DispatchRequest, DispatchResponse } from '@cleocode/contracts/gateway';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { GatewayHandler } from '../index.js';
+import { serveGateway } from '../serve.js';
+
+/** A fake gateway handler that echoes a success envelope. */
+function fakeHandler(): { handler: GatewayHandler; calls: DispatchRequest[] } {
+  const calls: DispatchRequest[] = [];
+  const handler: GatewayHandler = {
+    handle(req: DispatchRequest): Promise<DispatchResponse> {
+      calls.push(req);
+      return Promise.resolve({
+        meta: {
+          gateway: req.gateway,
+          domain: req.domain,
+          operation: req.operation,
+          timestamp: '2026-06-09T00:00:00.000Z',
+          duration_ms: 1,
+          source: req.source,
+          requestId: req.requestId,
+        },
+        success: true,
+        data: { ok: true },
+      });
+    },
+  };
+  return { handler, calls };
+}
+
+/** Issue one HTTP request in-process and resolve the parsed JSON body + status. */
+function httpRoundTrip(
+  port: number,
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<{ status: number; body: DispatchResponse }> {
+  return new Promise((resolve, reject) => {
+    const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port,
+        method,
+        path,
+        headers:
+          payload !== undefined
+            ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) }
+            : {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: JSON.parse(Buffer.concat(chunks).toString('utf8')) as DispatchResponse,
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    if (payload !== undefined) req.write(payload);
+    req.end();
+  });
+}
+
+describe('T11919 serveGateway — daemon-serve bootstrap', () => {
+  const closers: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    for (const close of closers.splice(0)) await close();
+  });
+
+  it('binds an ephemeral loopback port and round-trips /v1/tasks/show', async () => {
+    const { handler, calls } = fakeHandler();
+    const handle = await serveGateway({ handler, port: 0 });
+    closers.push(() => handle.close());
+
+    expect(handle.host).toBe('127.0.0.1');
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.scope).toBe('global');
+
+    const { status, body } = await httpRoundTrip(handle.port, 'POST', '/v1/tasks/show', {
+      taskId: 'T1',
+    });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    const httpCall = calls.find((c) => c.source === 'http');
+    expect(httpCall?.gateway).toBe('query'); // inferred from the registry
+    expect(httpCall?.domain).toBe('tasks');
+  });
+
+  it('serves GET /v1/health', async () => {
+    const { handler } = fakeHandler();
+    const handle = await serveGateway({ handler, port: 0 });
+    closers.push(() => handle.close());
+
+    const { status, body } = await httpRoundTrip(handle.port, 'GET', '/v1/health');
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('close() tears the listener down (idempotent)', async () => {
+    const { handler } = fakeHandler();
+    const handle = await serveGateway({ handler, port: 0 });
+    const { port } = handle;
+
+    await handle.close();
+    await handle.close(); // second call is a no-op
+
+    // A request to the closed port now fails to connect.
+    await expect(httpRoundTrip(port, 'GET', '/v1/health')).rejects.toBeDefined();
+  });
+});

--- a/packages/runtime/src/gateway/http/__tests__/v1-facade.test.ts
+++ b/packages/runtime/src/gateway/http/__tests__/v1-facade.test.ts
@@ -1,0 +1,197 @@
+/**
+ * `/v1` REST facade tests (T11919 · M5 · AC1+AC4+AC5).
+ *
+ * Asserts the versioned REST facade the daemon serves in front of the existing
+ * gateway dispatch:
+ *
+ *  1. {@link parseHttpRoute} accepts `POST /v1/<domain>/<operation>` (gateway
+ *     INFERRED from the registry — `tasks/show` → query, `tasks/projection.repair`
+ *     → mutate), keeps the legacy `/<gateway>/<domain>/<operation>` form, and
+ *     recognizes `GET /v1/health`.
+ *  2. The 405 (bad method) / 404 (unroutable + unknown operation) edge errors
+ *     are preserved as LAFS-shaped envelopes (AC5).
+ *  3. An in-process {@link startHttpServer} boot on an EPHEMERAL port round-trips
+ *     one operation through `/v1/tasks/show` returning a valid LAFS envelope, and
+ *     `GET /v1/health` returns a `200` health envelope (AC4).
+ *
+ * All round-trips are in-process (NO subprocess — tsx is unresolvable in CI) over
+ * a fake {@link GatewayHandler}, so the test exercises the wire edge + routing
+ * without standing up the full CLI dispatcher.
+ *
+ * @task T11919
+ * @epic T11769
+ * @saga T10400
+ */
+
+import { request } from 'node:http';
+import type { DispatchRequest, DispatchResponse } from '@cleocode/contracts/gateway';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { GatewayHandler } from '../../index.js';
+import { parseHttpRoute, startHttpServer } from '../listen.js';
+
+/** A fake gateway handler that records each request and echoes a success envelope. */
+function fakeHandler(): { handler: GatewayHandler; calls: DispatchRequest[] } {
+  const calls: DispatchRequest[] = [];
+  const handler: GatewayHandler = {
+    handle(req: DispatchRequest): Promise<DispatchResponse> {
+      calls.push(req);
+      return Promise.resolve({
+        meta: {
+          gateway: req.gateway,
+          domain: req.domain,
+          operation: req.operation,
+          timestamp: '2026-06-09T00:00:00.000Z',
+          duration_ms: 1,
+          source: req.source,
+          requestId: req.requestId,
+        },
+        success: true,
+        data: { echoed: true, params: req.params ?? null },
+      });
+    },
+  };
+  return { handler, calls };
+}
+
+/** Issue one HTTP request in-process and resolve the parsed JSON body + status. */
+function httpRoundTrip(
+  port: number,
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<{ status: number; body: DispatchResponse }> {
+  return new Promise((resolve, reject) => {
+    const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port,
+        method,
+        path,
+        headers:
+          payload !== undefined
+            ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) }
+            : {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8');
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(text) as DispatchResponse });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload !== undefined) req.write(payload);
+    req.end();
+  });
+}
+
+describe('T11919 parseHttpRoute — /v1 facade (AC1)', () => {
+  it('accepts POST /v1/<domain>/<operation> and INFERS the query gateway from the registry', () => {
+    const route = parseHttpRoute('POST', '/v1/tasks/show');
+    expect(route).toEqual({
+      ok: true,
+      kind: 'unary',
+      gateway: 'query',
+      domain: 'tasks',
+      operation: 'show',
+    });
+  });
+
+  it('infers the mutate gateway for a write operation', () => {
+    const route = parseHttpRoute('POST', '/v1/tasks/projection.repair');
+    expect(route.ok).toBe(true);
+    if (route.ok && route.kind === 'unary') expect(route.gateway).toBe('mutate');
+  });
+
+  it('retains the legacy POST /<gateway>/<domain>/<operation> form', () => {
+    const route = parseHttpRoute('POST', '/query/tasks/show');
+    expect(route).toEqual({
+      ok: true,
+      kind: 'unary',
+      gateway: 'query',
+      domain: 'tasks',
+      operation: 'show',
+    });
+  });
+
+  it('recognizes GET /v1/health as a liveness probe', () => {
+    expect(parseHttpRoute('GET', '/v1/health')).toEqual({ ok: true, kind: 'health' });
+  });
+
+  it('404s an unknown /v1 operation (registry has no match)', () => {
+    const route = parseHttpRoute('POST', '/v1/tasks/nope-not-real');
+    expect(route.ok).toBe(false);
+    if (!route.ok) expect(route.status).toBe(404);
+  });
+
+  it('405s a non-POST/GET method (AC5)', () => {
+    const route = parseHttpRoute('DELETE', '/v1/tasks/show');
+    expect(route.ok).toBe(false);
+    if (!route.ok) expect(route.status).toBe(405);
+  });
+
+  it('405s an unrecognized GET (streaming seam preserved for T11921/T11922)', () => {
+    const route = parseHttpRoute('GET', '/v1/tasks/show');
+    expect(route.ok).toBe(false);
+    if (!route.ok) expect(route.status).toBe(405);
+  });
+
+  it('404s a path that resolves to neither vocabulary', () => {
+    const route = parseHttpRoute('POST', '/totally/unknown');
+    expect(route.ok).toBe(false);
+    if (!route.ok) expect(route.status).toBe(404);
+  });
+});
+
+describe('T11919 in-process /v1 round-trip (AC4)', () => {
+  const closers: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    for (const close of closers.splice(0)) await close();
+  });
+
+  it('boots on an ephemeral port and round-trips POST /v1/tasks/show → a valid LAFS envelope', async () => {
+    const { handler, calls } = fakeHandler();
+    const server = await startHttpServer(handler, { port: 0 });
+    closers.push(() => server.close());
+    expect(typeof server.port).toBe('number');
+    expect(server.port).toBeGreaterThan(0);
+
+    const { status, body } = await httpRoundTrip(server.port, 'POST', '/v1/tasks/show', {
+      taskId: 'T1',
+    });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.meta.source).toBe('http');
+    expect(body.meta.domain).toBe('tasks');
+    expect(body.meta.operation).toBe('show');
+    // The gateway was inferred (client did not name query/mutate).
+    const httpCall = calls.find((c) => c.source === 'http');
+    expect(httpCall?.gateway).toBe('query');
+    expect(httpCall?.params).toEqual({ taskId: 'T1' });
+  });
+
+  it('serves GET /v1/health with a 200 health envelope (AC4)', async () => {
+    const { handler } = fakeHandler();
+    const server = await startHttpServer(handler, { port: 0 });
+    closers.push(() => server.close());
+
+    const { status, body } = await httpRoundTrip(server.port, 'GET', '/v1/health');
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.meta.operation).toBe('health');
+  });
+
+  it('preserves a 404 over the wire for an unknown /v1 operation (AC5)', async () => {
+    const { handler } = fakeHandler();
+    const server = await startHttpServer(handler, { port: 0 });
+    closers.push(() => server.close());
+
+    const { status, body } = await httpRoundTrip(server.port, 'POST', '/v1/tasks/nope', {});
+    expect(status).toBe(404);
+    expect(body.success).toBe(false);
+    expect(body.error?.code).toBe('E_HTTP_NOT_FOUND');
+  });
+});

--- a/packages/runtime/src/gateway/http/listen.ts
+++ b/packages/runtime/src/gateway/http/listen.ts
@@ -34,6 +34,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { DispatchResponse, Gateway } from '@cleocode/contracts/gateway';
 import { getLogger } from '@cleocode/core';
 import type { GatewayHandler } from '../index.js';
+import { inferGateway } from '../registry.js';
 import { routeUnary } from './server.js';
 import type { HttpUnaryRequest } from './types.js';
 
@@ -42,6 +43,13 @@ const GATEWAYS: ReadonlySet<string> = new Set<Gateway>(['query', 'mutate']);
 
 /** Maximum accepted request-body size (1 MiB) — a crude DoS guard at the edge. */
 const MAX_BODY_BYTES = 1_048_576;
+
+/**
+ * The versioned REST facade prefix (T11919). `/v1/<domain>/<operation>` infers
+ * the gateway from the registry; `/v1/health` is the liveness probe. The legacy
+ * `/<gateway>/<domain>/<operation>` form is retained for backward compatibility.
+ */
+const V1_PREFIX = 'v1';
 
 /**
  * Options for {@link startHttpServer}.
@@ -83,26 +91,64 @@ export interface HttpServerHandle {
 }
 
 /**
- * The result of parsing a request line into routing coordinates: either a
- * resolved unary triple or a rejection reason for the wire edge.
+ * The result of parsing a request line into routing coordinates: a resolved
+ * unary triple, a recognized health probe, or a rejection for the wire edge.
  */
 type ParsedRoute =
-  | { ok: true; gateway: Gateway; domain: string; operation: string }
+  | { ok: true; kind: 'unary'; gateway: Gateway; domain: string; operation: string }
+  | { ok: true; kind: 'health' }
   | { ok: false; status: number; code: string; message: string };
 
 /**
- * Parse `POST /<gateway>/<domain>/<operation>` into a routing triple.
+ * Parse a gateway request line into a routing decision.
  *
- * Rejects a non-POST method (`405`) and any path that does not resolve to a
- * known `(gateway, domain, operation)` triple (`404`). The gateway segment is
- * validated against the two CQRS gateways so a client cannot smuggle an
- * arbitrary value into the dispatch request.
+ * Two POST routing vocabularies are accepted (the wire payload is identical to
+ * every other transport — only the framing differs):
+ *
+ *   - `POST /v1/<domain>/<operation>` — the **versioned REST facade** (T11919).
+ *     The gateway (`query` | `mutate`) is INFERRED from the registry, so the
+ *     client need not name it. An unregistered `(domain, operation)` pair is a
+ *     `404`.
+ *   - `POST /<gateway>/<domain>/<operation>` — the **legacy** form, where the
+ *     client names the gateway segment explicitly (validated against the two
+ *     CQRS gateways so a client cannot smuggle an arbitrary value).
+ *
+ * `GET /v1/health` is recognized as a liveness probe (any other GET is a `405`).
+ * A non-POST/GET method is rejected at the edge (`405`); a path that resolves to
+ * neither vocabulary is a `404`. The injected {@link GatewayHandler} is never
+ * invoked with a malformed request.
+ *
+ * The `/v1` listener is shaped so a future streaming route (SSE — T11921, WS —
+ * T11922) slots in as an additional recognized `GET /v1/<domain>/<operation>`
+ * branch without disturbing the unary path: this parser deliberately rejects
+ * unknown GETs as `405` (not `404`) so the streaming seam can later distinguish
+ * "method not yet supported on this route" from "no such route".
  *
  * @param method - The HTTP request method.
  * @param url - The HTTP request URL (path + query).
  * @returns The parsed route, or a typed rejection for the wire edge.
  */
 export function parseHttpRoute(method: string | undefined, url: string | undefined): ParsedRoute {
+  // Parse against a dummy origin so only the path is consumed (query ignored).
+  const pathname = new URL(url ?? '/', 'http://localhost').pathname;
+  const segments = pathname.split('/').filter((s) => s.length > 0);
+
+  // GET /v1/health — liveness probe. The only non-POST route the gateway serves.
+  if (method === 'GET') {
+    if (segments.length === 2 && segments[0] === V1_PREFIX && segments[1] === 'health') {
+      return { ok: true, kind: 'health' };
+    }
+    // Streaming seam (T11921/T11922): a future GET /v1/<domain>/<operation>
+    // streaming branch lands here. Until then an unrecognized GET is a 405 so
+    // the caller can tell "route exists, method unsupported" from "no route".
+    return {
+      ok: false,
+      status: 405,
+      code: 'E_HTTP_METHOD_NOT_ALLOWED',
+      message: `method GET not allowed for '${pathname}'; only GET /v1/health is served`,
+    };
+  }
+
   if (method !== 'POST') {
     return {
       ok: false,
@@ -111,15 +157,29 @@ export function parseHttpRoute(method: string | undefined, url: string | undefin
       message: `method ${method ?? '<none>'} not allowed; gateway accepts POST`,
     };
   }
-  // Parse against a dummy origin so only the path is consumed (query ignored).
-  const pathname = new URL(url ?? '/', 'http://localhost').pathname;
-  const segments = pathname.split('/').filter((s) => s.length > 0);
+
+  // POST /v1/<domain>/<operation> — versioned facade; gateway inferred.
+  if (segments.length === 3 && segments[0] === V1_PREFIX) {
+    const [, domain, operation] = segments;
+    const gateway = inferGateway(domain, operation);
+    if (gateway === undefined) {
+      return {
+        ok: false,
+        status: 404,
+        code: 'E_HTTP_NOT_FOUND',
+        message: `unknown operation '${domain}/${operation}'; no registered query/mutate matches`,
+      };
+    }
+    return { ok: true, kind: 'unary', gateway, domain, operation };
+  }
+
+  // POST /<gateway>/<domain>/<operation> — legacy explicit-gateway form.
   if (segments.length !== 3) {
     return {
       ok: false,
       status: 404,
       code: 'E_HTTP_NOT_FOUND',
-      message: `expected POST /<gateway>/<domain>/<operation>, got '${pathname}'`,
+      message: `expected POST /v1/<domain>/<operation> or /<gateway>/<domain>/<operation>, got '${pathname}'`,
     };
   }
   const [gateway, domain, operation] = segments;
@@ -131,7 +191,7 @@ export function parseHttpRoute(method: string | undefined, url: string | undefin
       message: `unknown gateway '${gateway}'; expected one of query, mutate`,
     };
   }
-  return { ok: true, gateway: gateway as Gateway, domain, operation };
+  return { ok: true, kind: 'unary', gateway: gateway as Gateway, domain, operation };
 }
 
 /**
@@ -191,6 +251,33 @@ function writeEdgeError(res: ServerResponse, status: number, code: string, messa
 }
 
 /**
+ * Write a LAFS-shaped success envelope for the `GET /v1/health` liveness probe.
+ *
+ * The probe never touches the {@link GatewayHandler} (it is a pure wire-edge
+ * liveness signal), so it returns a self-contained `200` envelope reporting the
+ * server is up and the wire version it serves.
+ *
+ * @param res - The server response.
+ */
+function writeHealth(res: ServerResponse): void {
+  const body: DispatchResponse = {
+    meta: {
+      gateway: 'query',
+      domain: 'gateway',
+      operation: 'health',
+      timestamp: new Date().toISOString(),
+      duration_ms: 0,
+      source: 'http',
+      requestId: '',
+    },
+    success: true,
+    data: { status: 'ok', version: V1_PREFIX },
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
  * Handle a single inbound HTTP request: parse the route, read + JSON-parse the
  * body, route it through the gateway handler, and serialize the LAFS response.
  *
@@ -213,6 +300,11 @@ async function handleHttpRequest(
   const route = parseHttpRoute(req.method, req.url);
   if (!route.ok) {
     writeEdgeError(res, route.status, route.code, route.message);
+    return;
+  }
+  if (route.kind === 'health') {
+    writeHealth(res);
+    log.debug({ route: 'health' }, 'http health probe served');
     return;
   }
 

--- a/packages/runtime/src/gateway/index.ts
+++ b/packages/runtime/src/gateway/index.ts
@@ -114,6 +114,7 @@ export {
   getByTier,
   getCounts,
   getGatewayDomains,
+  inferGateway,
   OPERATIONS,
   resolve,
   validateRequiredParams,
@@ -132,6 +133,9 @@ export {
   routeFrame,
   startRpcServer,
 } from './rpc/index.js';
+// Daemon-side gateway server bootstrap (T11919) — the call-site `cleo daemon
+// serve` drives to start the HTTP transport over an injected handler.
+export { type ServeGatewayHandle, type ServeGatewayOptions, serveGateway } from './serve.js';
 
 /**
  * Transport-agnostic gateway entrypoint. Wraps a configured {@link Dispatcher}

--- a/packages/runtime/src/gateway/registry.ts
+++ b/packages/runtime/src/gateway/registry.ts
@@ -85,6 +85,27 @@ export function resolve(
 }
 
 /**
+ * Infer the CQRS {@link Gateway} for a `(domain, operation)` pair from the
+ * registry, without the caller naming `query`/`mutate` up front.
+ *
+ * This backs the versioned `/v1/<domain>/<operation>` REST facade (T11919),
+ * where — unlike the legacy `/<gateway>/<domain>/<operation>` form — the client
+ * does not spell the gateway segment: the registry is the single source of truth
+ * for whether an operation is a read (`query`) or a write (`mutate`). Each
+ * `(domain, operation)` pair maps to exactly one gateway in {@link OPERATIONS},
+ * so the inference is unambiguous.
+ *
+ * @param domain - The canonical domain segment (e.g. `'tasks'`).
+ * @param operation - The operation segment (e.g. `'show'`).
+ * @returns The owning gateway, or `undefined` when no registered operation
+ *   matches the pair (the wire edge then renders a `404`).
+ */
+export function inferGateway(domain: string, operation: string): Gateway | undefined {
+  const def = OPERATIONS.find((o) => o.domain === domain && o.operation === operation);
+  return def?.gateway;
+}
+
+/**
  * Validates that all required parameters are present in the request.
  * Returns an array of missing parameter keys.
  */

--- a/packages/runtime/src/gateway/serve.ts
+++ b/packages/runtime/src/gateway/serve.ts
@@ -1,0 +1,129 @@
+/**
+ * Daemon-side gateway server bootstrap — the call-site `cleo daemon serve`
+ * drives (T11919).
+ *
+ * The HTTP gateway adapter (`./http/listen.ts`, T11254) and the supervised
+ * `defineGatewaySubsystem` unit (`./daemon-subsystem.ts`, T11451) both already
+ * exist, but nothing started them: the daemon had no `serve` call-site. This
+ * module is that thin bootstrap — it assembles a {@link SubsystemRegistry} with
+ * one scoped gateway subsystem hosting the HTTP transport (loopback by default)
+ * over an INJECTED {@link GatewayHandler}, starts it, and returns a live handle
+ * with the bound port + an idempotent `close()`.
+ *
+ * It carries NO `@cleocode/cleo` dependency and NO drizzle (the runtime
+ * invariant): the caller (`cleo daemon serve`) injects the assembled CLI gateway
+ * handler and the resolved bind coordinates. Secrets never touch the wire —
+ * sealed-handle resolution happens server-side inside the dispatched handler,
+ * exactly as it does for an in-process CLI call. The HTTP listener binds
+ * `127.0.0.1` by default (loopback only); exposing it on a public interface is
+ * an explicit caller decision.
+ *
+ * The streaming transports (SSE — T11921, WS — T11922) extend the SAME
+ * subsystem: when their listeners land they bind alongside the unary HTTP server
+ * here, so this bootstrap deliberately owns only transport assembly + lifecycle,
+ * leaving the per-route seam to the adapter (`parseHttpRoute`).
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/gateway
+ *
+ * @task T11919
+ * @epic T11769
+ * @saga T10400
+ */
+
+import { defineGatewaySubsystem, type GatewayScope } from './daemon-subsystem.js';
+import type { GatewayHandler } from './index.js';
+
+/** Default loopback host for the HTTP gateway — local-process-facing only. */
+const DEFAULT_HOST = '127.0.0.1';
+
+/**
+ * Options for {@link serveGateway}.
+ *
+ * The caller injects the assembled {@link GatewayHandler} and resolves the bind
+ * coordinates so the runtime stays free of `@cleocode/paths`/`@cleocode/cleo`.
+ */
+export interface ServeGatewayOptions {
+  /** The transport-neutral gateway handler every hosted transport routes through. */
+  handler: GatewayHandler;
+  /** TCP port to bind. `0` selects an ephemeral port (readable from the handle). */
+  port: number;
+  /** Host/interface to bind. Defaults to `127.0.0.1` (loopback only). */
+  host?: string;
+  /** The scope this gateway process serves. Defaults to `'global'`. */
+  scope?: GatewayScope;
+}
+
+/**
+ * A live gateway server handle returned by {@link serveGateway}.
+ *
+ * Exposes the actually-bound `port`/`host` (resolved even when `0` was
+ * requested) and an idempotent {@link close} for deterministic teardown
+ * (daemon shutdown, tests). Mirrors the lower-level
+ * {@link import('./http/listen.js').HttpServerHandle} so a test can boot, probe,
+ * and tear down on an ephemeral port.
+ */
+export interface ServeGatewayHandle {
+  /** The actually-bound HTTP port (resolved when `0` was requested). */
+  port: number;
+  /** Host/interface the HTTP listener is bound to. */
+  host: string;
+  /** The scope the gateway process serves. */
+  scope: GatewayScope;
+  /** Stop every bound listener (best-effort, idempotent); resolves once closed. */
+  close(): Promise<void>;
+}
+
+/**
+ * Boot the HTTP gateway as a supervised subsystem and return a live handle.
+ *
+ * Declares one scoped gateway subsystem hosting the HTTP transport (loopback
+ * default) over the injected handler via {@link defineGatewaySubsystem}, starts
+ * it, and reads the actually-bound port from the start context (so the caller —
+ * and tests — learn the ephemeral port when `0` was requested). The returned
+ * `close()` drives the subsystem's `shutdown(context)` so teardown is the same
+ * lifecycle the daemon registry uses for every other supervised concern.
+ *
+ * Using `defineGatewaySubsystem` directly (rather than a full
+ * `SubsystemRegistry`) keeps the bound HTTP handle in reach for the port
+ * resolution while still routing through the canonical start→shutdown contract.
+ *
+ * @param opts - The injected handler + resolved bind coordinates.
+ * @returns A promise resolving to the live {@link ServeGatewayHandle}.
+ *
+ * @example
+ * ```ts
+ * const handle = await serveGateway({
+ *   handler: createCliGatewayHandler(),
+ *   port: 0, // ephemeral
+ * });
+ * // POST http://127.0.0.1:${handle.port}/v1/tasks/show
+ * await handle.close();
+ * ```
+ */
+export async function serveGateway(opts: ServeGatewayOptions): Promise<ServeGatewayHandle> {
+  const host = opts.host ?? DEFAULT_HOST;
+  const scope: GatewayScope = opts.scope ?? 'global';
+
+  const subsystem = defineGatewaySubsystem({
+    scope,
+    handler: opts.handler,
+    http: { port: opts.port, host },
+  });
+
+  const context = await subsystem.start();
+  // The HTTP transport is configured, so `start()` always binds it.
+  const boundPort = context.http?.port ?? opts.port;
+
+  let closed = false;
+  return {
+    port: boundPort,
+    host,
+    scope,
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      await subsystem.shutdown(context);
+    },
+  };
+}


### PR DESCRIPTION
## T11919 — `/v1` REST facade + wire HTTP gateway into `cleo daemon serve` (M5 · AC4+AC5)

Adds a versioned **`/v1` REST facade** over the existing (frozen v1.0) HTTP gateway adapter and a runnable **`cleo daemon serve`** call-site that actually starts the HTTP transport. gRPC is out of scope (reserved). The NDJSON IPC / RPC path is untouched.

### Acceptance criteria

| AC | Status | Where |
|----|--------|-------|
| **AC1** `parseHttpRoute` accepts `POST /v1/<domain>/<operation>` (gateway inferred from registry) + retains legacy `/<gateway>/<domain>/<operation>` | ✅ | `runtime/src/gateway/http/listen.ts` + new `inferGateway()` in `registry.ts` |
| **AC2** `cleo daemon serve` builds the handler via `createGatewayHandler`-equivalent and starts the HTTP transport through `defineGatewaySubsystem` with `http:{port}` (loopback default) | ✅ | `cleo/src/cli/commands/daemon.ts` (`serve` subcommand) → new `serveGateway()` bootstrap |
| **AC3** NDJSON IPC / RPC transport unchanged and co-listening | ✅ | RPC adapter untouched; subsystem still hosts both transports when configured |
| **AC4** http-adapter tests cover a `/v1` round-trip returning a LAFS envelope | ✅ | `http/__tests__/v1-facade.test.ts` + `__tests__/serve.test.ts` (in-process, ephemeral port) |
| **AC5** 405/404 edge errors preserved | ✅ | `parseHttpRoute` + wire-edge tests |

### How the daemon-serve wiring works (AC2/AC5)

- New runtime bootstrap `serveGateway()` (`runtime/src/gateway/serve.ts`) declares one scoped gateway subsystem hosting the HTTP transport over an **injected** `GatewayHandler` via the existing `defineGatewaySubsystem`, starts it, and returns a live handle with the bound port + idempotent `close()`. Carries no `@cleocode/cleo` / drizzle dependency (runtime invariant).
- New `createCliGatewayHandler()` (`cleo/src/dispatch/adapters/cli.ts`) wraps the singleton CLI dispatcher so an operation over `/v1` traverses the **same full middleware chain** (session-resolver, sanitizer, audit, MVI projection, …) as a CLI call — only `source` differs (forced `http`).
- New `cleo daemon serve` subcommand (flag/config gated): `--port` (default `7777`, `0` = ephemeral) / `--host` (default `127.0.0.1`). Foreground; blocks until SIGTERM/SIGINT then closes cleanly. Per North-Star the daemon stays OFF by default — this only provides the serve call-site so it *can* serve when invoked.

### Secrets never on the wire

The `/v1` facade carries only operation params. Sealed-handle / credential resolution happens **server-side inside the dispatched handler**, exactly as for an in-process CLI call — nothing sensitive is serialized onto the request. Loopback-only by default.

### Streaming seam (for T11921 SSE / T11922 WS)

`parseHttpRoute` rejects an unrecognized `GET` as **405** (not 404), so a future `GET /v1/<domain>/<operation>` streaming branch slots in alongside the unary path without disturbing routing. `serveGateway` owns only transport assembly + lifecycle; streaming listeners extend the same subsystem. The SSE primitives (`sse.ts`) are unchanged and ready.

### Tests (capped, in-process — no subprocess; tsx unresolvable in CI)

- `v1-facade.test.ts` — 8 route-parse cases (query/mutate inference, legacy form, health, 404/405 edges) + 3 in-process ephemeral-port round-trips (`/v1/tasks/show`, `/v1/health`, unknown-op 404).
- `serve.test.ts` — 3 `serveGateway` bootstrap cases (ephemeral bind + round-trip, health, idempotent `close()`).
- Full runtime gateway suite: **104 passed**. No regressions in `http-adapter.test.ts` / `daemon-subsystem.test.ts`.
- Live smoke (built CLI): `daemon serve --port 0` → bound port; `GET /v1/health` → `{"status":"ok","version":"v1"}`; `POST /v1/tasks/show` → real task record over the full dispatcher.

### Gates

- `pnpm biome check` — clean
- Scoped capped build (`MemoryMax=16G`) — green (contracts → core → runtime → cleo)
- `cleo check arch` (baseline) — **6/6 pass**, no net-new violations
- `lint-no-raw-define-command --check` — pass (138 vs baseline 139) · `lint-cli-package-boundary --check` — pass (33 = baseline 33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)