### PR TITLE
feat(T11937): universal service-vault foundation — schema + store + trust gate + github/google registry (M2/W1a)

### DIFF
--- a/packages/contracts/src/__tests__/service-provider.test.ts
+++ b/packages/contracts/src/__tests__/service-provider.test.ts
@@ -1,0 +1,56 @@
+/**
+ * T11937 — service-provider registry seed contract (AC5).
+ *
+ * Asserts the declarative `SERVICE_PROVIDERS` registry seeds EXACTLY the two
+ * pattern providers (github + google), each well-formed: a stable key, a display
+ * name, a valid auth kind, and (for OAuth services) a complete `oauth` config.
+ * The registry is DATA (no runtime helper) — this test is the only consumer that
+ * exercises its shape.
+ *
+ * @task T11937
+ * @epic T11765
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  SERVICE_AUTH_KINDS,
+  SERVICE_PROVIDERS,
+  type ServiceProviderDef,
+} from '../vault/service-provider.js';
+
+describe('SERVICE_PROVIDERS registry seed (T11937)', () => {
+  it('seeds EXACTLY github + google (pattern, not census)', () => {
+    expect(Object.keys(SERVICE_PROVIDERS).sort()).toEqual(['github', 'google']);
+  });
+
+  it('each entry is well-formed and self-consistent on its key', () => {
+    for (const [key, def] of Object.entries(SERVICE_PROVIDERS) as Array<
+      [string, ServiceProviderDef]
+    >) {
+      expect(def.provider).toBe(key);
+      expect(def.displayName.length).toBeGreaterThan(0);
+      expect(def.description.length).toBeGreaterThan(0);
+      expect(SERVICE_AUTH_KINDS).toContain(def.authKind);
+    }
+  });
+
+  it('github is a classic OAuth2 web flow with complete endpoints', () => {
+    const gh = SERVICE_PROVIDERS['github'];
+    expect(gh).toBeDefined();
+    expect(gh?.authKind).toBe('oauth2');
+    expect(gh?.oauth?.authorizationEndpoint).toContain('github.com');
+    expect(gh?.oauth?.tokenEndpoint).toContain('github.com');
+    expect(gh?.oauth?.clientId.length).toBeGreaterThan(0);
+    expect(gh?.defaultScopes).toContain('repo');
+  });
+
+  it('google is an installed-app OAuth2 + PKCE flow that requests offline access', () => {
+    const g = SERVICE_PROVIDERS['google'];
+    expect(g).toBeDefined();
+    expect(g?.authKind).toBe('oauth2-pkce');
+    expect(g?.oauth?.authorizationEndpoint).toContain('accounts.google.com');
+    expect(g?.oauth?.tokenEndpoint).toContain('oauth2.googleapis.com');
+    // Google needs access_type=offline + prompt=consent to issue a refresh token.
+    expect(g?.oauth?.extraAuthParams?.['access_type']).toBe('offline');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2394,6 +2394,12 @@ export {
   validatorRejectionSchema,
   validatorVerdictSchema,
 } from './validator/index.js';
+// === Universal Service Vault — declarative service-provider registry (T11937, epic T11765) ===
+export type {
+  ServiceAuthKind,
+  ServiceProviderDef,
+} from './vault/service-provider.js';
+export { SERVICE_AUTH_KINDS, SERVICE_PROVIDERS } from './vault/service-provider.js';
 export type {
   TasksFrontierParamsInput,
   TasksRollupParamsInput,

--- a/packages/contracts/src/vault/service-provider.ts
+++ b/packages/contracts/src/vault/service-provider.ts
@@ -1,0 +1,165 @@
+/**
+ * Universal service-vault — declarative service-provider registry (types + DATA).
+ *
+ * EP-UNIVERSAL-SERVICE-VAULT (epic T11765 · saga SG-VAULT-CORE T10409 · M2 W1a ·
+ * task T11937). The **service** half of the universal vault: machine-wide OAuth /
+ * API credentials for third-party SERVICES (github, google, notion, figma, …) —
+ * distinct from the LLM-provider credential pool (`accounts`, T11709) which holds
+ * model-API keys. A {@link ServiceProviderDef} is a purely declarative description
+ * of one connectable service: its stable key, display label, auth shape, and the
+ * default OAuth endpoints/scopes the (later) OAuth dance (T11939) will drive.
+ *
+ * ## Why this lives in `@cleocode/contracts` (Gate 10 purity)
+ *
+ * This module is **types + frozen DATA only**. {@link SERVICE_PROVIDERS} is a
+ * `const` record literal (no bodied function, no zod schema, no type guard) — it
+ * is configuration data, exactly like a routing table, so it satisfies the
+ * contracts-purity gate (`lint-no-runtime-in-contracts`). The runtime that
+ * CONSUMES the registry (the store, the trust gate, the OAuth flow) lives in
+ * `@cleocode/core`; this file never imports from core and carries no side effects.
+ *
+ * ## Pattern, not census (T11937 vs T11938)
+ *
+ * Only **github** and **google** are seeded here, deliberately — they prove the
+ * declarative pattern (one PKCE provider with a fixed loopback, one classic
+ * web-OAuth provider) before the fan-out to ~40 services in the follow-up
+ * (T11938). Adding a service is a single DATA entry; no code change.
+ *
+ * @module contracts/vault/service-provider
+ * @task T11937
+ * @epic T11765
+ * @saga T10409
+ * @see ../llm/oauth.js — `ProviderOAuthConfig` / `OAuthMode` (reused here)
+ * @see ../llm/sealed-credential.js — `SealedCredential` (the egress handle a resolved service credential is wrapped in)
+ */
+
+import type { ProviderOAuthConfig } from '../llm/oauth.js';
+
+/**
+ * Auth shape a service uses to obtain credentials.
+ *
+ * - `oauth2` — classic OAuth 2.0 Authorization Code grant (e.g. github web flow).
+ * - `oauth2-pkce` — OAuth 2.0 Authorization Code + PKCE (RFC 7636), for CLI /
+ *   headless flows (e.g. google installed-app flow).
+ * - `api-key` — a long-lived API token pasted/imported directly (no OAuth dance).
+ *
+ * The value drives which fields of {@link ServiceProviderDef.oauth} are required
+ * and which OAuth code path (T11939) runs for the service.
+ *
+ * @task T11937
+ */
+export const SERVICE_AUTH_KINDS = ['oauth2', 'oauth2-pkce', 'api-key'] as const;
+
+/** TypeScript union derived from {@link SERVICE_AUTH_KINDS}. */
+export type ServiceAuthKind = (typeof SERVICE_AUTH_KINDS)[number];
+
+/**
+ * Declarative description of one connectable third-party service.
+ *
+ * A `ServiceProviderDef` is pure configuration: it names a service, describes how
+ * it authenticates, and (for OAuth services) carries the default endpoints and
+ * scopes the OAuth flow will drive. It holds NO secret material — a user's actual
+ * tokens live encrypted in the `service_connections` table; BYOC client secrets
+ * (when the user brings their own OAuth app) live encrypted in `service_configs`.
+ *
+ * @task T11937
+ */
+export interface ServiceProviderDef {
+  /**
+   * Stable provider key (lowercase, kebab) — the join key against
+   * `service_connections.provider` / `service_configs.provider`. NEVER renamed
+   * once shipped (it is persisted in user rows). e.g. `'github'`, `'google'`.
+   */
+  readonly provider: string;
+  /** Human-readable display name for UI / CLI output. e.g. `'GitHub'`. */
+  readonly displayName: string;
+  /** Auth shape this service uses ({@link ServiceAuthKind}). */
+  readonly authKind: ServiceAuthKind;
+  /**
+   * Default OAuth configuration (endpoints + scopes + the public client id of
+   * CLEO's first-party OAuth app). `undefined` for an `api-key`-only service.
+   *
+   * Reuses the LLM-layer {@link ProviderOAuthConfig} shape verbatim — the OAuth
+   * mechanics (PKCE vs classic, endpoints, redirect, extra params) are identical
+   * whether the credential is for a model API or a service API. When the user
+   * supplies their own client id/secret (BYOC, stored in `service_configs`),
+   * those OVERRIDE the `clientId`/`scope` declared here at flow time (T11939).
+   */
+  readonly oauth?: ProviderOAuthConfig;
+  /**
+   * Default space-separated scopes requested when CLEO's first-party app is used
+   * and `oauth.scope` is not overridden by a BYOC `service_configs.settings`.
+   * Mirrors `oauth.scope`; kept as a top-level field so an `api-key` service can
+   * still document the access level a token is expected to carry.
+   */
+  readonly defaultScopes?: string;
+  /**
+   * One-line description of what connecting this service enables. Surfaced in the
+   * connect UI / `cleo service list`. Non-secret.
+   */
+  readonly description: string;
+}
+
+/**
+ * The seeded service-provider registry — **github + google only** (T11937).
+ *
+ * Keyed by {@link ServiceProviderDef.provider}. This is the SSoT the store reads
+ * when validating a `connect` and the OAuth flow (T11939) reads for default
+ * endpoints/scopes. The two seeds prove the two OAuth shapes:
+ *
+ *  - **github** — classic OAuth 2.0 web flow (`authKind: 'oauth2'`), fixed
+ *    loopback redirect; user grants `repo`/`read:user` scopes.
+ *  - **google** — installed-app OAuth 2.0 + PKCE (`authKind: 'oauth2-pkce'`),
+ *    loopback redirect; user grants offline-access + the requested API scopes.
+ *
+ * The `clientId` values are PLACEHOLDER public client ids for CLEO's first-party
+ * OAuth apps — the real ids are wired (or BYOC-overridden) when the OAuth dance
+ * lands in T11939. They are NOT secrets (a public OAuth client id is, by design,
+ * embeddable in a distributed CLI).
+ *
+ * Fan-out to the full ~40-service census is the follow-up (T11938): add a DATA
+ * entry here, nothing else.
+ *
+ * @task T11937
+ */
+export const SERVICE_PROVIDERS: Readonly<Record<string, ServiceProviderDef>> = {
+  github: {
+    provider: 'github',
+    displayName: 'GitHub',
+    authKind: 'oauth2',
+    description: 'Repositories, issues, pull requests, and Actions on GitHub.',
+    defaultScopes: 'repo read:user read:org',
+    oauth: {
+      mode: 'pkce',
+      // PLACEHOLDER public client id for CLEO's first-party GitHub OAuth app —
+      // real id (or a BYOC override from service_configs) wired in T11939.
+      clientId: 'cleo-github-client-id',
+      authorizationEndpoint: 'https://github.com/login/oauth/authorize',
+      tokenEndpoint: 'https://github.com/login/oauth/access_token',
+      scope: 'repo read:user read:org',
+      redirectUri: 'http://127.0.0.1:7878/service/github/callback',
+    },
+  },
+  google: {
+    provider: 'google',
+    displayName: 'Google',
+    authKind: 'oauth2-pkce',
+    description: 'Gmail, Drive, Calendar, and other Google APIs.',
+    defaultScopes: 'openid email profile https://www.googleapis.com/auth/drive.readonly',
+    oauth: {
+      mode: 'pkce',
+      // PLACEHOLDER public client id for CLEO's first-party Google installed-app
+      // OAuth client — real id (or a BYOC override) wired in T11939.
+      clientId: 'cleo-google-client-id.apps.googleusercontent.com',
+      authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+      tokenEndpoint: 'https://oauth2.googleapis.com/token',
+      scope: 'openid email profile https://www.googleapis.com/auth/drive.readonly',
+      redirectUri: 'http://127.0.0.1:7878/service/google/callback',
+      extraAuthParams: {
+        // Google requires these to return a refresh token on the first consent.
+        access_type: 'offline',
+        prompt: 'consent',
+      },
+    },
+  },
+};

--- a/packages/core/migrations/drizzle-cleo-global/20260609000000_t11937-service-vault/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260609000000_t11937-service-vault/migration.sql
@@ -1,0 +1,93 @@
+-- T11937 (EP-UNIVERSAL-SERVICE-VAULT · epic T11765 · saga SG-VAULT-CORE T10409 ·
+-- M2 W1a) — the universal SERVICE-credential vault in the consolidated GLOBAL
+-- cleo.db (drizzle-cleo-global scope ONLY — machine-wide service credentials with
+-- no project-tier analog, exactly like the `accounts` LLM-credential pool T11709,
+-- so NOT mirrored into drizzle-cleo-project).
+--
+-- Three tables, cannibalized from onecli `app_connections` / `app_configs` /
+-- `agent_app_connections` with EVERY org/project/billing column dropped:
+--
+--   service_connections   — one connected credential per (provider, label);
+--                           credentials_enc = encryptGlobal({access,refresh}) blob.
+--   service_configs        — per-provider BYOC OAuth app (enabled + client_secret_enc).
+--   agent_service_grants   — per-agent access + session_policy (the trust gate
+--                            evaluates this BEFORE any decrypt).
+--
+-- `credentials_enc` / `client_secret_enc` are encryptGlobal() ciphertext (T11710),
+-- NEVER plaintext. These are DISTINCT from the LLM `accounts` table (model-API
+-- credentials) — different physical names, different consumers, shared crypto.
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-global) which already creates dozens of tables, so none of these tables is
+-- the first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables. No journal pre-create is required.
+--
+-- ## Idempotency + breakpoints
+--
+-- `IF NOT EXISTS` on every statement so a re-open over an already-migrated DB is a
+-- no-op. Each statement is separated by a drizzle breakpoint marker line so
+-- node:sqlite prepare() does not silently truncate the multi-statement file to
+-- statement one (the marker token is the literal drizzle readMigrationFiles split
+-- substring — additive/forward-only).
+--
+-- ## CHECK constraints (schema-parity SSoT — T11364)
+--
+-- The consolidated schema-parity gate re-derives the CHECK set from the drizzle
+-- schema metadata (boolean → IN (0,1); enum → IN (...); `_at` TEXT → ISO-8601
+-- GLOB). The CHECKs below MUST match that derivation byte-for-byte.
+--
+-- @task T11937
+-- @epic T11765
+-- @saga T10409
+
+CREATE TABLE IF NOT EXISTS `service_connections` (
+  `id` integer PRIMARY KEY NOT NULL,
+  `provider` text NOT NULL,
+  `label` text NOT NULL,
+  `status` text NOT NULL DEFAULT 'active',
+  `credentials_enc` text,
+  `scopes` text NOT NULL DEFAULT '[]',
+  `expires_at` text,
+  `metadata` text NOT NULL DEFAULT '{}',
+  `connected_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  CHECK ("status" IN ('active', 'expired', 'revoked')),
+  CHECK ("expires_at" IS NULL OR "expires_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("connected_at" IS NULL OR "connected_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_service_connections_provider_label` ON `service_connections` (`provider`, `label`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_service_connections_provider_status` ON `service_connections` (`provider`, `status`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `service_configs` (
+  `id` integer PRIMARY KEY NOT NULL,
+  `provider` text NOT NULL,
+  `enabled` integer NOT NULL DEFAULT 0,
+  `client_secret_enc` text,
+  `settings` text NOT NULL DEFAULT '{}',
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  CHECK ("enabled" IN (0, 1)),
+  CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_service_configs_provider` ON `service_configs` (`provider`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `agent_service_grants` (
+  `agent_id` text NOT NULL,
+  `service_connection_id` integer NOT NULL,
+  `session_policy` text NOT NULL DEFAULT '{"mode":"allow"}',
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`agent_id`, `service_connection_id`),
+  FOREIGN KEY (`service_connection_id`) REFERENCES `service_connections`(`id`),
+  CHECK ("created_at" IS NULL OR "created_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*'),
+  CHECK ("updated_at" IS NULL OR "updated_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_agent_service_grants_agent` ON `agent_service_grants` (`agent_id`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -220,8 +220,42 @@ export {
   type CleoDbSnapshotOptions,
   openCleoDbSnapshot,
 } from './store/open-cleo-db.js';
+// Universal service-vault — store-level CRUD + policy-before-decrypt egress (T11937, epic T11765).
+export type {
+  AgentServiceGrantRow,
+  NewAgentServiceGrantRow,
+  NewServiceConfigRow,
+  NewServiceConnectionRow,
+  ServiceConfigRow,
+  ServiceConnectionRow,
+  ServiceConnectionStatus,
+} from './store/schema/cleo-global/services.js';
 // Skills DB chokepoint helpers — exposed for cleo dispatch (T9657 adopt-orphans wiring)
 export type { NewSkillRow, SkillRow, SkillSourceType } from './store/schema/skills-schema.js';
+export {
+  type ConnectServiceParams,
+  connectService,
+  getConnection,
+  grantAgentAccess,
+  listConnections,
+  openServiceVaultAtPath,
+  type ResolveServiceParams,
+  resolveSealedConnection,
+  revokeConnection,
+  type ServiceConnectionView,
+  type ServiceTokenBlob,
+  type ServiceVaultDeps,
+} from './store/service-connections-accessor.js';
+export {
+  evaluateServiceAccess,
+  parseSessionPolicy,
+  type ServiceGrant,
+  type SessionPolicy,
+  type SessionRateLimit,
+  type TrustDecision,
+  type TrustDenyReason,
+  type TrustEvalContext,
+} from './store/service-trust-gate.js';
 export {
   getSkillRow,
   listSkillsBySource,

--- a/packages/core/src/store/__tests__/service-vault.test.ts
+++ b/packages/core/src/store/__tests__/service-vault.test.ts
@@ -1,0 +1,255 @@
+/**
+ * T11937 — universal service-vault FOUNDATION round-trip + policy-before-decrypt.
+ *
+ * Proves the M2-W1a ACs against a TEMP-DIR global `cleo.db` (never `.cleo/*.db`):
+ *
+ *  - AC2/AC6 (migration): opening the global cleo.db applies the
+ *    `…_t11937-service-vault` forward migration → the three tables
+ *    (`service_connections` / `service_configs` / `agent_service_grants`)
+ *    materialize; a second open is a no-op (IF NOT EXISTS).
+ *  - AC3/AC6 (store CRUD round-trip): connect → get → list → revoke through the
+ *    accessor, with the REAL `encryptGlobal`/`decryptGlobal`. The token is
+ *    CIPHERTEXT at rest (never plaintext in the row) and the plaintext is reached
+ *    ONLY via the sealed handle's `fetch()`.
+ *  - AC4 (policy-before-decrypt): a denied agent (no grant) and a blocked agent
+ *    (`mode:'block'`) BOTH resolve to `null` WITHOUT the injected `decrypt` spy
+ *    ever being called; a granted agent resolves a sealed handle whose `fetch()`
+ *    materializes the access token.
+ *
+ * @task T11937
+ * @epic T11765
+ * @saga T10409
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CleoGlobalDb } from '../dual-scope-db.js';
+import { _resetDualScopeDbCache } from '../dual-scope-db.js';
+import {
+  connectService,
+  getConnection,
+  grantAgentAccess,
+  listConnections,
+  openServiceVaultAtPath,
+  resolveSealedConnection,
+  revokeConnection,
+  type ServiceTokenBlob,
+  type ServiceVaultDeps,
+} from '../service-connections-accessor.js';
+
+let testRoot: string;
+let db: CleoGlobalDb;
+
+beforeEach(async () => {
+  testRoot = join(
+    tmpdir(),
+    `service-vault-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+  db = await openServiceVaultAtPath(join(testRoot, 'cleo.db'));
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+/** Reach the native handle for raw sqlite_master / column-value assertions. */
+function native(handle: CleoGlobalDb): DatabaseSync {
+  return (handle as unknown as { $client: DatabaseSync }).$client;
+}
+
+describe('service-vault migration — global cleo.db', () => {
+  it('materialises the three service tables', () => {
+    const raw = native(db);
+    for (const table of ['service_connections', 'service_configs', 'agent_service_grants']) {
+      const row = raw
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+        .get(table) as { name: string } | undefined;
+      expect(row?.name, `table '${table}' must exist`).toBe(table);
+    }
+  }, 30_000);
+
+  it('re-opening the same DB is a no-op (IF NOT EXISTS idempotency)', async () => {
+    _resetDualScopeDbCache();
+    // Re-open the SAME path; the migration must not throw on already-present tables.
+    const db2 = await openServiceVaultAtPath(join(testRoot, 'cleo.db'));
+    const raw = native(db2);
+    const row = raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='service_connections'")
+      .get() as { name: string } | undefined;
+    expect(row?.name).toBe('service_connections');
+  }, 30_000);
+});
+
+describe('service-vault store CRUD round-trip (real crypto)', () => {
+  const tokens: ServiceTokenBlob = {
+    accessToken: 'gho_realAccessTokenSecret123',
+    refreshToken: 'ghr_realRefreshTokenSecret456',
+  };
+
+  it('connect → get → list → revoke with ciphertext at rest', async () => {
+    const deps: ServiceVaultDeps = { db };
+
+    const id = await connectService(
+      {
+        provider: 'github',
+        label: 'personal',
+        tokens,
+        scopes: ['repo', 'read:user'],
+        metadata: { username: 'octocat' },
+      },
+      deps,
+    );
+    expect(id).toBeGreaterThan(0);
+
+    // GET — non-secret view, no token.
+    const view = await getConnection('github', 'personal', deps);
+    expect(view).not.toBeNull();
+    expect(view?.provider).toBe('github');
+    expect(view?.status).toBe('active');
+    expect(view?.scopes).toEqual(['repo', 'read:user']);
+    expect(view?.metadata).toEqual({ username: 'octocat' });
+    expect(view?.hasCredentials).toBe(true);
+    // The view object carries NO plaintext token field anywhere.
+    expect(JSON.stringify(view)).not.toContain(tokens.accessToken);
+
+    // CIPHERTEXT AT REST — the raw row's credentials_enc is NOT the plaintext.
+    const raw = native(db);
+    const rowEnc = raw
+      .prepare('SELECT credentials_enc FROM service_connections WHERE provider=? AND label=?')
+      .get('github', 'personal') as { credentials_enc: string } | undefined;
+    expect(rowEnc?.credentials_enc).toBeTruthy();
+    expect(rowEnc?.credentials_enc).not.toContain(tokens.accessToken);
+    expect(rowEnc?.credentials_enc).not.toContain(tokens.refreshToken);
+
+    // LIST.
+    const all = await listConnections(undefined, deps);
+    expect(all.map((v) => `${v.provider}:${v.label}`)).toContain('github:personal');
+    const byProvider = await listConnections('github', deps);
+    expect(byProvider).toHaveLength(1);
+
+    // REVOKE — status flips, credential blob cleared.
+    const revoked = await revokeConnection('github', 'personal', deps);
+    expect(revoked).toBe(true);
+    const afterRevoke = await getConnection('github', 'personal', deps);
+    expect(afterRevoke?.status).toBe('revoked');
+    expect(afterRevoke?.hasCredentials).toBe(false);
+  }, 30_000);
+
+  it('plaintext is reachable ONLY via the sealed handle fetch() for a granted agent', async () => {
+    const deps: ServiceVaultDeps = { db };
+    const connId = await connectService({ provider: 'github', label: 'work', tokens }, deps);
+    await grantAgentAccess('agent-1', connId, { mode: 'allow' }, deps);
+
+    const sealed = await resolveSealedConnection(
+      { agentId: 'agent-1', provider: 'github', label: 'work' },
+      deps,
+    );
+    expect(sealed).not.toBeNull();
+    // The sealed handle names the credential but carries NO plaintext inline.
+    expect(JSON.stringify({ provider: sealed?.provider, account: sealed?.account })).not.toContain(
+      tokens.accessToken,
+    );
+    // Materialize at the wire — real encrypt→decrypt round-trip yields the token.
+    const decrypted = await sealed?.fetch();
+    expect(decrypted?.value).toBe(tokens.accessToken);
+  }, 30_000);
+});
+
+describe('service-vault policy-before-decrypt (AC4)', () => {
+  const tokens: ServiceTokenBlob = { accessToken: 'tok_secret_value_AAA' };
+
+  it('a denied agent (no grant) resolves null WITHOUT calling decrypt', async () => {
+    // Spy on decrypt — it must NEVER be called on a deny.
+    const decryptSpy = vi
+      .fn<(ciphertext: string, id: string) => Promise<string>>()
+      .mockResolvedValue(JSON.stringify(tokens));
+    const deps: ServiceVaultDeps = { db, decrypt: decryptSpy };
+
+    await connectService({ provider: 'github', label: 'guarded', tokens }, deps);
+    // NO grantAgentAccess → agent has no grant.
+
+    const sealed = await resolveSealedConnection(
+      { agentId: 'unauthorized-agent', provider: 'github', label: 'guarded' },
+      deps,
+    );
+    expect(sealed).toBeNull();
+    expect(decryptSpy).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it('a BLOCKED agent (policy mode:block) resolves null WITHOUT calling decrypt', async () => {
+    const decryptSpy = vi
+      .fn<(ciphertext: string, id: string) => Promise<string>>()
+      .mockResolvedValue(JSON.stringify(tokens));
+    const deps: ServiceVaultDeps = { db, decrypt: decryptSpy };
+
+    const connId = await connectService({ provider: 'github', label: 'blocked', tokens }, deps);
+    // Grant exists, but the policy BLOCKS.
+    await grantAgentAccess('blocked-agent', connId, { mode: 'block' }, deps);
+
+    const sealed = await resolveSealedConnection(
+      { agentId: 'blocked-agent', provider: 'github', label: 'blocked' },
+      deps,
+    );
+    expect(sealed).toBeNull();
+    expect(decryptSpy).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it('a manual-approval policy denies WITHOUT decrypt until approved:true is supplied', async () => {
+    const decryptSpy = vi
+      .fn<(ciphertext: string, id: string) => Promise<string>>()
+      .mockResolvedValue(JSON.stringify(tokens));
+    const deps: ServiceVaultDeps = { db, decrypt: decryptSpy };
+
+    const connId = await connectService({ provider: 'github', label: 'manual', tokens }, deps);
+    await grantAgentAccess('manual-agent', connId, { mode: 'allow', manualApproval: true }, deps);
+
+    // Without approval → denied, no decrypt.
+    const denied = await resolveSealedConnection(
+      { agentId: 'manual-agent', provider: 'github', label: 'manual' },
+      deps,
+    );
+    expect(denied).toBeNull();
+    expect(decryptSpy).not.toHaveBeenCalled();
+
+    // With approval → allowed; fetch() now triggers exactly one decrypt.
+    const approved = await resolveSealedConnection(
+      { agentId: 'manual-agent', provider: 'github', label: 'manual', approved: true },
+      deps,
+    );
+    expect(approved).not.toBeNull();
+    expect(decryptSpy).not.toHaveBeenCalled(); // still not called until the wire
+    const tok = await approved?.fetch();
+    expect(tok?.value).toBe(tokens.accessToken);
+    expect(decryptSpy).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it('a granted agent resolves; decrypt fires only at the wire (fetch), once', async () => {
+    const decryptSpy = vi
+      .fn<(ciphertext: string, id: string) => Promise<string>>()
+      .mockResolvedValue(JSON.stringify(tokens));
+    const deps: ServiceVaultDeps = { db, decrypt: decryptSpy };
+
+    const connId = await connectService({ provider: 'github', label: 'ok', tokens }, deps);
+    await grantAgentAccess('good-agent', connId, { mode: 'allow' }, deps);
+
+    const sealed = await resolveSealedConnection(
+      { agentId: 'good-agent', provider: 'github', label: 'ok' },
+      deps,
+    );
+    expect(sealed).not.toBeNull();
+    // Resolve did NOT decrypt — decrypt is deferred to the wire.
+    expect(decryptSpy).not.toHaveBeenCalled();
+    const tok = await sealed?.fetch();
+    expect(tok?.value).toBe(tokens.accessToken);
+    expect(decryptSpy).toHaveBeenCalledTimes(1);
+  }, 30_000);
+});

--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -96,6 +96,7 @@ export * from '../cleo-shared/index.js';
 export * from './accounts.js';
 export * from './agent-registry.js';
 export * from './nexus.js';
+export * from './services.js';
 export * from './session-manifest.js';
 export * from './skills.js';
 export * from './telemetry.js';

--- a/packages/core/src/store/schema/cleo-global/services.ts
+++ b/packages/core/src/store/schema/cleo-global/services.ts
@@ -1,0 +1,234 @@
+/**
+ * Global-scope `cleo.db` — **universal service-credential vault** (3 tables).
+ *
+ * EP-UNIVERSAL-SERVICE-VAULT (epic T11765 · saga SG-VAULT-CORE T10409 · M2 W1a ·
+ * task T11937). The **service** half of the universal vault — machine-wide OAuth /
+ * API credentials for third-party SERVICES (github, google, notion, figma, …) —
+ * cannibalized from onecli's `app_connections` / `app_configs` /
+ * `agent_app_connections`, DROPPING every org / project / billing column (the
+ * vault is machine-wide, exactly like the `accounts` LLM-credential pool — T11709,
+ * the established precedent this directory mirrors). Three tables:
+ *
+ *  - `service_connections` — one user-connected credential per `(provider, label)`:
+ *    the encrypted token blob + non-secret metadata (scopes, expiry, username).
+ *  - `service_configs` — per-provider BYOC (bring-your-own-client) OAuth app:
+ *    enabled flag + encrypted client secret + non-secret settings (client id,
+ *    scopes). One row per provider.
+ *  - `agent_service_grants` — per-agent access to a connection, plus the
+ *    `session_policy` (block / rate-limit / manual-approval) the trust gate
+ *    evaluates BEFORE any decrypt (T11937 AC4 — policy-before-decrypt).
+ *
+ * ## NOT the LLM credential pool (`accounts`) — do not confuse the two
+ *
+ * `accounts` (T11709) holds MODEL-API credentials (the pool the LLM runner picks
+ * from). These `service_*` tables hold SERVICE-API credentials (the things an
+ * agent's tools call: github, gmail, …). Different physical names, different
+ * consumers, different egress path. The crypto, ISO-timestamp typing, and
+ * accessor patterns are shared by design.
+ *
+ * ## Encrypted at rest (global KDF — reuse, no new crypto · T11710)
+ *
+ * `credentials_enc` (the `{access_token, refresh_token}` JSON blob) and
+ * `client_secret_enc` (the BYOC client secret) are `encryptGlobal()` ciphertext
+ * (packages/core/src/crypto/credentials.ts), NEVER plaintext. They keep the
+ * versioned `0x01 + 12B IV + 16B authTag` framing and decrypt via the project-
+ * INDEPENDENT KDF `HMAC-SHA256(machine-key || globalSalt, id)` with
+ * `id = service:${provider}:${label}` — so a service credential decrypts
+ * consistently for the machine regardless of the reading project's cwd.
+ *
+ * ## E10 typing (per docs/migration/sqlite-schema-canonical.md)
+ *
+ * TEXT ISO-8601 timestamps (`*_at`, GLOB-checked in the migration); named enums
+ * ({@link SERVICE_CONNECTION_STATUSES}); typed booleans (`enabled`); JSON-as-TEXT
+ * (`scopes`, `metadata`, `settings`, `session_policy`). The consolidated
+ * schema-parity gate (T11364) re-derives the CHECK set from THIS metadata, so the
+ * forward migration's CHECKs must match it exactly.
+ *
+ * @task T11937
+ * @epic T11765
+ * @saga T10409
+ * @see ../../../crypto/credentials.ts — `encryptGlobal` / `decryptGlobal` (T11710)
+ * @see ./accounts.ts — `accounts` (the SIBLING LLM-credential-pool table, T11709)
+ * @see ../../service-connections-accessor.ts — the store CRUD + sealed-handle egress
+ * @see ../../service-trust-gate.ts — policy-before-decrypt grant evaluation
+ * @see ../../../../migrations/drizzle-cleo-global — the forward migration
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, primaryKey, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
+/**
+ * Legal `service_connections.status` values — the lifecycle of a connection.
+ *
+ * - `active` — usable; the token is (or can be refreshed to) valid.
+ * - `expired` — the access token (and refresh, if any) has lapsed; needs re-auth.
+ * - `revoked` — the user (or provider) revoked the grant; never usable again.
+ *
+ * @task T11937
+ */
+export const SERVICE_CONNECTION_STATUSES = ['active', 'expired', 'revoked'] as const;
+
+/** TypeScript union derived from {@link SERVICE_CONNECTION_STATUSES}. */
+export type ServiceConnectionStatus = (typeof SERVICE_CONNECTION_STATUSES)[number];
+
+/**
+ * `service_connections` — one user-connected service credential per `(provider, label)`.
+ *
+ * `credentials_enc` is the `encryptGlobal()` ciphertext of the
+ * `{access_token, refresh_token}` JSON blob (NEVER plaintext). `scopes` is the
+ * JSON-serialized granted scope list; `metadata` is non-secret JSON (e.g. the
+ * connected `username`/`email`) safe to display. The `(provider, label)` pair is
+ * unique. The OAuth build/exchange/refresh that POPULATES `credentials_enc` is
+ * T11939 — this table is the clean seam it writes into.
+ *
+ * @task T11937
+ */
+export const serviceConnections = sqliteTable(
+  'service_connections',
+  {
+    /** Surrogate primary key (autoincrement via INTEGER PRIMARY KEY rowid alias). */
+    id: integer('id').primaryKey(),
+    /** Stable service-provider key (e.g. `github` | `google`). Joins SERVICE_PROVIDERS. */
+    provider: text('provider').notNull(),
+    /**
+     * Human-readable connection label, unique WITHIN a provider (e.g. `personal`,
+     * `work-org`). The `(provider, label)` pair is the natural unique key and the
+     * `${provider}:${label}` half of the `encryptGlobal` id.
+     */
+    label: text('label').notNull(),
+    /**
+     * Connection lifecycle — `active` | `expired` | `revoked`
+     * ({@link SERVICE_CONNECTION_STATUSES}). Only `active` connections resolve.
+     */
+    status: text('status', { enum: SERVICE_CONNECTION_STATUSES }).notNull().default('active'),
+    /**
+     * Encrypted credential blob — `encryptGlobal()` ciphertext of the
+     * `{access_token, refresh_token}` JSON (`0x01 + 12B IV + 16B authTag` framing,
+     * T11710). NEVER plaintext. NULL until the OAuth dance (T11939) writes a token.
+     */
+    credentialsEnc: text('credentials_enc'),
+    /** JSON-serialized granted scope list (non-secret). Serialized TEXT; defaults to `[]`. */
+    scopes: text('scopes').notNull().default('[]'),
+    /** ISO-8601 UTC access-token expiry; NULL for a non-expiring token. */
+    expiresAt: text('expires_at'),
+    /**
+     * Free-form NON-SECRET JSON (e.g. connected `username` / `email` / account id)
+     * safe to display. NEVER holds token material. Serialized TEXT; defaults `{}`.
+     */
+    metadata: text('metadata').notNull().default('{}'),
+    /** ISO-8601 UTC instant the connection was first established. Defaults to write time. */
+    connectedAt: text('connected_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant. Defaults to write time; bumped on mutation. */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // A label is unique within a provider — the natural unique key.
+    unique('ux_service_connections_provider_label').on(table.provider, table.label),
+    // Lookup index — resolve a provider's active connections.
+    index('idx_service_connections_provider_status').on(table.provider, table.status),
+  ],
+);
+
+/** Row type for `service_connections` SELECT queries. */
+export type ServiceConnectionRow = typeof serviceConnections.$inferSelect;
+/** Row type for `service_connections` INSERT/UPSERT operations. */
+export type NewServiceConnectionRow = typeof serviceConnections.$inferInsert;
+
+/**
+ * `service_configs` — per-provider BYOC (bring-your-own-client) OAuth app config.
+ *
+ * When a user brings their own OAuth client (rather than using CLEO's first-party
+ * app), the client id + non-secret OAuth settings live in `settings` (JSON) and
+ * the client SECRET lives encrypted in `client_secret_enc`. One row per provider
+ * (`UNIQUE(provider)`). `enabled` toggles whether the BYOC config is used. This
+ * is the clean seam the OAuth flow (T11939) reads to prefer a user client over
+ * the registry default.
+ *
+ * @task T11937
+ */
+export const serviceConfigs = sqliteTable(
+  'service_configs',
+  {
+    /** Surrogate primary key. */
+    id: integer('id').primaryKey(),
+    /** Stable service-provider key — unique (one BYOC config per provider). */
+    provider: text('provider').notNull(),
+    /** Whether this BYOC config is active. Typed boolean (CHECK IN (0,1)). Default false. */
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(false),
+    /**
+     * Encrypted BYOC client secret — `encryptGlobal()` ciphertext (id
+     * `service-config:${provider}`). NEVER plaintext. NULL for a public-client
+     * (PKCE) provider that has no secret.
+     */
+    clientSecretEnc: text('client_secret_enc'),
+    /**
+     * Non-secret BYOC settings JSON — the user's OAuth `client_id`, custom
+     * `scopes`, custom endpoints, etc. NEVER holds the client secret. Serialized
+     * TEXT; defaults `{}`.
+     */
+    settings: text('settings').notNull().default('{}'),
+    /** ISO-8601 UTC row-creation instant. Defaults to write time. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant. Defaults to write time; bumped on mutation. */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // One BYOC config per provider.
+    unique('ux_service_configs_provider').on(table.provider),
+  ],
+);
+
+/** Row type for `service_configs` SELECT queries. */
+export type ServiceConfigRow = typeof serviceConfigs.$inferSelect;
+/** Row type for `service_configs` INSERT/UPSERT operations. */
+export type NewServiceConfigRow = typeof serviceConfigs.$inferInsert;
+
+/**
+ * `agent_service_grants` — per-agent access to a service connection + policy.
+ *
+ * A grant authorizes one `agent_id` to use one `service_connection_id`, carrying
+ * the `session_policy` JSON (block / rate-limit / manual-approval) the trust gate
+ * (T11937 AC4) evaluates BEFORE any `decryptGlobal`. ABSENCE of a grant denies;
+ * a `block` policy denies; only a passing policy lets the store decrypt. The
+ * composite `(agent_id, service_connection_id)` is the primary key.
+ *
+ * `service_connection_id` references `service_connections(id)` — both tables live
+ * in the SAME global `cleo.db` file (Pattern A), so the FK is in-file and
+ * enforceable. The FK is declared natively (intra-domain, single global file —
+ * mirrors the agent-registry FK convention).
+ *
+ * @task T11937
+ */
+export const agentServiceGrants = sqliteTable(
+  'agent_service_grants',
+  {
+    /** The granted agent's id (FK-soft to the agent registry; string id). */
+    agentId: text('agent_id').notNull(),
+    /** The service connection this grant authorizes — references `service_connections(id)`. */
+    serviceConnectionId: integer('service_connection_id')
+      .notNull()
+      .references(() => serviceConnections.id),
+    /**
+     * Per-session access policy JSON evaluated BEFORE decrypt. Shape (see
+     * {@link import('../../service-trust-gate.js').SessionPolicy}):
+     * `{ mode: 'allow'|'block', rateLimit?: {...}, manualApproval?: boolean }`.
+     * Serialized TEXT; defaults `{"mode":"allow"}` (a bare grant = allow).
+     */
+    sessionPolicy: text('session_policy').notNull().default('{"mode":"allow"}'),
+    /** ISO-8601 UTC grant-creation instant. Defaults to write time. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant. Defaults to write time; bumped on mutation. */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // A grant is uniquely identified by (agent, connection).
+    primaryKey({ columns: [table.agentId, table.serviceConnectionId] }),
+    // Lookup index — resolve all grants for one agent.
+    index('idx_agent_service_grants_agent').on(table.agentId),
+  ],
+);
+
+/** Row type for `agent_service_grants` SELECT queries. */
+export type AgentServiceGrantRow = typeof agentServiceGrants.$inferSelect;
+/** Row type for `agent_service_grants` INSERT/UPSERT operations. */
+export type NewAgentServiceGrantRow = typeof agentServiceGrants.$inferInsert;

--- a/packages/core/src/store/service-connections-accessor.ts
+++ b/packages/core/src/store/service-connections-accessor.ts
@@ -1,0 +1,466 @@
+/**
+ * Service-vault accessor — store-level CRUD + policy-before-decrypt egress.
+ *
+ * EP-UNIVERSAL-SERVICE-VAULT (epic T11765 · saga SG-VAULT-CORE T10409 · M2 W1a ·
+ * task T11937 · AC3). The store layer for the universal SERVICE-credential vault
+ * (`service_connections` / `service_configs` / `agent_service_grants`).
+ *
+ * ## DB Open Guard (Gate 3 — strict)
+ *
+ * EVERY open goes through {@link openDualScopeDb}`('global')` (or its path-aware
+ * sibling {@link openDualScopeDbAtPath} for an injected test DB) — there is ZERO
+ * raw `new DatabaseSync(`. The typed Drizzle handle drives all CRUD; the accessor
+ * never constructs a native handle itself.
+ *
+ * ## Crypto reuse (DRY — no new crypto · T11710)
+ *
+ * `credentials_enc` holds the {@link encryptGlobal} ciphertext of the
+ * `{access_token, refresh_token}` JSON, keyed `id = service:${provider}:${label}`.
+ * The accessor calls {@link encryptGlobal}/{@link decryptGlobal} from
+ * `crypto/credentials.ts` — it adds no crypto of its own. The crypto functions are
+ * injectable ({@link ServiceVaultDeps}) so a test can spy on `decryptGlobal` and
+ * PROVE it is never invoked on a denied access (policy-before-decrypt, AC4).
+ *
+ * ## Policy-before-decrypt egress (AC4)
+ *
+ * {@link resolveSealedConnection} evaluates the {@link evaluateServiceAccess}
+ * trust gate FIRST (a pure decision from the agent's grant rows). It calls
+ * `decryptGlobal` ONLY when the gate returns `allowed: true`. A denied agent
+ * returns `null` BEFORE the decrypt call — the decrypt closure never runs. On
+ * allow, the plaintext is not surfaced inline: it is wrapped in a
+ * {@link makeSealedCredential} handle whose `resolveToken` thunk performs the
+ * decrypt at the wire (the same egress the LLM credential pool uses).
+ *
+ * ## OAuth seam (T11939)
+ *
+ * The OAuth build/exchange/refresh dance is the FOLLOW-UP (T11939). This accessor
+ * leaves the clean seam: {@link connectService} accepts an already-obtained token
+ * blob and writes its `encryptGlobal` ciphertext into `credentials_enc`; the OAuth
+ * flow simply calls `connectService` (or `updateConnectionCredentials`) with the
+ * tokens it negotiates. No OAuth logic lives here.
+ *
+ * @module store/service-connections-accessor
+ * @task T11937
+ * @epic T11765
+ * @saga T10409
+ * @see ./schema/cleo-global/services.ts — the three tables
+ * @see ./service-trust-gate.ts — the policy-before-decrypt decision
+ * @see ../crypto/credentials.ts — `encryptGlobal` / `decryptGlobal` (reused, not re-implemented)
+ * @see ../llm/sealed-credential.ts — `makeSealedCredential` (the shared egress handle)
+ */
+
+import type { SealedCredential } from '@cleocode/contracts';
+import { and, eq } from 'drizzle-orm';
+import { decryptGlobal, encryptGlobal } from '../crypto/credentials.js';
+import { makeSealedCredential, tokenPreview } from '../llm/sealed-credential.js';
+import { type CleoGlobalDb, openDualScopeDb, openDualScopeDbAtPath } from './dual-scope-db.js';
+import {
+  agentServiceGrants,
+  type ServiceConnectionStatus,
+  serviceConnections,
+} from './schema/cleo-global/services.js';
+import {
+  evaluateServiceAccess,
+  parseSessionPolicy,
+  type ServiceGrant,
+  type SessionPolicy,
+} from './service-trust-gate.js';
+
+/**
+ * The token blob persisted (encrypted) in `service_connections.credentials_enc`.
+ *
+ * Serialized to JSON, encrypted via {@link encryptGlobal}. The OAuth flow (T11939)
+ * produces this; this accessor only stores/loads it.
+ *
+ * @task T11937
+ */
+export interface ServiceTokenBlob {
+  /** The bearer access token. */
+  readonly accessToken: string;
+  /** The refresh token, when the provider issued one. */
+  readonly refreshToken?: string;
+}
+
+/**
+ * Injectable crypto + DB dependencies — defaults bind the real implementations.
+ *
+ * The crypto functions are injectable so a test can supply a SPY for
+ * `decryptGlobal` and assert it is never called on a denied access (AC4
+ * policy-before-decrypt proof).
+ *
+ * @task T11937
+ */
+export interface ServiceVaultDeps {
+  /** Encrypt a plaintext with the global KDF keyed by `id`. Defaults to {@link encryptGlobal}. */
+  readonly encrypt?: (plaintext: string, id: string) => Promise<string>;
+  /** Decrypt ciphertext with the global KDF keyed by `id`. Defaults to {@link decryptGlobal}. */
+  readonly decrypt?: (ciphertext: string, id: string) => Promise<string>;
+  /**
+   * An already-open global Drizzle handle. When omitted the accessor opens via
+   * {@link openDualScopeDb}`('global')`. Tests pass a temp-DB handle (opened via
+   * {@link openServiceVaultAtPath}) to stay off `.cleo/*.db`.
+   */
+  readonly db?: CleoGlobalDb;
+}
+
+/** Parameters for {@link connectService}. */
+export interface ConnectServiceParams {
+  /** Stable provider key (e.g. `github`). */
+  readonly provider: string;
+  /** Connection label, unique within the provider (e.g. `personal`). */
+  readonly label: string;
+  /** The token blob to encrypt + store (from the OAuth flow, T11939). */
+  readonly tokens: ServiceTokenBlob;
+  /** Granted scopes (non-secret) — stored as JSON. */
+  readonly scopes?: readonly string[];
+  /** ISO-8601 access-token expiry, if known. */
+  readonly expiresAt?: string;
+  /** Non-secret metadata (e.g. `{ username, email }`) — stored as JSON. */
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** A non-secret view of a `service_connections` row (NEVER carries the token). */
+export interface ServiceConnectionView {
+  readonly id: number;
+  readonly provider: string;
+  readonly label: string;
+  readonly status: ServiceConnectionStatus;
+  readonly scopes: readonly string[];
+  readonly expiresAt: string | null;
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly connectedAt: string;
+  readonly updatedAt: string;
+  /** Whether a credential blob has been written (the OAuth flow ran). */
+  readonly hasCredentials: boolean;
+}
+
+/** The `encryptGlobal`/`decryptGlobal` id for a connection's token blob. */
+function credentialId(provider: string, label: string): string {
+  return `service:${provider}:${label}`;
+}
+
+/**
+ * Open the global service-vault handle at an EXPLICIT path (test seam).
+ *
+ * Production callers MUST use {@link openDualScopeDb}`('global')` (resolved
+ * canonical path). This path-aware variant exists so tests open a temp-dir
+ * `cleo.db` — never `.cleo/*.db`. Returns the typed global Drizzle handle.
+ *
+ * @param dbPath - Absolute path to the temp `cleo.db`.
+ * @returns The typed {@link CleoGlobalDb} handle.
+ * @task T11937
+ */
+export async function openServiceVaultAtPath(dbPath: string): Promise<CleoGlobalDb> {
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return handle.db;
+}
+
+/** Resolve the global Drizzle handle — injected, else canonical open. */
+async function resolveDb(deps?: ServiceVaultDeps): Promise<CleoGlobalDb> {
+  if (deps?.db !== undefined) return deps.db;
+  const handle = await openDualScopeDb('global');
+  return handle.db;
+}
+
+/**
+ * CONNECT a service: encrypt the token blob and upsert the connection row.
+ *
+ * The token blob is JSON-serialized and {@link encryptGlobal}-encrypted under
+ * `id = service:${provider}:${label}` — only the ciphertext is written. On a
+ * repeat `connect` for the same `(provider, label)` the row's credentials/scopes/
+ * metadata/expiry are REFRESHED in place and `status` is reset to `active` (an
+ * expired/revoked connection is re-activated by re-connecting).
+ *
+ * @returns The connection id.
+ * @task T11937
+ */
+export async function connectService(
+  params: ConnectServiceParams,
+  deps?: ServiceVaultDeps,
+): Promise<number> {
+  const db = await resolveDb(deps);
+  const encrypt = deps?.encrypt ?? encryptGlobal;
+  const id = credentialId(params.provider, params.label);
+  const credentialsEnc = await encrypt(JSON.stringify(params.tokens), id);
+  const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const scopesJson = JSON.stringify(params.scopes ?? []);
+  const metadataJson = JSON.stringify(params.metadata ?? {});
+
+  const existing = await db
+    .select({ id: serviceConnections.id })
+    .from(serviceConnections)
+    .where(
+      and(
+        eq(serviceConnections.provider, params.provider),
+        eq(serviceConnections.label, params.label),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0 && existing[0] !== undefined) {
+    const connId = existing[0].id;
+    await db
+      .update(serviceConnections)
+      .set({
+        status: 'active',
+        credentialsEnc,
+        scopes: scopesJson,
+        expiresAt: params.expiresAt ?? null,
+        metadata: metadataJson,
+        updatedAt: now,
+      })
+      .where(eq(serviceConnections.id, connId));
+    return connId;
+  }
+
+  const inserted = await db
+    .insert(serviceConnections)
+    .values({
+      provider: params.provider,
+      label: params.label,
+      status: 'active',
+      credentialsEnc,
+      scopes: scopesJson,
+      expiresAt: params.expiresAt ?? null,
+      metadata: metadataJson,
+    })
+    .returning({ id: serviceConnections.id });
+  const row = inserted[0];
+  if (row === undefined) {
+    throw new Error('service connect: insert returned no id');
+  }
+  return row.id;
+}
+
+/** Map a raw connection row to a non-secret {@link ServiceConnectionView}. */
+function toView(row: typeof serviceConnections.$inferSelect): ServiceConnectionView {
+  let scopes: string[] = [];
+  let metadata: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(row.scopes);
+    if (Array.isArray(parsed)) scopes = parsed.filter((s): s is string => typeof s === 'string');
+  } catch {
+    // malformed scopes JSON → empty list (non-secret display only)
+  }
+  try {
+    const parsed = JSON.parse(row.metadata);
+    if (typeof parsed === 'object' && parsed !== null) {
+      metadata = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // malformed metadata JSON → empty object
+  }
+  return {
+    id: row.id,
+    provider: row.provider,
+    label: row.label,
+    status: row.status,
+    scopes,
+    expiresAt: row.expiresAt,
+    metadata,
+    connectedAt: row.connectedAt,
+    updatedAt: row.updatedAt,
+    hasCredentials: row.credentialsEnc !== null && row.credentialsEnc !== '',
+  };
+}
+
+/**
+ * GET one connection as a non-secret view (NEVER decrypts the token).
+ *
+ * @returns The view, or `null` when no such `(provider, label)` exists.
+ * @task T11937
+ */
+export async function getConnection(
+  provider: string,
+  label: string,
+  deps?: ServiceVaultDeps,
+): Promise<ServiceConnectionView | null> {
+  const db = await resolveDb(deps);
+  const rows = await db
+    .select()
+    .from(serviceConnections)
+    .where(and(eq(serviceConnections.provider, provider), eq(serviceConnections.label, label)))
+    .limit(1);
+  const row = rows[0];
+  return row === undefined ? null : toView(row);
+}
+
+/**
+ * LIST connections as non-secret views (NEVER decrypts), optionally by provider.
+ *
+ * @param provider - When set, restrict to one provider; otherwise all.
+ * @task T11937
+ */
+export async function listConnections(
+  provider?: string,
+  deps?: ServiceVaultDeps,
+): Promise<ServiceConnectionView[]> {
+  const db = await resolveDb(deps);
+  const rows =
+    provider === undefined
+      ? await db.select().from(serviceConnections)
+      : await db.select().from(serviceConnections).where(eq(serviceConnections.provider, provider));
+  return rows.map(toView);
+}
+
+/**
+ * REVOKE a connection: flip `status` to `revoked` and CLEAR the credential blob.
+ *
+ * Clearing `credentials_enc` makes the secret unrecoverable (the ciphertext is
+ * gone) — a revoke is permanent until a fresh `connect`. The row is kept (not
+ * deleted) so grants/audit referencing it remain coherent.
+ *
+ * @returns `true` if a row was revoked, `false` if no such connection.
+ * @task T11937
+ */
+export async function revokeConnection(
+  provider: string,
+  label: string,
+  deps?: ServiceVaultDeps,
+): Promise<boolean> {
+  const db = await resolveDb(deps);
+  const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const updated = await db
+    .update(serviceConnections)
+    .set({ status: 'revoked', credentialsEnc: null, updatedAt: now })
+    .where(and(eq(serviceConnections.provider, provider), eq(serviceConnections.label, label)))
+    .returning({ id: serviceConnections.id });
+  return updated.length > 0;
+}
+
+/**
+ * GRANT an agent access to a connection with a session policy.
+ *
+ * @param agentId - The agent to grant.
+ * @param serviceConnectionId - The connection id (from {@link connectService}).
+ * @param policy - The {@link SessionPolicy}; defaults to a bare allow.
+ * @task T11937
+ */
+export async function grantAgentAccess(
+  agentId: string,
+  serviceConnectionId: number,
+  policy: SessionPolicy = { mode: 'allow' },
+  deps?: ServiceVaultDeps,
+): Promise<void> {
+  const db = await resolveDb(deps);
+  const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const policyJson = JSON.stringify(policy);
+  const existing = await db
+    .select({ agentId: agentServiceGrants.agentId })
+    .from(agentServiceGrants)
+    .where(
+      and(
+        eq(agentServiceGrants.agentId, agentId),
+        eq(agentServiceGrants.serviceConnectionId, serviceConnectionId),
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) {
+    await db
+      .update(agentServiceGrants)
+      .set({ sessionPolicy: policyJson, updatedAt: now })
+      .where(
+        and(
+          eq(agentServiceGrants.agentId, agentId),
+          eq(agentServiceGrants.serviceConnectionId, serviceConnectionId),
+        ),
+      );
+    return;
+  }
+  await db
+    .insert(agentServiceGrants)
+    .values({ agentId, serviceConnectionId, sessionPolicy: policyJson });
+}
+
+/** Load an agent's grants as the gate-shaped {@link ServiceGrant} projection. */
+async function loadAgentGrants(db: CleoGlobalDb, agentId: string): Promise<ServiceGrant[]> {
+  const rows = await db
+    .select()
+    .from(agentServiceGrants)
+    .where(eq(agentServiceGrants.agentId, agentId));
+  return rows.map((r) => ({
+    agentId: r.agentId,
+    serviceConnectionId: r.serviceConnectionId,
+    sessionPolicy: parseSessionPolicy(r.sessionPolicy),
+  }));
+}
+
+/** Parameters for {@link resolveSealedConnection}. */
+export interface ResolveServiceParams {
+  /** The agent requesting access (trust-gated). */
+  readonly agentId: string;
+  /** The provider key. */
+  readonly provider: string;
+  /** The connection label. */
+  readonly label: string;
+  /** Whether an out-of-band manual approval was granted for this session. */
+  readonly approved?: boolean;
+}
+
+/**
+ * RESOLVE a connection to a sealed credential — **policy-before-decrypt** egress.
+ *
+ * The trust gate runs FIRST (a pure {@link evaluateServiceAccess} decision over
+ * the agent's grants). `decryptGlobal` is invoked ONLY when the gate returns
+ * `allowed: true` — and even then NOT inline: the plaintext is materialized lazily
+ * inside the {@link makeSealedCredential} `resolveToken` thunk at the wire. A
+ * denied agent returns `null` BEFORE the decrypt closure is ever built or run, so
+ * a spy on `decryptGlobal` records ZERO calls on a deny (AC4 proof).
+ *
+ * @returns A {@link SealedCredential} on allow; `null` when denied or when the
+ *   connection is missing / not `active` / has no stored credential.
+ * @task T11937
+ */
+export async function resolveSealedConnection(
+  params: ResolveServiceParams,
+  deps?: ServiceVaultDeps,
+): Promise<SealedCredential | null> {
+  const db = await resolveDb(deps);
+  const decrypt = deps?.decrypt ?? decryptGlobal;
+
+  // 1. Load the connection (non-secret) — needed for the gate's connection id.
+  const rows = await db
+    .select()
+    .from(serviceConnections)
+    .where(
+      and(
+        eq(serviceConnections.provider, params.provider),
+        eq(serviceConnections.label, params.label),
+      ),
+    )
+    .limit(1);
+  const conn = rows[0];
+  if (conn === undefined || conn.status !== 'active' || conn.credentialsEnc === null) {
+    return null;
+  }
+
+  // 2. POLICY BEFORE DECRYPT — evaluate the trust gate. No crypto has run yet.
+  const grants = await loadAgentGrants(db, params.agentId);
+  const decision = evaluateServiceAccess(grants, {
+    agentId: params.agentId,
+    serviceConnectionId: conn.id,
+    approved: params.approved,
+  });
+  if (!decision.allowed) {
+    // Denied — return BEFORE building/running the decrypt thunk. `decrypt`
+    // (the spied `decryptGlobal`) is never called on this path (AC4).
+    return null;
+  }
+
+  // 3. Allowed — wrap in a sealed handle whose resolveToken decrypts AT THE WIRE.
+  const ciphertext = conn.credentialsEnc;
+  const id = credentialId(params.provider, params.label);
+  return makeSealedCredential({
+    provider: params.provider,
+    account: params.label,
+    // Non-secret preview: we have not decrypted, so name the credential by id.
+    tokenPreview: tokenPreview('', 'oauth'),
+    resolveToken: async (): Promise<string> => {
+      // The SOLE decrypt point — runs only when the wire calls fetch(). Returns
+      // the access token (the wire-bound bearer); refresh stays in the blob.
+      const plaintext = await decrypt(ciphertext, id);
+      const blob = JSON.parse(plaintext) as ServiceTokenBlob;
+      return blob.accessToken;
+    },
+  });
+}

--- a/packages/core/src/store/service-trust-gate.ts
+++ b/packages/core/src/store/service-trust-gate.ts
@@ -1,0 +1,221 @@
+/**
+ * Service-vault trust gate — **policy-before-decrypt** per-agent access control.
+ *
+ * EP-UNIVERSAL-SERVICE-VAULT (epic T11765 · saga SG-VAULT-CORE T10409 · M2 W1a ·
+ * task T11937 · AC4). Ports onecli `connect.rs` selective-mode: an agent may use a
+ * service connection ONLY when (a) a row exists in `agent_service_grants` linking
+ * the agent to the connection, AND (b) the grant's `session_policy` evaluates to
+ * an allow. This module evaluates that decision from already-loaded grant data —
+ * it performs ZERO crypto. The store
+ * ({@link import('./service-connections-accessor.js')}) calls `decryptGlobal`
+ * ONLY after this gate returns `allowed: true`, so a denied/blocked agent NEVER
+ * triggers a decrypt (the policy-before-decrypt invariant, proven by unit test).
+ *
+ * ## Why the gate is decrypt-free
+ *
+ * The gate takes the grant rows as INPUT and returns a pure decision. It cannot
+ * decrypt even if it wanted to — it imports no crypto. The decryption chokepoint
+ * lives one layer up (the accessor), guarded by this decision. That separation is
+ * exactly what makes "a denied agent never decrypts" structurally true and
+ * spy-assertable: the spy is placed on `decryptGlobal`, and a deny path returns
+ * before the accessor reaches the decrypt call.
+ *
+ * ## Policy shape ({@link SessionPolicy})
+ *
+ * Mirrors onecli's `PolicyAction` (block / rate-limit / manual-approval) collapsed
+ * to a per-grant JSON:
+ *
+ *   - `mode: 'allow' | 'block'` — `block` is a hard deny (no decrypt).
+ *   - `rateLimit?` — advisory rate cap; the gate surfaces it but does not itself
+ *     count requests (the caller enforces). Presence alone does not deny.
+ *   - `manualApproval?: true` — the connection requires an out-of-band human
+ *     approval that has not been granted for this session → deny (no decrypt)
+ *     until the caller supplies `approved: true` in the evaluation context.
+ *
+ * A bare grant (`{"mode":"allow"}`, the column default) allows.
+ *
+ * @module store/service-trust-gate
+ * @task T11937
+ * @epic T11765
+ * @saga T10409
+ * @see ./service-connections-accessor.ts — the accessor that decrypts ONLY on allow
+ * @see ../../../onecli — `apps/gateway/src/connect.rs` selective-mode (the ported model)
+ */
+
+/**
+ * Advisory rate-limit clause on a {@link SessionPolicy}.
+ *
+ * The gate reports it on an allow decision; it does NOT itself maintain a counter
+ * (the consumer enforces the cap). Presence never denies access — it shapes how
+ * the caller throttles an already-permitted credential use.
+ *
+ * @task T11937
+ */
+export interface SessionRateLimit {
+  /** Maximum requests permitted within `window`. */
+  readonly maxRequests: number;
+  /** Rolling window the cap applies over. */
+  readonly window: 'minute' | 'hour' | 'day';
+}
+
+/**
+ * Per-grant session policy evaluated by the trust gate BEFORE any decrypt.
+ *
+ * Serialized as the `agent_service_grants.session_policy` JSON column. The column
+ * default `{"mode":"allow"}` makes a bare grant permissive.
+ *
+ * @task T11937
+ */
+export interface SessionPolicy {
+  /** `block` is a hard deny (no decrypt); `allow` permits (subject to other clauses). */
+  readonly mode: 'allow' | 'block';
+  /** Advisory rate cap surfaced on an allow decision (never itself denies). */
+  readonly rateLimit?: SessionRateLimit;
+  /**
+   * When `true`, the connection requires an out-of-band human approval. The gate
+   * DENIES unless the evaluation context carries `approved: true` for this
+   * session.
+   */
+  readonly manualApproval?: boolean;
+}
+
+/**
+ * Minimal grant projection the gate evaluates — exactly the
+ * `agent_service_grants` columns the decision needs, no token material.
+ *
+ * @task T11937
+ */
+export interface ServiceGrant {
+  /** The granted agent. */
+  readonly agentId: string;
+  /** The connection this grant authorizes. */
+  readonly serviceConnectionId: number;
+  /** The parsed {@link SessionPolicy} (already JSON-decoded from the column). */
+  readonly sessionPolicy: SessionPolicy;
+}
+
+/**
+ * Context for a single access evaluation.
+ *
+ * @task T11937
+ */
+export interface TrustEvalContext {
+  /** The agent requesting access. */
+  readonly agentId: string;
+  /** The connection the agent wants to use. */
+  readonly serviceConnectionId: number;
+  /**
+   * Whether an out-of-band manual approval has been granted for this session.
+   * Required to pass a `manualApproval: true` policy. Defaults to `false`.
+   */
+  readonly approved?: boolean;
+}
+
+/**
+ * Reason an access evaluation was DENIED — stable codes for diagnostics/audit.
+ *
+ * @task T11937
+ */
+export type TrustDenyReason = 'no-grant' | 'policy-block' | 'manual-approval-required';
+
+/**
+ * The pure decision returned by {@link evaluateServiceAccess}.
+ *
+ * On `allowed: false` the accessor MUST NOT decrypt. On `allowed: true` the
+ * accessor may decrypt and (optionally) honor `rateLimit`.
+ *
+ * @task T11937
+ */
+export type TrustDecision =
+  | { readonly allowed: true; readonly rateLimit?: SessionRateLimit }
+  | { readonly allowed: false; readonly reason: TrustDenyReason };
+
+/**
+ * Parse a raw `session_policy` JSON string into a {@link SessionPolicy}, failing
+ * CLOSED (to `block`) on any malformed input.
+ *
+ * SECURITY: a corrupt/unparseable policy must NEVER silently widen access — it
+ * resolves to `{ mode: 'block' }` so the gate denies and no decrypt occurs.
+ *
+ * @param raw - The `agent_service_grants.session_policy` column value.
+ * @returns A well-formed {@link SessionPolicy}; `block` on parse failure.
+ * @task T11937
+ */
+export function parseSessionPolicy(raw: string): SessionPolicy {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { mode: 'block' };
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { mode: 'block' };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const mode = obj['mode'] === 'block' ? 'block' : obj['mode'] === 'allow' ? 'allow' : 'block';
+  const policy: {
+    mode: 'allow' | 'block';
+    rateLimit?: SessionRateLimit;
+    manualApproval?: boolean;
+  } = { mode };
+  if (obj['manualApproval'] === true) {
+    policy.manualApproval = true;
+  }
+  const rl = obj['rateLimit'];
+  if (typeof rl === 'object' && rl !== null) {
+    const rlObj = rl as Record<string, unknown>;
+    const maxRequests = rlObj['maxRequests'];
+    const window = rlObj['window'];
+    if (
+      typeof maxRequests === 'number' &&
+      maxRequests > 0 &&
+      (window === 'minute' || window === 'hour' || window === 'day')
+    ) {
+      policy.rateLimit = { maxRequests, window };
+    }
+  }
+  return policy;
+}
+
+/**
+ * Evaluate whether an agent may access a service connection — the **policy-
+ * before-decrypt** chokepoint.
+ *
+ * Pure: takes the agent's grants (already loaded) + the evaluation context and
+ * returns a {@link TrustDecision} WITHOUT touching crypto. The store calls
+ * `decryptGlobal` ONLY when the returned `allowed` is `true`. Deny order:
+ *
+ *  1. no matching grant → `no-grant` (denied).
+ *  2. grant policy `mode: 'block'` → `policy-block` (denied).
+ *  3. policy `manualApproval` set but context not `approved` →
+ *     `manual-approval-required` (denied).
+ *  4. otherwise → allowed (carrying any advisory `rateLimit`).
+ *
+ * @param grants - The agent's grant rows (the accessor loads these from
+ *   `agent_service_grants`). Only grants for `ctx.agentId` /
+ *   `ctx.serviceConnectionId` are considered.
+ * @param ctx - The evaluation context (agent, connection, approval flag).
+ * @returns The access decision. NEVER decrypts.
+ * @task T11937
+ */
+export function evaluateServiceAccess(
+  grants: readonly ServiceGrant[],
+  ctx: TrustEvalContext,
+): TrustDecision {
+  const grant = grants.find(
+    (g) => g.agentId === ctx.agentId && g.serviceConnectionId === ctx.serviceConnectionId,
+  );
+  if (grant === undefined) {
+    return { allowed: false, reason: 'no-grant' };
+  }
+  const policy = grant.sessionPolicy;
+  if (policy.mode === 'block') {
+    return { allowed: false, reason: 'policy-block' };
+  }
+  if (policy.manualApproval === true && ctx.approved !== true) {
+    return { allowed: false, reason: 'manual-approval-required' };
+  }
+  return policy.rateLimit !== undefined
+    ? { allowed: true, rateLimit: policy.rateLimit }
+    : { allowed: true };
+}


### PR DESCRIPTION
## T11937 — M2/W1a: universal service-vault FOUNDATION

The **service** half of the universal vault (epic **T11765** · saga SG-VAULT-CORE **T10409**). Machine-wide OAuth / API credentials for third-party **services** (github, google, …) — distinct from the LLM `accounts` credential pool (**T11709**), whose accessor/migration/typing patterns this mirrors exactly. Cannibalized from onecli `app_connections`/`app_configs`/`agent_app_connections` with every org/project/billing column dropped (machine-wide, like `accounts`).

Store-level only: **no CLI verbs** (T11941), **no OAuth dance** (T11939) — a clean `credentials_enc` seam is left for the token blob. No new OPERATIONS → no op-count snapshot change.

### Acceptance criteria

- **AC1 — schema.** `service_connections` / `service_configs` / `agent_service_grants` as Drizzle `sqliteTable`s in `packages/core/src/store/schema/cleo-global/services.ts` (named enums, TEXT ISO-8601 timestamps, typed booleans, JSON-as-TEXT), exported from the cleo-global barrel.
- **AC2 — migration.** `…_t11937-service-vault/migration.sql`: `IF NOT EXISTS` + `--> statement-breakpoint` separators, additive/forward-only. Runs **after** the consolidation baseline (page-2 invariant — never the first CREATE), so a re-open is a no-op. CHECKs match the schema-parity gate derivation byte-for-byte (`enum → IN (...)`; `boolean → IN (0,1)`; `_at → ISO-8601 GLOB`); the `consolidated-schema-parity-fk` gate auto-discovers the 3 tables and passes.
- **AC3 — store.** `service-connections-accessor.ts` opens via `openDualScopeDb('global')` **exclusively** (zero raw `DatabaseSync` — DB-Open-Guard Gate 3 strict OK) and **reuses** `encryptGlobal`/`decryptGlobal` (`id = service:${provider}:${label}`) — no new crypto. CRUD: connect / get / list / revoke + grant.
- **AC4 — trust gate.** `service-trust-gate.ts` evaluates the per-agent grant + `session_policy` (block / rate-limit / manual-approval) as a **pure, crypto-free** decision. The accessor calls `decryptGlobal` **only on `allowed:true`**, and even then defers it to the sealed-handle `resolveToken` thunk at the wire.
- **AC5 — registry.** `ServiceProviderDef` declarative type in `packages/contracts/src/vault/service-provider.ts` + `SERVICE_PROVIDERS` seeded with **only github + google** — DATA, not a runtime helper (contracts-purity Gate 10 OK). Fan-out to ~40 is the follow-up **T11938**.

### Crypto reuse (DRY)
`credentials_enc` holds the `encryptGlobal` ciphertext of `{access_token, refresh_token}` JSON; `client_secret_enc` (BYOC) likewise. The accessor imports `encryptGlobal`/`decryptGlobal` from `crypto/credentials.ts` and adds no crypto. Egress reuses `makeSealedCredential` — the same on-demand-decrypt handle the LLM pool uses.

### Policy-before-decrypt proof
The trust gate imports no crypto and returns a pure decision; the accessor's `resolveSealedConnection` evaluates it **first** and returns `null` for a denied / blocked / unapproved agent **before** the decrypt closure is ever built. Tests inject a `decrypt` spy and assert `toHaveBeenCalledTimes(0)` on every deny path; on allow, decrypt fires exactly once and only at `fetch()` (the wire).

### Migration safety
Applies on a fresh global `cleo.db` (after baseline) **and** on the consolidated baseline; re-open is a no-op (`IF NOT EXISTS`). `agent_service_grants.service_connection_id` FK → `service_connections(id)` is in-file (same scope, Pattern A) and enforceable.

### Tests (in-process, temp-dir `cleo.db` — never `.cleo/*.db`)
- core `service-vault.test.ts` (8): CRUD round-trip + ciphertext-at-rest + sealed-handle plaintext; policy-before-decrypt for no-grant / block / manual-approval; migration idempotency.
- contracts `service-provider.test.ts` (4): exactly github + google, well-formed OAuth.

### Gate results (all capped `MemoryMax=16G`)
- **FULL** `pnpm run typecheck` clean · full workspace build green · `biome check` clean.
- DB-Open-Guard `--strict` OK · contracts-purity (baseline 53, no net-new) OK · contracts-fan-out OK · paths-ssot / ssot-exempt / define-command / cli-boundary OK.
- `consolidated-schema-parity-fk` + `accounts-credential-pool` + `migration-baseline` + `migration-reconcile` + `nexus-ddl-snapshot` all green; no regressions.
- No new `.md` (canon clean); no skill-coverage paths touched (no skill-drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)