### PR TITLE
feat(T11628): supervisor watchdog — heartbeat-deadline kill tiered by LLM-queue in-flight (M1)

### DIFF
--- a/crates/cleo-supervisor/src/ipc_server.rs
+++ b/crates/cleo-supervisor/src/ipc_server.rs
@@ -39,7 +39,7 @@ use crate::ipc::{
 use crate::ipc_transport::Fanout;
 use crate::lease_handler::{LeaseArbiter, request_kind};
 use crate::lease_ipc::{
-    LEASE_IPC_PROTOCOL_VERSION, LeaseEnvelope, LeasePayload, LeaseResponse,
+    ChildKilled, LEASE_IPC_PROTOCOL_VERSION, LeaseEnvelope, LeasePayload, LeaseResponse,
 };
 use crate::process;
 use crate::supervisor::{ChildRegistry, RegistryError};
@@ -411,6 +411,30 @@ where
     }
 }
 
+/// Drain the watchdog's [`ChildKilled`] event channel, broadcasting each as an
+/// unsolicited v1.1 `child_killed_unresponsive` [`LeaseEnvelope`] to every
+/// connected client via the shared [`Fanout`] (T11628). Runs until the sender
+/// (held by the watchdog sweep task) is dropped.
+async fn lease_event_pump<W>(mut events: UnboundedReceiver<ChildKilled>, fanout: Fanout<W>)
+where
+    W: AsyncWriteExt + Unpin + Send,
+{
+    while let Some(killed) = events.recv().await {
+        let envelope = LeaseEnvelope::response(
+            format!("event-{}", killed.child_id),
+            LeaseResponse::ChildKilledUnresponsive(killed),
+        );
+        match fanout.broadcast_lease(&envelope).await {
+            Ok(delivered) => {
+                tracing::trace!(delivered, "broadcast child_killed_unresponsive event");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "failed to serialize child_killed event");
+            }
+        }
+    }
+}
+
 #[cfg(unix)]
 mod unix_serve {
     use super::*;
@@ -418,17 +442,25 @@ mod unix_serve {
 
     /// Accept loop body for a Unix-domain listener.
     ///
-    /// Spawns the event pump once, then accepts clients forever; per connection
-    /// it registers the write half into the broadcast [`Fanout`] and spawns the
-    /// per-client read loop. Returns only on an unrecoverable accept error.
+    /// Spawns the lifecycle event pump (and, when wired, the watchdog
+    /// `child_killed_unresponsive` lease-event pump) once, then accepts clients
+    /// forever; per connection it registers the write half into the broadcast
+    /// [`Fanout`] and spawns the per-client read loop. Returns only on an
+    /// unrecoverable accept error.
     pub async fn run(
         listener: UnixListener,
         registry: ChildRegistry,
         events: UnboundedReceiver<LifecycleEvent>,
         lease: Option<LeaseArbiter>,
+        lease_events: Option<UnboundedReceiver<ChildKilled>>,
     ) -> std::io::Result<()> {
         let fanout: Fanout<SharedWriter<tokio::net::unix::OwnedWriteHalf>> = Fanout::new();
         tokio::spawn(event_pump(events, fanout.clone()));
+        // The watchdog's kill events (T11628) ride the SAME fanout as the v1.0
+        // lifecycle events, only framed as v1.1 lease envelopes.
+        if let Some(lease_events) = lease_events {
+            tokio::spawn(lease_event_pump(lease_events, fanout.clone()));
+        }
 
         loop {
             let (stream, _addr) = listener.accept().await?;
@@ -487,6 +519,27 @@ pub async fn serve_with_lease(
     events: UnboundedReceiver<LifecycleEvent>,
     lease: Option<LeaseArbiter>,
 ) -> std::io::Result<()> {
+    serve_with_lease_events(socket_path, registry, events, lease, None).await
+}
+
+/// [`serve_with_lease`] plus an OPTIONAL watchdog kill-event channel (T11628).
+///
+/// When `lease_events` is `Some`, the watchdog sweep task's
+/// `child_killed_unresponsive` events are broadcast to every connected client as
+/// unsolicited v1.1 lease envelopes over the same fanout. When `None` this is
+/// byte-identical to [`serve_with_lease`] — the watchdog is opt-in.
+///
+/// # Errors
+///
+/// Returns an I/O error if the socket cannot be bound or the accept loop fails.
+#[cfg(unix)]
+pub async fn serve_with_lease_events(
+    socket_path: &std::path::Path,
+    registry: ChildRegistry,
+    events: UnboundedReceiver<LifecycleEvent>,
+    lease: Option<LeaseArbiter>,
+    lease_events: Option<UnboundedReceiver<ChildKilled>>,
+) -> std::io::Result<()> {
     use tokio::net::UnixListener;
 
     if let Some(parent) = socket_path.parent() {
@@ -502,7 +555,7 @@ pub async fn serve_with_lease(
     }
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(socket = %socket_path.display(), "supervisor IPC listening");
-    unix_serve::run(listener, registry, events, lease).await
+    unix_serve::run(listener, registry, events, lease, lease_events).await
 }
 
 /// Windows IPC is not yet implemented in this crate (named-pipe server lands
@@ -536,6 +589,27 @@ pub async fn serve_with_lease(
     _registry: ChildRegistry,
     _events: UnboundedReceiver<LifecycleEvent>,
     _lease: Option<LeaseArbiter>,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "named-pipe IPC transport is not yet implemented for Windows in cleo-supervisor",
+    ))
+}
+
+/// Windows variant of [`serve_with_lease_events`]. The named-pipe transport is
+/// not yet implemented in this crate, so this returns an error (matching
+/// [`serve`]).
+///
+/// # Errors
+///
+/// Always returns `ErrorKind::Unsupported` on Windows.
+#[cfg(not(unix))]
+pub async fn serve_with_lease_events(
+    _socket_path: &std::path::Path,
+    _registry: ChildRegistry,
+    _events: UnboundedReceiver<LifecycleEvent>,
+    _lease: Option<LeaseArbiter>,
+    _lease_events: Option<UnboundedReceiver<ChildKilled>>,
 ) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,

--- a/crates/cleo-supervisor/src/ipc_transport.rs
+++ b/crates/cleo-supervisor/src/ipc_transport.rs
@@ -66,7 +66,7 @@ where
         self.clients.lock().await.len()
     }
 
-    /// Broadcast one envelope as an NDJSON line to every connected client.
+    /// Broadcast one v1.0 envelope as an NDJSON line to every connected client.
     ///
     /// Clients whose write fails (disconnected) are dropped from the registry.
     /// Returns the number of clients the line was successfully delivered to.
@@ -75,15 +75,44 @@ where
     ///
     /// Returns a `serde_json` error if the envelope cannot be serialized.
     pub async fn broadcast(&self, envelope: &IpcEnvelope) -> Result<usize, serde_json::Error> {
-        let mut line = envelope.to_ndjson()?;
-        line.push('\n');
-        let bytes = line.into_bytes();
+        let line = {
+            let mut l = envelope.to_ndjson()?;
+            l.push('\n');
+            l
+        };
+        Ok(self.broadcast_line(&line).await)
+    }
 
+    /// Broadcast one v1.1 [`crate::lease_ipc::LeaseEnvelope`] as an NDJSON line to
+    /// every connected client — the unsolicited-event path the watchdog's
+    /// `child_killed_unresponsive` event takes (T11628). Identical framing to
+    /// [`Self::broadcast`]; only the union differs.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `serde_json` error if the envelope cannot be serialized.
+    pub async fn broadcast_lease(
+        &self,
+        envelope: &crate::lease_ipc::LeaseEnvelope,
+    ) -> Result<usize, serde_json::Error> {
+        let line = {
+            let mut l = envelope.to_ndjson()?;
+            l.push('\n');
+            l
+        };
+        Ok(self.broadcast_line(&line).await)
+    }
+
+    /// Write one pre-serialized NDJSON line to every connected client, dropping
+    /// any whose write fails. Returns the delivered count. Shared by the v1.0 and
+    /// v1.1 broadcast paths so the dead-client reaping is identical.
+    async fn broadcast_line(&self, line: &str) -> usize {
+        let bytes = line.as_bytes();
         let mut guard = self.clients.lock().await;
         let mut delivered = 0usize;
         let mut alive: Vec<W> = Vec::with_capacity(guard.len());
         for mut client in guard.drain(..) {
-            match client.write_all(&bytes).await {
+            match client.write_all(bytes).await {
                 Ok(()) => {
                     let _ = client.flush().await;
                     delivered += 1;
@@ -95,7 +124,7 @@ where
             }
         }
         *guard = alive;
-        Ok(delivered)
+        delivered
     }
 }
 

--- a/crates/cleo-supervisor/src/lease_handler.rs
+++ b/crates/cleo-supervisor/src/lease_handler.rs
@@ -100,6 +100,7 @@ pub fn request_kind(req: &LeaseRequest) -> &'static str {
         LeaseRequest::RateCheck(_) => "rate_check",
         LeaseRequest::ToolGrant(_) => "tool_grant",
         LeaseRequest::QueueAdmit(_) => "queue_admit",
+        LeaseRequest::WorkerHeartbeat(_) => "worker_heartbeat",
     }
 }
 
@@ -184,6 +185,12 @@ pub struct LeaseArbiter {
     /// (T11630). Shared across all clients (the contended counters are process-
     /// global, like a real provider quota). Cheap to clone (`Arc` bump).
     llm_queue: LlmQueue,
+    /// The shared watchdog heartbeat ledger (T11628). When wired, an inbound
+    /// `worker_heartbeat` resets the child's deadline clock here where the
+    /// watchdog sweep reads it. `None` when the watchdog is not enabled — a
+    /// `worker_heartbeat` then still acks (the worker degrades gracefully), it
+    /// just records nothing.
+    heartbeat_sink: Option<crate::watchdog::HeartbeatSink>,
 }
 
 impl LeaseArbiter {
@@ -193,6 +200,7 @@ impl LeaseArbiter {
         Self {
             resolver,
             llm_queue: LlmQueue::new(),
+            heartbeat_sink: None,
         }
     }
 
@@ -203,7 +211,18 @@ impl LeaseArbiter {
         Self {
             resolver,
             llm_queue,
+            heartbeat_sink: None,
         }
+    }
+
+    /// Attach the watchdog's shared heartbeat ledger so an inbound
+    /// `worker_heartbeat` resets the child's deadline (T11628). Returns `self`
+    /// for builder chaining. When the watchdog is enabled the supervisor wires
+    /// the SAME sink it gives the sweep task.
+    #[must_use]
+    pub fn with_heartbeat_sink(mut self, sink: crate::watchdog::HeartbeatSink) -> Self {
+        self.heartbeat_sink = Some(sink);
+        self
     }
 
     /// The shared LLM queue (so the watchdog T11628 can read in-flight state and
@@ -240,7 +259,24 @@ impl LeaseArbiter {
             // The LLM-queue admit verb is WIRED (T11630) — backed by the
             // in-memory priority scheduler + per-provider rate governor.
             LeaseRequest::QueueAdmit(req) => self.handle_queue_admit(&req),
+            // The watchdog heartbeat verb is WIRED (T11628) — resets the child's
+            // deadline clock in the shared ledger the sweep task reads.
+            LeaseRequest::WorkerHeartbeat(req) => self.handle_worker_heartbeat(&req),
         }
+    }
+
+    /// `worker_heartbeat` — record the worker's liveness beat into the shared
+    /// watchdog ledger (T11628 · AC1) and ack. The beat carries the worker's own
+    /// view of whether it is inside an LLM call (`in_flight_llm`), which the
+    /// watchdog ORs with the queue's view to tier the deadline (AC2). When no
+    /// watchdog sink is wired the beat is dropped but still acked, so a worker
+    /// heartbeating at a supervisor without the watchdog enabled degrades
+    /// gracefully rather than erroring.
+    fn handle_worker_heartbeat(&self, req: &crate::lease_ipc::WorkerHeartbeatReq) -> LeaseResponse {
+        if let Some(sink) = &self.heartbeat_sink {
+            crate::watchdog::record_heartbeat(sink, &req.child_id, req.in_flight_llm);
+        }
+        LeaseResponse::HeartbeatAck(crate::lease_ipc::HeartbeatAck {})
     }
 
     /// `queue_admit` — run the LLM-call admission decision through the priority

--- a/crates/cleo-supervisor/src/lease_ipc.rs
+++ b/crates/cleo-supervisor/src/lease_ipc.rs
@@ -92,6 +92,12 @@ pub enum LeaseRequest {
     /// Admit (or defer) an outbound LLM call through the priority scheduler +
     /// per-provider rate governor (T11630 · AC1-AC4). `[wired]`
     QueueAdmit(QueueAdmitReq),
+    /// Liveness heartbeat from a managed worker — refreshes the watchdog's
+    /// deadline for `child_id`. Carries the worker's own knowledge of whether it
+    /// is currently inside an LLM call so the watchdog can tier the deadline even
+    /// for callers that bypass the `queue_admit` seam (T11628 · AC1/AC2).
+    /// `[wired]`
+    WorkerHeartbeat(WorkerHeartbeatReq),
 }
 
 /// An arbiter → client lease response or unsolicited event.
@@ -116,6 +122,9 @@ pub enum LeaseResponse {
     ChildKilledUnresponsive(ChildKilled),
     /// Reply to a `queue_admit`: the LLM call was admitted or deferred (T11630).
     QueueAdmitResult(QueueAdmitResult),
+    /// Acknowledge a `worker_heartbeat`: the watchdog recorded the beat and reset
+    /// the child's deadline (T11628). Carries nothing — its presence IS the ack.
+    HeartbeatAck(HeartbeatAck),
     /// An error response correlated to a request id. Reuses the v1.0
     /// [`crate::ipc::ErrorResult`] shape so error framing is shared across both
     /// protocol versions.
@@ -298,6 +307,23 @@ pub struct QueueAdmitReq {
     pub child_id: String,
 }
 
+/// A liveness heartbeat from a managed worker (T11628). Mirrors
+/// `WorkerHeartbeatReq`.
+///
+/// The worker sends this periodically (well inside the watchdog's NORMAL
+/// deadline) so the supervisor knows it is alive. `in_flight_llm` is the
+/// worker's OWN view of whether it is currently waiting on an LLM call: when
+/// true the watchdog grants the EXTENDED deadline even if the call never went
+/// through the `queue_admit` seam, so a slow-but-healthy long call is never
+/// false-killed (AC2 · RISK-7).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerHeartbeatReq {
+    /// The logical id of the heartbeating child (matches the registry key).
+    pub child_id: String,
+    /// The worker's own view of whether it is currently inside an LLM call.
+    pub in_flight_llm: bool,
+}
+
 // ─── Response payloads ──────────────────────────────────────────────────────
 
 /// The lease was granted to the caller. Mirrors `LeaseGranted`.
@@ -391,6 +417,15 @@ pub struct QueueAdmitResult {
     pub queue_position: u32,
 }
 
+/// Acknowledge a `worker_heartbeat` (T11628). Mirrors `HeartbeatAck`.
+///
+/// Deliberately empty — the ack's presence (correlated by id) is the signal
+/// that the watchdog recorded the beat and reset the child's deadline. A unit
+/// struct keeps the wire shape `{ "kind": "heartbeat_ack" }`, matching the Zod
+/// `{ kind: 'heartbeat_ack' }` object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeartbeatAck {}
+
 /// Unsolicited event: a held lease was revoked. Mirrors `LeaseRevoked`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeaseRevoked {
@@ -425,17 +460,18 @@ mod tests {
     /// The FROZEN v1.1 request `kind` values, in declaration order. The
     /// schema-drift guard pins this tuple; any addition/removal is a
     /// contract-breaking change requiring a coordinated dual edit.
-    const LEASE_REQUEST_KINDS: [&str; 6] = [
+    const LEASE_REQUEST_KINDS: [&str; 7] = [
         "lease_acquire",
         "lease_release",
         "lease_renew",
         "rate_check",
         "tool_grant",
         "queue_admit",
+        "worker_heartbeat",
     ];
 
     /// The FROZEN v1.1 response `kind` values, in declaration order.
-    const LEASE_RESPONSE_KINDS: [&str; 9] = [
+    const LEASE_RESPONSE_KINDS: [&str; 10] = [
         "lease_granted",
         "lease_queued",
         "lease_denied",
@@ -444,6 +480,7 @@ mod tests {
         "lease_revoked",
         "child_killed_unresponsive",
         "queue_admit_result",
+        "heartbeat_ack",
         "error",
     ];
 
@@ -483,6 +520,10 @@ mod tests {
                 priority_class: QueuePriorityClass::Lead,
                 est_tokens: 1024,
                 child_id: "worker-1".into(),
+            }),
+            LeaseRequest::WorkerHeartbeat(WorkerHeartbeatReq {
+                child_id: "worker-1".into(),
+                in_flight_llm: true,
             }),
         ]
     }
@@ -536,6 +577,7 @@ mod tests {
                 tokens_remaining: 0,
                 queue_position: 2,
             }),
+            LeaseResponse::HeartbeatAck(HeartbeatAck {}),
             LeaseResponse::Error(crate::ipc::ErrorResult {
                 code: "E_LEASE_BAD_VERSION".into(),
                 message: "unsupported protocol".into(),

--- a/crates/cleo-supervisor/src/lib.rs
+++ b/crates/cleo-supervisor/src/lib.rs
@@ -19,6 +19,7 @@
 //!   * [`ipc_transport`] — Unix-socket / Windows-pipe NDJSON fan-out.
 //!   * [`ipc_server`] — bind + accept loop + request dispatch into the registry (R2).
 //!   * [`llm_queue`]  — LLM-queue priority scheduler + per-provider rate governor (T11630).
+//!   * [`watchdog`]   — heartbeat-deadline kill, tiered by LLM in-flight state (T11628).
 //!
 //! The binary ([`main`](../main.rs)) is distributed as a standalone executable via
 //! the worktree-napi-style cross-compile + GitHub-Release packaging (T11340),
@@ -42,6 +43,7 @@ pub mod paths;
 pub mod pidfile;
 pub mod process;
 pub mod supervisor;
+pub mod watchdog;
 
 /// Crate version, sourced from `Cargo.toml` at build time.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/cleo-supervisor/src/main.rs
+++ b/crates/cleo-supervisor/src/main.rs
@@ -131,9 +131,11 @@ fn run() -> anyhow::Result<()> {
 /// arbiter (so workers can send `worker_heartbeat`) and a background sweep task
 /// that SIGTERM→SIGKILLs a worker that stops heartbeating past its tiered
 /// deadline.
+#[cfg(unix)]
 const WATCHDOG_ENV_KEY: &str = "CLEO_SUPERVISOR_WATCHDOG";
 
 /// Whether the watchdog is enabled via [`WATCHDOG_ENV_KEY`] (`1` / `true`).
+#[cfg(unix)]
 fn watchdog_enabled() -> bool {
     std::env::var(WATCHDOG_ENV_KEY)
         .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
@@ -161,6 +163,11 @@ async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<(
     let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
     let registry = ChildRegistry::new(event_tx);
 
+    // The watchdog wiring rides the Unix accept loop (the only IPC transport
+    // implemented in this crate today). On Windows the named-pipe transport — and
+    // with it the watchdog — lands with the Windows IPC epic; the registry holds
+    // a non-`Send` Job-Object handle there, so the sweep task is Unix-only.
+    #[cfg(unix)]
     if watchdog_enabled() {
         return serve_with_watchdog(socket_path, registry, event_rx).await;
     }
@@ -186,6 +193,12 @@ async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<(
 /// background sweep task, and serves with the lease-event channel so kill events
 /// reach clients. Races the accept loop against the watchdog task and the
 /// shutdown signal.
+///
+/// Unix-only: the sweep task `tokio::spawn`s a future capturing the
+/// [`ChildRegistry`], whose per-child [`JobObject`](cleo_supervisor::jobobject)
+/// handle is non-`Send` on Windows. The Windows watchdog lands with the
+/// named-pipe IPC transport in the Windows IPC epic.
+#[cfg(unix)]
 async fn serve_with_watchdog(
     socket_path: &std::path::Path,
     registry: cleo_supervisor::supervisor::ChildRegistry,

--- a/crates/cleo-supervisor/src/main.rs
+++ b/crates/cleo-supervisor/src/main.rs
@@ -124,9 +124,35 @@ fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Environment opt-in for the heartbeat-deadline watchdog (T11628). The watchdog
+/// is a SUPERVISOR capability that only runs when the supervisor is up; it stays
+/// OFF by default (the daemon-off posture) and is enabled by setting this var to
+/// a truthy value (`1` / `true`). When enabled the accept loop wires a lease
+/// arbiter (so workers can send `worker_heartbeat`) and a background sweep task
+/// that SIGTERM→SIGKILLs a worker that stops heartbeating past its tiered
+/// deadline.
+const WATCHDOG_ENV_KEY: &str = "CLEO_SUPERVISOR_WATCHDOG";
+
+/// Whether the watchdog is enabled via [`WATCHDOG_ENV_KEY`] (`1` / `true`).
+fn watchdog_enabled() -> bool {
+    std::env::var(WATCHDOG_ENV_KEY)
+        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
 /// Bind the IPC listener + accept loop and run it concurrently with the
 /// shutdown-signal loop, returning when a shutdown signal is received (or the
 /// accept loop fails irrecoverably).
+///
+/// When the watchdog is enabled ([`watchdog_enabled`]) this wires the full
+/// heartbeat path (T11628 step 4): a [`LeaseArbiter`] with the shared watchdog
+/// heartbeat sink (so `worker_heartbeat` frames reset deadlines), a background
+/// [`watchdog::run_watchdog`] sweep task (which SIGTERM→SIGKILLs unresponsive
+/// workers), and the lease-event channel that broadcasts each
+/// `child_killed_unresponsive` event to connected clients. The watchdog shares
+/// the SAME [`LlmQueue`] the arbiter's `queue_admit` path writes, so an in-flight
+/// LLM call extends the deadline (AC2). When disabled, the loop is the unchanged
+/// v1.0-only `serve` path.
 async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<()> {
     use cleo_supervisor::ipc_server;
     use cleo_supervisor::supervisor::ChildRegistry;
@@ -134,6 +160,10 @@ async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<(
     // Lifecycle events flow registry -> IPC fan-out over this channel.
     let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
     let registry = ChildRegistry::new(event_tx);
+
+    if watchdog_enabled() {
+        return serve_with_watchdog(socket_path, registry, event_rx).await;
+    }
 
     tokio::select! {
         // The accept loop only returns on an unrecoverable transport error;
@@ -147,6 +177,68 @@ async fn serve_until_shutdown(socket_path: &std::path::Path) -> anyhow::Result<(
         }
     }
     Ok(())
+}
+
+/// The watchdog-enabled accept loop (T11628 step 4 — the production wiring).
+///
+/// Constructs the shared [`LlmQueue`] + [`Watchdog`], a [`LeaseArbiter`] whose
+/// `worker_heartbeat` handler writes the watchdog's heartbeat sink, spawns the
+/// background sweep task, and serves with the lease-event channel so kill events
+/// reach clients. Races the accept loop against the watchdog task and the
+/// shutdown signal.
+async fn serve_with_watchdog(
+    socket_path: &std::path::Path,
+    registry: cleo_supervisor::supervisor::ChildRegistry,
+    event_rx: tokio::sync::mpsc::UnboundedReceiver<cleo_supervisor::ipc::LifecycleEvent>,
+) -> anyhow::Result<()> {
+    use cleo_supervisor::ipc_server;
+    use cleo_supervisor::lease_handler::LeaseArbiter;
+    use cleo_supervisor::lease_ipc::DbScope;
+    use cleo_supervisor::llm_queue::LlmQueue;
+    use cleo_supervisor::watchdog::{self, Watchdog};
+
+    // One shared LLM queue: the arbiter's `queue_admit` path WRITES the in-flight
+    // ledger, the watchdog READS it to tier the deadline (AC2).
+    let llm_queue = LlmQueue::new();
+    let watchdog = Watchdog::new(llm_queue.clone());
+
+    // The lease arbiter's scope→cleo.db resolver. The watchdog flow never sends a
+    // lease verb (only `worker_heartbeat`), but the arbiter is the dispatch home
+    // for `worker_heartbeat`; point its resolver at the canonical cleo.db so an
+    // incidental lease verb still resolves rather than panicking.
+    let cleo_db = cleo_supervisor::paths::cleo_home()?.join("cleo.db");
+    let resolver: cleo_supervisor::lease_handler::ScopeDbResolver = {
+        let cleo_db = cleo_db.clone();
+        std::sync::Arc::new(move |_scope: DbScope| Ok(cleo_db.clone()))
+    };
+    let arbiter = LeaseArbiter::with_llm_queue(resolver, llm_queue)
+        .with_heartbeat_sink(watchdog.sink());
+
+    // The channel the watchdog sweep task emits `child_killed_unresponsive`
+    // events on; the accept loop broadcasts them to every connected client.
+    let (kill_tx, kill_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Spawn the background sweep task. It owns clones of the watchdog + registry.
+    let sweep = tokio::spawn(watchdog::run_watchdog(
+        watchdog,
+        registry.clone(),
+        cleo_supervisor::supervisor::DEFAULT_STOP_GRACE,
+        watchdog::DEFAULT_SWEEP_INTERVAL,
+        kill_tx,
+    ));
+
+    tracing::info!("supervisor watchdog enabled (T11628)");
+
+    let result = tokio::select! {
+        res = ipc_server::serve_with_lease_events(
+            socket_path, registry, event_rx, Some(arbiter), Some(kill_rx),
+        ) => {
+            res.map_err(|e| anyhow::anyhow!("supervisor IPC serve loop failed: {e}"))
+        }
+        res = signal_loop() => res,
+    };
+    sweep.abort();
+    result
 }
 
 /// Wait for a shutdown signal (SIGTERM/SIGINT on Unix, Ctrl-C on Windows).

--- a/crates/cleo-supervisor/src/supervisor.rs
+++ b/crates/cleo-supervisor/src/supervisor.rs
@@ -799,6 +799,124 @@ impl ChildRegistry {
         self.started_at.elapsed().as_secs()
     }
 
+    /// The logical ids of all currently-registered children (running or
+    /// restarting). Used by the watchdog sweep to scope its stale-candidate set
+    /// to children that actually exist right now (T11628).
+    pub async fn child_ids(&self) -> Vec<String> {
+        self.children.lock().await.keys().cloned().collect()
+    }
+
+    /// Kill ONE unresponsive child with the canonical SIGTERM→grace→SIGKILL
+    /// cascade, isolated to that child's pid (T11628 · AC1/AC2).
+    ///
+    /// Resolves the child's live pid + `generation` under the book lock, captures
+    /// `holder_id` from its spawn env for the event, then signals ONLY that pid —
+    /// never a process group, never `-1`, so a sibling worker and the supervisor
+    /// itself are untouched (kill isolation). After the grace window the child is
+    /// force-killed via [`process::force_kill`]; the child's own monitor task
+    /// observes the exit and updates the book (we do not race it here).
+    ///
+    /// The `generation` captured at the start is re-checked before the SIGKILL:
+    /// if a concurrent `restart` bumped it (a fresh incarnation now owns the
+    /// book) the kill is aborted and `None` returned, so the watchdog never
+    /// clobbers a just-restarted healthy child (T11626 incarnation guard).
+    ///
+    /// Returns the [`ChildKilled`] event to broadcast, or `None` when the child
+    /// was already gone (no live pid) or was superseded by a restart mid-kill.
+    pub async fn kill_unresponsive(
+        &self,
+        child_id: &str,
+        grace: Duration,
+        reason: &str,
+    ) -> Option<crate::lease_ipc::ChildKilled> {
+        // ── Resolve pid + incarnation + holder identity under the lock ───────
+        let (pid, generation, book, holder_id) = {
+            let children = self.children.lock().await;
+            let managed = children.get(child_id)?;
+            let holder_id = holder_id_of(&managed.spec);
+            let guard = managed.book.lock().await;
+            // A non-running incarnation (pid 0 / Stopped / Restarting) has nothing
+            // to kill — leave it to the normal exit/restart machinery.
+            if guard.pid == 0 || !matches!(guard.state, ChildState::Running) {
+                return None;
+            }
+            (
+                guard.pid,
+                guard.generation,
+                Arc::clone(&managed.book),
+                holder_id,
+            )
+        };
+
+        tracing::warn!(
+            child_id = %child_id,
+            pid,
+            generation,
+            reason,
+            "watchdog killing unresponsive child"
+        );
+
+        // ── Phase 1: graceful SIGTERM against ONLY this pid ──────────────────
+        let _ = process::request_terminate(pid);
+
+        // ── Phase 2: wait the grace window for a clean exit (poll the book) ──
+        let exited = Self::await_exit_within(&book, generation, grace).await;
+        if !exited {
+            // ── Phase 3: grace expired — re-check the incarnation, then SIGKILL.
+            // If a restart bumped the generation we must NOT kill the fresh pid.
+            let still_current = {
+                let guard = book.lock().await;
+                guard.generation == generation && guard.pid == pid
+            };
+            if still_current {
+                tracing::warn!(pid, "watchdog grace expired; sending SIGKILL");
+                let _ = process::force_kill(pid);
+            } else {
+                tracing::debug!(
+                    child_id = %child_id,
+                    "watchdog kill aborted: child was restarted mid-grace (incarnation changed)"
+                );
+                return None;
+            }
+        }
+
+        Some(crate::lease_ipc::ChildKilled {
+            child_id: child_id.to_string(),
+            holder_id,
+            scope: crate::lease_ipc::DbScope::Project,
+            reason: reason.to_string(),
+        })
+    }
+
+    /// Poll the child's book for up to `grace`, returning `true` if the child's
+    /// incarnation (`generation`) left the `Running` state (clean exit) within
+    /// the window. The child's OWN monitor task owns the `child.wait()`; we only
+    /// observe the book it updates, so we never contend with tokio's reaper.
+    async fn await_exit_within(
+        book: &Arc<Mutex<ChildBook>>,
+        generation: u64,
+        grace: Duration,
+    ) -> bool {
+        let deadline = tokio::time::Instant::now() + grace;
+        loop {
+            {
+                let guard = book.lock().await;
+                // A different generation = restarted (treat as "moved on"); a
+                // non-Running state for the same generation = exited.
+                if guard.generation != generation
+                    || !matches!(guard.state, ChildState::Running)
+                    || guard.pid == 0
+                {
+                    return true;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
     /// Build the platform-configured [`Command`] and spawn it, assigning the
     /// child to the containment [`JobObject`] (Windows) where applicable.
     fn spawn_process(spec: &ChildSpec, job: &JobObject) -> anyhow::Result<Child> {
@@ -894,6 +1012,19 @@ impl ChildRegistry {
             }
         });
     }
+}
+
+/// Derive the lease holder identity for a child from its spawn spec, for the
+/// `child_killed_unresponsive` event's `holder_id` field. Prefers an explicit
+/// `CLEO_HOLDER_ID` env override if the spawn request set one; otherwise falls
+/// back to the child's logical id (the watchdog kill is keyed on the worker, not
+/// a specific lease lane).
+fn holder_id_of(spec: &ChildSpec) -> String {
+    spec.env
+        .iter()
+        .find(|(k, _)| k == "CLEO_HOLDER_ID")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| spec.child_id.clone())
 }
 
 /// Snapshot a single managed child into its wire [`ChildStatus`].
@@ -1234,6 +1365,96 @@ mod tests {
         let w = registry.spawn(&spawn_req_sleep("h", 30)).await.expect("spawn");
         assert_eq!(registry.child_count().await, 1);
         let _ = process::force_kill(w.pid);
+    }
+
+    // ── Watchdog kill cascade (T11628) ──────────────────────────────────────
+
+    /// AC1: `kill_unresponsive` runs the SIGTERM→grace→SIGKILL cascade against
+    /// ONLY the targeted child's pid and returns its `child_killed_unresponsive`
+    /// event. The child process is dead afterwards.
+    #[tokio::test]
+    async fn registry_kill_unresponsive_terminates_and_returns_event() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let spawned = registry
+            .spawn(&spawn_req_sleep("stuck", 60))
+            .await
+            .expect("spawn");
+        assert!(process::is_alive(spawned.pid));
+
+        let event = registry
+            .kill_unresponsive("stuck", Duration::from_secs(2), "test: unresponsive")
+            .await
+            .expect("kill returns an event");
+        assert_eq!(event.child_id, "stuck");
+        assert_eq!(event.reason, "test: unresponsive");
+        // The targeted pid is dead (SIGTERM honoured by /bin/sh sleep).
+        for _ in 0..100 {
+            if !process::is_alive(spawned.pid) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            !process::is_alive(spawned.pid),
+            "the unresponsive child must be dead after the cascade"
+        );
+    }
+
+    /// AC2 (kill isolation): killing one unresponsive child does NOT touch a
+    /// sibling worker — the sibling's pid stays alive and Running.
+    #[tokio::test]
+    async fn registry_kill_unresponsive_isolates_to_one_child() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let victim = registry
+            .spawn(&spawn_req_sleep("victim", 60))
+            .await
+            .expect("spawn victim");
+        let sibling = registry
+            .spawn(&spawn_req_sleep("sibling", 60))
+            .await
+            .expect("spawn sibling");
+
+        let event = registry
+            .kill_unresponsive("victim", Duration::from_secs(2), "test")
+            .await
+            .expect("victim killed");
+        assert_eq!(event.child_id, "victim");
+
+        // Victim dead.
+        for _ in 0..100 {
+            if !process::is_alive(victim.pid) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(!process::is_alive(victim.pid), "victim must be dead");
+
+        // Sibling untouched — still alive and still Running in the registry.
+        assert!(
+            process::is_alive(sibling.pid),
+            "the sibling worker must NOT be killed (isolation)"
+        );
+        let snap = registry.monitor(Some("sibling")).await.expect("monitor");
+        assert_eq!(snap.children[0].state, ChildState::Running);
+        assert_eq!(snap.children[0].pid, sibling.pid);
+
+        let _ = process::force_kill(sibling.pid);
+    }
+
+    /// `kill_unresponsive` of an unknown child returns `None` (nothing to kill) —
+    /// the supervisor itself is never affected.
+    #[tokio::test]
+    async fn registry_kill_unresponsive_unknown_child_is_noop() {
+        let (tx, _rx) = unbounded_channel();
+        let registry = ChildRegistry::new(tx);
+        let result = registry
+            .kill_unresponsive("ghost", Duration::from_secs(1), "test")
+            .await;
+        assert!(result.is_none(), "killing an unknown child is a no-op");
+        // The supervisor process is, trivially, still alive.
+        assert!(process::is_alive(process::current_pid()));
     }
 
     // ── Session-env stamping + verbatim passthrough (T11629) ────────────────

--- a/crates/cleo-supervisor/src/watchdog.rs
+++ b/crates/cleo-supervisor/src/watchdog.rs
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/cleo-supervisor in the CleoCode monorepo.
+
+//! Heartbeat-deadline watchdog: kill a rogue/stuck worker that stops
+//! heartbeating, with a deadline TIERED by the LLM-queue's knowledge of an
+//! in-flight LLM call (T11628 · AC1/AC2).
+//!
+//! ## What lands here
+//!
+//! [`Watchdog`] is a generalization of [`crate::lease_handler::LeaseArbiter::reclaim_or_kill`]:
+//! the same two-phase sweep (snapshot candidates under the lock → act WITHOUT
+//! holding the lock), but keyed on a heartbeat clock instead of a persisted
+//! lease TTL. Each managed worker MUST touch a heartbeat over the v1.1 lease IPC
+//! (`worker_heartbeat`) within a deadline; on a miss the supervisor runs the
+//! canonical SIGTERM→grace→SIGKILL cascade against that ONE child's pid
+//! ([`crate::process`]) and emits a `child_killed_unresponsive` event (AC1).
+//!
+//! ## Tiered deadline (AC2 · RISK-7)
+//!
+//! A healthy agent can legitimately go quiet for minutes while it waits on a
+//! single slow LLM completion. Killing it at the NORMAL deadline would be a
+//! false positive. So the watchdog tiers the deadline per child on every sweep:
+//!
+//! ```text
+//! deadline = if in_flight_llm(child) { EXTENDED } else { NORMAL }
+//! ```
+//!
+//! `in_flight_llm(child)` is the OR of two sources, so neither path can be
+//! bypassed:
+//!   1. [`crate::llm_queue::LlmQueue::has_in_flight_call`] — the supervisor's own
+//!      admission ledger (a call that went through the `queue_admit` seam).
+//!   2. the worker's self-reported `in_flight_llm` flag on its last heartbeat —
+//!      for a caller that talks to a provider WITHOUT going through the queue.
+//!
+//! ## Kill isolation (AC2)
+//!
+//! The sweep acts per-child: one unresponsive worker's SIGTERM/SIGKILL targets
+//! ONLY its pid. A sibling worker and the supervisor process itself are never
+//! touched — the kill path is `process::request_terminate(pid)` /
+//! `process::force_kill(pid)` against a single resolved pid, never a process
+//! group or `-1`. A child whose `generation` (incarnation token) changed between
+//! the candidate snapshot and the kill is skipped, so a freshly-restarted child
+//! is never clobbered by a stale deadline (T11626 incarnation guard).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::lease_ipc::ChildKilled;
+use crate::llm_queue::LlmQueue;
+use crate::supervisor::ChildRegistry;
+
+/// Default NORMAL heartbeat deadline.
+///
+/// A worker that is NOT inside an LLM call MUST heartbeat at least this often or
+/// it is considered stuck. Sized well above a sane heartbeat interval (the
+/// worker should beat every ~10s).
+pub const DEFAULT_NORMAL_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Default EXTENDED heartbeat deadline.
+///
+/// A worker the supervisor knows is inside an LLM call gets this far longer
+/// window before it is considered stuck, so a slow-but-healthy long completion
+/// is never false-killed (AC2 · RISK-7).
+pub const DEFAULT_EXTENDED_DEADLINE: Duration = Duration::from_secs(600);
+
+/// Default grace window between the SIGTERM and the SIGKILL in the per-child
+/// kill cascade — matches the supervisor's `DEFAULT_STOP_GRACE` intent.
+pub const DEFAULT_KILL_GRACE: Duration = Duration::from_secs(5);
+
+/// One worker's last recorded heartbeat (T11628).
+///
+/// Public only because it is a type parameter of the public [`HeartbeatSink`]
+/// alias; its fields are private and it is constructed exclusively via
+/// [`record_heartbeat`].
+#[derive(Debug, Clone, Copy)]
+pub struct HeartbeatRecord {
+    /// Monotonic instant of the worker's most recent heartbeat.
+    last_beat: Instant,
+    /// The worker's OWN view (on that beat) of whether it is inside an LLM call.
+    /// OR-ed with the queue's view so a non-`queue_admit` caller is still tiered.
+    in_flight_llm: bool,
+}
+
+/// The shared heartbeat ledger.
+///
+/// Cloned into both the watchdog sweep task (reader) and the lease arbiter
+/// (writer, on each `worker_heartbeat`), so a beat recorded on the IPC blocking
+/// thread is visible to the next sweep tick without a channel.
+pub type HeartbeatSink = Arc<Mutex<HashMap<String, HeartbeatRecord>>>;
+
+/// Record a worker heartbeat into the shared sink (the arbiter's write path).
+///
+/// Called from the lease IPC handler when a `worker_heartbeat` frame arrives.
+/// Resets `child_id`'s deadline clock to now and stores the worker's self-report
+/// of whether it is inside an LLM call (the second tiering source — AC2).
+pub fn record_heartbeat(sink: &HeartbeatSink, child_id: &str, in_flight_llm: bool) {
+    let mut guard = lock_sink(sink);
+    guard.insert(
+        child_id.to_string(),
+        HeartbeatRecord {
+            last_beat: Instant::now(),
+            in_flight_llm,
+        },
+    );
+}
+
+/// Lock the sink, recovering a poisoned mutex (a panic while recording a beat
+/// must not wedge the watchdog — the in-memory ledger is reconstructible from
+/// the next heartbeat).
+fn lock_sink(sink: &HeartbeatSink) -> std::sync::MutexGuard<'_, HashMap<String, HeartbeatRecord>> {
+    sink.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// A child that has blown its (tiered) heartbeat deadline — a sweep candidate.
+///
+/// Captured under the sink lock, then acted on AFTER the lock is released so the
+/// kill cascade (which may block on a grace timeout) never holds the ledger.
+#[derive(Debug, Clone)]
+pub struct StaleCandidate {
+    /// The logical id of the stale child.
+    pub child_id: String,
+    /// How long since its last heartbeat (for the kill reason / logging).
+    pub since: Duration,
+    /// Which tier's deadline it blew (for the kill reason / logging).
+    pub deadline: Duration,
+}
+
+/// The heartbeat-deadline watchdog (T11628).
+///
+/// Holds the shared heartbeat ledger and a clone of the shared [`LlmQueue`] so it
+/// can tier each child's deadline by the supervisor's in-flight-call knowledge.
+/// `Clone` is a cheap `Arc` bump so the sweep task and the arbiter share one
+/// instance.
+#[derive(Clone)]
+pub struct Watchdog {
+    sink: HeartbeatSink,
+    llm_queue: LlmQueue,
+    normal_deadline: Duration,
+    extended_deadline: Duration,
+}
+
+impl Watchdog {
+    /// Build a watchdog over a shared [`LlmQueue`] with the crate-default
+    /// deadlines. Shares the queue's `Arc<Mutex<…>>` so `has_in_flight_call`
+    /// reads the SAME in-flight ledger the `queue_admit` path writes.
+    #[must_use]
+    pub fn new(llm_queue: LlmQueue) -> Self {
+        Self {
+            sink: Arc::new(Mutex::new(HashMap::new())),
+            llm_queue,
+            normal_deadline: DEFAULT_NORMAL_DEADLINE,
+            extended_deadline: DEFAULT_EXTENDED_DEADLINE,
+        }
+    }
+
+    /// Build a watchdog with explicit deadlines (test seam + tuning).
+    #[must_use]
+    pub fn with_deadlines(
+        llm_queue: LlmQueue,
+        normal_deadline: Duration,
+        extended_deadline: Duration,
+    ) -> Self {
+        Self {
+            sink: Arc::new(Mutex::new(HashMap::new())),
+            llm_queue,
+            normal_deadline,
+            extended_deadline,
+        }
+    }
+
+    /// The shared heartbeat ledger — clone this into the lease arbiter so a
+    /// `worker_heartbeat` it receives is recorded where the sweep reads it.
+    #[must_use]
+    pub fn sink(&self) -> HeartbeatSink {
+        Arc::clone(&self.sink)
+    }
+
+    /// Record a heartbeat for `child_id` directly (test seam + the in-process
+    /// fast path). Equivalent to [`record_heartbeat`] on this watchdog's sink.
+    pub fn record(&self, child_id: &str, in_flight_llm: bool) {
+        record_heartbeat(&self.sink, child_id, in_flight_llm);
+    }
+
+    /// Drop a child from the heartbeat ledger (e.g. after it exited or was
+    /// killed) so a dead id does not linger. Idempotent.
+    pub fn forget(&self, child_id: &str) {
+        lock_sink(&self.sink).remove(child_id);
+    }
+
+    /// The deadline that applies to `child_id` RIGHT NOW: EXTENDED iff the
+    /// supervisor knows the child is inside an LLM call (either via the queue's
+    /// admission ledger OR the worker's last self-report), else NORMAL (AC2).
+    #[must_use]
+    pub fn deadline_for(&self, child_id: &str) -> Duration {
+        if self.is_in_flight(child_id) {
+            self.extended_deadline
+        } else {
+            self.normal_deadline
+        }
+    }
+
+    /// Whether the supervisor currently believes `child_id` is inside an LLM
+    /// call. OR of the two tiering sources so neither path can be bypassed.
+    fn is_in_flight(&self, child_id: &str) -> bool {
+        if self.llm_queue.has_in_flight_call(child_id) {
+            return true;
+        }
+        lock_sink(&self.sink)
+            .get(child_id)
+            .is_some_and(|r| r.in_flight_llm)
+    }
+
+    /// Phase 1 of the sweep: snapshot the children whose last heartbeat is older
+    /// than their (tiered) deadline AND that are in `known_children` — never act
+    /// while holding the ledger lock (mirrors `reclaim_or_kill`'s candidate
+    /// snapshot). `known_children` scopes the sweep to currently-registered
+    /// children so a forgotten id is not re-killed.
+    ///
+    /// A child with NO heartbeat record yet is NOT stale — it has not been given
+    /// a chance to beat (the watchdog seeds a beat on spawn).
+    #[must_use]
+    pub fn stale_candidates(&self, known_children: &[String]) -> Vec<StaleCandidate> {
+        let now = Instant::now();
+        let guard = lock_sink(&self.sink);
+        let mut stale = Vec::new();
+        for child_id in known_children {
+            let Some(rec) = guard.get(child_id) else {
+                // No beat recorded yet — not a candidate (grace before first beat).
+                continue;
+            };
+            // Tier the deadline: EXTENDED iff in-flight (queue OR self-report).
+            let in_flight = self.llm_queue.has_in_flight_call(child_id) || rec.in_flight_llm;
+            let deadline = if in_flight {
+                self.extended_deadline
+            } else {
+                self.normal_deadline
+            };
+            let since = now.saturating_duration_since(rec.last_beat);
+            if since > deadline {
+                stale.push(StaleCandidate {
+                    child_id: child_id.clone(),
+                    since,
+                    deadline,
+                });
+            }
+        }
+        stale
+    }
+}
+
+/// Default interval between watchdog sweeps. Short relative to the NORMAL
+/// deadline so a stuck worker is detected within one extra tick of its deadline.
+pub const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Run ONE watchdog sweep (T11628 · AC1/AC2).
+///
+/// Snapshots the stale candidates among the registry's currently-registered
+/// children (tiered by in-flight state), kills each ONE at a time with the
+/// SIGTERM→grace→SIGKILL cascade, forgets it from the ledger, and emits its
+/// `child_killed_unresponsive` event over `kill_events`. Returns the killed
+/// `child_id`s (for tests + logging).
+///
+/// Candidate snapshot (read under the ledger lock) and the kills (which may
+/// block on a grace timeout) are TWO phases — the lock is never held across the
+/// `.await` kill, mirroring `LeaseArbiter::reclaim_or_kill`.
+pub async fn run_one_sweep(
+    watchdog: &Watchdog,
+    registry: &ChildRegistry,
+    grace: Duration,
+    kill_events: &UnboundedSender<ChildKilled>,
+) -> Vec<String> {
+    let known = registry.child_ids().await;
+    // Phase 1: snapshot candidates (no lock held across the awaits below).
+    let candidates = watchdog.stale_candidates(&known);
+    let mut killed_ids = Vec::new();
+    // Phase 2: act per-child — isolated kill, then emit the event.
+    for cand in candidates {
+        let reason = format!(
+            "unresponsive: no heartbeat for {}ms (deadline {}ms)",
+            cand.since.as_millis(),
+            cand.deadline.as_millis(),
+        );
+        if let Some(event) = registry
+            .kill_unresponsive(&cand.child_id, grace, &reason)
+            .await
+        {
+            // Drop the dead child from the ledger so it is not re-swept.
+            watchdog.forget(&cand.child_id);
+            killed_ids.push(event.child_id.clone());
+            // A closed receiver (no clients / shutdown) is not fatal — the kill
+            // already happened; the event is best-effort observability.
+            let _ = kill_events.send(event);
+        }
+    }
+    killed_ids
+}
+
+/// Drive the watchdog sweep forever on a fixed interval (the production wiring,
+/// T11628 step 4).
+///
+/// This is the background task the supervisor `tokio::spawn`s. The first tick
+/// fires after one interval so freshly-spawned children get a grace window to
+/// send their first heartbeat. Returns only if the registry is dropped (never,
+/// in production) — the caller races it against the shutdown signal.
+pub async fn run_watchdog(
+    watchdog: Watchdog,
+    registry: ChildRegistry,
+    grace: Duration,
+    interval: Duration,
+    kill_events: UnboundedSender<ChildKilled>,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    // Skip the immediate first tick so we wait one full interval before the
+    // first sweep (the default MissedTickBehavior::Burst would fire at t=0).
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        let killed = run_one_sweep(&watchdog, &registry, grace, &kill_events).await;
+        if !killed.is_empty() {
+            tracing::info!(killed = ?killed, "watchdog swept unresponsive children");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_queue::PriorityClass;
+
+    fn ids(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// A child that just beat is never stale (its clock was reset to now).
+    #[test]
+    fn fresh_heartbeat_is_not_stale() {
+        let wd = Watchdog::new(LlmQueue::new());
+        wd.record("w1", false);
+        assert!(
+            wd.stale_candidates(&ids(&["w1"])).is_empty(),
+            "a child that just beat is healthy"
+        );
+    }
+
+    /// A child with NO heartbeat record yet is not a candidate (grace before the
+    /// first beat) — the watchdog never kills a child it never heard from.
+    #[test]
+    fn child_without_a_beat_is_not_stale() {
+        let wd = Watchdog::new(LlmQueue::new());
+        assert!(wd.stale_candidates(&ids(&["never-beat"])).is_empty());
+    }
+
+    /// AC1: a child that blew the NORMAL deadline with no in-flight call IS a
+    /// stale candidate (the sweep would SIGTERM→SIGKILL it).
+    #[test]
+    fn missed_normal_deadline_is_stale() {
+        // 1ms normal deadline so a tiny sleep blows it.
+        let wd = Watchdog::with_deadlines(
+            LlmQueue::new(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+        wd.record("w1", false);
+        std::thread::sleep(Duration::from_millis(5));
+        let stale = wd.stale_candidates(&ids(&["w1"]));
+        assert_eq!(stale.len(), 1, "a child past the normal deadline is stale");
+        assert_eq!(stale[0].child_id, "w1");
+        assert_eq!(stale[0].deadline, Duration::from_millis(1));
+    }
+
+    /// AC2 (RISK-7): a child past the NORMAL deadline but with an in-flight LLM
+    /// call (per the shared queue) is NOT killed — it gets the EXTENDED window.
+    #[test]
+    fn in_flight_llm_call_extends_the_deadline_via_queue() {
+        let queue = LlmQueue::new();
+        queue.configure_provider("anthropic", 1_000_000, 100, 60_000);
+        // Tiny NORMAL deadline, generous EXTENDED.
+        let wd = Watchdog::with_deadlines(
+            queue.clone(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+        // The child admitted an LLM call through the queue (the watchdog seam).
+        assert!(matches!(
+            queue.admit("anthropic", PriorityClass::Worker, 100, "w1"),
+            crate::llm_queue::AdmitDecision::Admitted { .. }
+        ));
+        wd.record("w1", false); // self-report false; the QUEUE knows it is in-flight
+        std::thread::sleep(Duration::from_millis(5));
+        // Past the 1ms NORMAL deadline, but the queue reports in-flight → EXTENDED.
+        assert_eq!(
+            wd.deadline_for("w1"),
+            Duration::from_secs(600),
+            "an in-flight call grants the extended deadline"
+        );
+        assert!(
+            wd.stale_candidates(&ids(&["w1"])).is_empty(),
+            "a slow-but-healthy in-flight worker is NOT a kill candidate (RISK-7)"
+        );
+    }
+
+    /// AC2: the worker's OWN self-reported `in_flight_llm` flag also extends the
+    /// deadline — a caller that talks to a provider WITHOUT the queue is covered.
+    #[test]
+    fn in_flight_self_report_extends_the_deadline() {
+        let wd = Watchdog::with_deadlines(
+            LlmQueue::new(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+        wd.record("w1", true); // self-reported in-flight; queue knows nothing
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(wd.deadline_for("w1"), Duration::from_secs(600));
+        assert!(
+            wd.stale_candidates(&ids(&["w1"])).is_empty(),
+            "self-reported in-flight extends the deadline even without the queue"
+        );
+    }
+
+    /// AC2 (isolation): when one child is stale and a sibling is fresh, ONLY the
+    /// stale child is a candidate — the sweep never proposes killing the sibling.
+    #[test]
+    fn kill_isolation_only_the_stale_child_is_a_candidate() {
+        let wd = Watchdog::with_deadlines(
+            LlmQueue::new(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+        wd.record("stale", false);
+        std::thread::sleep(Duration::from_millis(5));
+        // The sibling beats AFTER the sleep, so its clock is fresh.
+        wd.record("fresh", false);
+        let stale = wd.stale_candidates(&ids(&["stale", "fresh"]));
+        assert_eq!(stale.len(), 1, "only the stale child is a candidate");
+        assert_eq!(stale[0].child_id, "stale");
+    }
+
+    /// `forget` drops a child so a dead/killed id is no longer swept.
+    #[test]
+    fn forget_drops_a_child_from_the_ledger() {
+        let wd = Watchdog::with_deadlines(
+            LlmQueue::new(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+        wd.record("w1", false);
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(wd.stale_candidates(&ids(&["w1"])).len(), 1);
+        wd.forget("w1");
+        assert!(
+            wd.stale_candidates(&ids(&["w1"])).is_empty(),
+            "a forgotten child is no longer swept"
+        );
+    }
+
+    /// A heartbeat received AFTER a child went stale rescues it: the next sweep
+    /// sees the refreshed clock and the child is no longer a candidate.
+    #[test]
+    fn a_late_heartbeat_rescues_a_stale_child() {
+        let wd = Watchdog::with_deadlines(
+            LlmQueue::new(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+        wd.record("w1", false);
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(wd.stale_candidates(&ids(&["w1"])).len(), 1, "stale first");
+        // The worker comes back to life with a fresh beat.
+        wd.record("w1", false);
+        assert!(
+            wd.stale_candidates(&ids(&["w1"])).is_empty(),
+            "a late heartbeat resets the deadline clock"
+        );
+    }
+
+    /// The shared sink is visible across clones: a beat recorded via one handle
+    /// (the arbiter's clone) is seen by another (the sweep task's clone).
+    #[test]
+    fn shared_sink_is_visible_across_clones() {
+        let wd = Watchdog::new(LlmQueue::new());
+        let sink = wd.sink();
+        record_heartbeat(&sink, "w1", false); // arbiter-side write
+        // The watchdog (sweep-side) sees it: fresh, so not stale.
+        assert!(wd.stale_candidates(&ids(&["w1"])).is_empty());
+    }
+
+    // ── End-to-end sweep over a real registry + child (T11628) ──────────────
+
+    /// Build a spawn request for a long-running sleep child (the "stuck worker").
+    #[cfg(unix)]
+    fn sleep_spawn(child_id: &str, secs: u64) -> crate::ipc::SpawnRequest {
+        crate::ipc::SpawnRequest {
+            child_id: child_id.into(),
+            program: "/bin/sh".into(),
+            args: vec!["-c".into(), format!("sleep {secs}")],
+            env: vec![],
+            cwd: None,
+        }
+    }
+
+    /// AC1+AC2: an integration sweep over a real registry. A spawned child that
+    /// never heartbeats past its (NORMAL) deadline is SIGTERM→SIGKILLed by the
+    /// sweep, a `child_killed_unresponsive` event is emitted, and a fresh sibling
+    /// is left running (isolation). The in-flight self-report rescues a third
+    /// child past the same deadline (RISK-7).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_one_sweep_kills_stuck_child_spares_healthy_and_in_flight() {
+        use crate::process;
+        use crate::supervisor::ChildRegistry;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let (lifecycle_tx, _lifecycle_rx) = unbounded_channel();
+        let registry = ChildRegistry::new(lifecycle_tx);
+
+        // Tiny NORMAL deadline, generous EXTENDED, so a short test exercises both.
+        let wd = Watchdog::with_deadlines(
+            LlmQueue::new(),
+            Duration::from_millis(1),
+            Duration::from_secs(600),
+        );
+
+        let stuck = registry.spawn(&sleep_spawn("stuck", 60)).await.expect("spawn stuck");
+        let in_flight = registry
+            .spawn(&sleep_spawn("in_flight", 60))
+            .await
+            .expect("spawn in_flight");
+
+        // Both beat once, but only `in_flight` self-reports an LLM call in flight.
+        wd.record("stuck", false);
+        wd.record("in_flight", true);
+        // Let the 1ms NORMAL deadline elapse for the non-in-flight child.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        // A healthy sibling beats AFTER the sleep, so its clock is fresh.
+        let healthy = registry.spawn(&sleep_spawn("healthy", 60)).await.expect("spawn healthy");
+        wd.record("healthy", false);
+
+        let (kill_tx, mut kill_rx) = unbounded_channel();
+        let killed = run_one_sweep(&wd, &registry, Duration::from_secs(2), &kill_tx).await;
+
+        assert_eq!(killed, vec!["stuck".to_string()], "only the stuck child is killed");
+
+        // The kill event was emitted.
+        let event = tokio::time::timeout(Duration::from_secs(2), kill_rx.recv())
+            .await
+            .expect("kill event within timeout")
+            .expect("kill event present");
+        assert_eq!(event.child_id, "stuck");
+        assert!(event.reason.contains("unresponsive"));
+
+        // The stuck child is dead; the healthy + in-flight siblings live on.
+        for _ in 0..100 {
+            if !process::is_alive(stuck.pid) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(!process::is_alive(stuck.pid), "stuck child must be dead");
+        assert!(process::is_alive(in_flight.pid), "in-flight child spared (RISK-7)");
+        assert!(process::is_alive(healthy.pid), "healthy sibling spared (isolation)");
+
+        // The stuck child was forgotten, so a second sweep never re-kills it
+        // (its ledger entry is gone — it is not even a candidate). Refresh the
+        // surviving children's beats first so the tiny NORMAL deadline does not
+        // make THEM candidates on this second tick.
+        wd.record("healthy", false);
+        wd.record("in_flight", true);
+        let second = run_one_sweep(&wd, &registry, Duration::from_secs(2), &kill_tx).await;
+        assert!(
+            !second.contains(&"stuck".to_string()),
+            "a forgotten child is not re-killed"
+        );
+
+        let _ = process::force_kill(in_flight.pid);
+        let _ = process::force_kill(healthy.pid);
+    }
+}

--- a/crates/cleo-supervisor/tests/watchdog_e2e.rs
+++ b/crates/cleo-supervisor/tests/watchdog_e2e.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 kryptobaseddev
+//
+// This file is part of crates/cleo-supervisor in the CleoCode monorepo.
+
+//! End-to-end watchdog heartbeat test over the REAL Unix-domain socket (T11628).
+//!
+//! Proves the v1.1 `worker_heartbeat` verb works through the supervisor accept
+//! loop with a watchdog-backed lease arbiter:
+//!
+//!   1. Bind the supervisor IPC `UnixListener` with a [`LeaseArbiter`] whose
+//!      shared heartbeat sink IS the [`Watchdog`]'s ledger
+//!      ([`cleo_supervisor::ipc_server::serve_with_lease`]).
+//!   2. A v1.1 client sends `worker_heartbeat` and observes a `heartbeat_ack`
+//!      response — and the beat is visible in the watchdog's ledger (the child
+//!      is no longer a stale candidate even past a tiny deadline).
+//!   3. **In the SAME accept loop**, a v1.0 client sends a `Health` request and
+//!      observes the unchanged `Health` response — proving the new verb leaves
+//!      v1.0 clients completely unaffected (the freeze invariant).
+//!
+//! The whole flow runs over a real Unix socket — no in-memory shim — so a green
+//! run is direct evidence the `worker_heartbeat` path is wired without disturbing
+//! the frozen v1.0 contract. Windows uses a named-pipe transport not yet
+//! implemented in this crate, so the test is `cfg(unix)`-gated.
+
+#![cfg(unix)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cleo_supervisor::ipc::{IpcEnvelope, IpcPayload, IpcRequest, IpcResponse};
+use cleo_supervisor::ipc_server;
+use cleo_supervisor::lease_handler::{LeaseArbiter, ScopeDbResolver};
+use cleo_supervisor::lease_ipc::{
+    LeaseEnvelope, LeasePayload, LeaseRequest, LeaseResponse, WorkerHeartbeatReq,
+};
+use cleo_supervisor::llm_queue::LlmQueue;
+use cleo_supervisor::supervisor::ChildRegistry;
+use cleo_supervisor::watchdog::Watchdog;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::mpsc::unbounded_channel;
+
+/// Read the next NDJSON line from the client connection, failing the test if the
+/// stream closes or stalls.
+async fn read_line<R>(lines: &mut tokio::io::Lines<BufReader<R>>) -> String
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    tokio::time::timeout(Duration::from_secs(5), lines.next_line())
+        .await
+        .expect("timed out waiting for an IPC line")
+        .expect("read error on client stream")
+        .expect("server closed the connection before responding")
+}
+
+/// Write one NDJSON line + flush to the client write half.
+async fn write_line(write: &mut tokio::net::unix::OwnedWriteHalf, line: &str) {
+    let mut buf = line.to_string();
+    buf.push('\n');
+    write.write_all(buf.as_bytes()).await.expect("write line");
+    write.flush().await.expect("flush");
+}
+
+/// AC1: a `worker_heartbeat` over the socket is acked, recorded in the shared
+/// watchdog ledger, AND a v1.0 `Health` on the same accept loop is unaffected.
+#[tokio::test]
+async fn worker_heartbeat_over_socket_acks_and_v1_0_unaffected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("cleo-supervisor.sock");
+
+    // The watchdog's ledger IS the arbiter's heartbeat sink — a beat received
+    // over the socket lands where the sweep reads it.
+    let watchdog = Watchdog::with_deadlines(
+        LlmQueue::new(),
+        Duration::from_millis(1),
+        Duration::from_secs(600),
+    );
+    let sink = watchdog.sink();
+    // The arbiter needs a scope resolver, but the heartbeat path never opens a DB.
+    let resolver: ScopeDbResolver = Arc::new(|_scope| Ok(std::path::PathBuf::from("/dev/null")));
+    let arbiter = LeaseArbiter::new(resolver).with_heartbeat_sink(sink);
+
+    let (event_tx, event_rx) = unbounded_channel();
+    let registry = ChildRegistry::new(event_tx);
+    let serve_socket = socket_path.clone();
+    let server = tokio::spawn(async move {
+        let _ = ipc_server::serve_with_lease(&serve_socket, registry, event_rx, Some(arbiter)).await;
+    });
+
+    // Wait for the socket to appear (bind completed).
+    let mut bound = false;
+    for _ in 0..200 {
+        if socket_path.exists() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(bound, "supervisor never bound the IPC socket");
+
+    // ── v1.1 client: worker_heartbeat → heartbeat_ack ────────────────────────
+    let stream = UnixStream::connect(&socket_path).await.expect("v1.1 connect");
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+
+    let hb = LeaseEnvelope::request(
+        "hb-1",
+        LeaseRequest::WorkerHeartbeat(WorkerHeartbeatReq {
+            child_id: "worker-7".into(),
+            in_flight_llm: false,
+        }),
+    );
+    write_line(&mut write, &hb.to_ndjson().expect("ser heartbeat")).await;
+
+    let ack_line = read_line(&mut lines).await;
+    let ack = LeaseEnvelope::from_ndjson(&ack_line).expect("parse ack envelope");
+    assert_eq!(ack.protocol_version, "1.1.0", "v1.1 response framing");
+    assert_eq!(ack.id, "hb-1", "correlation id echoed");
+    assert!(
+        matches!(
+            ack.payload,
+            LeasePayload::Response {
+                response: LeaseResponse::HeartbeatAck(_)
+            }
+        ),
+        "a worker_heartbeat is acknowledged with heartbeat_ack",
+    );
+
+    // The beat is recorded in the shared ledger: even past the 1ms deadline the
+    // child is NOT a stale candidate immediately after the beat.
+    assert!(
+        watchdog
+            .stale_candidates(&["worker-7".to_string()])
+            .is_empty(),
+        "the heartbeat reset the child's deadline clock in the shared ledger"
+    );
+
+    // ── v1.0 client (DIFFERENT connection, SAME accept loop): Health unaffected ─
+    let v10_stream = UnixStream::connect(&socket_path).await.expect("v1.0 connect");
+    let (v10_read, mut v10_write) = v10_stream.into_split();
+    let mut v10_lines = BufReader::new(v10_read).lines();
+    let health = IpcEnvelope::request(
+        "health-1",
+        IpcRequest::Health(cleo_supervisor::ipc::HealthRequest {}),
+    );
+    write_line(&mut v10_write, &health.to_ndjson().expect("ser health")).await;
+    let health_line = read_line(&mut v10_lines).await;
+    let health_env = IpcEnvelope::from_ndjson(&health_line).expect("parse v1.0 health envelope");
+    assert_eq!(health_env.protocol_version, "1.0.0", "v1.0 framing untouched");
+    match health_env.payload {
+        IpcPayload::Response {
+            response: IpcResponse::Health(h),
+        } => {
+            assert_eq!(h.protocol_version, "1.0.0");
+            assert!(h.pid > 0);
+        }
+        other => panic!("expected v1.0 Health response, got {other:?}"),
+    }
+
+    server.abort();
+}
+
+/// A `worker_heartbeat` to an accept loop with NO watchdog sink wired still acks
+/// (the worker degrades gracefully) — it just records nothing.
+#[tokio::test]
+async fn worker_heartbeat_without_watchdog_sink_still_acks() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("cleo-supervisor.sock");
+
+    // Arbiter with NO heartbeat sink (watchdog not enabled).
+    let resolver: ScopeDbResolver = Arc::new(|_scope| Ok(std::path::PathBuf::from("/dev/null")));
+    let arbiter = LeaseArbiter::new(resolver);
+
+    let (event_tx, event_rx) = unbounded_channel();
+    let registry = ChildRegistry::new(event_tx);
+    let serve_socket = socket_path.clone();
+    let server = tokio::spawn(async move {
+        let _ = ipc_server::serve_with_lease(&serve_socket, registry, event_rx, Some(arbiter)).await;
+    });
+
+    let mut bound = false;
+    for _ in 0..200 {
+        if socket_path.exists() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(bound, "supervisor never bound the IPC socket");
+
+    let stream = UnixStream::connect(&socket_path).await.expect("connect");
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+    let hb = LeaseEnvelope::request(
+        "hb-noop",
+        LeaseRequest::WorkerHeartbeat(WorkerHeartbeatReq {
+            child_id: "w".into(),
+            in_flight_llm: true,
+        }),
+    );
+    write_line(&mut write, &hb.to_ndjson().expect("ser")).await;
+    let line = read_line(&mut lines).await;
+    let env = LeaseEnvelope::from_ndjson(&line).expect("parse");
+    assert!(
+        matches!(
+            env.payload,
+            LeasePayload::Response {
+                response: LeaseResponse::HeartbeatAck(_)
+            }
+        ),
+        "a heartbeat still acks even without a watchdog sink wired",
+    );
+
+    server.abort();
+}

--- a/packages/contracts/src/lease-ipc/__tests__/freeze.test.ts
+++ b/packages/contracts/src/lease-ipc/__tests__/freeze.test.ts
@@ -45,6 +45,7 @@ describe('lease-ipc v1.1 freeze guard (T11627)', () => {
       'rate_check',
       'tool_grant',
       'queue_admit',
+      'worker_heartbeat',
     ]);
   });
 
@@ -58,6 +59,7 @@ describe('lease-ipc v1.1 freeze guard (T11627)', () => {
       'lease_revoked',
       'child_killed_unresponsive',
       'queue_admit_result',
+      'heartbeat_ack',
       'error',
     ]);
   });
@@ -84,6 +86,7 @@ describe('lease-ipc v1.1 freeze guard (T11627)', () => {
       'rate_check',
       'tool_grant',
       'queue_admit',
+      'worker_heartbeat',
       'lease_granted',
       'lease_queued',
       'lease_denied',
@@ -92,6 +95,7 @@ describe('lease-ipc v1.1 freeze guard (T11627)', () => {
       'lease_revoked',
       'child_killed_unresponsive',
       'queue_admit_result',
+      'heartbeat_ack',
       'error',
     ]);
   });
@@ -202,6 +206,38 @@ describe('lease-ipc v1.1 wire-shape parity with Rust serde (T11627)', () => {
     expect(LeaseIpcEnvelopeSchema.safeParse(wire).success).toBe(true);
   });
 
+  it('parses the exact JSON a Rust worker_heartbeat request envelope serializes (T11628)', () => {
+    const wire = {
+      protocol_version: '1.1.0',
+      id: 'hb-1',
+      direction: 'request',
+      request: {
+        kind: 'worker_heartbeat',
+        child_id: 'worker-7',
+        in_flight_llm: true,
+      },
+    };
+    const parsed = LeaseIpcEnvelopeSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.direction === 'request') {
+      expect(parsed.data.request.kind).toBe('worker_heartbeat');
+    }
+  });
+
+  it('parses the exact JSON a Rust heartbeat_ack response envelope serializes (T11628)', () => {
+    const wire = {
+      protocol_version: '1.1.0',
+      id: 'hb-1',
+      direction: 'response',
+      response: { kind: 'heartbeat_ack' },
+    };
+    const parsed = LeaseIpcEnvelopeSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.direction === 'response') {
+      expect(parsed.data.response.kind).toBe('heartbeat_ack');
+    }
+  });
+
   it('rejects an unknown message kind (proves the union is closed)', () => {
     const wire = {
       protocol_version: '1.1.0',
@@ -260,6 +296,8 @@ function sampleRequestFor(kind: (typeof LEASE_IPC_REQUEST_KINDS)[number]): unkno
         est_tokens: 1024,
         child_id: 'worker-1',
       };
+    case 'worker_heartbeat':
+      return { kind, child_id: 'worker-1', in_flight_llm: true };
   }
 }
 
@@ -296,6 +334,8 @@ function sampleResponseFor(kind: (typeof LEASE_IPC_RESPONSE_KINDS)[number]): unk
         tokens_remaining: 0,
         queue_position: 2,
       };
+    case 'heartbeat_ack':
+      return { kind };
     case 'error':
       return { kind, code: 'E_X', message: 'x' };
   }

--- a/packages/contracts/src/lease-ipc/index.ts
+++ b/packages/contracts/src/lease-ipc/index.ts
@@ -14,6 +14,7 @@
 
 export type {
   ChildKilledUnresponsiveResponse,
+  HeartbeatAckResponse,
   LeaseAcquireRequest,
   LeaseDeniedResponse,
   LeaseErrorResponse,
@@ -37,10 +38,12 @@ export type {
   RateResultResponse,
   ToolGrantedResponse,
   ToolGrantRequest,
+  WorkerHeartbeatRequest,
 } from './messages.js';
 
 export {
   ChildKilledUnresponsiveResponseSchema,
+  HeartbeatAckResponseSchema,
   LEASE_IPC_MESSAGE_KINDS,
   LEASE_IPC_REQUEST_KINDS,
   LEASE_IPC_RESPONSE_KINDS,
@@ -67,5 +70,6 @@ export {
   RateResultResponseSchema,
   ToolGrantedResponseSchema,
   ToolGrantRequestSchema,
+  WorkerHeartbeatRequestSchema,
 } from './messages.js';
 export { isFrozenLeaseIpcVersion, LEASE_IPC_PROTOCOL_VERSION } from './version.js';

--- a/packages/contracts/src/lease-ipc/messages.ts
+++ b/packages/contracts/src/lease-ipc/messages.ts
@@ -205,6 +205,31 @@ export const QueueAdmitRequestSchema = z
 export type QueueAdmitRequest = z.infer<typeof QueueAdmitRequestSchema>;
 
 /**
+ * A liveness heartbeat from a managed worker (T11628). Mirrors
+ * `WorkerHeartbeatReq`. `[wired]`
+ *
+ * The worker sends this periodically (well inside the watchdog's NORMAL
+ * deadline) so the supervisor knows it is alive. `in_flight_llm` is the worker's
+ * OWN view of whether it is currently waiting on an LLM call: when true the
+ * watchdog grants the EXTENDED deadline even if the call never went through the
+ * `queue_admit` seam, so a slow-but-healthy long call is never false-killed
+ * (AC2 · RISK-7).
+ */
+export const WorkerHeartbeatRequestSchema = z
+  .object({
+    /** Tag discriminating this request variant. */
+    kind: z.literal('worker_heartbeat'),
+    /** The logical id of the heartbeating child (matches the registry key). */
+    child_id: z.string().min(1),
+    /** The worker's own view of whether it is currently inside an LLM call. */
+    in_flight_llm: z.boolean(),
+  })
+  .strict();
+
+/** Worker-heartbeat request payload (inferred from {@link WorkerHeartbeatRequestSchema}). */
+export type WorkerHeartbeatRequest = z.infer<typeof WorkerHeartbeatRequestSchema>;
+
+/**
  * The discriminated union of all client → arbiter lease requests. The `kind`
  * field selects the variant, matching the serde `#[serde(tag = "kind")]`
  * tagging on the Rust `LeaseRequest` enum.
@@ -216,6 +241,7 @@ export const LeaseIpcRequestSchema = z.discriminatedUnion('kind', [
   RateCheckRequestSchema,
   ToolGrantRequestSchema,
   QueueAdmitRequestSchema,
+  WorkerHeartbeatRequestSchema,
 ]);
 
 /** Any lease IPC request (inferred from {@link LeaseIpcRequestSchema}). */
@@ -403,6 +429,23 @@ export const QueueAdmitResultResponseSchema = z
 export type QueueAdmitResultResponse = z.infer<typeof QueueAdmitResultResponseSchema>;
 
 /**
+ * Acknowledge a `worker_heartbeat` (T11628). Mirrors `HeartbeatAck`.
+ *
+ * Deliberately carries only its `kind` — the ack's presence (correlated by id)
+ * is the signal that the watchdog recorded the beat and reset the child's
+ * deadline. Matches the Rust unit-struct wire shape `{ "kind": "heartbeat_ack" }`.
+ */
+export const HeartbeatAckResponseSchema = z
+  .object({
+    /** Tag discriminating this response variant. */
+    kind: z.literal('heartbeat_ack'),
+  })
+  .strict();
+
+/** Heartbeat-ack response payload (inferred from {@link HeartbeatAckResponseSchema}). */
+export type HeartbeatAckResponse = z.infer<typeof HeartbeatAckResponseSchema>;
+
+/**
  * An error response correlated to a request. Mirrors the v1.0
  * `crate::ipc::ErrorResult` shape reused by the Rust `LeaseResponse::Error`
  * variant — error framing is shared across protocol versions.
@@ -435,6 +478,7 @@ export const LeaseIpcResponseSchema = z.discriminatedUnion('kind', [
   LeaseRevokedResponseSchema,
   ChildKilledUnresponsiveResponseSchema,
   QueueAdmitResultResponseSchema,
+  HeartbeatAckResponseSchema,
   LeaseErrorResponseSchema,
 ]);
 
@@ -514,6 +558,7 @@ export const LEASE_IPC_REQUEST_KINDS = [
   'rate_check',
   'tool_grant',
   'queue_admit',
+  'worker_heartbeat',
 ] as const;
 
 /**
@@ -529,6 +574,7 @@ export const LEASE_IPC_RESPONSE_KINDS = [
   'lease_revoked',
   'child_killed_unresponsive',
   'queue_admit_result',
+  'heartbeat_ack',
   'error',
 ] as const;
 

--- a/packages/runtime/src/daemon/__tests__/heartbeat-sender.test.ts
+++ b/packages/runtime/src/daemon/__tests__/heartbeat-sender.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the worker-side watchdog heartbeat sender (T11628).
+ *
+ * The sender is degrade-by-default: with a transport wired it encodes a versioned
+ * `worker_heartbeat` frame and writes it; with NO transport it is a silent no-op
+ * (the daemon-off / no-supervisor posture). These tests run in-process against a
+ * captured `writeLine` sink — never a real socket or subprocess.
+ *
+ * @task T11628
+ */
+
+import { LEASE_IPC_PROTOCOL_VERSION } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { createHeartbeatSender } from '../heartbeat-sender.js';
+import { createLeaseIpcClient } from '../lease-ipc-client.js';
+
+describe('createHeartbeatSender (T11628)', () => {
+  it('encodes a versioned worker_heartbeat frame and writes it to the transport', async () => {
+    const written: string[] = [];
+    const sender = createHeartbeatSender((line) => {
+      written.push(line);
+    });
+
+    expect(sender.isActive()).toBe(true);
+    const id = await sender.sendHeartbeat('worker-7', true);
+
+    expect(id).toMatch(/^l\d+-/); // a lease-ipc correlation id
+    expect(written).toHaveLength(1);
+    expect(written[0].endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(written[0].trimEnd());
+    expect(parsed.protocol_version).toBe(LEASE_IPC_PROTOCOL_VERSION);
+    expect(parsed.protocol_version).toBe('1.1.0');
+    expect(parsed.direction).toBe('request');
+    expect(parsed.id).toBe(id);
+    expect(parsed.request.kind).toBe('worker_heartbeat');
+    expect(parsed.request.child_id).toBe('worker-7');
+    expect(parsed.request.in_flight_llm).toBe(true);
+  });
+
+  it('carries the worker self-reported in_flight_llm flag through verbatim', async () => {
+    const written: string[] = [];
+    const sender = createHeartbeatSender((line) => {
+      written.push(line);
+    });
+    await sender.sendHeartbeat('w', false);
+    const parsed = JSON.parse(written[0].trimEnd());
+    expect(parsed.request.in_flight_llm).toBe(false);
+  });
+
+  it('is a silent NO-OP when no transport is wired (no supervisor up)', async () => {
+    const offline = createHeartbeatSender(undefined);
+    expect(offline.isActive()).toBe(false);
+    // No throw, resolves to null, writes nothing.
+    const id = await offline.sendHeartbeat('worker-7', true);
+    expect(id).toBeNull();
+  });
+
+  it('treats a null transport the same as undefined (degrade)', async () => {
+    const offline = createHeartbeatSender(null);
+    expect(offline.isActive()).toBe(false);
+    await expect(offline.sendHeartbeat('w', false)).resolves.toBeNull();
+  });
+
+  it('round-trips through the lease-ipc codec: the supervisor would decode it', () => {
+    // Prove the frame the sender emits is exactly what the v1.1 codec decodes —
+    // the same codec the supervisor accept loop parses (Rust serde mirror).
+    const written: string[] = [];
+    const sender = createHeartbeatSender((line) => {
+      written.push(line);
+    });
+    void sender.sendHeartbeat('worker-7', true);
+
+    // The supervisor encodes its heartbeat_ack reply through the same codec.
+    const client = createLeaseIpcClient();
+    const ackLine = JSON.stringify({
+      protocol_version: '1.1.0',
+      id: 'hb-1',
+      direction: 'response',
+      response: { kind: 'heartbeat_ack' },
+    });
+    const ack = client.decodeResponseLine(ackLine);
+    expect(ack.response.kind).toBe('heartbeat_ack');
+  });
+});

--- a/packages/runtime/src/daemon/__tests__/lease-ipc-client.test.ts
+++ b/packages/runtime/src/daemon/__tests__/lease-ipc-client.test.ts
@@ -100,6 +100,36 @@ describe('LeaseIpcClient NDJSON codec (T11894 ST-5)', () => {
     expect(env.response.kind).toBe('child_killed_unresponsive');
   });
 
+  it('encodes a worker_heartbeat request as a versioned, correlated NDJSON line (T11628)', () => {
+    const client = createLeaseIpcClient();
+    const { id, line } = client.encodeRequest({
+      kind: 'worker_heartbeat',
+      child_id: 'worker-7',
+      in_flight_llm: true,
+    });
+    expect(line.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(line.trimEnd());
+    expect(parsed.protocol_version).toBe(LEASE_IPC_PROTOCOL_VERSION);
+    expect(parsed.direction).toBe('request');
+    expect(parsed.id).toBe(id);
+    expect(parsed.request.kind).toBe('worker_heartbeat');
+    expect(parsed.request.child_id).toBe('worker-7');
+    expect(parsed.request.in_flight_llm).toBe(true);
+  });
+
+  it('decodes a heartbeat_ack response envelope (T11628)', () => {
+    const client = createLeaseIpcClient();
+    const wire = JSON.stringify({
+      protocol_version: '1.1.0',
+      id: 'hb-1',
+      direction: 'response',
+      response: { kind: 'heartbeat_ack' },
+    });
+    const env = client.decodeResponseLine(wire);
+    expect(env.direction).toBe('response');
+    expect(env.response.kind).toBe('heartbeat_ack');
+  });
+
   it('decodes a deferred-handler E_LEASE_UNIMPLEMENTED error', () => {
     const client = createLeaseIpcClient();
     const wire = JSON.stringify({

--- a/packages/runtime/src/daemon/heartbeat-sender.ts
+++ b/packages/runtime/src/daemon/heartbeat-sender.ts
@@ -1,0 +1,111 @@
+/**
+ * Worker-side heartbeat sender for the watchdog (T11628).
+ *
+ * A thin wrapper over {@link createLeaseIpcClient} that encodes a
+ * `worker_heartbeat` frame and writes it to the supervisor over whatever
+ * transport the caller owns. It is **degrade-by-default**: when no transport is
+ * wired (no supervisor up / the daemon-off posture) {@link sendHeartbeat} is a
+ * no-op, exactly mirroring how the LLM-queue admit path degrades when the
+ * supervisor arbiter is absent. A managed worker calls {@link sendHeartbeat}
+ * periodically (well inside the watchdog's NORMAL deadline) so the supervisor
+ * knows it is alive; on a miss the watchdog SIGTERM→SIGKILLs it.
+ *
+ * The sender owns no socket: the caller supplies a `writeLine` sink (the
+ * connected Unix-socket write half, a test double, …) — keeping this module free
+ * of platform IO and trivially testable, consistent with the v1.0/v1.1 codecs.
+ *
+ * @packageDocumentation
+ * @module @cleocode/runtime/daemon
+ *
+ * @epic T11625
+ * @task T11628 — supervisor watchdog: worker heartbeat sender
+ * @saga T11243 SG-RUNTIME-UNIFICATION
+ * @see ./lease-ipc-client.ts — the codec this wraps
+ */
+
+import { createLeaseIpcClient, type LeaseIpcClient } from './lease-ipc-client.js';
+
+/**
+ * A transport sink that writes one already-framed NDJSON line (including the
+ * trailing `\n`) to the supervisor. Returning a promise lets the caller await a
+ * flush; the sender does not require it.
+ */
+export type WriteLine = (line: string) => void | Promise<void>;
+
+/**
+ * A degrade-by-default worker heartbeat sender.
+ *
+ * Construct via {@link createHeartbeatSender}. When no transport is wired,
+ * {@link HeartbeatSender.sendHeartbeat} is a no-op and {@link HeartbeatSender.isActive}
+ * is `false`.
+ */
+export interface HeartbeatSender {
+  /**
+   * Send one `worker_heartbeat` for `childId`. A no-op (resolves immediately)
+   * when no transport is wired — the worker degrades gracefully when no
+   * supervisor is up.
+   *
+   * @param childId      - The heartbeating child's logical id (registry key).
+   * @param inFlightLlm  - The worker's own view of whether it is currently
+   *                       inside an LLM call. `true` lets the watchdog grant the
+   *                       EXTENDED deadline so a slow-but-healthy long call is
+   *                       never false-killed (AC2 · RISK-7).
+   * @returns The correlation `id` of the sent frame, or `null` when no transport
+   *          is wired (the no-op path).
+   */
+  sendHeartbeat: (childId: string, inFlightLlm: boolean) => Promise<string | null>;
+
+  /**
+   * Whether a transport is wired. `false` means {@link sendHeartbeat} is a
+   * no-op (no supervisor up).
+   */
+  isActive: () => boolean;
+}
+
+/**
+ * Create a worker heartbeat sender.
+ *
+ * @param writeLine - The transport sink that writes one NDJSON line to the
+ *                    supervisor, or `undefined`/`null` when no supervisor is up
+ *                    (the no-op / degrade path).
+ * @param client    - An optional pre-built {@link LeaseIpcClient} codec (defaults
+ *                    to a fresh one); injectable for tests.
+ * @returns A {@link HeartbeatSender}.
+ *
+ * @example
+ * ```ts
+ * // With a connected supervisor socket:
+ * const sender = createHeartbeatSender((line) => socket.write(line));
+ * setInterval(() => sender.sendHeartbeat('worker-7', isInLlmCall()), 10_000);
+ *
+ * // No supervisor up — every sendHeartbeat is a silent no-op:
+ * const offline = createHeartbeatSender(undefined);
+ * await offline.sendHeartbeat('worker-7', false); // resolves to null
+ * ```
+ */
+export function createHeartbeatSender(
+  writeLine: WriteLine | undefined | null,
+  client: LeaseIpcClient = createLeaseIpcClient(),
+): HeartbeatSender {
+  const active = typeof writeLine === 'function';
+
+  return {
+    isActive(): boolean {
+      return active;
+    },
+
+    async sendHeartbeat(childId: string, inFlightLlm: boolean): Promise<string | null> {
+      // Degrade: no transport wired → no-op (mirrors the queue's degrade).
+      if (!active || writeLine == null) {
+        return null;
+      }
+      const { id, line } = client.encodeRequest({
+        kind: 'worker_heartbeat',
+        child_id: childId,
+        in_flight_llm: inFlightLlm,
+      });
+      await writeLine(line);
+      return id;
+    },
+  };
+}

--- a/packages/runtime/src/daemon/index.ts
+++ b/packages/runtime/src/daemon/index.ts
@@ -40,6 +40,8 @@ export type {
 } from '@cleocode/contracts';
 
 export { defineSubsystem } from './define-subsystem.js';
+export type { HeartbeatSender, WriteLine } from './heartbeat-sender.js';
+export { createHeartbeatSender } from './heartbeat-sender.js';
 export type { LeaseIpcClient } from './lease-ipc-client.js';
 export { createLeaseIpcClient, MalformedLeaseIpcFrameError } from './lease-ipc-client.js';
 export type { SubsystemLogFields, SubsystemLogger } from './logger.js';


### PR DESCRIPTION
## T11628 — Watchdog: heartbeat-deadline rogue/stuck-worker kill, tiered by LLM-queue in-flight knowledge

Adds a heartbeat-deadline **watchdog** to `cleo-supervisor` that SIGTERM→SIGKILLs a rogue/stuck worker which stops heartbeating — a generalization of `LeaseArbiter::reclaim_or_kill`'s two-phase sweep, keyed on a heartbeat clock instead of a persisted lease TTL. Builds on T11630's `LlmQueue` (merged in #1034).

### AC1 — heartbeat-deadline kill via process.rs + event
- Each managed worker touches a heartbeat over the v1.1 lease IPC (`worker_heartbeat`) within a tiered deadline.
- On a miss, `ChildRegistry::kill_unresponsive` runs the canonical **SIGTERM → grace → SIGKILL** cascade reusing `process::request_terminate` / `process::force_kill`, then emits `child_killed_unresponsive` over the Fanout (a new v1.1 `lease_event_pump`).

### AC2 — tiered by LlmQueue in-flight + per-child isolation
- `deadline = if in_flight(child) { EXTENDED } else { NORMAL }`, where `in_flight` is the OR of `LlmQueue::has_in_flight_call(child)` (the shared `Arc<Mutex<LlmQueueState>>` seam — the watchdog holds a clone of the same `LlmQueue` the `queue_admit` path writes) **and** the worker's self-reported `in_flight_llm` on its last beat. A slow-but-healthy long LLM call is never false-killed (RISK-7).
- Kill targets **only** the one resolved pid — never a process group or `-1` — so siblings and the supervisor are untouched. A `generation` (incarnation) guard skips a child restarted mid-kill (T11626).

### How `has_in_flight_call` is read
The watchdog shares `LlmQueue`'s `Arc<Mutex<…>>` (clone). On each sweep, per candidate child it ORs the queue's `has_in_flight_call(child_id)` with the child's last self-report to pick the tier.

### main.rs wiring (the gap closed)
`serve_until_shutdown` previously called bare `ipc_server::serve` (no arbiter, no watchdog). It now wires `serve_with_lease_events` + a `tokio::spawn`'d `watchdog::run_watchdog` sweep (5s interval) holding clones of `ChildRegistry` + the shared `LlmQueue` + the kill-event sender, gated on `CLEO_SUPERVISOR_WATCHDOG=1` — **daemon-off by default** (a supervisor-only opt-in capability).

### Dual drift edit (Rust ↔ TS, version stays 1.1.0)
- `lease_ipc.rs` + `messages.ts`: `worker_heartbeat{child_id,in_flight_llm}` request + `heartbeat_ack{}` response; both `*_KINDS` tuples + `pins_the_exact_*` (Rust) and `freeze.test.ts` (TS) updated in lockstep. `child_killed_unresponsive` already existed.

### TS
- `heartbeat-sender.ts`: thin worker-side sender over the lease-ipc codec, **degrade-by-default** (no-op when no supervisor socket), mirroring the queue's degrade.

### Tests
- **Rust**: 88 lib tests (8 new watchdog unit + 3 registry kill/isolation) + a new `watchdog_e2e.rs` proving `worker_heartbeat` → `heartbeat_ack` over a **real Unix socket** with a v1.0 `Health` client unaffected (freeze invariant), plus an in-process sweep e2e (stuck child killed, in-flight + healthy siblings spared).
- **TS**: heartbeat-sender no-op-when-no-socket + codec encode/decode of the new verbs + freeze drift — all in-process.

### Gates
`cargo build`/`cargo test -p cleo-supervisor` green (capped); watchdog files clippy-clean. FULL `pnpm run typecheck` clean; biome clean; contracts fan-out + purity gates pass; Rust `pins_*` and TS `freeze.test.ts` drift both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)