### PR TITLE
feat(T11918): zod→OpenAPI 3.1 bridge + cleo gateway openapi command (M5/AC2)

### DIFF
--- a/packages/cleo/src/cli/commands/gateway.ts
+++ b/packages/cleo/src/cli/commands/gateway.ts
@@ -1,0 +1,86 @@
+/**
+ * `cleo gateway` — REST gateway introspection surface.
+ *
+ * Currently exposes a single subverb:
+ *
+ *   - `cleo gateway openapi [--out <file>]` — project the canonical OPERATIONS
+ *     registry into an OpenAPI 3.1 document (one `POST /v1/<domain>/<operation>`
+ *     path per operation, requestBody from the input schema, `200` response from
+ *     the resolved output schema). Prints the spec as a LAFS envelope, or writes
+ *     it to `--out` and emits a summary envelope.
+ *
+ * This is the projection source for the generated SDK client (T11920) — the
+ * spec is derived from the registry, NOT hand-authored, so it never drifts.
+ *
+ * @task T11918 — M5/AC2: zod→OpenAPI 3.1 bridge + `cleo gateway openapi`
+ * @epic T11769 — E-API-STANDARD-FOUNDATION
+ */
+
+import { resolve } from 'node:path';
+import { generateOpenApi, getProjectRoot } from '@cleocode/core';
+import { defineCommand } from '../lib/define-cli-command.js';
+import { cliOutput } from '../renderers/index.js';
+
+/**
+ * `cleo gateway openapi [--out <file>]` — emit the OpenAPI 3.1 spec.
+ *
+ * With no `--out`, the full spec is the envelope `data`. With `--out`, the spec
+ * is written to disk (path resolved against the project root for relative
+ * targets) and the envelope `data` is a summary `{ out, pathCount, version }`.
+ *
+ * @task T11918 — AC3
+ */
+export const gatewayOpenapiSubCommand = defineCommand({
+  meta: {
+    name: 'openapi',
+    description: 'Emit the OpenAPI 3.1 spec projected from the OPERATIONS registry',
+  },
+  args: {
+    out: {
+      type: 'string',
+      description: 'Write the spec to this file (JSON). When omitted, prints the spec.',
+      alias: 'o',
+    },
+    version: {
+      type: 'string',
+      description: "API-surface version stamped into info.version (default '1.0.0')",
+    },
+  },
+  async run({ args }) {
+    const doc = generateOpenApi(
+      typeof args.version === 'string' && args.version.length > 0
+        ? { version: args.version }
+        : undefined,
+    );
+    const json = `${JSON.stringify(doc, null, 2)}\n`;
+    const pathCount = Object.keys(doc.paths).length;
+
+    if (typeof args.out === 'string' && args.out.length > 0) {
+      const { writeFileSync } = await import('node:fs');
+      const target = resolve(getProjectRoot(), args.out);
+      writeFileSync(target, json, 'utf8');
+      cliOutput(
+        { out: target, pathCount, version: doc.info.version, openapi: doc.openapi },
+        { command: 'gateway', operation: 'gateway.openapi' },
+      );
+      return;
+    }
+
+    cliOutput(doc, { command: 'gateway', operation: 'gateway.openapi' });
+  },
+});
+
+/**
+ * `cleo gateway` — parent command grouping the gateway introspection subverbs.
+ *
+ * @task T11918
+ */
+export const gatewayCommand = defineCommand({
+  meta: {
+    name: 'gateway',
+    description: 'REST gateway introspection (openapi spec projection)',
+  },
+  subCommands: {
+    openapi: gatewayOpenapiSubCommand,
+  },
+});

--- a/packages/cleo/src/cli/generated/command-manifest.ts
+++ b/packages/cleo/src/cli/generated/command-manifest.ts
@@ -479,6 +479,19 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     load: async () => (await import('../commands/focus.js')).focusCommand as CommandDef,
   },
   {
+    exportName: 'gatewayOpenapiSubCommand',
+    name: 'openapi',
+    description: 'Emit the OpenAPI 3.1 spec projected from the OPERATIONS registry',
+    load: async () =>
+      (await import('../commands/gateway.js')).gatewayOpenapiSubCommand as CommandDef,
+  },
+  {
+    exportName: 'gatewayCommand',
+    name: 'gateway',
+    description: 'REST gateway introspection (openapi spec projection)',
+    load: async () => (await import('../commands/gateway.js')).gatewayCommand as CommandDef,
+  },
+  {
     exportName: 'gcCommand',
     name: 'gc',
     description: 'Transcript garbage collection: manual trigger and status',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -751,6 +751,20 @@ export {
   classifyReadiness,
   classifyTask,
 } from './orchestration/index.js';
+// T11918 (M5 / E-API-STANDARD-FOUNDATION T11769) — zod→OpenAPI 3.1 bridge:
+// projects the OPERATIONS registry into an OpenAPI 3.1 document (POST
+// /v1/<domain>/<operation>) for `cleo gateway openapi` + the generated SDK client.
+export {
+  type GenerateOpenApiOptions,
+  generateOpenApi,
+  type OpenApiDocument,
+  type OpenApiInfo,
+  type OpenApiMediaType,
+  type OpenApiOperation,
+  type OpenApiPathItem,
+  type OpenApiRequestBody,
+  type OpenApiResponse,
+} from './runtime/openapi/index.js';
 // Setup wizard `--config-json` merger
 export { mergeConfigJson, WIZARD_SECTION_IDS } from './setup/config-json-merge.js';
 // Backup bundle inspect primitives (tar parser, encryption detect, byte fmt)

--- a/packages/core/src/runtime/openapi/__tests__/generate-openapi.test.ts
+++ b/packages/core/src/runtime/openapi/__tests__/generate-openapi.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for {@link generateOpenApi} — the zod→OpenAPI 3.1 bridge (T11918 / M5).
+ *
+ * Coverage maps to the task acceptance criteria:
+ *   - AC1: the builder emits a valid OpenAPI 3.1 document.
+ *   - AC2: each op → `POST /v1/<domain>/<operation>` with requestBody from the
+ *          input schema and a 200 response from the resolved output schema.
+ *   - AC4: the document validates against an OpenAPI 3.1 meta-schema AND every
+ *          embedded Schema Object compiles under the JSON Schema 2020-12 dialect.
+ *   - AC5: the number of paths equals OPERATIONS.length.
+ *
+ * @task T11918
+ */
+
+import { OPERATIONS } from '@cleocode/contracts';
+// Ajv 2020 carries the JSON Schema 2020-12 vocabulary OpenAPI 3.1 mandates.
+import Ajv2020 from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+import { generateOpenApi, type OpenApiDocument } from '../generate-openapi.js';
+
+// ---------------------------------------------------------------------------
+// OpenAPI 3.1 meta-schema (focused — enforces the spec's structural invariants
+// this builder is contractually bound to). Authored against
+// https://spec.openapis.org/oas/v3.1.0. Embedded schema objects are validated
+// SEPARATELY by compiling them under the 2020-12 dialect (AC4, second half).
+// ---------------------------------------------------------------------------
+const OPENAPI_31_META_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  required: ['openapi', 'info', 'paths'],
+  properties: {
+    openapi: { type: 'string', pattern: '^3\\.1\\.\\d+$' },
+    jsonSchemaDialect: { type: 'string', format: 'uri' },
+    info: {
+      type: 'object',
+      required: ['title', 'version'],
+      properties: {
+        title: { type: 'string', minLength: 1 },
+        version: { type: 'string', minLength: 1 },
+        summary: { type: 'string' },
+        description: { type: 'string' },
+      },
+    },
+    paths: {
+      type: 'object',
+      // Every path key MUST be a templated route starting with '/'.
+      propertyNames: { pattern: '^/' },
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          post: { $ref: '#/$defs/operation' },
+          get: { $ref: '#/$defs/operation' },
+          put: { $ref: '#/$defs/operation' },
+          delete: { $ref: '#/$defs/operation' },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  $defs: {
+    operation: {
+      type: 'object',
+      required: ['responses'],
+      properties: {
+        operationId: { type: 'string', minLength: 1 },
+        summary: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } },
+        requestBody: {
+          type: 'object',
+          required: ['content'],
+          properties: {
+            required: { type: 'boolean' },
+            description: { type: 'string' },
+            content: { $ref: '#/$defs/content' },
+          },
+        },
+        responses: {
+          type: 'object',
+          minProperties: 1,
+          // Response keys are HTTP status codes or 'default'.
+          propertyNames: { pattern: '^([1-5][0-9]{2}|default)$' },
+          additionalProperties: {
+            type: 'object',
+            required: ['description'],
+            properties: {
+              description: { type: 'string' },
+              content: { $ref: '#/$defs/content' },
+            },
+          },
+        },
+      },
+    },
+    content: {
+      type: 'object',
+      minProperties: 1,
+      additionalProperties: {
+        type: 'object',
+        required: ['schema'],
+        properties: { schema: { type: 'object' } },
+      },
+    },
+  },
+} as const;
+
+function makeAjv(): Ajv2020 {
+  // strict:false — OpenAPI/JSON-Schema docs carry annotation keywords ajv would
+  // otherwise warn on; allErrors for diagnosable failures.
+  return new Ajv2020({ strict: false, allErrors: true });
+}
+
+describe('generateOpenApi', () => {
+  const doc: OpenApiDocument = generateOpenApi();
+
+  it('emits an OpenAPI 3.1.0 document (AC1)', () => {
+    expect(doc.openapi).toBe('3.1.0');
+    expect(doc.info.title.length).toBeGreaterThan(0);
+    expect(doc.info.version).toBe('1.0.0');
+    expect(doc.jsonSchemaDialect).toBe('https://json-schema.org/draft/2020-12/schema');
+  });
+
+  it('validates against the OpenAPI 3.1 meta-schema (AC4)', () => {
+    const ajv = makeAjv();
+    const validate = ajv.compile(OPENAPI_31_META_SCHEMA);
+    const ok = validate(doc);
+    if (!ok) {
+      // Surface the first few errors for a diagnosable failure.
+      throw new Error(
+        `OpenAPI 3.1 meta-schema validation failed: ${ajv.errorsText(validate.errors)}`,
+      );
+    }
+    expect(ok).toBe(true);
+  });
+
+  it('has exactly OPERATIONS.length paths — one route per registry entry (AC5)', () => {
+    expect(Object.keys(doc.paths)).toHaveLength(OPERATIONS.length);
+  });
+
+  it('every path is POST-only with a 200 JSON response and an x-cleo-gateway tag (AC2)', () => {
+    for (const route of Object.keys(doc.paths)) {
+      const item = doc.paths[route];
+      // POST-only path item.
+      expect(Object.keys(item)).toEqual(['post']);
+      const post = item.post;
+      // Route begins with the /v1 prefix and the operation's domain segment.
+      expect(route.startsWith('/v1/')).toBe(true);
+      expect(post.tags.length).toBeGreaterThan(0);
+      expect(post['x-cleo-gateway']).toMatch(/^(query|mutate)$/);
+      // AC2: every op has a 200 response carrying a JSON schema.
+      const ok200 = post.responses['200'];
+      expect(ok200, `${route} missing 200 response`).toBeDefined();
+      expect(ok200.content?.['application/json']?.schema).toBeDefined();
+    }
+  });
+
+  it('routes every registry entry to its clean /v1/<domain>/<operation> form (AC2)', () => {
+    // Non-colliding ops (the vast majority) use the clean path verbatim.
+    const pairCounts = new Map<string, number>();
+    for (const op of OPERATIONS) {
+      const pair = `${op.domain}/${op.operation}`;
+      pairCounts.set(pair, (pairCounts.get(pair) ?? 0) + 1);
+    }
+    for (const op of OPERATIONS) {
+      const pair = `${op.domain}/${op.operation}`;
+      if ((pairCounts.get(pair) ?? 0) > 1) continue; // collisions are gateway-suffixed
+      const route = `/v1/${op.domain}/${op.operation}`;
+      const item = doc.paths[route];
+      expect(item, `missing clean path ${route}`).toBeDefined();
+      expect(item.post.operationId).toBe(`${op.gateway}.${op.domain}.${op.operation}`);
+      expect(item.post.tags).toContain(op.domain);
+    }
+  });
+
+  it('all operationIds are unique across the document (OpenAPI invariant)', () => {
+    const ids = Object.values(doc.paths).map((p) => p.post.operationId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('projects a representative read op (tasks.show) with requestBody from its params (AC2)', () => {
+    const showItem = doc.paths['/v1/tasks/show'];
+    expect(showItem).toBeDefined();
+    const post = showItem.post;
+    expect(post.operationId).toBe('query.tasks.show');
+    expect(post['x-cleo-gateway']).toBe('query');
+
+    // requestBody is derived from the op's params — taskId is a required string.
+    const reqSchema = post.requestBody?.content['application/json']?.schema as
+      | { type?: string; properties?: Record<string, unknown>; required?: string[] }
+      | undefined;
+    expect(reqSchema).toBeDefined();
+    expect(reqSchema?.type).toBe('object');
+    expect(reqSchema?.properties).toHaveProperty('taskId');
+    expect(reqSchema?.required).toContain('taskId');
+
+    // 200 response wraps the resolved output schema in the LAFS envelope.
+    const respSchema = post.responses['200'].content?.['application/json']?.schema as
+      | { properties?: { data?: unknown } }
+      | undefined;
+    expect(respSchema?.properties).toHaveProperty('success');
+    expect(respSchema?.properties).toHaveProperty('data');
+    expect(respSchema?.properties).toHaveProperty('meta');
+  });
+
+  it('every embedded request/response Schema Object compiles under JSON Schema 2020-12 (AC4)', () => {
+    const ajv = makeAjv();
+    let compiled = 0;
+    for (const route of Object.keys(doc.paths)) {
+      const post = doc.paths[route].post;
+      const reqSchema = post.requestBody?.content['application/json']?.schema;
+      if (reqSchema !== undefined) {
+        expect(() => ajv.compile(reqSchema), `request schema invalid for ${route}`).not.toThrow();
+        compiled++;
+      }
+      const respSchema = post.responses['200'].content?.['application/json']?.schema;
+      expect(respSchema, `${route} missing 200 schema`).toBeDefined();
+      if (respSchema !== undefined) {
+        expect(() => ajv.compile(respSchema), `response schema invalid for ${route}`).not.toThrow();
+        compiled++;
+      }
+    }
+    // Sanity: we actually exercised a substantial number of schemas.
+    expect(compiled).toBeGreaterThan(OPERATIONS.length);
+  });
+
+  it('honors the version + pathPrefix options', () => {
+    const custom = generateOpenApi({ version: '2.5.0', pathPrefix: '/api/v2' });
+    expect(custom.info.version).toBe('2.5.0');
+    const someOp = OPERATIONS[0];
+    expect(custom.paths[`/api/v2/${someOp.domain}/${someOp.operation}`]).toBeDefined();
+  });
+});

--- a/packages/core/src/runtime/openapi/generate-openapi.ts
+++ b/packages/core/src/runtime/openapi/generate-openapi.ts
@@ -1,0 +1,469 @@
+/**
+ * generateOpenApi — projects the CLEO operations registry into an OpenAPI 3.1
+ * document (DHQ-033/057 SDK-projection · T11918 · AC2 · M5/E-API-STANDARD-FOUNDATION
+ * T11769).
+ *
+ * ## Why this exists
+ *
+ * The `/v1` REST gateway routes `POST /v1/<domain>/<operation>` for every entry
+ * in the 413-row {@link OPERATIONS} registry. Downstream task T11920 generates a
+ * typed SDK client; its projection source is an OpenAPI 3.1 spec. Hand-authoring
+ * 413 path objects (and keeping them in lock-step with the registry) is exactly
+ * the drift trap the schema-first SSoT (`inputSchema`/`outputSchema`) was built
+ * to close. This builder DERIVES the whole spec from the single source of truth:
+ *
+ *   - paths        ← {@link OPERATIONS} (`POST /v1/<domain>/<operation>`)
+ *   - requestBody  ← {@link getInputContract}(op).schema, else a JSON Schema
+ *                    synthesised from `def.params` (richest available input shape)
+ *   - 200 response ← {@link getOutputContract}(op).dataSchema (hand-authored
+ *                    {@link OUTPUT_CONTRACTS}, else {@link deriveOutputContract})
+ *
+ * Because `OperationInputContract.schema` and `OperationOutputContract.dataSchema`
+ * are ALREADY JSON Schema (draft-07) documents, and OpenAPI 3.1's Schema Object
+ * IS a superset of JSON Schema (it adopts the JSON Schema 2020-12 vocabulary),
+ * the schemas embed directly — no zod→OpenAPI conversion pass, no `zod-to-openapi`
+ * dependency. Zod (v4) is the authoring substrate for the contracts upstream; by
+ * the time a schema reaches this builder it is already plain JSON Schema, so this
+ * module stays a zero-runtime-dependency projection over the registry.
+ *
+ * ## Boundary
+ *
+ * Lives in `core/src/runtime` (NOT `contracts`): it reads {@link getOutputContract}
+ * / {@link getInputContract}, which are core-resident bodied resolvers, and it is
+ * itself a bodied runtime helper (the contracts-purity Gate 10 forbids net-new
+ * bodied functions in `contracts`). Import-time side-effect-free: it builds
+ * nothing at module load, only when {@link generateOpenApi} is called.
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/runtime/openapi/generate-openapi
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0 | OpenAPI 3.1.0 Specification}
+ * @see OperationOutputContract — the OUTPUT-side JSON Schema SSoT this projects
+ * @see OperationInputContract — the INPUT-side JSON Schema SSoT this projects
+ *
+ * @epic T11769
+ * @task T11918 — AC2: zod→OpenAPI 3.1 bridge + `cleo gateway openapi`
+ */
+
+import { type JsonSchema, OPERATIONS, type OperationDef, type ParamDef } from '@cleocode/contracts';
+import { getInputContract } from '../../dispatch/contracts/input-contracts.js';
+import { getOutputContract } from '../../dispatch/contracts/output-contracts.js';
+
+// ---------------------------------------------------------------------------
+// OpenAPI 3.1 document shape (minimal — only the members this builder emits)
+// ---------------------------------------------------------------------------
+
+/**
+ * OpenAPI 3.1 `info` object — API identity surfaced to SDK generators and docs
+ * tooling.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#info-object}
+ */
+export interface OpenApiInfo {
+  /** Human-readable API title. */
+  title: string;
+  /**
+   * Semantic version of the API surface (NOT the package version). The `/v1`
+   * REST gateway is version `1.x`; defaults to `'1.0.0'`.
+   */
+  version: string;
+  /** Optional one-line summary (OpenAPI 3.1 adds `summary` to the info object). */
+  summary?: string;
+  /** Optional CommonMark description. */
+  description?: string;
+}
+
+/**
+ * OpenAPI 3.1 Media Type object — pairs a content type with its schema.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#media-type-object}
+ */
+export interface OpenApiMediaType {
+  /** The JSON Schema (2020-12 vocabulary) describing the payload. */
+  schema: JsonSchema;
+}
+
+/**
+ * OpenAPI 3.1 Request Body object.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#request-body-object}
+ */
+export interface OpenApiRequestBody {
+  /** Content keyed by media type (always `application/json` here). */
+  content: Record<string, OpenApiMediaType>;
+  /** Whether the request body is required (true iff the op has required params). */
+  required: boolean;
+  /** Optional human description. */
+  description?: string;
+}
+
+/**
+ * OpenAPI 3.1 Response object.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#response-object}
+ */
+export interface OpenApiResponse {
+  /** Required CommonMark description of the response. */
+  description: string;
+  /** Optional content keyed by media type. */
+  content?: Record<string, OpenApiMediaType>;
+}
+
+/**
+ * OpenAPI 3.1 Operation object — one HTTP operation on a path.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#operation-object}
+ */
+export interface OpenApiOperation {
+  /** Unique, machine-friendly id (`<gateway>.<domain>.<operation>`) for SDK method naming. */
+  operationId: string;
+  /** Short summary (the registry `description`). */
+  summary: string;
+  /** Grouping tags — the canonical domain. */
+  tags: string[];
+  /** Request body, omitted when the op declares no input params. */
+  requestBody?: OpenApiRequestBody;
+  /** Responses keyed by HTTP status code (always at least `'200'`). */
+  responses: Record<string, OpenApiResponse>;
+  /**
+   * Vendor extension carrying the CQRS gateway (`'query'` | `'mutate'`) this
+   * operation routes through. The clean `/v1/<domain>/<operation>` path omits the
+   * gateway for readability, so the SDK reads this extension to pick the right
+   * dispatch gateway. OpenAPI tooling ignores `x-`-prefixed members it does not
+   * recognise, so emitting it keeps the document valid.
+   */
+  'x-cleo-gateway': 'query' | 'mutate';
+}
+
+/**
+ * OpenAPI 3.1 Path Item object — the set of HTTP operations on one path. The
+ * CLEO `/v1` gateway only routes `POST`, so only `post` is ever populated.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#path-item-object}
+ */
+export interface OpenApiPathItem {
+  /** The single `POST` operation served at this path. */
+  post: OpenApiOperation;
+}
+
+/**
+ * A minimal, structurally-typed OpenAPI 3.1 document — exactly the members
+ * {@link generateOpenApi} emits. The `openapi` field is pinned to the `3.1.x`
+ * literal family so consumers can statically assert the version.
+ *
+ * @see {@link https://spec.openapis.org/oas/v3.1.0#openapi-object}
+ */
+export interface OpenApiDocument {
+  /** OpenAPI version string — always `'3.1.0'`. */
+  openapi: '3.1.0';
+  /** API identity. */
+  info: OpenApiInfo;
+  /**
+   * The JSON Schema dialect every embedded Schema Object uses, declared once at
+   * the document root per OpenAPI 3.1. The contracts ship draft-07 schemas,
+   * which validate under the 2020-12 dialect OpenAPI 3.1 mandates.
+   */
+  jsonSchemaDialect: string;
+  /**
+   * Path → path-item map, keyed by `<pathPrefix>/<domain>/<operation>` (with a
+   * trailing `/<gateway>` segment for the cross-gateway collision pairs).
+   */
+  paths: Record<string, OpenApiPathItem>;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link generateOpenApi}.
+ */
+export interface GenerateOpenApiOptions {
+  /**
+   * Semantic version stamped into `info.version`. This is the API-surface
+   * version (the `/v1` gateway), NOT the npm package version.
+   *
+   * @default '1.0.0'
+   */
+  version?: string;
+  /**
+   * Path prefix prepended to every operation route. The SDK-facing REST surface
+   * is versioned under `/v1` (T11769); each op maps to
+   * `POST <pathPrefix>/<domain>/<operation>`.
+   *
+   * @default '/v1'
+   */
+  pathPrefix?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input-schema derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a {@link ParamDef.type} to its JSON Schema `type` keyword.
+ *
+ * `array` params are modelled as `{ type: 'array', items: { type: 'string' } }`
+ * — the CLI/dispatch layer accepts array params as comma-separated or repeated
+ * strings, so a string-item array is the faithful wire shape.
+ *
+ * @internal
+ */
+function paramSchema(param: ParamDef): JsonSchema {
+  const base: JsonSchema = { description: param.description };
+  if (param.enum !== undefined && param.enum.length > 0) {
+    return { ...base, type: 'string', enum: [...param.enum] };
+  }
+  switch (param.type) {
+    case 'number':
+      return { ...base, type: 'number' };
+    case 'boolean':
+      return { ...base, type: 'boolean' };
+    case 'array':
+      return { ...base, type: 'array', items: { type: 'string' } };
+    default:
+      return { ...base, type: 'string' };
+  }
+}
+
+/**
+ * Synthesise a JSON Schema `object` from an operation's `params` (or, when
+ * `params` is absent/empty, from its `requiredParams`). Hidden params are
+ * excluded — they are CLI-only knobs (`--dry-run`, `--offset`) and not part of
+ * the public API surface (see {@link ParamDef.hidden}).
+ *
+ * Returns `null` when the operation declares no API-visible input at all, so the
+ * caller can omit the `requestBody` entirely.
+ *
+ * @internal
+ */
+function inputSchemaFromParams(def: OperationDef): JsonSchema | null {
+  const params = (def.params ?? []).filter((p) => p.hidden !== true);
+  if (params.length > 0) {
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+    for (const p of params) {
+      properties[p.name] = paramSchema(p);
+      if (p.required) required.push(p.name);
+    }
+    const schema: JsonSchema = { type: 'object', properties, additionalProperties: false };
+    if (required.length > 0) schema.required = required;
+    return schema;
+  }
+
+  // Legacy ops with no `params` array but a `requiredParams` list: emit a
+  // minimal object so the contract is still expressed.
+  if (def.requiredParams.length > 0) {
+    const properties: Record<string, JsonSchema> = {};
+    for (const name of def.requiredParams) properties[name] = { type: 'string' };
+    return {
+      type: 'object',
+      properties,
+      required: [...def.requiredParams],
+      additionalProperties: true,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the richest available JSON Schema for an operation's request body.
+ *
+ * Precedence: a hand-authored {@link getInputContract}(op) wins (it carries
+ * curated constraints + examples); otherwise the schema is derived from the
+ * operation's `params`. A `null` return means "no API-visible input" and the
+ * caller omits `requestBody`.
+ *
+ * @internal
+ */
+function resolveRequestSchema(def: OperationDef): JsonSchema | null {
+  const key = `${def.domain}.${def.operation}`;
+  const contract = getInputContract(key);
+  if (contract !== null) return contract.schema;
+  return inputSchemaFromParams(def);
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build one OpenAPI 3.1 {@link OpenApiOperation} from a single registry entry.
+ *
+ * @param def - The registry operation definition.
+ * @param operationId - The document-unique operationId assigned by the caller
+ *   (the caller owns uniqueness because two registry entries can share a
+ *   `<domain>.<operation>` across gateways).
+ * @internal
+ */
+function buildOperation(def: OperationDef, operationId: string): OpenApiOperation {
+  // The output contract is keyed on canonical `<domain>.<operation>` (NOT the
+  // disambiguated operationId), so resolve it from the registry coordinates.
+  const contractKey = `${def.domain}.${def.operation}`;
+  const operation: OpenApiOperation = {
+    operationId,
+    summary: def.description,
+    tags: [def.domain],
+    'x-cleo-gateway': def.gateway,
+    responses: {
+      '200': buildSuccessResponse(contractKey),
+    },
+  };
+
+  const requestSchema = resolveRequestSchema(def);
+  if (requestSchema !== null) {
+    operation.requestBody = {
+      required: def.requiredParams.length > 0,
+      content: { 'application/json': { schema: requestSchema } },
+    };
+  }
+
+  return operation;
+}
+
+/**
+ * Build the `200` response object for an operation, wrapping the resolved
+ * `dataSchema` in the canonical LAFS envelope shape
+ * (`{ success, data, meta }`) so the spec describes the ACTUAL wire response —
+ * not just the inner `data` payload.
+ *
+ * @internal
+ */
+function buildSuccessResponse(operationId: string): OpenApiResponse {
+  const output = getOutputContract(operationId);
+  const dataSchema: JsonSchema = output?.dataSchema ?? {
+    type: 'object',
+    additionalProperties: true,
+  };
+  const description = output?.shapeNote ?? 'Successful LAFS response envelope.';
+
+  const envelopeSchema: JsonSchema = {
+    type: 'object',
+    required: ['success', 'data', 'meta'],
+    properties: {
+      success: { type: 'boolean', const: true },
+      data: dataSchema,
+      meta: { type: 'object', additionalProperties: true, description: 'LAFS response metadata.' },
+    },
+    additionalProperties: true,
+  };
+
+  return {
+    description,
+    content: { 'application/json': { schema: envelopeSchema } },
+  };
+}
+
+/**
+ * Allocate a document-unique key from a desired base, appending `/2`, `/3`, …
+ * (or `.2`, `.3`, … for dotted ids) only when the base is already taken.
+ *
+ * Used for BOTH path routes and operationIds. The CLEO operations registry is
+ * NOT collision-free on `<domain>/<operation>`: 8 ops appear under both the
+ * `query` AND `mutate` gateways (e.g. `admin/map`, `release/gate`), and one op
+ * (`tasks/tree`) is a genuine same-gateway duplicate. OpenAPI mandates unique
+ * path keys and unique operationIds, so each registry entry MUST still map to a
+ * distinct slot to keep the path count equal to `OPERATIONS.length` (AC5). The
+ * cross-gateway collisions are disambiguated by the caller (gateway suffix); a
+ * residual exact duplicate falls back to the numeric suffix here.
+ *
+ * @internal
+ */
+function uniqueKey(base: string, taken: Set<string>, sep: string): string {
+  if (!taken.has(base)) {
+    taken.add(base);
+    return base;
+  }
+  let n = 2;
+  let candidate = `${base}${sep}${n}`;
+  while (taken.has(candidate)) {
+    n++;
+    candidate = `${base}${sep}${n}`;
+  }
+  taken.add(candidate);
+  return candidate;
+}
+
+/**
+ * Project the {@link OPERATIONS} registry into a complete OpenAPI 3.1 document.
+ *
+ * Walks every registry entry, mapping each to a `POST` path whose `requestBody`
+ * is the resolved input schema and whose `200` response is the resolved output
+ * schema (`deriveOutputContract` coverage), wrapped in the LAFS envelope.
+ *
+ * Routing: the clean form is `POST <pathPrefix>/<domain>/<operation>`. Because
+ * the registry has cross-gateway collisions on `<domain>/<operation>` (the same
+ * pair under both `query` and `mutate`), a colliding entry is disambiguated by
+ * appending its gateway segment (`<pathPrefix>/<domain>/<operation>/<gateway>`).
+ * Each operation also carries an `x-cleo-gateway` extension so the SDK knows
+ * which CQRS gateway to dispatch through regardless of the path form.
+ *
+ * The number of paths in the returned document equals `OPERATIONS.length` (AC5):
+ * every registry entry gets a unique route (and a unique operationId).
+ *
+ * @param options - {@link GenerateOpenApiOptions} (version, path prefix).
+ * @returns A structurally-valid OpenAPI 3.1 {@link OpenApiDocument}.
+ *
+ * @example
+ * ```ts
+ * const doc = generateOpenApi();
+ * doc.openapi;                                       // '3.1.0'
+ * Object.keys(doc.paths).length;                     // === OPERATIONS.length
+ * doc.paths['/v1/tasks/show'].post.operationId;      // 'query.tasks.show'
+ * doc.paths['/v1/tasks/show'].post['x-cleo-gateway'];// 'query'
+ * ```
+ *
+ * @task T11918 — AC1/AC2/AC5
+ */
+export function generateOpenApi(options: GenerateOpenApiOptions = {}): OpenApiDocument {
+  const version = options.version ?? '1.0.0';
+  const pathPrefix = options.pathPrefix ?? '/v1';
+
+  // Pre-compute which `<domain>/<operation>` pairs collide across gateways so
+  // only the colliding ones take the gateway-suffixed path (keeping the clean
+  // `/v1/<domain>/<operation>` form for the unambiguous majority).
+  const pairCounts = new Map<string, number>();
+  for (const def of OPERATIONS) {
+    const pair = `${def.domain}/${def.operation}`;
+    pairCounts.set(pair, (pairCounts.get(pair) ?? 0) + 1);
+  }
+
+  const paths: Record<string, OpenApiPathItem> = {};
+  const takenRoutes = new Set<string>();
+  const takenOperationIds = new Set<string>();
+
+  for (const def of OPERATIONS) {
+    const pair = `${def.domain}/${def.operation}`;
+    const collides = (pairCounts.get(pair) ?? 0) > 1;
+    const baseRoute = collides
+      ? `${pathPrefix}/${def.domain}/${def.operation}/${def.gateway}`
+      : `${pathPrefix}/${def.domain}/${def.operation}`;
+    const route = uniqueKey(baseRoute, takenRoutes, '/');
+
+    // operationId is always gateway-qualified so it is unique even for the
+    // cross-gateway pairs; a residual same-gateway dup gets a numeric suffix.
+    const operationId = uniqueKey(
+      `${def.gateway}.${def.domain}.${def.operation}`,
+      takenOperationIds,
+      '.',
+    );
+
+    paths[route] = { post: buildOperation(def, operationId) };
+  }
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'CLEO Gateway API',
+      version,
+      summary: 'CQRS operations gateway projected from the CLEO operations registry.',
+      description:
+        'Auto-generated from the canonical OPERATIONS registry. Every operation is reachable ' +
+        `via POST ${pathPrefix}/<domain>/<operation> with a JSON request body and a LAFS ` +
+        'response envelope. This document is the projection source for the generated SDK client.',
+    },
+    jsonSchemaDialect: 'https://json-schema.org/draft/2020-12/schema',
+    paths,
+  };
+}

--- a/packages/core/src/runtime/openapi/index.ts
+++ b/packages/core/src/runtime/openapi/index.ts
@@ -1,0 +1,26 @@
+/**
+ * OpenAPI 3.1 projection — public surface.
+ *
+ * Re-exports the {@link generateOpenApi} builder and its OpenAPI 3.1 document
+ * types. The builder projects the canonical {@link OPERATIONS} registry into an
+ * OpenAPI 3.1 spec consumed by `cleo gateway openapi` and the downstream
+ * generated SDK client (T11920).
+ *
+ * @packageDocumentation
+ * @module @cleocode/core/runtime/openapi
+ *
+ * @epic T11769
+ * @task T11918
+ */
+
+export {
+  type GenerateOpenApiOptions,
+  generateOpenApi,
+  type OpenApiDocument,
+  type OpenApiInfo,
+  type OpenApiMediaType,
+  type OpenApiOperation,
+  type OpenApiPathItem,
+  type OpenApiRequestBody,
+  type OpenApiResponse,
+} from './generate-openapi.js';


### PR DESCRIPTION
## Summary

Builds the **zod→OpenAPI 3.1 bridge** that projects the canonical `OPERATIONS` registry (412 ops) into an OpenAPI 3.1 document, exposed via a new `cleo gateway openapi` command. This is the projection source for the generated SDK client (downstream **T11920** depends on this). Part of M5 / Epic **T11769** (E-API-STANDARD-FOUNDATION).

## Acceptance criteria

| AC | Requirement | Implementation |
|----|-------------|----------------|
| AC1 | `generateOpenApi()` builder in core/runtime walks OPERATIONS → valid OpenAPI 3.1 | `packages/core/src/runtime/openapi/generate-openapi.ts` — walks `OPERATIONS`, emits `openapi: '3.1.0'` + `jsonSchemaDialect: 2020-12`. |
| AC2 | Each op → `POST /v1/<domain>/<operation>`; requestBody=inputSchema, 200=resolved outputSchema (`deriveOutputContract`) | requestBody from `getInputContract` or a JSON Schema synthesised from `params`; 200 from `getOutputContract → deriveOutputContract`, wrapped in the LAFS `{ success, data, meta }` envelope. |
| AC3 | `cleo gateway openapi [--out <file>]` prints/writes the spec as a LAFS envelope (ADR-086) | `packages/cleo/src/cli/commands/gateway.ts` — prints the full doc, or writes the file and emits a summary `{ out, pathCount, version }` envelope. |
| AC4 | Output validates against the OpenAPI 3.1 meta-schema in a test | Test validates against an OpenAPI 3.1 meta-schema **and** compiles every embedded Schema Object under the JSON Schema 2020-12 dialect (`ajv/dist/2020`). |
| AC5 | Spec op count equals `OPERATIONS.length` | 412 paths — one per registry entry (verified end-to-end). |

## Design notes

- **No new dependency.** `inputSchema.schema` / `outputSchema.dataSchema` already carry **JSON Schema** (draft-07) documents, and OpenAPI 3.1's Schema Object is a superset of JSON Schema (it adopts the 2020-12 vocabulary), so the schemas embed directly — no `zod-to-openapi` conversion pass. Zod (v4) is the upstream authoring substrate; by the time a schema reaches this builder it is already plain JSON Schema.
- **core IS the SDK.** Per the ratified North-Star, there is no separate `@cleocode/sdk` package — the spec is emitted as an artifact (`cleo gateway openapi --out`), not a minted package.
- **Registry collisions.** The registry has 8 cross-gateway `query`/`mutate` pairs sharing a `<domain>/<operation>` (e.g. `admin/map`, `release/gate`) plus one genuine same-gateway dup (`tasks/tree`). To keep path count == `OPERATIONS.length` while honoring AC2's `/v1/<domain>/<operation>` form for the 403 unambiguous ops, colliding entries take a trailing `/<gateway>` segment, every op carries an `x-cleo-gateway` extension, and operationIds are gateway-qualified (`query.tasks.show`) for document-wide uniqueness.

## Gates (all capped via `systemd-run --user --scope -p MemoryMax=16G`)

- `pnpm biome check` — clean
- full build — green
- unit test (`generate-openapi.test.ts`) — 9/9 pass
- `lint-no-raw-define-command.mjs --check` — PASS (138 vs baseline 139; gateway command imports the SSoT wrapper)
- `cleo check arch` (baseline) — 6/6 pass
- end-to-end smoke: `cleo gateway openapi` (412 paths) + `--out` + `--version` verified

## Files changed

- `packages/core/src/runtime/openapi/generate-openapi.ts` (new) — the builder + OpenAPI 3.1 types
- `packages/core/src/runtime/openapi/index.ts` (new) — barrel
- `packages/core/src/runtime/openapi/__tests__/generate-openapi.test.ts` (new) — unit test
- `packages/core/src/index.ts` — export `generateOpenApi` + types
- `packages/cleo/src/cli/commands/gateway.ts` (new) — `cleo gateway openapi`
- `packages/cleo/src/cli/generated/command-manifest.ts` — regenerated (picks up the new command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)