### PR TITLE
feat(T11935): cleo tui dispatch parity — keyboard dispatch→orchestrate.spawn + live worker SSE

### DIFF
--- a/packages/cleo/src/cli/lib/tui/__tests__/cockpit-dispatch.test.ts
+++ b/packages/cleo/src/cli/lib/tui/__tests__/cockpit-dispatch.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the cockpit's dispatch action + live worker-stream wiring at the
+ * component level (T11935 dispatch · T11936 SSE).
+ *
+ * Drives the exported {@link KanbanBoardComponent} directly with INJECTED
+ * dispatch + subscribe functions (the same seams `runCockpit` wires) so the
+ * confirm-gate, the Running-lane transition, the inline-error surface, and the
+ * SSE subscribe/unsubscribe lifecycle are all exercised with NO daemon, NO
+ * socket, and NO pi-tui.
+ *
+ * @task T11935
+ * @task T11936
+ * @epic T11916
+ */
+
+import type { GatewayStreamEvent } from '@cleocode/contracts/gateway';
+import { describe, expect, it, vi } from 'vitest';
+import { type DispatchFn, KanbanBoardComponent, type SubscribeFn } from '../cockpit.js';
+import { buildKanbanBoard, type TuiTaskRow } from '../kanban-board.js';
+
+const BASE = 'http://127.0.0.1:7777';
+
+/** A no-op SSE subscribe (no frames). */
+const noopSubscribe: SubscribeFn = () => ({ unsubscribe: () => {} });
+
+/** A dispatch fn that always succeeds. */
+const okDispatch: DispatchFn = async (_baseUrl, taskId, tier) => ({
+  ok: true,
+  taskId,
+  tier,
+  data: {},
+});
+
+/** Build a component over the given rows with injected deps. */
+function makeComponent(
+  rows: TuiTaskRow[],
+  deps: { dispatch?: DispatchFn; subscribe?: SubscribeFn } = {},
+): KanbanBoardComponent {
+  return new KanbanBoardComponent(buildKanbanBoard(rows), {
+    baseUrl: BASE,
+    dispatch: deps.dispatch ?? okDispatch,
+    subscribe: deps.subscribe ?? noopSubscribe,
+  });
+}
+
+/** Rows that land in the Ready lane (pending + deps met + spawn-worker hint). */
+const READY_ROW: TuiTaskRow = {
+  id: 'TR1',
+  title: 'ready one',
+  status: 'pending',
+  nextAction: 'spawn-worker',
+};
+/** A Running-lane row (active worker). */
+const RUNNING_ROW: TuiTaskRow = { id: 'TX1', title: 'running one', status: 'active' };
+
+describe('KanbanBoardComponent dispatch — confirm gate (T11935 · AC1/AC3)', () => {
+  it('first dispatch key latches a confirm prompt, does NOT spawn', async () => {
+    const dispatch = vi.fn(okDispatch);
+    const c = makeComponent([READY_ROW], { dispatch });
+    // Focus the Ready lane (index 1 in canonical order).
+    c.focusNextLane();
+    expect(c.focusedLaneId()).toBe('ready');
+
+    await c.requestDispatch();
+    expect(c.isConfirming()).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(c.statusLine()).toContain('Press [d] again');
+  });
+
+  it('second dispatch key spawns through the injected SDK dispatch fn', async () => {
+    const dispatch = vi.fn(okDispatch);
+    const c = makeComponent([READY_ROW], { dispatch });
+    c.focusNextLane();
+    await c.requestDispatch(); // confirm
+    await c.requestDispatch(); // spawn
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(BASE, 'TR1', 1);
+    expect(c.statusLine()).toContain('→ Running');
+  });
+
+  it('cycles the spawn tier and dispatches with it', async () => {
+    const dispatch = vi.fn(okDispatch);
+    const c = makeComponent([READY_ROW], { dispatch });
+    c.focusNextLane();
+    c.cycleTier(); // 1 → 2
+    expect(c.currentTier()).toBe(2);
+    await c.requestDispatch();
+    await c.requestDispatch();
+    expect(dispatch).toHaveBeenCalledWith(BASE, 'TR1', 2);
+  });
+
+  it('refuses dispatch on a non-dispatchable lane (Running) and never spawns', async () => {
+    const dispatch = vi.fn(okDispatch);
+    const c = makeComponent([RUNNING_ROW], { dispatch });
+    c.focusNextLane();
+    c.focusNextLane(); // → running
+    expect(c.focusedLaneId()).toBe('running');
+    await c.requestDispatch();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(c.statusLine()).toContain('Backlog/Ready');
+  });
+
+  it('cancelConfirm clears the latch without spawning', async () => {
+    const dispatch = vi.fn(okDispatch);
+    const c = makeComponent([READY_ROW], { dispatch });
+    c.focusNextLane();
+    await c.requestDispatch(); // confirm
+    c.cancelConfirm();
+    expect(c.isConfirming()).toBe(false);
+    await c.requestDispatch(); // back to confirm, not spawn
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('KanbanBoardComponent dispatch — inline error surface (T11935 · AC3)', () => {
+  it('renders a dispatch failure on the status line, never throws', async () => {
+    const failing: DispatchFn = async (_b, taskId) => ({
+      ok: false,
+      taskId,
+      code: 'E_GATEWAY_UNREACHABLE',
+      message: 'daemon down',
+    });
+    const c = makeComponent([READY_ROW], { dispatch: failing });
+    c.focusNextLane();
+    await c.requestDispatch(); // confirm
+    await expect(c.requestDispatch()).resolves.toBeUndefined(); // spawn — no throw
+    expect(c.statusLine()).toContain('E_GATEWAY_UNREACHABLE');
+    expect(c.statusLine()).toContain('daemon down');
+  });
+
+  it('the dispatch result + confirm prompt are rendered in the board body', async () => {
+    const c = makeComponent([READY_ROW]);
+    c.focusNextLane();
+    await c.requestDispatch();
+    const body = c.render(80).join('\n');
+    expect(body).toContain('Conductor:'); // role lane for a dispatchable card
+    expect(body).toContain('Press [d] again');
+  });
+});
+
+describe('KanbanBoardComponent SSE worker panel (T11936)', () => {
+  it('subscribes when a Running card gains focus and renders the panel', () => {
+    const unsubscribe = vi.fn();
+    let pushFrame: ((f: GatewayStreamEvent) => void) | null = null;
+    const subscribe: SubscribeFn = (_opts, handlers) => {
+      pushFrame = handlers.onFrame;
+      return { unsubscribe };
+    };
+    const c = makeComponent([RUNNING_ROW], { subscribe });
+    c.focusNextLane();
+    c.focusNextLane(); // → running (subscribes)
+    expect(typeof pushFrame).toBe('function');
+
+    pushFrame?.({ kind: 'data', seq: 0, data: { line: 'building…' }, requestId: 'r' });
+    const body = c.render(80).join('\n');
+    expect(body).toContain('Worker TX1');
+    expect(body).toContain('building…');
+  });
+
+  it('unsubscribes the previous stream when focus leaves the Running card', () => {
+    const unsubscribe = vi.fn();
+    const subscribe: SubscribeFn = () => ({ unsubscribe });
+    const c = makeComponent([RUNNING_ROW], { subscribe });
+    c.focusNextLane();
+    c.focusNextLane(); // → running (subscribes)
+    expect(unsubscribe).not.toHaveBeenCalled();
+    c.focusNextLane(); // → review (blur → unsubscribe)
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('teardownWorkerPanel unsubscribes (used on quit)', () => {
+    const unsubscribe = vi.fn();
+    const subscribe: SubscribeFn = () => ({ unsubscribe });
+    const c = makeComponent([RUNNING_ROW], { subscribe });
+    c.focusNextLane();
+    c.focusNextLane(); // → running (subscribes)
+    c.teardownWorkerPanel();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT subscribe for a non-Running focused card', () => {
+    const subscribe = vi.fn(noopSubscribe);
+    const c = makeComponent([READY_ROW], { subscribe });
+    c.focusNextLane(); // → ready (not running)
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an SSE error inline without crashing', () => {
+    const subscribe: SubscribeFn = (_opts, handlers) => {
+      handlers.onError?.('connection refused');
+      return { unsubscribe: () => {} };
+    };
+    const c = makeComponent([RUNNING_ROW], { subscribe });
+    c.focusNextLane();
+    c.focusNextLane(); // → running (subscribes → immediate error)
+    expect(c.statusLine()).toContain('connection refused');
+  });
+});

--- a/packages/cleo/src/cli/lib/tui/__tests__/dispatch.test.ts
+++ b/packages/cleo/src/cli/lib/tui/__tests__/dispatch.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the TUI dispatch path + Conductor role-lane builder (T11935).
+ *
+ * `dispatchWorker` is exercised against a MOCKED gateway SDK client so the spawn
+ * path (SDK → gateway) is covered with no daemon: success, daemon-unreachable
+ * (no `response`), a rejected spawn envelope, and a thrown transport error all
+ * resolve to a typed {@link import('../dispatch.js').DispatchResult} — never a
+ * throw (AC3: errors surface inline, never crash). The Conductor lane builder is
+ * a pure function tested directly.
+ *
+ * The mock asserts the SPAWN goes through `client.orchestrate.spawn` with the
+ * `{ taskId, tier }` body — i.e. through the SDK, with NO `child_process` /
+ * CLI shell-out (AC3).
+ *
+ * @task T11935
+ * @epic T11916
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/** Captured spawn invocations, asserted per-test. */
+const spawnCalls: Array<{ body: { taskId: string; tier?: number } }> = [];
+/** The next spawn result the mock returns (set per-test). */
+let nextSpawnResult: unknown;
+/** When set, the mock spawn throws this instead of resolving. */
+let spawnThrows: Error | null = null;
+
+vi.mock('@cleocode/core/gateway-client', () => ({
+  createCleoClient: () => ({
+    orchestrate: {
+      spawn: (opts: { body: { taskId: string; tier?: number } }) => {
+        spawnCalls.push(opts);
+        if (spawnThrows !== null) throw spawnThrows;
+        return Promise.resolve(nextSpawnResult);
+      },
+    },
+  }),
+}));
+
+// Import AFTER the mock is registered.
+const { dispatchWorker, clampTier, buildConductorLane, renderConductorLane } = await import(
+  '../dispatch.js'
+);
+
+afterEach(() => {
+  spawnCalls.length = 0;
+  nextSpawnResult = undefined;
+  spawnThrows = null;
+  vi.clearAllMocks();
+});
+
+describe('dispatchWorker — SDK spawn path (T11935 · AC1/AC3)', () => {
+  it('calls orchestrate.spawn through the SDK with the taskId + tier body', async () => {
+    nextSpawnResult = { response: {}, data: { success: true, data: { worktree: '/wt/T1' } } };
+    const result = await dispatchWorker('http://127.0.0.1:7777', 'T1', 2);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.body).toEqual({ taskId: 'T1', tier: 2 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.taskId).toBe('T1');
+      expect(result.tier).toBe(2);
+      expect(result.data).toEqual({ worktree: '/wt/T1' });
+    }
+  });
+
+  it('maps a missing `response` (connection refused) to E_GATEWAY_UNREACHABLE', async () => {
+    // hey-api yields a result with NO `response` when the daemon is not serving.
+    nextSpawnResult = { data: undefined };
+    const result = await dispatchWorker('http://127.0.0.1:7777', 'T2');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_GATEWAY_UNREACHABLE');
+      expect(result.message).toContain('cleo daemon serve');
+    }
+  });
+
+  it('surfaces a rejected spawn envelope as E_SPAWN_REJECTED with the message', async () => {
+    nextSpawnResult = {
+      response: {},
+      data: { success: false, error: { message: 'task not ready to spawn' } },
+    };
+    const result = await dispatchWorker('http://127.0.0.1:7777', 'T3');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_SPAWN_REJECTED');
+      expect(result.message).toBe('task not ready to spawn');
+    }
+  });
+
+  it('never throws — a transport error resolves to E_SPAWN_ERROR', async () => {
+    spawnThrows = new Error('socket hang up');
+    const result = await dispatchWorker('http://127.0.0.1:7777', 'T4');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('E_SPAWN_ERROR');
+      expect(result.message).toBe('socket hang up');
+    }
+  });
+
+  it('defaults the tier to 1 when omitted', async () => {
+    nextSpawnResult = { response: {}, data: { success: true, data: {} } };
+    await dispatchWorker('http://127.0.0.1:7777', 'T5');
+    expect(spawnCalls[0]?.body.tier).toBe(1);
+  });
+});
+
+describe('clampTier (T11935)', () => {
+  it('passes through 0 and 2', () => {
+    expect(clampTier(0)).toBe(0);
+    expect(clampTier(2)).toBe(2);
+  });
+  it('clamps anything else to 1', () => {
+    expect(clampTier(1)).toBe(1);
+    expect(clampTier(3)).toBe(1);
+    expect(clampTier(-1)).toBe(1);
+  });
+});
+
+describe('buildConductorLane / renderConductorLane (T11935 · AC2)', () => {
+  it('builds the orchestrator → Lead → worker chain', () => {
+    const roles = buildConductorLane('T9', null);
+    expect(roles.map((r) => r.label)).toEqual(['Orchestrator', 'Lead', 'Worker']);
+    expect(roles[2]?.value).toBe('worktree');
+    expect(roles[2]?.hint).toContain('T9');
+  });
+
+  it('uses a claimed assignee as the worker value when present', () => {
+    const roles = buildConductorLane('T9', 'agent-7');
+    expect(roles[2]?.value).toBe('agent-7');
+  });
+
+  it('renders the chain as a single compact line', () => {
+    const line = renderConductorLane(buildConductorLane('T9', null));
+    expect(line).toBe('Conductor: Orchestrator(you) → Lead(orchestrate) → Worker(worktree)');
+  });
+});

--- a/packages/cleo/src/cli/lib/tui/__tests__/sse-client.test.ts
+++ b/packages/cleo/src/cli/lib/tui/__tests__/sse-client.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the gateway SSE consumer (T11936).
+ *
+ * Covers the pure `decodeSseRecord` parser and the live
+ * `subscribeOrchestrateEvents` reader against an in-process `http.Server` that
+ * emits the SAME `id: <seq>\ndata: <json>\n\n` wire the gateway encoder produces
+ * (`packages/runtime/src/gateway/http/sse.ts`). Asserts: frames decode in order;
+ * a terminal `done` frame tears the stream down; `unsubscribe()` aborts cleanly;
+ * and a connection refusal reports `onError` WITHOUT throwing (graceful degrade).
+ *
+ * @task T11936
+ * @epic T11916
+ */
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { GatewayStreamEvent } from '@cleocode/contracts/gateway';
+import { afterEach, describe, expect, it } from 'vitest';
+import { decodeSseRecord, subscribeOrchestrateEvents } from '../sse-client.js';
+
+/** Encode a frame as the gateway does: `id: <seq>\ndata: <json>\n\n`. */
+function encode(frame: GatewayStreamEvent): string {
+  return `id: ${frame.seq}\ndata: ${JSON.stringify(frame)}\n\n`;
+}
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (server !== null) {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = null;
+  }
+});
+
+/** Start a server that streams the given frames then ends. */
+function startServer(frames: GatewayStreamEvent[]): Promise<string> {
+  return new Promise((resolve) => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      for (const f of frames) res.write(encode(f));
+      // Frames include a terminal done/error in tests that want teardown; if not,
+      // end the socket so `onClose` fires.
+      res.end();
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server?.address() as AddressInfo).port;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+describe('decodeSseRecord (T11936)', () => {
+  it('decodes a `data:`-only record into a typed frame', () => {
+    const frame: GatewayStreamEvent = { kind: 'data', seq: 0, data: { line: 'x' }, requestId: 'r' };
+    const decoded = decodeSseRecord(`id: 0\ndata: ${JSON.stringify(frame)}`);
+    expect(decoded).toEqual(frame);
+  });
+
+  it('returns null for a comment/keepalive record', () => {
+    expect(decodeSseRecord(': keepalive')).toBeNull();
+  });
+
+  it('returns null for an unparseable or wrong-shape payload', () => {
+    expect(decodeSseRecord('data: {not json')).toBeNull();
+    expect(decodeSseRecord('data: {"kind":"bogus","seq":0}')).toBeNull();
+    expect(decodeSseRecord('data: {"kind":"data"}')).toBeNull(); // missing seq
+  });
+});
+
+describe('subscribeOrchestrateEvents — live reader (T11936)', () => {
+  it('forwards each decoded frame in order and closes on done', async () => {
+    const frames: GatewayStreamEvent[] = [
+      { kind: 'data', seq: 0, data: { line: 'a' }, requestId: 'r' },
+      { kind: 'data', seq: 1, data: { line: 'b' }, requestId: 'r' },
+      { kind: 'done', seq: 2, data: {}, requestId: 'r' },
+    ];
+    const baseUrl = await startServer(frames);
+    const received: GatewayStreamEvent[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      subscribeOrchestrateEvents(
+        { baseUrl, taskId: 'T1' },
+        {
+          onFrame: (f) => received.push(f),
+          onError: (reason) => reject(new Error(reason)),
+          onClose: () => resolve(),
+        },
+      );
+    });
+
+    expect(received.map((f) => f.kind)).toEqual(['data', 'data', 'done']);
+    expect(received.map((f) => f.seq)).toEqual([0, 1, 2]);
+  });
+
+  it('handles a frame split across two chunks (buffering)', async () => {
+    const frame: GatewayStreamEvent = {
+      kind: 'data',
+      seq: 0,
+      data: { line: 'split' },
+      requestId: 'r',
+    };
+    const done: GatewayStreamEvent = { kind: 'done', seq: 1, data: {}, requestId: 'r' };
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      const wire = encode(frame) + encode(done);
+      // Write the wire in two halves to exercise the record buffer.
+      const mid = Math.floor(wire.length / 2);
+      res.write(wire.slice(0, mid));
+      setTimeout(() => {
+        res.write(wire.slice(mid));
+        res.end();
+      }, 5);
+    });
+    const baseUrl: string = await new Promise((resolve) => {
+      server?.listen(0, '127.0.0.1', () => {
+        const port = (server?.address() as AddressInfo).port;
+        resolve(`http://127.0.0.1:${port}`);
+      });
+    });
+
+    const received: GatewayStreamEvent[] = [];
+    await new Promise<void>((resolve) => {
+      subscribeOrchestrateEvents(
+        { baseUrl },
+        { onFrame: (f) => received.push(f), onClose: () => resolve() },
+      );
+    });
+    expect(received.map((f) => f.kind)).toEqual(['data', 'done']);
+  });
+
+  it('reports onError WITHOUT throwing when the daemon is unreachable', async () => {
+    let reason = '';
+    await new Promise<void>((resolve) => {
+      subscribeOrchestrateEvents(
+        { baseUrl: 'http://127.0.0.1:1' }, // never a server
+        {
+          onFrame: () => {},
+          onError: (r) => {
+            reason = r;
+            resolve();
+          },
+        },
+      );
+    });
+    expect(reason.length).toBeGreaterThan(0);
+  });
+
+  it('unsubscribe() aborts the stream without delivering further frames', async () => {
+    // A server that keeps the connection open indefinitely.
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write(encode({ kind: 'data', seq: 0, data: { tick: 0 }, requestId: 'r' }));
+      // Never end — the subscription must tear it down.
+    });
+    const baseUrl: string = await new Promise((resolve) => {
+      server?.listen(0, '127.0.0.1', () => {
+        const port = (server?.address() as AddressInfo).port;
+        resolve(`http://127.0.0.1:${port}`);
+      });
+    });
+
+    let frames = 0;
+    const sub = subscribeOrchestrateEvents({ baseUrl }, { onFrame: () => frames++ });
+    // Allow the first frame through, then unsubscribe.
+    await new Promise((r) => setTimeout(r, 30));
+    const before = frames;
+    sub.unsubscribe();
+    sub.unsubscribe(); // idempotent — second call is a no-op.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(frames).toBe(before); // no frames after unsubscribe.
+  });
+
+  it('reports an error on a non-2xx status', async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(503);
+      res.end();
+    });
+    const baseUrl: string = await new Promise((resolve) => {
+      server?.listen(0, '127.0.0.1', () => {
+        const port = (server?.address() as AddressInfo).port;
+        resolve(`http://127.0.0.1:${port}`);
+      });
+    });
+    let reason = '';
+    await new Promise<void>((resolve) => {
+      subscribeOrchestrateEvents(
+        { baseUrl },
+        {
+          onFrame: () => {},
+          onError: (r) => {
+            reason = r;
+          },
+          onClose: () => resolve(),
+        },
+      );
+    });
+    expect(reason).toContain('503');
+  });
+});

--- a/packages/cleo/src/cli/lib/tui/__tests__/worker-stream.test.ts
+++ b/packages/cleo/src/cli/lib/tui/__tests__/worker-stream.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the pure worker-stream fold + panel renderer (T11936).
+ *
+ * Verifies the gateway `GatewayStreamEvent` → worker-view fold (output tail,
+ * usage meter, checkpoints, heartbeat, terminal done/error) and the plain-text
+ * panel render. No socket, no pi-tui, no TTY required.
+ *
+ * @task T11936
+ * @epic T11916
+ */
+
+import type { GatewayStreamEvent } from '@cleocode/contracts/gateway';
+import { describe, expect, it } from 'vitest';
+import {
+  applyWorkerStreamFrame,
+  emptyWorkerStreamView,
+  formatUsageMeter,
+  isStreamStalled,
+  renderWorkerStreamPanel,
+  type WorkerStreamView,
+} from '../worker-stream.js';
+
+/** Build a `data` frame with the given payload. */
+function dataFrame(seq: number, data: unknown): GatewayStreamEvent {
+  return { kind: 'data', seq, data, requestId: 'req-1' };
+}
+
+describe('applyWorkerStreamFrame — frame folding (T11936)', () => {
+  it('starts in the connecting state with empty slots', () => {
+    const v = emptyWorkerStreamView();
+    expect(v.status).toBe('connecting');
+    expect(v.outputTail).toEqual([]);
+    expect(v.usage).toBeNull();
+    expect(v.checkpoints).toEqual([]);
+    expect(v.error).toBeNull();
+  });
+
+  it('appends an output line and goes live', () => {
+    const v = applyWorkerStreamFrame(
+      emptyWorkerStreamView(),
+      dataFrame(0, { line: 'compiling…', ts: '2026-06-09T00:00:00.000Z' }),
+    );
+    expect(v.status).toBe('live');
+    expect(v.outputTail).toEqual(['compiling…']);
+    expect(v.lastFrameTs).toBe('2026-06-09T00:00:00.000Z');
+  });
+
+  it('accepts the `output` field as an alias for a line', () => {
+    const v = applyWorkerStreamFrame(emptyWorkerStreamView(), dataFrame(0, { output: 'hi' }));
+    expect(v.outputTail).toEqual(['hi']);
+  });
+
+  it('caps the output tail to maxTail (oldest roll off)', () => {
+    let v = emptyWorkerStreamView();
+    for (let i = 0; i < 5; i++) v = applyWorkerStreamFrame(v, dataFrame(i, { line: `l${i}` }), 3);
+    expect(v.outputTail).toEqual(['l2', 'l3', 'l4']);
+  });
+
+  it('folds a nested usage snapshot into the meter', () => {
+    const v = applyWorkerStreamFrame(
+      emptyWorkerStreamView(),
+      dataFrame(0, { usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150, records: 2 } }),
+    );
+    expect(v.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      records: 2,
+    });
+  });
+
+  it('derives totalTokens from input+output when absent', () => {
+    const v = applyWorkerStreamFrame(
+      emptyWorkerStreamView(),
+      dataFrame(0, { inputTokens: 10, outputTokens: 5 }),
+    );
+    expect(v.usage?.totalTokens).toBe(15);
+    expect(v.usage?.records).toBe(1);
+  });
+
+  it('records a checkpoint of a known kind', () => {
+    const v = applyWorkerStreamFrame(
+      emptyWorkerStreamView(),
+      dataFrame(0, { checkpoint: { kind: 'commit', label: 'abc1234' } }),
+    );
+    expect(v.checkpoints).toEqual([{ kind: 'commit', label: 'abc1234' }]);
+  });
+
+  it('ignores an unknown checkpoint kind (treats frame as heartbeat)', () => {
+    const v = applyWorkerStreamFrame(
+      emptyWorkerStreamView(),
+      dataFrame(0, { checkpoint: { kind: 'bogus', label: 'x' } }),
+    );
+    expect(v.checkpoints).toEqual([]);
+    expect(v.status).toBe('live');
+  });
+
+  it('treats an unrecognised data payload (tick heartbeat) as a live heartbeat', () => {
+    const v = applyWorkerStreamFrame(emptyWorkerStreamView(), dataFrame(0, { tick: 1, ts: 'X' }));
+    expect(v.status).toBe('live');
+    expect(v.outputTail).toEqual([]);
+    expect(v.lastFrameTs).toBe('X');
+  });
+
+  it('ends on a done frame', () => {
+    const done: GatewayStreamEvent = { kind: 'done', seq: 9, data: {}, requestId: 'r' };
+    const v = applyWorkerStreamFrame(emptyWorkerStreamView(), done);
+    expect(v.status).toBe('ended');
+  });
+
+  it('captures the error message on an error frame', () => {
+    const errFrame: GatewayStreamEvent = {
+      kind: 'error',
+      seq: 1,
+      error: { code: 'E_X', message: 'boom' },
+      requestId: 'r',
+    };
+    const v = applyWorkerStreamFrame(emptyWorkerStreamView(), errFrame);
+    expect(v.status).toBe('error');
+    expect(v.error).toBe('boom');
+  });
+
+  it('never mutates the input view (pure fold)', () => {
+    const base = emptyWorkerStreamView();
+    const next = applyWorkerStreamFrame(base, dataFrame(0, { line: 'x' }));
+    expect(base.outputTail).toEqual([]);
+    expect(next).not.toBe(base);
+  });
+});
+
+describe('formatUsageMeter (T11936)', () => {
+  it('dashes when there is no usage', () => {
+    expect(formatUsageMeter(null)).toBe('— tokens');
+  });
+
+  it('renders a compact token + call meter', () => {
+    expect(
+      formatUsageMeter({ inputTokens: 0, outputTokens: 0, totalTokens: 12_400, records: 3 }),
+    ).toBe('12.4k tok · 3 calls');
+  });
+
+  it('uses the singular call form for one record', () => {
+    expect(
+      formatUsageMeter({ inputTokens: 0, outputTokens: 0, totalTokens: 500, records: 1 }),
+    ).toBe('500 tok · 1 call');
+  });
+});
+
+describe('renderWorkerStreamPanel (T11936)', () => {
+  it('renders a header with the task id, status, and usage meter', () => {
+    const lines = renderWorkerStreamPanel('T42', emptyWorkerStreamView());
+    expect(lines[0]).toContain('T42');
+    expect(lines[0]).toContain('connecting');
+    expect(lines.join('\n')).toContain('waiting for worker output');
+  });
+
+  it('renders the output tail and checkpoint chips', () => {
+    let v = emptyWorkerStreamView();
+    v = applyWorkerStreamFrame(v, dataFrame(0, { line: 'line-1' }));
+    v = applyWorkerStreamFrame(v, dataFrame(1, { checkpoint: { kind: 'pr', label: '#7' } }));
+    const text = renderWorkerStreamPanel('T7', v).join('\n');
+    expect(text).toContain('line-1');
+    expect(text).toContain('pr:#7');
+  });
+});
+
+describe('isStreamStalled (T11936)', () => {
+  it('reports stalled when no frame has arrived past the window', () => {
+    const v: WorkerStreamView = {
+      ...emptyWorkerStreamView(),
+      lastFrameTs: '2026-06-09T00:00:00.000Z',
+    };
+    const now = Date.parse('2026-06-09T00:00:30.000Z');
+    expect(isStreamStalled(v, now, 10_000)).toBe(true);
+    expect(isStreamStalled(v, now, 60_000)).toBe(false);
+  });
+
+  it('is never stalled once ended or errored', () => {
+    const ended: WorkerStreamView = { ...emptyWorkerStreamView(), status: 'ended' };
+    expect(isStreamStalled(ended, Date.now(), 1)).toBe(false);
+  });
+});

--- a/packages/cleo/src/cli/lib/tui/cockpit.ts
+++ b/packages/cleo/src/cli/lib/tui/cockpit.ts
@@ -38,14 +38,45 @@ import {
   type TuiInstance,
 } from '../pi-tui-loader.js';
 import {
+  buildConductorLane,
+  clampTier,
+  dispatchWorker,
+  renderConductorLane,
+  type SpawnTier,
+} from './dispatch.js';
+import {
   buildKanbanBoard,
   type KanbanBoard,
+  type KanbanCard,
+  type KanbanLaneColumn,
   renderKanbanBoardText,
   type TuiTaskRow,
 } from './kanban-board.js';
+import { type SseSubscription, subscribeOrchestrateEvents } from './sse-client.js';
+import {
+  applyWorkerStreamFrame,
+  emptyWorkerStreamView,
+  renderWorkerStreamPanel,
+  type WorkerStreamView,
+} from './worker-stream.js';
 
 /** The default loopback gateway base URL (`cleo daemon serve` listener). */
 export const DEFAULT_TUI_BASE_URL = 'http://127.0.0.1:7777';
+
+/**
+ * The dispatch function the cockpit calls to spawn a worker. Defaults to the
+ * real {@link dispatchWorker} (SDK → gateway); overridable by unit tests so the
+ * dispatch action is exercisable without a daemon. Mirrors the
+ * {@link import('./dispatch.js').dispatchWorker} signature.
+ */
+export type DispatchFn = typeof dispatchWorker;
+
+/**
+ * The SSE subscribe function the cockpit calls to tail a Running card's worker
+ * stream. Defaults to the real {@link subscribeOrchestrateEvents}; overridable
+ * by unit tests so the stream wiring is exercisable without a socket.
+ */
+export type SubscribeFn = typeof subscribeOrchestrateEvents;
 
 /** Options for {@link runCockpit}. */
 export interface CockpitOptions {
@@ -57,6 +88,16 @@ export interface CockpitOptions {
    * command is testable and CI-safe). Defaults to `false`.
    */
   readonly once?: boolean;
+  /**
+   * Override the worker-dispatch function (test seam). Defaults to the real
+   * SDK-backed {@link dispatchWorker}.
+   */
+  readonly dispatch?: DispatchFn;
+  /**
+   * Override the SSE subscribe function (test seam). Defaults to the real
+   * {@link subscribeOrchestrateEvents}.
+   */
+  readonly subscribe?: SubscribeFn;
 }
 
 /** A line-emitting sink (defaults to stdout) — injectable for tests. */
@@ -107,54 +148,287 @@ async function fetchTaskRows(baseUrl: string): Promise<TuiTaskRow[] | null> {
   }
 }
 
+/** Lanes a card may be DISPATCHED from (`d`/Enter spawns a worker). */
+const DISPATCHABLE_LANES: ReadonlySet<string> = new Set(['backlog', 'ready']);
+
 /**
  * A pi-tui {@link import('../pi-tui-loader.js').Component} that renders the
- * Kanban board's plain-text body and reports which lane currently has keyboard
- * focus. The render output is the SAME body the fallback prints, so the two
- * paths can never diverge.
+ * Kanban board's plain-text body, tracks lane AND card keyboard focus, owns the
+ * confirm-gated dispatch action (T11935), and renders the live worker stream
+ * panel for a focused Running card (T11936).
+ *
+ * The board-body render is the SAME body the fallback prints (so the two paths
+ * can never diverge); the focus indicator, status line, conductor lane, and
+ * worker panel are appended below it. ALL dispatch + SSE go through injected
+ * functions ({@link DispatchFn} / {@link SubscribeFn}) — the component never
+ * imports a core domain or shells out (T11935 · AC3).
  */
 class KanbanBoardComponent {
   /** Index of the lane that currently holds keyboard focus. */
   private focusedLane = 0;
+  /** Index of the focused card WITHIN the focused lane. */
+  private focusedCard = 0;
+  /** Two-step confirm latch — set on the first dispatch key, cleared on action/move. */
+  private confirming = false;
+  /** Spawn tier for the next dispatch (cycled with `t`). */
+  private tier: SpawnTier = 1;
+  /** A transient single-line status message (dispatch result / hint). */
+  private status = '';
+  /** The folded worker-stream view for the focused Running card, or null. */
+  private workerView: WorkerStreamView | null = null;
+  /** The task id the worker panel is currently bound to. */
+  private workerTaskId: string | null = null;
+  /** The live SSE subscription for the worker panel, or null. */
+  private workerSub: SseSubscription | null = null;
 
-  constructor(private board: KanbanBoard) {}
+  constructor(
+    private board: KanbanBoard,
+    private readonly deps: {
+      readonly baseUrl: string;
+      readonly dispatch: DispatchFn;
+      readonly subscribe: SubscribeFn;
+      /** Ask the loop to re-render (set by the loop after construction). */
+      requestRender?: () => void;
+      /** Ask the loop to re-fetch + rebuild the board (set by the loop). */
+      refresh?: () => Promise<void>;
+    },
+  ) {}
 
-  /** Replace the board model (e.g. after a refresh) and reset cached render. */
+  /** Wire the render/refresh callbacks the loop owns. */
+  bind(requestRender: () => void, refresh: () => Promise<void>): void {
+    this.deps.requestRender = requestRender;
+    this.deps.refresh = refresh;
+  }
+
+  /** Replace the board model (e.g. after a refresh) and clamp focus. */
   setBoard(board: KanbanBoard): void {
     this.board = board;
     if (this.focusedLane >= board.columns.length) this.focusedLane = 0;
+    this.clampCardFocus();
+    // If the focused card moved off the Running lane, drop the worker stream.
+    this.reconcileWorkerPanel();
   }
 
-  /** Move keyboard focus one lane right (wraps). */
+  /** The currently-focused lane column, or undefined. */
+  private currentLane(): KanbanLaneColumn | undefined {
+    return this.board.columns[this.focusedLane];
+  }
+
+  /** The currently-focused card, or undefined. */
+  focusedCardModel(): KanbanCard | undefined {
+    return this.currentLane()?.cards[this.focusedCard];
+  }
+
+  /** Keep {@link focusedCard} within the focused lane's card range. */
+  private clampCardFocus(): void {
+    const count = this.currentLane()?.cards.length ?? 0;
+    if (count === 0) {
+      this.focusedCard = 0;
+      return;
+    }
+    if (this.focusedCard >= count) this.focusedCard = count - 1;
+    if (this.focusedCard < 0) this.focusedCard = 0;
+  }
+
+  /** Move keyboard focus one lane right (wraps), resetting card focus. */
   focusNextLane(): void {
     const n = this.board.columns.length || 1;
     this.focusedLane = (this.focusedLane + 1) % n;
+    this.focusedCard = 0;
+    this.confirming = false;
+    this.clampCardFocus();
+    this.reconcileWorkerPanel();
   }
 
-  /** Move keyboard focus one lane left (wraps). */
+  /** Move keyboard focus one lane left (wraps), resetting card focus. */
   focusPrevLane(): void {
     const n = this.board.columns.length || 1;
     this.focusedLane = (this.focusedLane - 1 + n) % n;
+    this.focusedCard = 0;
+    this.confirming = false;
+    this.clampCardFocus();
+    this.reconcileWorkerPanel();
+  }
+
+  /** Move card focus down within the lane (wraps). */
+  focusNextCard(): void {
+    const count = this.currentLane()?.cards.length ?? 0;
+    if (count === 0) return;
+    this.focusedCard = (this.focusedCard + 1) % count;
+    this.confirming = false;
+    this.reconcileWorkerPanel();
+  }
+
+  /** Move card focus up within the lane (wraps). */
+  focusPrevCard(): void {
+    const count = this.currentLane()?.cards.length ?? 0;
+    if (count === 0) return;
+    this.focusedCard = (this.focusedCard - 1 + count) % count;
+    this.confirming = false;
+    this.reconcileWorkerPanel();
   }
 
   /** The id of the currently-focused lane (for the status bar / tests). */
   focusedLaneId(): string {
-    return this.board.columns[this.focusedLane]?.lane ?? '';
+    return this.currentLane()?.lane ?? '';
+  }
+
+  /** Cycle the spawn tier 1 → 2 → 0 → 1 (for the next dispatch). */
+  cycleTier(): void {
+    this.tier = clampTier((this.tier + 1) % 3);
+  }
+
+  /** The current spawn tier (for tests / status). */
+  currentTier(): SpawnTier {
+    return this.tier;
+  }
+
+  /** The current transient status line (for tests). */
+  statusLine(): string {
+    return this.status;
+  }
+
+  /** Whether the component is awaiting a dispatch confirm (for tests). */
+  isConfirming(): boolean {
+    return this.confirming;
+  }
+
+  /**
+   * Handle the dispatch key (`d` / Enter) on the focused card.
+   *
+   * Two-step confirm — spawning is real + expensive. The first press latches
+   * `confirming` and shows the confirm prompt; the second press performs the
+   * spawn via the injected dispatch fn (SDK → gateway), surfaces the result
+   * inline, and (on success) re-fetches so the worker lands in the Running lane.
+   * NEVER throws — a failed dispatch sets the status line, never crashes.
+   */
+  async requestDispatch(): Promise<void> {
+    const lane = this.focusedLaneId();
+    const card = this.focusedCardModel();
+    if (card === undefined) {
+      this.status = 'No card focused to dispatch.';
+      this.deps.requestRender?.();
+      return;
+    }
+    if (!DISPATCHABLE_LANES.has(lane)) {
+      this.status = `Dispatch is only available on Backlog/Ready cards (focused: ${lane}).`;
+      this.confirming = false;
+      this.deps.requestRender?.();
+      return;
+    }
+    if (!this.confirming) {
+      this.confirming = true;
+      this.status = `Spawn a real worker for ${card.id} (tier ${this.tier})? Press [d] again to confirm, [Esc] to cancel.`;
+      this.deps.requestRender?.();
+      return;
+    }
+
+    // Second press — perform the spawn.
+    this.confirming = false;
+    this.status = `Dispatching ${card.id} (tier ${this.tier})…`;
+    this.deps.requestRender?.();
+
+    const result = await this.deps.dispatch(this.deps.baseUrl, card.id, this.tier);
+    if (result.ok) {
+      this.status = `Dispatched ${result.taskId} → Running (tier ${result.tier}).`;
+      // Re-fetch so the spawned worker surfaces in the Running lane.
+      await this.deps.refresh?.();
+    } else {
+      this.status = `Dispatch failed for ${result.taskId}: ${result.code} — ${result.message}`;
+    }
+    this.deps.requestRender?.();
+  }
+
+  /** Clear the confirm latch (Esc) without dispatching. */
+  cancelConfirm(): void {
+    if (this.confirming) {
+      this.confirming = false;
+      this.status = 'Dispatch cancelled.';
+      this.deps.requestRender?.();
+    }
+  }
+
+  /**
+   * Bind / rebind the live worker stream to the focused card when (and only
+   * when) it is a Running card, tearing down any prior subscription. Idempotent
+   * for the same task — re-focusing the same Running card does not churn the
+   * socket.
+   */
+  private reconcileWorkerPanel(): void {
+    const lane = this.focusedLaneId();
+    const card = this.focusedCardModel();
+    const targetId = lane === 'running' && card !== undefined ? card.id : null;
+
+    if (targetId === this.workerTaskId) return; // No change — keep the stream.
+
+    // Detach the previous stream first (clean unsubscribe on blur).
+    this.teardownWorkerPanel();
+
+    if (targetId === null) return; // Focused card is not a Running worker.
+
+    this.workerTaskId = targetId;
+    this.workerView = emptyWorkerStreamView();
+    this.workerSub = this.deps.subscribe(
+      { baseUrl: this.deps.baseUrl, taskId: targetId },
+      {
+        onFrame: (frame) => {
+          // Drop late frames for a card we've since blurred away from.
+          if (this.workerTaskId !== targetId || this.workerView === null) return;
+          this.workerView = applyWorkerStreamFrame(this.workerView, frame);
+          this.deps.requestRender?.();
+        },
+        onError: (reason) => {
+          if (this.workerTaskId !== targetId) return;
+          this.status = `Worker stream for ${targetId} unavailable: ${reason}`;
+          this.deps.requestRender?.();
+        },
+      },
+    );
+  }
+
+  /** Tear down the active worker subscription + panel state (leak-free). */
+  teardownWorkerPanel(): void {
+    if (this.workerSub !== null) {
+      this.workerSub.unsubscribe();
+      this.workerSub = null;
+    }
+    this.workerView = null;
+    this.workerTaskId = null;
   }
 
   /** No cached state to clear — render is pure over the current board. */
   invalidate(): void {}
 
-  /** Render the board body plus a focus indicator + key legend. */
+  /** Render the board body plus the focus indicator, dispatch affordances,
+   * conductor lane, status line, and (on a Running card) the worker panel. */
   render(_width: number): string[] {
     const lines = renderKanbanBoardText(this.board);
-    const focused = this.board.columns[this.focusedLane];
+    const lane = this.currentLane();
+    const card = this.focusedCardModel();
+
+    // Focus indicator — lane + the specific focused card.
+    const focusCard = card !== undefined ? `${card.id}` : '—';
+    lines.push(`Focus: ${lane?.label ?? '—'} › ${focusCard}   (tier ${this.tier})`);
+
+    // Conductor role lane for a dispatchable focused card.
+    if (card !== undefined && DISPATCHABLE_LANES.has(lane?.lane ?? '')) {
+      lines.push(renderConductorLane(buildConductorLane(card.id, card.assignee)));
+    }
+
+    // Live worker stream panel for a focused Running card (T11936).
+    if (this.workerView !== null && this.workerTaskId !== null) {
+      for (const l of renderWorkerStreamPanel(this.workerTaskId, this.workerView)) {
+        lines.push(l);
+      }
+    }
+
+    // Transient status line (dispatch result / confirm prompt / hint).
+    if (this.status.length > 0) lines.push(this.status);
+
     lines.push(
-      `Focus: ${focused?.label ?? '—'}   ` +
-        `[←/→ or h/l] move lane   [Tab] cycle   [r] refresh   [q] quit`,
+      '[←/→ h/l] lane   [↑/↓ j/k] card   [Tab] cycle lane   [d/Enter] dispatch   ' +
+        '[t] tier   [Esc] cancel   [r] refresh   [q] quit',
     );
-    // TODO(T11935): dispatch via orchestrate.spawn — Enter on a focused card in
-    // the Ready lane will transition + spawn a worker. Read-only home view for now.
     return lines;
   }
 }
@@ -177,14 +451,27 @@ function runInteractiveLoop(
     const tui: TuiInstance = new piTui.TUI(terminal);
     tui.addChild(component);
 
+    // Wire the component's render + refresh callbacks. Async dispatch results,
+    // SSE frames, and the post-dispatch re-fetch all drive a re-render through
+    // these, so the component never references the loop directly.
+    component.bind(
+      () => tui.requestRender(),
+      async () => {
+        await refresh();
+        tui.requestRender(true);
+      },
+    );
+
     const dispose = tui.addInputListener((data: string) => {
-      // Minimal keyboard-navigation skeleton (arrow keys + vim h/l + Tab).
+      // Quit — tear the worker stream down first so no socket leaks.
       if (data === 'q' || data === '' /* Ctrl-C */) {
+        component.teardownWorkerPanel();
         dispose();
         tui.stop();
         resolve();
         return { consume: true };
       }
+      // Lane navigation (arrow keys + vim h/l + Tab).
       if (data === '[C' || data === 'l' || data === '\t') {
         component.focusNextLane();
         tui.requestRender();
@@ -192,6 +479,35 @@ function runInteractiveLoop(
       }
       if (data === '[D' || data === 'h') {
         component.focusPrevLane();
+        tui.requestRender();
+        return { consume: true };
+      }
+      // Card navigation within the focused lane (arrow keys + vim j/k).
+      if (data === '[B' || data === 'j') {
+        component.focusNextCard();
+        tui.requestRender();
+        return { consume: true };
+      }
+      if (data === '[A' || data === 'k') {
+        component.focusPrevCard();
+        tui.requestRender();
+        return { consume: true };
+      }
+      // Dispatch (confirm-gated) — `d` or Enter (CR/LF). requestDispatch drives
+      // its own re-renders via the bound callback (it awaits the async SDK spawn).
+      if (data === 'd' || data === '\r' || data === '\n') {
+        void component.requestDispatch();
+        return { consume: true };
+      }
+      // Cycle the spawn tier for the next dispatch.
+      if (data === 't') {
+        component.cycleTier();
+        tui.requestRender();
+        return { consume: true };
+      }
+      // Cancel a pending dispatch confirm (Esc).
+      if (data === '') {
+        component.cancelConfirm();
         tui.requestRender();
         return { consume: true };
       }
@@ -221,6 +537,10 @@ export async function runCockpit(
   sink: LineSink = (line) => process.stdout.write(`${line}\n`), // stdout-write-allowed: interactive TUI / plain-text board + degrade render (T11933) // stdout-discipline-allowed: interactive TUI / plain-text board + degrade render (T11933)
 ): Promise<CockpitResult> {
   const baseUrl = options.baseUrl ?? DEFAULT_TUI_BASE_URL;
+  // Dispatch + SSE go through these (test-overridable; default to the real
+  // SDK-backed implementations — NO core domain import, NO CLI shell-out).
+  const dispatch: DispatchFn = options.dispatch ?? dispatchWorker;
+  const subscribe: SubscribeFn = options.subscribe ?? subscribeOrchestrateEvents;
 
   // 1. Fetch home data through the SDK. null ⇒ daemon unreachable.
   const rows = await fetchTaskRows(baseUrl);
@@ -258,7 +578,7 @@ export async function runCockpit(
     return { outcome: 'degraded-pi', baseUrl, piTui: false };
   }
 
-  const component = new KanbanBoardComponent(board);
+  const component = new KanbanBoardComponent(board, { baseUrl, dispatch, subscribe });
   const refresh = async (): Promise<void> => {
     const fresh = await fetchTaskRows(baseUrl);
     if (fresh !== null) component.setBoard(buildKanbanBoard(fresh));

--- a/packages/cleo/src/cli/lib/tui/dispatch.ts
+++ b/packages/cleo/src/cli/lib/tui/dispatch.ts
@@ -1,0 +1,189 @@
+/**
+ * Dispatch path for the `cleo tui` cockpit — spawn a worker for a focused
+ * Backlog/Ready card via `orchestrate.spawn` THROUGH the gateway SDK client
+ * (T11935 · M5). Plus the pure Conductor role-lane builder the dispatch UI
+ * renders (orchestrator → Lead → worker).
+ *
+ * ## SDK-only, no shell-out (T11935 · AC3)
+ *
+ * Spawning is real + expensive (it provisions a git worktree). It routes ONLY
+ * through {@link createCleoClient}`.orchestrate.spawn` against the daemon's
+ * `/v1` listener — there is NO `child_process`, NO `cleo` CLI shell-out, NO
+ * direct `@cleocode/core` domain import. This mirrors the Studio dispatch route
+ * (`/api/tasks/[id]/dispatch`, relate T11930): the SAME bound SDK method, the
+ * SAME gateway-only policy, the SAME typed-error surface so the two human
+ * surfaces dispatch identically.
+ *
+ * The generated SDK types `orchestrate.spawn` with `body?: never` (the op's
+ * params are not individually contracted in the OpenAPI projection yet), but the
+ * gateway reads the POST JSON body as the operation params at runtime. We type
+ * the body locally and forward it via the bound method, casting ONLY the options
+ * bag at this single boundary — no `any`, no `as unknown as` chain on data.
+ *
+ * Errors NEVER throw out of {@link dispatchWorker}: a daemon-down connection, a
+ * rejected spawn, and an unexpected failure all resolve to a typed
+ * {@link DispatchResult} the cockpit renders inline on a status line — the TUI
+ * never crashes (T11935 · AC3).
+ *
+ * @packageDocumentation
+ * @task T11935
+ * @epic T11916
+ * @see packages/studio/src/routes/api/tasks/[id]/dispatch/+server.ts — the Studio reference (relate T11930)
+ */
+
+import { createCleoClient } from '@cleocode/core/gateway-client';
+
+/** Spawn tier — the `--tier` knob on `orchestrate.spawn` (0=minimal,1=default,2=full). */
+export type SpawnTier = 0 | 1 | 2;
+
+/**
+ * The `orchestrate.spawn` request body shape (taskId + spawn knobs). Typed
+ * locally because the generated SDK declares the op body as `never`; the gateway
+ * reads it as the operation params at runtime.
+ */
+interface SpawnBody {
+  /** The task to dispatch a worker for. */
+  taskId: string;
+  /** Spawn prompt tier. */
+  tier?: SpawnTier;
+}
+
+/** The bound spawn method, re-typed to accept the runtime body params. */
+type SpawnInvoker = (opts: { body: SpawnBody }) => Promise<{
+  data?: { success?: boolean; data?: Record<string, unknown>; error?: { message?: string } };
+  response?: unknown;
+}>;
+
+/** Outcome of a {@link dispatchWorker} call. */
+export type DispatchResult =
+  | {
+      /** The spawn succeeded — the worker is provisioned. */
+      readonly ok: true;
+      /** The task dispatched. */
+      readonly taskId: string;
+      /** The tier requested. */
+      readonly tier: SpawnTier;
+      /** The raw `/data` payload from the spawn envelope (worktree path, branch, …). */
+      readonly data: Record<string, unknown>;
+    }
+  | {
+      /** The spawn did not happen. */
+      readonly ok: false;
+      /** The task that failed to dispatch. */
+      readonly taskId: string;
+      /** A typed reason code for the inline status line. */
+      readonly code: 'E_GATEWAY_UNREACHABLE' | 'E_SPAWN_REJECTED' | 'E_SPAWN_ERROR';
+      /** A human-readable, single-line message. */
+      readonly message: string;
+    };
+
+/** Clamp an arbitrary tier to the valid `0 | 1 | 2` set, defaulting to `1`. */
+export function clampTier(raw: number): SpawnTier {
+  return raw === 0 || raw === 2 ? raw : 1;
+}
+
+/**
+ * Dispatch a worker for `taskId` by calling `orchestrate.spawn` through the
+ * gateway SDK client. NEVER throws — every failure (daemon unreachable, rejected
+ * spawn, unexpected error) resolves to a typed {@link DispatchResult} the
+ * cockpit renders inline.
+ *
+ * The hey-api client does NOT throw on a failed connection; it yields a result
+ * with NO `response` object (the request never reached an HTTP server) — the
+ * same daemon-down signal the cockpit's unary read path keys on. We map that to
+ * `E_GATEWAY_UNREACHABLE`.
+ *
+ * @param baseUrl - The gateway base URL (the cockpit's configured target).
+ * @param taskId - The Backlog/Ready task to spawn a worker for.
+ * @param tier - The spawn prompt tier (defaults to `1`).
+ * @returns A {@link DispatchResult} — success carries the spawn `/data`, failure
+ *   a typed code + message.
+ */
+export async function dispatchWorker(
+  baseUrl: string,
+  taskId: string,
+  tier: SpawnTier = 1,
+): Promise<DispatchResult> {
+  try {
+    const client = createCleoClient({ baseUrl });
+    // The wrapper forwards the options bag verbatim (injecting the client), so a
+    // body reaches the gateway as the operation params despite the `never` type.
+    const spawn = client.orchestrate.spawn as unknown as SpawnInvoker;
+    const res = await spawn({ body: { taskId, tier } });
+
+    // No `response` object ⇒ the request never reached an HTTP server (daemon
+    // not serving) — distinct from a reachable daemon that rejected the spawn.
+    if (res.response == null) {
+      return {
+        ok: false,
+        taskId,
+        code: 'E_GATEWAY_UNREACHABLE',
+        message: 'daemon gateway not reachable — start it with `cleo daemon serve`',
+      };
+    }
+
+    const envelope = res.data;
+    if (envelope && envelope.success === false) {
+      return {
+        ok: false,
+        taskId,
+        code: 'E_SPAWN_REJECTED',
+        message: envelope.error?.message ?? 'spawn rejected',
+      };
+    }
+
+    return { ok: true, taskId, tier, data: envelope?.data ?? {} };
+  } catch (e) {
+    // Defensive: a thrown transport error is also "could not dispatch".
+    const message = e instanceof Error ? e.message : 'spawn failed';
+    return { ok: false, taskId, code: 'E_SPAWN_ERROR', message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conductor role lane (orchestrator → Lead → worker)
+// ---------------------------------------------------------------------------
+
+/** One node in the Conductor role chain. */
+export interface ConductorRole {
+  /** Role label (`Orchestrator` | `Lead` | `Worker`). */
+  readonly label: string;
+  /** The concrete value bound to this role (e.g. `you`, `orchestrate`, the assignee). */
+  readonly value: string;
+  /** A one-line hint describing the role's part in the dispatch. */
+  readonly hint: string;
+}
+
+/**
+ * Build the Conductor role lane the dispatch UI renders for a card — the
+ * orchestrator → Lead → worker chain the spawn composes, from the data already
+ * on the card (no extra fetch). Mirrors the Studio ConductorBar role chain
+ * (relate T11930) so both surfaces show the same lifecycle.
+ *
+ * @param taskId - The task being dispatched.
+ * @param assignee - The claimed worker/agent id, when known (else `worktree`).
+ * @returns The three-node {@link ConductorRole} chain in dispatch order.
+ */
+export function buildConductorLane(taskId: string, assignee: string | null): ConductorRole[] {
+  return [
+    { label: 'Orchestrator', value: 'you', hint: 'cockpit dispatcher' },
+    { label: 'Lead', value: 'orchestrate', hint: 'spawn pipeline' },
+    {
+      label: 'Worker',
+      value: assignee && assignee.length > 0 ? assignee : 'worktree',
+      hint: `isolated agent · ${taskId}`,
+    },
+  ];
+}
+
+/**
+ * Render the Conductor role lane as a single compact terminal line, e.g.
+ * `Conductor: Orchestrator(you) → Lead(orchestrate) → Worker(worktree)`.
+ *
+ * @param roles - The chain from {@link buildConductorLane}.
+ * @returns One render line.
+ */
+export function renderConductorLane(roles: readonly ConductorRole[]): string {
+  const chain = roles.map((r) => `${r.label}(${r.value})`).join(' → ');
+  return `Conductor: ${chain}`;
+}

--- a/packages/cleo/src/cli/lib/tui/sse-client.ts
+++ b/packages/cleo/src/cli/lib/tui/sse-client.ts
@@ -1,0 +1,224 @@
+/**
+ * Minimal SSE consumer for the gateway streaming surface (T11936 · M5).
+ *
+ * The generated gateway SDK client ({@link import('@cleocode/core/gateway-client')})
+ * covers only the UNARY operations — streaming ops (`OperationDef.streaming`,
+ * served as `GET /v1/<domain>/<operation>`, T11921) are deliberately NOT in the
+ * flat SDK because a `text/event-stream` response is not a single JSON envelope.
+ * This module is the thin, dependency-free SSE reader the cockpit uses to tail
+ * `GET /v1/orchestrate/events` and feed decoded
+ * {@link import('@cleocode/contracts/gateway').GatewayStreamEvent} frames into
+ * the pure {@link import('./worker-stream.js') | worker-stream fold}.
+ *
+ * ## Wire format (mirrors the gateway encoder)
+ *
+ * The gateway encodes each frame as a `data:`-only SSE record —
+ * `id: <seq>\ndata: <json-of-GatewayStreamEvent>\n\n` (see
+ * `packages/runtime/src/gateway/http/sse.ts` `encodeStreamEvent`). The client
+ * demultiplexes on the decoded frame's `kind`/`seq`; no named `event:` field is
+ * used. We buffer the chunked body, split on the blank-line record terminator,
+ * extract the `data:` payload, `JSON.parse` it, and hand each frame to the
+ * caller's `onFrame`.
+ *
+ * ## Lifecycle + graceful degrade
+ *
+ * {@link subscribeOrchestrateEvents} opens ONE `http.get` request and returns a
+ * {@link SseSubscription} with an `unsubscribe()` that aborts the request and
+ * detaches all listeners — so the cockpit can subscribe on Running-card focus
+ * and tear down cleanly on blur / quit, leak-free. A connection failure (daemon
+ * down) is reported via `onError` and NEVER thrown — the cockpit already keys
+ * daemon-down off `res.response == null` for the unary path, and the worker
+ * panel degrades to a "daemon not reachable" line rather than crashing.
+ *
+ * Uses `node:http` directly (not `fetch`/`EventSource`) so it works on the Node
+ * 24 baseline with zero new dependency and gives us a synchronous `req.destroy()`
+ * for deterministic teardown.
+ *
+ * @packageDocumentation
+ * @task T11936
+ * @epic T11916
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+import type { GatewayStreamEvent } from '@cleocode/contracts/gateway';
+
+/** A live SSE subscription handle. */
+export interface SseSubscription {
+  /**
+   * Abort the underlying request and detach every listener. Idempotent — a
+   * second call is a no-op. Called on Running-card blur, on a switch to another
+   * card, and on cockpit quit.
+   */
+  unsubscribe(): void;
+}
+
+/** Callbacks for {@link subscribeOrchestrateEvents}. */
+export interface SseSubscribeHandlers {
+  /** Invoked once per decoded {@link GatewayStreamEvent} frame. */
+  onFrame(frame: GatewayStreamEvent): void;
+  /**
+   * Invoked when the connection fails or the socket errors. NON-FATAL — the
+   * cockpit renders a degraded panel line; the TUI never crashes.
+   */
+  onError?(reason: string): void;
+  /** Invoked once when the stream closes (terminal frame or socket end). */
+  onClose?(): void;
+}
+
+/** Options for {@link subscribeOrchestrateEvents}. */
+export interface SseSubscribeOptions {
+  /** Gateway base URL (the `cleo daemon serve` listener). */
+  readonly baseUrl: string;
+  /**
+   * Task id to scope the worker stream to, forwarded as the `taskId` query
+   * param. The default tick source ignores it; a daemon-injected origin-tailing
+   * source filters its frames by it.
+   */
+  readonly taskId?: string;
+  /** Default headers (e.g. an `Authorization` bearer) merged into the request. */
+  readonly headers?: Record<string, string>;
+}
+
+/**
+ * A no-op subscription (already torn down). Returned when the base URL cannot be
+ * parsed, so the caller always gets a stable `unsubscribe()` to call.
+ */
+const NOOP_SUBSCRIPTION: SseSubscription = { unsubscribe: () => {} };
+
+/**
+ * Decode one SSE record (the text between blank-line terminators) into a
+ * {@link GatewayStreamEvent}. Extracts the `data:` field (joining multi-line
+ * `data:` continuations per the SSE spec) and `JSON.parse`s it. Returns `null`
+ * for a comment/keepalive record or an unparseable payload, so a malformed frame
+ * is skipped rather than crashing the reader.
+ *
+ * @param record - One SSE record (no trailing blank line).
+ * @returns The decoded frame, or `null` to skip.
+ */
+export function decodeSseRecord(record: string): GatewayStreamEvent | null {
+  const dataLines: string[] = [];
+  for (const rawLine of record.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (line.startsWith(':')) continue; // SSE comment / keepalive.
+    if (line.startsWith('data:')) {
+      // Strip `data:` and at most one leading space (SSE field-value rule).
+      dataLines.push(line.slice(5).replace(/^ /, ''));
+    }
+  }
+  if (dataLines.length === 0) return null;
+  try {
+    const parsed = JSON.parse(dataLines.join('\n')) as unknown;
+    if (parsed === null || typeof parsed !== 'object') return null;
+    const obj = parsed as Record<string, unknown>;
+    if (obj.kind !== 'data' && obj.kind !== 'done' && obj.kind !== 'error') return null;
+    if (typeof obj.seq !== 'number') return null;
+    return parsed as GatewayStreamEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribe to the gateway `orchestrate.events` SSE stream and forward each
+ * decoded {@link GatewayStreamEvent} to `handlers.onFrame`.
+ *
+ * Opens `GET <baseUrl>/v1/orchestrate/events[?taskId=…]` with an
+ * `Accept: text/event-stream` header, streams the chunked body, splits it into
+ * SSE records, and decodes each into a frame. A connection error (daemon down)
+ * is reported through `handlers.onError` — NEVER thrown — and the returned
+ * subscription is a clean teardown either way.
+ *
+ * @param options - {@link SseSubscribeOptions} (at minimum the gateway base URL).
+ * @param handlers - {@link SseSubscribeHandlers} for frames / errors / close.
+ * @returns An {@link SseSubscription} whose `unsubscribe()` aborts the request.
+ */
+export function subscribeOrchestrateEvents(
+  options: SseSubscribeOptions,
+  handlers: SseSubscribeHandlers,
+): SseSubscription {
+  let url: URL;
+  try {
+    url = new URL('/v1/orchestrate/events', options.baseUrl);
+  } catch {
+    handlers.onError?.('invalid gateway base URL');
+    return NOOP_SUBSCRIPTION;
+  }
+  if (typeof options.taskId === 'string' && options.taskId.length > 0) {
+    url.searchParams.set('taskId', options.taskId);
+  }
+
+  const transport = url.protocol === 'https:' ? https : http;
+
+  let buffer = '';
+  let closed = false;
+  let request: http.ClientRequest | null = null;
+
+  /** Tear down exactly once: abort the request, detach listeners, fire onClose. */
+  const teardown = (fireClose: boolean): void => {
+    if (closed) return;
+    closed = true;
+    if (request !== null) {
+      request.removeAllListeners();
+      // `destroy()` aborts the in-flight request synchronously (no late frames).
+      request.destroy();
+      request = null;
+    }
+    if (fireClose) handlers.onClose?.();
+  };
+
+  request = transport.get(
+    url,
+    {
+      headers: {
+        Accept: 'text/event-stream',
+        ...(options.headers ?? {}),
+      },
+    },
+    (res) => {
+      const status = res.statusCode ?? 0;
+      if (status < 200 || status >= 300) {
+        res.resume(); // drain so the socket can free.
+        handlers.onError?.(`gateway stream returned HTTP ${status}`);
+        teardown(true);
+        return;
+      }
+
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        if (closed) return;
+        buffer += chunk;
+        // SSE records are separated by a blank line (`\n\n`). Process every
+        // complete record; keep the trailing partial in the buffer.
+        let sep = buffer.indexOf('\n\n');
+        while (sep !== -1) {
+          const record = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+          const frame = decodeSseRecord(record);
+          if (frame !== null) {
+            handlers.onFrame(frame);
+            if (frame.kind === 'done' || frame.kind === 'error') {
+              teardown(true);
+              return;
+            }
+          }
+          sep = buffer.indexOf('\n\n');
+        }
+      });
+      res.on('end', () => teardown(true));
+      res.on('error', (e: Error) => {
+        handlers.onError?.(e.message);
+        teardown(true);
+      });
+    },
+  );
+
+  request.on('error', (e: Error) => {
+    handlers.onError?.(e.message);
+    teardown(true);
+  });
+
+  return {
+    unsubscribe: () => teardown(false),
+  };
+}

--- a/packages/cleo/src/cli/lib/tui/worker-stream.ts
+++ b/packages/cleo/src/cli/lib/tui/worker-stream.ts
@@ -1,0 +1,306 @@
+/**
+ * Pure aggregation for the LIVE WORKER STREAM rendered on a focused Running-lane
+ * card in the `cleo tui` cockpit (T11936 · M5).
+ *
+ * A focused Running card subscribes to the gateway SSE stream
+ * (`GET /v1/orchestrate/events`, T11921) and folds the sequence of
+ * {@link import('@cleocode/contracts/gateway').GatewayStreamEvent} frames into a
+ * single render-ready {@link WorkerStreamView}: the worker output tail, the
+ * usage / cost meter, the heartbeat clock, and any proof checkpoints. The fold
+ * mirrors the Studio worker-stream fold (relate T11936 ↔ T11929) so the terminal
+ * and web surfaces render the SAME live-worker semantics from the SAME wire
+ * frames — one stream contract, two renderers, zero divergence.
+ *
+ * This module is deliberately FRAMEWORK-FREE — no pi-tui, no `node:http`, no
+ * gateway client. It takes already-decoded {@link GatewayStreamEvent} frames and
+ * returns plain view-models + render lines, so the fold + the meter formatting
+ * are trivially unit-testable under vitest's node environment without a TTY, a
+ * socket, or the optional pi-tui dep. The SSE socket lifecycle (subscribe on
+ * focus, unsubscribe on blur/close, degrade when the daemon is down) lives in
+ * the {@link import('./sse-client.js') | SSE client} and is wired by the cockpit.
+ *
+ * ## Frame mapping (gateway `GatewayStreamEvent` → worker view)
+ *
+ * The gateway emits a generic `{ kind: 'data' | 'done' | 'error', seq, data }`
+ * frame. The cockpit's running-worker source carries the lifecycle payload in
+ * `data`; this fold narrows that payload defensively (every field optional, read
+ * with a type guard) so a heartbeat tick, an output line, a usage snapshot, and
+ * a checkpoint all route to the right slot, and an unrecognised `data` frame is
+ * treated as a heartbeat (it still proves the stream is live) rather than
+ * crashing the view.
+ *
+ * @task T11936
+ * @epic T11916
+ * @see packages/studio/src/lib/components/tasks/worker-stream.ts — the Studio fold (relate T11929)
+ */
+
+import type { GatewayStreamEvent } from '@cleocode/contracts/gateway';
+
+/** Live-connection state of the stream, driving the panel's status indicator. */
+export type WorkerStreamStatus = 'connecting' | 'live' | 'stalled' | 'ended' | 'error';
+
+/** Usage / cost snapshot folded from `usage`-bearing frames. */
+export interface WorkerUsageSnapshot {
+  /** Cumulative input tokens for this worker's task. */
+  readonly inputTokens: number;
+  /** Cumulative output tokens for this worker's task. */
+  readonly outputTokens: number;
+  /** Cumulative total tokens (input + output). */
+  readonly totalTokens: number;
+  /** Number of token-usage records aggregated. */
+  readonly records: number;
+}
+
+/** A proof checkpoint a worker reaches — surfaced as a chip in the panel. */
+export interface WorkerCheckpoint {
+  /** Checkpoint kind. */
+  readonly kind: 'commit' | 'pr' | 'test';
+  /** Short human-readable label (e.g. a sha7, `#123`, `42 passed`). */
+  readonly label: string;
+}
+
+/** The folded, render-ready view-model for one worker stream. */
+export interface WorkerStreamView {
+  /** Connection state. */
+  readonly status: WorkerStreamStatus;
+  /**
+   * The tail of the worker's output — most-recent-last, capped at
+   * {@link DEFAULT_OUTPUT_TAIL}. The panel renders the last N of these.
+   */
+  readonly outputTail: readonly string[];
+  /** Latest usage / cost snapshot, or `null` until a usage frame arrives. */
+  readonly usage: WorkerUsageSnapshot | null;
+  /** Proof checkpoints reached, in observation order. */
+  readonly checkpoints: readonly WorkerCheckpoint[];
+  /** ISO timestamp of the most recent frame of ANY kind (the heartbeat clock). */
+  readonly lastFrameTs: string | null;
+  /** A terminal error message, when the stream ended via an `error` frame. */
+  readonly error: string | null;
+}
+
+/** How many output lines the tail retains (older lines roll off). */
+export const DEFAULT_OUTPUT_TAIL = 200;
+
+/**
+ * The empty view-model — the initial state before any frame arrives.
+ *
+ * @returns A fresh {@link WorkerStreamView} in the `connecting` state.
+ */
+export function emptyWorkerStreamView(): WorkerStreamView {
+  return {
+    status: 'connecting',
+    outputTail: [],
+    usage: null,
+    checkpoints: [],
+    lastFrameTs: null,
+    error: null,
+  };
+}
+
+/** Read a string field off a loosely-typed payload, or `undefined`. */
+function readString(payload: Record<string, unknown>, key: string): string | undefined {
+  const v = payload[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+/** Read a finite-number field off a loosely-typed payload, or `0`. */
+function readNumber(payload: Record<string, unknown>, key: string): number {
+  const v = payload[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+/**
+ * Narrow a frame's `data` payload into a {@link WorkerUsageSnapshot} when it
+ * carries token-usage fields, else `null`. Accepts either a nested `usage`
+ * object or flat `inputTokens` / `outputTokens` / `totalTokens` fields.
+ *
+ * @param payload - The frame `data` object.
+ * @returns A usage snapshot, or `null` when the payload carries no usage.
+ */
+function readUsage(payload: Record<string, unknown>): WorkerUsageSnapshot | null {
+  const source =
+    payload.usage && typeof payload.usage === 'object'
+      ? (payload.usage as Record<string, unknown>)
+      : payload;
+  const hasUsage =
+    'inputTokens' in source ||
+    'outputTokens' in source ||
+    'totalTokens' in source ||
+    'records' in source;
+  if (!hasUsage) return null;
+  const inputTokens = readNumber(source, 'inputTokens');
+  const outputTokens = readNumber(source, 'outputTokens');
+  const totalTokens =
+    'totalTokens' in source ? readNumber(source, 'totalTokens') : inputTokens + outputTokens;
+  const records = 'records' in source ? readNumber(source, 'records') : 1;
+  return { inputTokens, outputTokens, totalTokens, records };
+}
+
+/**
+ * Narrow a frame's `data` payload into a {@link WorkerCheckpoint} when it carries
+ * a `checkpoint` of a known kind, else `null`.
+ *
+ * @param payload - The frame `data` object.
+ * @returns A checkpoint, or `null` when the payload carries none.
+ */
+function readCheckpoint(payload: Record<string, unknown>): WorkerCheckpoint | null {
+  const cp = payload.checkpoint;
+  if (cp === null || typeof cp !== 'object') return null;
+  const obj = cp as Record<string, unknown>;
+  const kind = obj.kind;
+  if (kind !== 'commit' && kind !== 'pr' && kind !== 'test') return null;
+  const label = readString(obj, 'label') ?? '';
+  return { kind, label };
+}
+
+/**
+ * Fold ONE {@link GatewayStreamEvent} frame into the running view-model,
+ * returning a NEW view (pure — never mutates the input).
+ *
+ * Frame routing:
+ *  - `error` → terminal `error` state, carrying the error message.
+ *  - `done`  → terminal `ended` state.
+ *  - `data`  → narrowed by payload shape: an `output` line appends to the tail,
+ *              a `usage` snapshot updates the meter, a `checkpoint` is recorded;
+ *              anything else is a heartbeat (proves the stream is live).
+ *
+ * @param view - The current view-model.
+ * @param frame - The decoded gateway stream frame to apply.
+ * @param maxTail - Output-tail cap (defaults to {@link DEFAULT_OUTPUT_TAIL}).
+ * @returns The next view-model.
+ */
+export function applyWorkerStreamFrame(
+  view: WorkerStreamView,
+  frame: GatewayStreamEvent,
+  maxTail: number = DEFAULT_OUTPUT_TAIL,
+): WorkerStreamView {
+  if (frame.kind === 'error') {
+    return {
+      ...view,
+      status: 'error',
+      error: frame.error?.message ?? 'stream error',
+    };
+  }
+
+  const payload =
+    frame.data && typeof frame.data === 'object'
+      ? (frame.data as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+  const lastFrameTs = readString(payload, 'ts') ?? new Date().toISOString();
+
+  if (frame.kind === 'done') {
+    return { ...view, status: 'ended', lastFrameTs };
+  }
+
+  // kind === 'data' — narrow by payload shape.
+  const usage = readUsage(payload);
+  if (usage !== null) {
+    return { ...view, status: 'live', usage, lastFrameTs };
+  }
+
+  const checkpoint = readCheckpoint(payload);
+  if (checkpoint !== null) {
+    return {
+      ...view,
+      status: 'live',
+      checkpoints: [...view.checkpoints, checkpoint],
+      lastFrameTs,
+    };
+  }
+
+  const line = readString(payload, 'line') ?? readString(payload, 'output');
+  if (line !== undefined) {
+    const next = [...view.outputTail, line];
+    const outputTail = next.length > maxTail ? next.slice(next.length - maxTail) : next;
+    return { ...view, status: 'live', outputTail, lastFrameTs };
+  }
+
+  // Unrecognised data payload (e.g. a `{ tick, ts }` heartbeat) — the stream is
+  // live; just advance the heartbeat clock.
+  return { ...view, status: 'live', lastFrameTs };
+}
+
+/**
+ * Format a {@link WorkerUsageSnapshot} into a compact meter string, e.g.
+ * `"12.4k tok · 3 calls"`. Returns a dash when no usage yet.
+ *
+ * @param usage - The usage snapshot, or `null`.
+ * @returns A compact human-readable meter label.
+ */
+export function formatUsageMeter(usage: WorkerUsageSnapshot | null): string {
+  if (!usage || usage.totalTokens === 0) return '— tokens';
+  const tok =
+    usage.totalTokens >= 1000
+      ? `${(usage.totalTokens / 1000).toFixed(1)}k`
+      : String(usage.totalTokens);
+  const calls = usage.records === 1 ? '1 call' : `${usage.records} calls`;
+  return `${tok} tok · ${calls}`;
+}
+
+/**
+ * Render the worker stream as plain-text panel lines — one string per terminal
+ * line. Used both as the body of the cockpit's pi-tui worker panel AND as a
+ * graceful fallback render. Shows the connection state, usage meter, checkpoint
+ * chips, and the output tail (capped to `tailLines`).
+ *
+ * @param taskId - The Running-lane task whose worker is streaming.
+ * @param view - The folded stream view-model.
+ * @param options - Optional cap on the number of output lines rendered.
+ * @returns Panel lines (no trailing newline per line).
+ */
+export function renderWorkerStreamPanel(
+  taskId: string,
+  view: WorkerStreamView,
+  options?: { readonly tailLines?: number },
+): string[] {
+  const tailLines = options?.tailLines ?? 8;
+  const lines: string[] = [];
+  const statusDot =
+    view.status === 'live'
+      ? '●'
+      : view.status === 'ended'
+        ? '✓'
+        : view.status === 'error'
+          ? '✗'
+          : view.status === 'stalled'
+            ? '◌'
+            : '○';
+  lines.push(
+    `── Worker ${taskId}  ${statusDot} ${view.status}  ·  ${formatUsageMeter(view.usage)}`,
+  );
+
+  if (view.checkpoints.length > 0) {
+    const chips = view.checkpoints.map((c) => `${c.kind}:${c.label}`).join('  ');
+    lines.push(`   ${chips}`);
+  }
+
+  if (view.status === 'error' && view.error) {
+    lines.push(`   error: ${view.error}`);
+  }
+
+  const tail = view.outputTail.slice(Math.max(0, view.outputTail.length - tailLines));
+  if (tail.length === 0) {
+    lines.push('   (waiting for worker output…)');
+  } else {
+    for (const out of tail) lines.push(`   │ ${out}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Decide whether a stream that last spoke at {@link WorkerStreamView.lastFrameTs}
+ * is STALLED (no frame within the staleness window) — drives a "reconnecting"
+ * affordance distinct from a clean `ended`.
+ *
+ * @param view - The current view-model.
+ * @param now - Current epoch ms (injectable for tests).
+ * @param staleMs - Staleness threshold in ms.
+ * @returns `true` when the stream is live-but-silent past the threshold.
+ */
+export function isStreamStalled(view: WorkerStreamView, now: number, staleMs: number): boolean {
+  if (view.status === 'ended' || view.status === 'error' || view.lastFrameTs === null) return false;
+  const last = Date.parse(view.lastFrameTs);
+  if (Number.isNaN(last)) return false;
+  return now - last > staleMs;
+}

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -92,6 +92,14 @@ export default defineConfig({
         '../../packages/contracts/src/render/envelope.ts',
         import.meta.url,
       ).pathname,
+      // T11936: the TUI worker-stream fold imports `GatewayStreamEvent` via
+      // `@cleocode/contracts/gateway`. Like the subpaths above, this MUST appear
+      // before the bare alias or vitest rewrites it to `index.ts/gateway`
+      // (ENOTDIR). Maps to the contracts gateway source module.
+      '@cleocode/contracts/gateway': new URL(
+        '../../packages/contracts/src/gateway.ts',
+        import.meta.url,
+      ).pathname,
       '@cleocode/contracts': new URL('../../packages/contracts/src/index.ts', import.meta.url)
         .pathname,
       '@cleocode/core/internal': new URL('../../packages/core/src/internal.ts', import.meta.url)


### PR DESCRIPTION
Gives the `cleo tui` cockpit DISPATCH parity with the Studio Kanban board (#1028). Two tasks under epic T11916.

## T11935 — keyboard dispatch → `orchestrate.spawn` (Conductor lane)

- **AC1** — `d`/Enter on a focused **Backlog/Ready** card dispatches a worker via `createCleoClient(...).orchestrate.spawn` through the generated gateway SDK (the op already in the operations registry; a worker is provisioned in a worktree server-side).
- **AC2** — on success the worker re-fetches into the **Running** lane; a **Conductor role lane** (orchestrator → Lead → worker) is rendered for the dispatchable focused card, built from card data.
- **AC3** — dispatch errors surface **inline** on a status line and **never crash** the TUI (daemon-down, rejected spawn, transport error all resolve to a typed `DispatchResult`). **No direct core/CLI shell-out** — dispatch routes through the SDK only (no `child_process`, no `cleo` shell-out, no `@cleocode/core` domain import).
- **Confirm-gate** — spawning is real + expensive, so it is a **two-step confirm** (first `d` latches a prompt, second `d` spawns; `Esc` cancels). `t` cycles the spawn tier (0/1/2).

## T11936 — live worker SSE stream on the Running lane

- **AC1** — a focused **Running** card subscribes to the M5 gateway SSE stream `GET /v1/orchestrate/events` (T11921) and renders the live worker **output tail + usage/cost meter** in a terminal panel.
- **AC2** — consumed through a dependency-free `node:http` SSE reader (the generated SDK covers unary ops only; streaming ops are SSE). Graceful drop/error handling, no per-card polling; clean `unsubscribe()` on blur / quit (leak-free).
- **AC3** — keyboard-driven; the board reconciles from streamed frames (server owns state). Degrades gracefully when the daemon is down.

## How it wires through the SDK
- **Dispatch** (`dispatch.ts`): `dispatchWorker()` → `client.orchestrate.spawn({ body: { taskId, tier } })`, mirroring the Studio `/api/tasks/[id]/dispatch` reference. Maps a missing `response` (connection refused) to `E_GATEWAY_UNREACHABLE`, a `success:false` envelope to `E_SPAWN_REJECTED`, a thrown error to `E_SPAWN_ERROR` — never throws.
- **SSE** (`sse-client.ts`): tails `GET /v1/orchestrate/events`, decodes the gateway's `data:`-only frames into `GatewayStreamEvent`, folds them through the pure `worker-stream.ts` view-model.
- The cockpit's `KanbanBoardComponent` takes injected `DispatchFn` / `SubscribeFn` seams (default to the real SDK-backed impls), so the action is unit-testable with no daemon/socket. The `TODO(T11935)` seam in the cockpit is resolved.

## Tests (64 cleo/tui tests pass)
- `worker-stream` — frame fold (output/usage/checkpoint/heartbeat/done/error), meter, panel, stall.
- `dispatch` — mocked SDK: success / unreachable / rejected / thrown; Conductor lane builder.
- `sse-client` — in-process server: frame order, chunk buffering, `done` teardown, `unsubscribe`, non-2xx, daemon-down `onError` (no throw).
- `cockpit-dispatch` — component-level confirm-gate, Running-lane transition, inline-error surface, SSE subscribe/unsubscribe lifecycle.

## Gates
- Full `tsc -b` typecheck **clean**.
- biome **clean**; scoped `@cleocode/cleo` build **green**.
- `cleo check arch` baseline **6/0/0**; define-command gate **pass**.
- `lint-stdout-write-allowlist` + `lint-stdout-discipline` at **baseline** (no net-new violations — no new stdout writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)