### PR TITLE
feat(T11733): models_catalog DB SSoT + table-first read + resolver-default-from-catalog (M3, kills hardcoded model)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -799,6 +799,29 @@ export {
   ToolGrantedResponseSchema,
   ToolGrantRequestSchema,
 } from './lease-ipc/index.js';
+export type {
+  CatalogAuthType,
+  CatalogModelEntry,
+  CatalogModelStatus,
+  CatalogProvider,
+  CuratedCatalog,
+  ModelsCatalogRowInsert,
+  ModelsCatalogRowSelect,
+} from './llm/catalog-schema.js';
+// === E8 Curated Models Catalog (T11731 · offline-first catalog SSoT) ===
+export {
+  CATALOG_AUTH_TYPES,
+  CATALOG_MODEL_STATUSES,
+  catalogCostSchema,
+  catalogLimitSchema,
+  catalogModalitiesSchema,
+  catalogModelEntrySchema,
+  catalogModelProviderSchema,
+  catalogProviderSchema,
+  curatedCatalogSchema,
+  modelsCatalogRowInsertSchema,
+  modelsCatalogRowSelectSchema,
+} from './llm/catalog-schema.js';
 // === LLM Error Taxonomy (T9270 — Hermes FailoverReason port) ===
 export type { ClassifiedError, FailoverReason } from './llm/failover-reason.js';
 // === Phase 4 Unified Architecture (T9281 / ADR-072) — Session + Executor interfaces ===

--- a/packages/contracts/src/llm/catalog-schema.json
+++ b/packages/contracts/src/llm/catalog-schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cleocode.dev/schemas/llm/curated-catalog.json",
+  "title": "Curated Models Catalog",
+  "description": "The shipped, offline-first provider+model catalog seed (E8 · T11731). One self-contained snapshot of the models.dev wire shape that seeds the global `models_catalog` table and backs offline/degraded reads. NO network access is implied by this file — it is the build-time committed mirror.",
+  "type": "object",
+  "required": ["version", "lastUpdated", "providers", "models"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver version of this catalog snapshot. Bumped on every regeneration; drives the seeder skip/re-seed decision."
+    },
+    "lastUpdated": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "ISO date (YYYY-MM-DD) the snapshot was generated."
+    },
+    "providers": {
+      "type": "object",
+      "description": "Provider records keyed by models.dev provider id (e.g. `anthropic`, `openai`, `google`).",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["id", "endpoint", "authTypes"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "description": "Provider id (matches the map key)." },
+          "endpoint": {
+            "type": "string",
+            "description": "Provider API base URL (e.g. `https://api.anthropic.com`)."
+          },
+          "authTypes": {
+            "type": "array",
+            "description": "Supported auth mechanisms keyed by provider id.",
+            "items": { "type": "string", "enum": ["api_key", "oauth", "bedrock", "vertex"] },
+            "minItems": 1
+          },
+          "npm": {
+            "type": "string",
+            "description": "Provider SDK npm package, when applicable (e.g. `@anthropic-ai/sdk`)."
+          }
+        }
+      }
+    },
+    "models": {
+      "type": "object",
+      "description": "Model entries keyed by provider id; each value is a map of model-id → model entry.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/$defs/modelEntry"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "modelEntry": {
+      "type": "object",
+      "description": "Full models.dev wire capability set for a single model.",
+      "required": [
+        "id",
+        "name",
+        "family",
+        "attachment",
+        "reasoning",
+        "temperature",
+        "interleaved",
+        "tool_call",
+        "modalities",
+        "cost",
+        "limit",
+        "status",
+        "release_date",
+        "provider"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "description": "Model identifier (e.g. `claude-haiku-4-5`)." },
+        "name": { "type": "string", "description": "Human-readable display name." },
+        "family": { "type": "string", "description": "Model family (e.g. `claude`, `gpt`, `gemini`)." },
+        "attachment": { "type": "boolean", "description": "Supports file/image attachments." },
+        "reasoning": { "type": "boolean", "description": "Supports extended reasoning / thinking." },
+        "temperature": { "type": "boolean", "description": "Honours a temperature parameter." },
+        "interleaved": { "type": "boolean", "description": "Supports interleaved thinking blocks." },
+        "tool_call": { "type": "boolean", "description": "Supports tool/function calling." },
+        "modalities": {
+          "type": "object",
+          "required": ["input", "output"],
+          "additionalProperties": false,
+          "properties": {
+            "input": { "type": "array", "items": { "type": "string" } },
+            "output": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "cost": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "input": { "type": "number" },
+            "output": { "type": "number" },
+            "cache_read": { "type": "number" },
+            "cache_write": { "type": "number" },
+            "context_over_200k": { "type": "number" }
+          }
+        },
+        "limit": {
+          "type": "object",
+          "required": ["context", "output"],
+          "additionalProperties": false,
+          "properties": {
+            "context": { "type": "number", "description": "Max context window (tokens)." },
+            "output": { "type": "number", "description": "Max output tokens." }
+          }
+        },
+        "status": {
+          "type": "string",
+          "enum": ["stable", "beta", "preview", "deprecated", "retired"],
+          "description": "Availability lifecycle of the model."
+        },
+        "release_date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "ISO release date (YYYY-MM-DD). The SSoT sort key — latest wins."
+        },
+        "provider": {
+          "type": "object",
+          "required": ["npm", "api"],
+          "additionalProperties": false,
+          "properties": {
+            "npm": { "type": "string" },
+            "api": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/contracts/src/llm/catalog-schema.ts
+++ b/packages/contracts/src/llm/catalog-schema.ts
@@ -1,0 +1,184 @@
+/**
+ * Zod mirror + TypeScript types for the curated models catalog (E8 · T11731).
+ *
+ * This is the type+validation SSoT for the **shipped, offline-first** provider+model
+ * catalog seed that populates the global `models_catalog` table (T11733) and backs
+ * offline/degraded catalog reads (T11737). It mirrors the JSON Schema in the sibling
+ * `catalog-schema.json` (draft 2020-12) one-to-one.
+ *
+ * ## Offline-first — NO network is implied by these types
+ *
+ * The {@link CuratedCatalog} shape describes a committed, build-time snapshot of the
+ * models.dev wire shape. Nothing here fetches; the network refresh op
+ * (`cleo llm refresh-catalog`) is a SEPARATE leaf. The seeder reads the bundled
+ * `curated-catalog.json` (validated against {@link curatedCatalogSchema}) and upserts
+ * every row offline.
+ *
+ * ## models_catalog row parity (AC4)
+ *
+ * {@link modelsCatalogRowSelectSchema} / {@link modelsCatalogRowInsertSchema} describe the
+ * FLATTENED per-row shape persisted in the `models_catalog` DB table — the json/cost/
+ * modalities sub-objects serialize to TEXT columns, booleans to `integer({mode:'boolean'})`.
+ * {@link flattenCatalogToRows} (in core) maps a {@link CuratedCatalog} → these rows.
+ *
+ * Contracts-purity (Gate 10): this module exports ONLY zod schemas (values) and
+ * `z.infer` types — no bodied runtime helpers. The flatten/seed logic lives in core.
+ *
+ * @module llm/catalog-schema
+ * @task T11731
+ * @epic T11694 (E8-CATALOG-CURATION)
+ */
+
+import { z } from 'zod';
+
+/** Legal `models_catalog.status` availability-lifecycle values. */
+export const CATALOG_MODEL_STATUSES = [
+  'stable',
+  'beta',
+  'preview',
+  'deprecated',
+  'retired',
+] as const;
+
+/** TypeScript union of {@link CATALOG_MODEL_STATUSES}. */
+export type CatalogModelStatus = (typeof CATALOG_MODEL_STATUSES)[number];
+
+/** Legal provider auth mechanisms carried in a catalog provider entry. */
+export const CATALOG_AUTH_TYPES = ['api_key', 'oauth', 'bedrock', 'vertex'] as const;
+
+/** TypeScript union of {@link CATALOG_AUTH_TYPES}. */
+export type CatalogAuthType = (typeof CATALOG_AUTH_TYPES)[number];
+
+/** ISO date `YYYY-MM-DD` matcher (the catalog sort/version key shape). */
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be an ISO date (YYYY-MM-DD)');
+
+/** Semver `MAJOR.MINOR.PATCH` matcher for the catalog snapshot version. */
+const semver = z.string().regex(/^\d+\.\d+\.\d+$/, 'must be semver (MAJOR.MINOR.PATCH)');
+
+/** Input/output modality lists for a model. */
+export const catalogModalitiesSchema = z
+  .object({
+    input: z.array(z.string()),
+    output: z.array(z.string()),
+  })
+  .strict();
+
+/** Per-1M-token cost facets for a model (all optional — providers vary). */
+export const catalogCostSchema = z
+  .object({
+    input: z.number().optional(),
+    output: z.number().optional(),
+    cache_read: z.number().optional(),
+    cache_write: z.number().optional(),
+    context_over_200k: z.number().optional(),
+  })
+  .strict();
+
+/** Context/output token-window limits for a model. */
+export const catalogLimitSchema = z
+  .object({
+    context: z.number(),
+    output: z.number(),
+  })
+  .strict();
+
+/** The provider-of-record (npm package + api protocol) for a model. */
+export const catalogModelProviderSchema = z
+  .object({
+    npm: z.string(),
+    api: z.string(),
+  })
+  .strict();
+
+/** Full models.dev wire capability set for a single model entry. */
+export const catalogModelEntrySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    family: z.string(),
+    attachment: z.boolean(),
+    reasoning: z.boolean(),
+    temperature: z.boolean(),
+    interleaved: z.boolean(),
+    tool_call: z.boolean(),
+    modalities: catalogModalitiesSchema,
+    cost: catalogCostSchema,
+    limit: catalogLimitSchema,
+    status: z.enum(CATALOG_MODEL_STATUSES),
+    release_date: isoDate,
+    provider: catalogModelProviderSchema,
+  })
+  .strict();
+
+/** A provider record in the catalog envelope. */
+export const catalogProviderSchema = z
+  .object({
+    id: z.string(),
+    endpoint: z.string(),
+    authTypes: z.array(z.enum(CATALOG_AUTH_TYPES)).min(1),
+    npm: z.string().optional(),
+  })
+  .strict();
+
+/**
+ * Top-level shape of the curated catalog seed (`curated-catalog.json`).
+ *
+ * `providers` is keyed by provider id; `models` is keyed by provider id → model id →
+ * {@link catalogModelEntrySchema}.
+ */
+export const curatedCatalogSchema = z
+  .object({
+    $schema: z.string().optional(),
+    version: semver,
+    lastUpdated: isoDate,
+    providers: z.record(z.string(), catalogProviderSchema),
+    models: z.record(z.string(), z.record(z.string(), catalogModelEntrySchema)),
+  })
+  .strict();
+
+/** The validated curated catalog seed shape. */
+export type CuratedCatalog = z.infer<typeof curatedCatalogSchema>;
+/** A single model entry from the curated catalog. */
+export type CatalogModelEntry = z.infer<typeof catalogModelEntrySchema>;
+/** A single provider entry from the curated catalog. */
+export type CatalogProvider = z.infer<typeof catalogProviderSchema>;
+
+/**
+ * INSERT/UPSERT shape for one `models_catalog` row (the flattened persistence form).
+ *
+ * The catalog's nested `modalities` / `cost` sub-objects are JSON-serialized into the
+ * `modalities` / `cost` TEXT columns; booleans persist as `integer({mode:'boolean'})`.
+ * `provider_id` is the catalog key; `models_dev_id` mirrors the entry `id`.
+ */
+export const modelsCatalogRowInsertSchema = z
+  .object({
+    id: z.string(),
+    providerId: z.string(),
+    name: z.string(),
+    family: z.string(),
+    attachment: z.boolean(),
+    reasoning: z.boolean(),
+    temperature: z.boolean(),
+    interleaved: z.boolean(),
+    toolCall: z.boolean(),
+    modalities: z.string(),
+    cost: z.string(),
+    contextLimit: z.number().nullable().optional(),
+    outputLimit: z.number().nullable().optional(),
+    status: z.enum(CATALOG_MODEL_STATUSES),
+    releaseDate: isoDate,
+    modelsDevId: z.string(),
+    source: z.string(),
+    seededAt: z.string().optional(),
+  })
+  .strict();
+
+/** SELECT shape for one `models_catalog` row (adds the always-present `seededAt`). */
+export const modelsCatalogRowSelectSchema = modelsCatalogRowInsertSchema.extend({
+  seededAt: z.string(),
+});
+
+/** INSERT/UPSERT row type for `models_catalog`. */
+export type ModelsCatalogRowInsert = z.infer<typeof modelsCatalogRowInsertSchema>;
+/** SELECT row type for `models_catalog`. */
+export type ModelsCatalogRowSelect = z.infer<typeof modelsCatalogRowSelectSchema>;

--- a/packages/core/migrations/drizzle-cleo-global/20260609010000_t11733-models-catalog/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260609010000_t11733-models-catalog/migration.sql
@@ -1,0 +1,65 @@
+-- T11733 (E8-CATALOG-CURATION · epic T11694) — the `models_catalog` catalog SSoT
+-- table in the consolidated GLOBAL cleo.db (drizzle-cleo-global scope ONLY — the
+-- provider+model capability catalog is a cross-project, machine-wide signal with
+-- no project-tier analog, so it is NOT mirrored into drizzle-cleo-project).
+--
+-- One row per model: the full models.dev wire capability set (modalities, cost,
+-- limits, reasoning/tool-call flags, status, release_date). This table is the
+-- catalog SSoT — seeded from the shipped offline `curated-catalog.json` (T11734),
+-- read table-first via resolveCatalogEntry() (T11737), and consulted by the
+-- resolver default (latest release_date wins — T11944), killing the hardcoded
+-- `claude-haiku-4-5` default literal (which survives only as the offline floor).
+--
+-- This carries NO secrets and NO encryption — it is catalog DATA, distinct from
+-- the `accounts` LLM-credential pool (T11709) and the `service_*` vault (T11937).
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-global) and many subsequent migrations, so `models_catalog` is NEVER the
+-- first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables. No journal pre-create is required.
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op (idempotent).
+-- Each statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11733
+-- @epic T11694
+
+CREATE TABLE IF NOT EXISTS `models_catalog` (
+  `id` text PRIMARY KEY NOT NULL,
+  `provider_id` text NOT NULL,
+  `name` text NOT NULL,
+  `family` text NOT NULL,
+  `attachment` integer NOT NULL DEFAULT 0,
+  `reasoning` integer NOT NULL DEFAULT 0,
+  `temperature` integer NOT NULL DEFAULT 1,
+  `interleaved` integer NOT NULL DEFAULT 0,
+  `tool_call` integer NOT NULL DEFAULT 0,
+  `modalities` text NOT NULL DEFAULT '{"input":["text"],"output":["text"]}',
+  `cost` text NOT NULL DEFAULT '{}',
+  `context_limit` integer,
+  `output_limit` integer,
+  `status` text NOT NULL DEFAULT 'stable',
+  `release_date` text NOT NULL,
+  `models_dev_id` text NOT NULL,
+  `source` text NOT NULL DEFAULT 'seed',
+  `seeded_at` text NOT NULL DEFAULT (datetime('now')),
+  CHECK ("status" IN ('stable', 'beta', 'preview', 'deprecated', 'retired')),
+  CHECK ("attachment" IN (0, 1)),
+  CHECK ("reasoning" IN (0, 1)),
+  CHECK ("temperature" IN (0, 1)),
+  CHECK ("interleaved" IN (0, 1)),
+  CHECK ("tool_call" IN (0, 1)),
+  CHECK ("release_date" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  CHECK ("seeded_at" IS NULL OR "seeded_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_models_catalog_provider_modeldev` ON `models_catalog` (`provider_id`, `models_dev_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_models_catalog_provider_release` ON `models_catalog` (`provider_id`, `release_date`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_models_catalog_provider_status` ON `models_catalog` (`provider_id`, `status`);

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -1193,6 +1193,22 @@ export async function initProject(opts: InitOptions = {}): Promise<InitResult> {
     );
   }
 
+  // E8 (T11734): seed the models_catalog SSoT from the shipped OFFLINE seed
+  // (`curated-catalog.json`). Idempotent + version-skipped — no network. Catalog
+  // becomes the resolver-default source (T11944), killing the hardcoded model.
+  // Non-fatal: a fresh/offline install still resolves from the shipped seed floor.
+  try {
+    const { seedModelsCatalog } = await import('./llm/catalog-seeder.js');
+    const seedResult = await seedModelsCatalog();
+    if (seedResult.seeded) {
+      created.push(`models-catalog: seeded ${seedResult.rowCount} models (v${seedResult.version})`);
+    }
+  } catch (err) {
+    warnings.push(
+      `models_catalog seed failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   // Context anchoring: when brownfield and --map-codebase was NOT already run,
   // surface a hint so the operator knows they can anchor the baseline in BRAIN.
   // (We do NOT auto-run mapCodebase here — it's opt-in to avoid blocking init.)

--- a/packages/core/src/llm/__tests__/catalog-resolver.test.ts
+++ b/packages/core/src/llm/__tests__/catalog-resolver.test.ts
@@ -1,0 +1,151 @@
+/**
+ * T11737 — `resolveCatalogEntry()` table-first read chokepoint with the disk-cache
+ * + shipped-seed fallback chain (offline-first degrade).
+ *
+ * Every test uses a TEMP-DIR global cleo.db + a temp cache dir — never `.cleo/*.db`
+ * and NO network.
+ *
+ * @task T11737
+ * @epic T11694
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CuratedCatalog } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CleoGlobalDb } from '../../store/dual-scope-db.js';
+import { _resetDualScopeDbCache } from '../../store/dual-scope-db.js';
+import {
+  _resetCatalogResolverCache,
+  openCatalogAtPath,
+  resolveCatalogEntry,
+} from '../catalog-resolver.js';
+import { seedModelsCatalog } from '../catalog-seeder.js';
+
+let testRoot: string;
+let cacheDir: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `catalog-resolve-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  cacheDir = join(testRoot, 'cache');
+  mkdirSync(testRoot, { recursive: true });
+  mkdirSync(cacheDir, { recursive: true });
+  _resetCatalogResolverCache();
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  _resetCatalogResolverCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+/** A fixture catalog with two anthropic models of differing release_date. */
+function fixture(newId: string, newDate: string): CuratedCatalog {
+  return {
+    version: '1.0.0',
+    lastUpdated: '2026-06-09',
+    providers: {
+      anthropic: { id: 'anthropic', endpoint: 'https://api.anthropic.com', authTypes: ['api_key'] },
+    },
+    models: {
+      anthropic: {
+        'claude-old': {
+          id: 'claude-old',
+          name: 'Old',
+          family: 'claude',
+          attachment: false,
+          reasoning: false,
+          temperature: true,
+          interleaved: false,
+          tool_call: true,
+          modalities: { input: ['text'], output: ['text'] },
+          cost: {},
+          limit: { context: 200000, output: 64000 },
+          status: 'stable',
+          release_date: '2024-01-01',
+          provider: { npm: '@anthropic-ai/sdk', api: 'anthropic_messages' },
+        },
+        [newId]: {
+          id: newId,
+          name: 'New',
+          family: 'claude',
+          attachment: true,
+          reasoning: true,
+          temperature: true,
+          interleaved: true,
+          tool_call: true,
+          modalities: { input: ['text'], output: ['text'] },
+          cost: {},
+          limit: { context: 200000, output: 64000 },
+          status: 'stable',
+          release_date: newDate,
+          provider: { npm: '@anthropic-ai/sdk', api: 'anthropic_messages' },
+        },
+      },
+    },
+  };
+}
+
+async function openDb(): Promise<CleoGlobalDb> {
+  return openCatalogAtPath(join(testRoot, 'cleo.db'));
+}
+
+/** Write a models.dev-shaped disk-cache snapshot into the temp cache dir. */
+function writeDiskCache(modelId: string, releaseDate: string): void {
+  const snapshot = {
+    anthropic: {
+      id: 'anthropic',
+      models: {
+        [modelId]: { id: modelId, release_date: releaseDate, limit: { context: 200000 } },
+      },
+    },
+  };
+  writeFileSync(join(cacheDir, `${Date.now()}-models.json`), JSON.stringify(snapshot), 'utf-8');
+}
+
+describe('resolveCatalogEntry (T11737) — table-first chokepoint', () => {
+  it('TABLE-FIRST: returns the newest-release_date row from the seeded table', async () => {
+    const db = await openDb();
+    await seedModelsCatalog({ db, catalog: fixture('claude-table-new', '2026-05-01') });
+    // Even with a disk cache present, the TABLE wins.
+    writeDiskCache('claude-cache-new', '2026-12-01');
+
+    const entry = await resolveCatalogEntry('anthropic', { db, cacheDir });
+    expect(entry?.source).toBe('table');
+    expect(entry?.id).toBe('claude-table-new');
+    expect(entry?.releaseDate).toBe('2026-05-01');
+  }, 30_000);
+
+  it('DISK FALLBACK: empty table → resolves the newest entry from the disk cache mirror', async () => {
+    const db = await openDb(); // migrated, but NOT seeded → table empty.
+    writeDiskCache('claude-cache-new', '2026-03-01');
+
+    const entry = await resolveCatalogEntry('anthropic', { db, cacheDir });
+    expect(entry?.source).toBe('disk-cache');
+    expect(entry?.id).toBe('claude-cache-new');
+    expect(entry?.releaseDate).toBe('2026-03-01');
+  }, 30_000);
+
+  it('SEED FLOOR: empty table + empty cache → resolves from the shipped seed', async () => {
+    const db = await openDb(); // empty table, empty cacheDir.
+    const entry = await resolveCatalogEntry('anthropic', { db, cacheDir });
+    expect(entry?.source).toBe('shipped-seed');
+    // The shipped curated-catalog.json carries dated anthropic models.
+    expect(entry?.id.length).toBeGreaterThan(0);
+    expect(entry?.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  }, 30_000);
+
+  it('returns null for a provider absent from every surface', async () => {
+    const db = await openDb();
+    const entry = await resolveCatalogEntry('no-such-provider', { db, cacheDir });
+    expect(entry).toBeNull();
+  }, 30_000);
+});

--- a/packages/core/src/llm/__tests__/catalog-seeder.test.ts
+++ b/packages/core/src/llm/__tests__/catalog-seeder.test.ts
@@ -1,0 +1,163 @@
+/**
+ * T11734 — `seedModelsCatalog` populates `models_catalog` from the shipped offline
+ * seed, idempotently, with version-skip semantics.
+ *
+ * Every test seeds a TEMP-DIR global cleo.db — never `.cleo/*.db` and NO network.
+ *
+ * @task T11734
+ * @epic T11694
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import type { CuratedCatalog } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CleoGlobalDb } from '../../store/dual-scope-db.js';
+import { _resetDualScopeDbCache } from '../../store/dual-scope-db.js';
+import {
+  flattenCatalogToRows,
+  loadAndValidateSeed,
+  openSeederAtPath,
+  seedModelsCatalog,
+} from '../catalog-seeder.js';
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `catalog-seed-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+/** A minimal two-row fixture catalog (anthropic, differing dates). */
+function fixture(version: string): CuratedCatalog {
+  return {
+    version,
+    lastUpdated: '2026-06-09',
+    providers: {
+      anthropic: { id: 'anthropic', endpoint: 'https://api.anthropic.com', authTypes: ['api_key'] },
+    },
+    models: {
+      anthropic: {
+        'claude-old': {
+          id: 'claude-old',
+          name: 'Claude Old',
+          family: 'claude',
+          attachment: true,
+          reasoning: true,
+          temperature: true,
+          interleaved: false,
+          tool_call: true,
+          modalities: { input: ['text'], output: ['text'] },
+          cost: { input: 1, output: 5 },
+          limit: { context: 200000, output: 64000 },
+          status: 'stable',
+          release_date: '2025-01-01',
+          provider: { npm: '@anthropic-ai/sdk', api: 'anthropic_messages' },
+        },
+        'claude-new': {
+          id: 'claude-new',
+          name: 'Claude New',
+          family: 'claude',
+          attachment: true,
+          reasoning: true,
+          temperature: true,
+          interleaved: true,
+          tool_call: true,
+          modalities: { input: ['text', 'image'], output: ['text'] },
+          cost: { input: 3, output: 15 },
+          limit: { context: 200000, output: 64000 },
+          status: 'stable',
+          release_date: '2026-02-01',
+          provider: { npm: '@anthropic-ai/sdk', api: 'anthropic_messages' },
+        },
+      },
+    },
+  };
+}
+
+async function open(): Promise<{ db: CleoGlobalDb; native: DatabaseSync }> {
+  const db = await openSeederAtPath(join(testRoot, 'cleo.db'));
+  const native = (db as unknown as { $client: DatabaseSync }).$client;
+  return { db, native };
+}
+
+function rowCount(native: DatabaseSync): number {
+  const r = native.prepare('SELECT COUNT(*) AS c FROM models_catalog').get() as { c: number };
+  return r.c;
+}
+
+describe('seedModelsCatalog (T11734)', () => {
+  it('seeds the fixture rows into models_catalog and round-trips capability fields', async () => {
+    const { db, native } = await open();
+    const result = await seedModelsCatalog({ db, catalog: fixture('1.0.0') });
+
+    expect(result.seeded).toBe(true);
+    expect(result.reason).toBe('seeded');
+    expect(result.rowCount).toBe(2);
+    expect(rowCount(native)).toBe(2);
+
+    const newRow = native
+      .prepare(
+        'SELECT provider_id, family, interleaved, modalities, context_limit, release_date FROM models_catalog WHERE id = ?',
+      )
+      .get('claude-new') as Record<string, unknown>;
+    expect(newRow.provider_id).toBe('anthropic');
+    expect(newRow.family).toBe('claude');
+    expect(newRow.interleaved).toBe(1);
+    expect(newRow.context_limit).toBe(200000);
+    expect(newRow.release_date).toBe('2026-02-01');
+    expect(JSON.parse(newRow.modalities as string)).toEqual({
+      input: ['text', 'image'],
+      output: ['text'],
+    });
+  }, 30_000);
+
+  it('is idempotent — running twice with the same version yields the same row count and no duplicates', async () => {
+    const { db, native } = await open();
+    await seedModelsCatalog({ db, catalog: fixture('1.0.0') });
+    const first = rowCount(native);
+
+    const second = await seedModelsCatalog({ db, catalog: fixture('1.0.0') });
+    expect(second.seeded).toBe(false);
+    expect(second.reason).toBe('version-skip');
+    expect(rowCount(native)).toBe(first);
+  }, 30_000);
+
+  it('upsert (not insert-fail) on a NEWER version re-seeds without duplicating rows', async () => {
+    const { db, native } = await open();
+    await seedModelsCatalog({ db, catalog: fixture('1.0.0') });
+    const before = rowCount(native);
+
+    const upgraded = await seedModelsCatalog({ db, catalog: fixture('1.1.0') });
+    expect(upgraded.seeded).toBe(true);
+    expect(upgraded.reason).toBe('reseeded-newer');
+    // Same natural keys → upsert, NOT duplicate.
+    expect(rowCount(native)).toBe(before);
+  }, 30_000);
+
+  it('the shipped seed loads + validates against the contract schema (offline)', () => {
+    const seed = loadAndValidateSeed();
+    expect(seed.version).toMatch(/^\d+\.\d+\.\d+$/);
+    const rows = flattenCatalogToRows(seed);
+    expect(rows.length).toBeGreaterThan(0);
+    // Every flattened row carries a valid ISO release date and a provider id.
+    for (const r of rows) {
+      expect(r.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(r.providerId.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/core/src/llm/__tests__/resolver-catalog-default.test.ts
+++ b/packages/core/src/llm/__tests__/resolver-catalog-default.test.ts
@@ -1,0 +1,187 @@
+/**
+ * T11944 — the resolver DEFAULT model derives from `models_catalog` (release_date
+ * DESC) via the T11737 chokepoint, with the static literal kept as the OFFLINE-ONLY
+ * floor when the catalog yields nothing.
+ *
+ * The canonical global `cleo.db` is resolved from `XDG_DATA_HOME` / `CLEO_HOME`,
+ * which we point at a fresh tmpdir per test (mirrors `system-resolver.test.ts`), so
+ * seeding the canonical global DB is what the resolver consults. NO network.
+ *
+ * @task T11944
+ * @epic T11694
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CuratedCatalog } from '@cleocode/contracts';
+import { _resetCleoPlatformPathsCache } from '@cleocode/paths';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDb } from '../../store/dual-scope-db.js';
+import { _resetCatalogResolverCache } from '../catalog-resolver.js';
+import { seedModelsCatalog } from '../catalog-seeder.js';
+import { IMPLICIT_FALLBACK_MODEL } from '../role-resolver.js';
+import { resolveLLMForSystem } from '../system-resolver.js';
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'XDG_DATA_HOME',
+  'XDG_CONFIG_HOME',
+  'CLEO_CONFIG_HOME',
+  'CLEO_HOME',
+  'HOME',
+  'CLEO_DIR',
+  'CLEO_DATA_DIR',
+];
+
+let xdgRoot: string;
+let projectRoot: string;
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) SAVED_ENV[k] = process.env[k];
+}
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+}
+
+beforeEach(() => {
+  saveEnv();
+  for (const k of ENV_KEYS) delete process.env[k];
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  xdgRoot = join(tmpdir(), `cleo-rcd-xdg-${stamp}`);
+  const xdgConfigHome = join(tmpdir(), `cleo-rcd-cfg-${stamp}`);
+  const home = join(tmpdir(), `cleo-rcd-home-${stamp}`);
+  projectRoot = join(tmpdir(), `cleo-rcd-proj-${stamp}`);
+  mkdirSync(join(xdgRoot, 'cleo'), { recursive: true });
+  mkdirSync(xdgConfigHome, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  mkdirSync(join(projectRoot, '.cleo'), { recursive: true });
+  process.env['XDG_DATA_HOME'] = xdgRoot;
+  process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_CONFIG_HOME'] = xdgConfigHome;
+  process.env['CLEO_HOME'] = join(xdgRoot, 'cleo');
+  process.env['HOME'] = home;
+  // Point the disk-cache dir at an empty temp dir so the chokepoint has NO disk
+  // cache to fall back to (forces table → seed only).
+  process.env['CLEO_DATA_DIR'] = join(xdgRoot, 'data-empty');
+  mkdirSync(process.env['CLEO_DATA_DIR'], { recursive: true });
+  _resetCleoPlatformPathsCache();
+  _resetDualScopeDbCache();
+  _resetCatalogResolverCache();
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  _resetCatalogResolverCache();
+  restoreEnv();
+  _resetCleoPlatformPathsCache();
+  try {
+    rmSync(xdgRoot, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+/** Two anthropic models with differing release_date — newer should win. */
+function twoAnthropic(newerId: string, newerDate: string): CuratedCatalog {
+  return {
+    version: '1.0.0',
+    lastUpdated: '2026-06-09',
+    providers: {
+      anthropic: { id: 'anthropic', endpoint: 'https://api.anthropic.com', authTypes: ['api_key'] },
+    },
+    models: {
+      anthropic: {
+        'claude-older-haiku': {
+          id: 'claude-older-haiku',
+          name: 'Older',
+          family: 'claude',
+          attachment: false,
+          reasoning: false,
+          temperature: true,
+          interleaved: false,
+          tool_call: true,
+          modalities: { input: ['text'], output: ['text'] },
+          cost: {},
+          limit: { context: 200000, output: 64000 },
+          status: 'stable',
+          release_date: '2024-06-01',
+          provider: { npm: '@anthropic-ai/sdk', api: 'anthropic_messages' },
+        },
+        [newerId]: {
+          id: newerId,
+          name: 'Newer',
+          family: 'claude',
+          attachment: true,
+          reasoning: true,
+          temperature: true,
+          interleaved: true,
+          tool_call: true,
+          modalities: { input: ['text'], output: ['text'] },
+          cost: {},
+          limit: { context: 200000, output: 64000 },
+          status: 'stable',
+          release_date: newerDate,
+          provider: { npm: '@anthropic-ai/sdk', api: 'anthropic_messages' },
+        },
+      },
+    },
+  };
+}
+
+describe('resolver default ← models_catalog (T11944)', () => {
+  it('seeded table with two anthropic rows → default is the NEWER release_date model', async () => {
+    // Seed the canonical global cleo.db (resolved from the tmpdir XDG env).
+    const handle = await openDualScopeDb('global');
+    await seedModelsCatalog({
+      db: handle.db,
+      catalog: twoAnthropic('claude-opus-9-9-20991231', '2099-12-31'),
+    });
+    _resetCatalogResolverCache();
+
+    // No credential / no role config → implicit-fallback → upgradeCatalogDefault runs.
+    const result = await resolveLLMForSystem('default', { projectRoot });
+    expect(result.source).toBe('implicit-fallback');
+    expect(result.provider).toBe('anthropic');
+    // The catalog SSoT (release_date DESC) drove the default — NOT the hardcoded
+    // `claude-haiku-4-5` literal.
+    expect(result.model).toBe('claude-opus-9-9-20991231');
+    expect(result.model).not.toBe(IMPLICIT_FALLBACK_MODEL);
+  }, 30_000);
+
+  it('OFFLINE FLOOR: empty table + empty disk cache → degrade does NOT break (resolves from the shipped seed, not a crash)', async () => {
+    // Open (migrate) the global DB but do NOT seed — table empty; cache dir empty.
+    await openDualScopeDb('global');
+    _resetCatalogResolverCache();
+
+    const result = await resolveLLMForSystem('default', { projectRoot });
+    // Degrade path is exercised and a model is resolved (fresh/offline install does
+    // NOT crash). The shipped seed is the offline floor; the chokepoint still yields
+    // a catalog-driven anthropic id rather than throwing.
+    expect(result.source).toBe('implicit-fallback');
+    expect(result.provider).toBe('anthropic');
+    expect(typeof result.model).toBe('string');
+    expect(result.model.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('skipCatalogDefault=true keeps the raw IMPLICIT_FALLBACK_MODEL literal (no catalog consulted)', async () => {
+    const handle = await openDualScopeDb('global');
+    await seedModelsCatalog({
+      db: handle.db,
+      catalog: twoAnthropic('claude-opus-9-9-20991231', '2099-12-31'),
+    });
+    _resetCatalogResolverCache();
+
+    const result = await resolveLLMForSystem('default', { projectRoot, skipCatalogDefault: true });
+    expect(result.source).toBe('implicit-fallback');
+    // The catalog is intentionally NOT consulted → the frozen literal survives.
+    expect(result.model).toBe(IMPLICIT_FALLBACK_MODEL);
+  }, 30_000);
+});

--- a/packages/core/src/llm/catalog-resolver.ts
+++ b/packages/core/src/llm/catalog-resolver.ts
@@ -1,0 +1,268 @@
+/**
+ * Table-first catalog read chokepoint — `resolveCatalogEntry()` (E8 · T11737).
+ *
+ * ## The single read chokepoint
+ *
+ * The provider+model catalog now has THREE physical surfaces, in strict priority:
+ *
+ *   1. **`models_catalog` DB table** (cleo-global · T11733) — the SSoT. Seeded
+ *      from the shipped offline `curated-catalog.json` (T11734).
+ *   2. **disk JSON cache** (`llm-catalog/` · T9314 · `catalog-cache.ts`) — the
+ *      offline/degraded fallback MIRROR (the most-recent models.dev snapshot).
+ *   3. **shipped seed** (`curated-catalog.json`) — the last-resort floor that
+ *      always ships in the package, so a fresh/offline install always resolves.
+ *
+ * Every catalog reader (the resolver default — T11944; future capability lookups)
+ * funnels through {@link resolveCatalogEntry} so the table and the cache can NEVER
+ * silently diverge: one chokepoint, table-or-fallback, in that order.
+ *
+ * ## Offline-first (degrade) — NO network at read time
+ *
+ * This module NEVER fetches. The network refresh op (`cleo llm refresh-catalog`)
+ * is a SEPARATE leaf. `resolveCatalogEntry()` reads the DB table first; when the
+ * table is empty/unseeded it falls back to the disk-cache snapshot, then to the
+ * shipped seed. A fresh install with no DB rows and no disk cache still resolves
+ * from the bundled `curated-catalog.json`.
+ *
+ * @module llm/catalog-resolver
+ * @task T11737
+ * @epic T11694 (E8-CATALOG-CURATION)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CuratedCatalog } from '@cleocode/contracts';
+import { getLogger } from '../logger.js';
+import {
+  type CleoGlobalDb,
+  openDualScopeDb,
+  openDualScopeDbAtPath,
+} from '../store/dual-scope-db.js';
+import { modelsCatalog } from '../store/schema/cleo-global/models-catalog.js';
+import { findLatestCacheFile, getCatalogDir, readCacheFile } from './catalog-cache.js';
+
+const logger = getLogger('llm-catalog-resolver');
+
+/**
+ * A normalized catalog entry returned by {@link resolveCatalogEntry}.
+ *
+ * The shape is the union of the fields the resolver-default path (T11944) and the
+ * capability lookups actually consume — it is provenance-agnostic so callers do
+ * NOT care whether the entry came from the table, the disk cache, or the seed.
+ */
+export interface ResolvedCatalogEntry {
+  /** Model id (e.g. `claude-haiku-4-5-20251001`). */
+  readonly id: string;
+  /** Provider key (models.dev id, e.g. `anthropic`). */
+  readonly providerId: string;
+  /** ISO release date `YYYY-MM-DD`. The SSoT sort key. */
+  readonly releaseDate: string;
+  /** Max context window (tokens), when known. */
+  readonly contextLimit: number | null;
+  /** Where this entry was resolved from (provenance). */
+  readonly source: CatalogResolutionSource;
+}
+
+/** Provenance of a {@link ResolvedCatalogEntry} (table-first, then fallbacks). */
+export type CatalogResolutionSource = 'table' | 'disk-cache' | 'shipped-seed';
+
+/** Injectable seam for {@link resolveCatalogEntry} (tests pass a temp-DB handle). */
+export interface CatalogResolverDeps {
+  /**
+   * An already-open global Drizzle handle. When omitted the resolver opens via
+   * {@link openDualScopeDb}`('global')`. Tests pass a temp-DB handle (opened via
+   * {@link openCatalogAtPath}) to stay off `.cleo/*.db`.
+   */
+  readonly db?: CleoGlobalDb;
+  /**
+   * Disk-cache directory override (tests). Defaults to {@link getCatalogDir}.
+   */
+  readonly cacheDir?: string;
+}
+
+/** In-memory shipped-seed cache for the process lifetime. */
+let _seed: CuratedCatalog | null | undefined;
+
+/**
+ * Open the global catalog handle at an EXPLICIT path (test seam).
+ *
+ * Production callers MUST use {@link openDualScopeDb}`('global')`. This path-aware
+ * variant exists so tests open a temp-dir `cleo.db` — never `.cleo/*.db`.
+ *
+ * @param dbPath - Absolute path to the temp `cleo.db`.
+ * @task T11737
+ */
+export async function openCatalogAtPath(dbPath: string): Promise<CleoGlobalDb> {
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return handle.db;
+}
+
+/**
+ * Load the shipped seed (`curated-catalog.json`) from disk — no network.
+ *
+ * Read once and cached for the process lifetime. Returns `null` only if the
+ * bundled file is missing/unparseable (never expected — it ships in the package).
+ *
+ * @internal
+ */
+export function loadShippedSeed(): CuratedCatalog | null {
+  if (_seed !== undefined) return _seed;
+  try {
+    const thisDir = dirname(fileURLToPath(import.meta.url));
+    const jsonPath = join(thisDir, 'curated-catalog.json');
+    _seed = JSON.parse(readFileSync(jsonPath, 'utf-8')) as CuratedCatalog;
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'catalog-resolver: shipped seed unreadable',
+    );
+    _seed = null;
+  }
+  return _seed;
+}
+
+/** Resolve the global Drizzle handle — injected, else canonical open. */
+async function resolveDb(deps?: CatalogResolverDeps): Promise<CleoGlobalDb> {
+  if (deps?.db !== undefined) return deps.db;
+  const handle = await openDualScopeDb('global');
+  return handle.db;
+}
+
+/**
+ * Read the latest-released entry for a provider from the `models_catalog` table.
+ *
+ * Returns the single newest row (ordered by `release_date` DESC, `id` DESC as a
+ * stable tie-break) for the provider, or `null` when the provider has no rows
+ * (table empty/unseeded for that provider). LIMIT 1 — never scans the whole table.
+ *
+ * @internal
+ */
+async function readLatestFromTable(
+  db: CleoGlobalDb,
+  providerId: string,
+): Promise<ResolvedCatalogEntry | null> {
+  const { desc, eq } = await import('drizzle-orm');
+  const rows = await db
+    .select({
+      id: modelsCatalog.id,
+      providerId: modelsCatalog.providerId,
+      releaseDate: modelsCatalog.releaseDate,
+      contextLimit: modelsCatalog.contextLimit,
+    })
+    .from(modelsCatalog)
+    .where(eq(modelsCatalog.providerId, providerId))
+    .orderBy(desc(modelsCatalog.releaseDate), desc(modelsCatalog.id))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    releaseDate: row.releaseDate,
+    contextLimit: row.contextLimit ?? null,
+    source: 'table',
+  };
+}
+
+/**
+ * Resolve the latest-released catalog entry for a provider from a catalog snapshot
+ * (disk-cache file or shipped seed), sorted by `release_date` DESC.
+ *
+ * The two fallback surfaces carry different shapes — the disk cache is the raw
+ * models.dev `{ [provider]: { models: { [id]: { release_date, limit } } } }`, the
+ * shipped seed is the curated `{ models: { [provider]: { [id]: entry } } }`. This
+ * helper accepts the already-extracted per-provider model map.
+ *
+ * @internal
+ */
+function latestFromModelMap(
+  models: Record<string, { release_date?: string; limit?: { context?: number } }>,
+  providerId: string,
+  source: 'disk-cache' | 'shipped-seed',
+): ResolvedCatalogEntry | null {
+  let bestId: string | null = null;
+  let bestDate = '';
+  let bestCtx: number | null = null;
+  for (const [id, entry] of Object.entries(models)) {
+    const rd = entry.release_date;
+    if (!rd) continue;
+    if (rd > bestDate || (rd === bestDate && bestId !== null && id > bestId)) {
+      bestDate = rd;
+      bestId = id;
+      bestCtx = entry.limit?.context ?? null;
+    }
+  }
+  if (bestId === null) return null;
+  return { id: bestId, providerId, releaseDate: bestDate, contextLimit: bestCtx, source };
+}
+
+/**
+ * Resolve the latest-released catalog entry for a provider — the SINGLE table-first
+ * read chokepoint (T11737).
+ *
+ * Resolution order (offline-first, no network):
+ *   1. `models_catalog` DB table (SSoT) — newest `release_date` row for the provider.
+ *   2. disk JSON cache (`llm-catalog/`) — newest entry when the table has no rows.
+ *   3. shipped `curated-catalog.json` seed — last-resort floor (always present).
+ *
+ * Returns `null` only when NONE of the three surfaces carry a dated entry for the
+ * provider — callers then degrade to their own static literal floor (the resolver
+ * default keeps `IMPLICIT_FALLBACK_MODEL` for exactly this case — T11944).
+ *
+ * @param providerCatalogKey - The models.dev provider key (e.g. `anthropic`).
+ * @param deps - Optional injected DB handle / cache dir (tests).
+ * @returns The newest-released entry for the provider, or `null` when unresolved.
+ *
+ * @task T11737
+ */
+export async function resolveCatalogEntry(
+  providerCatalogKey: string,
+  deps?: CatalogResolverDeps,
+): Promise<ResolvedCatalogEntry | null> {
+  const providerId = providerCatalogKey.toLowerCase();
+
+  // 1. Table-first (SSoT).
+  try {
+    const db = await resolveDb(deps);
+    const fromTable = await readLatestFromTable(db, providerId);
+    if (fromTable) return fromTable;
+  } catch (err) {
+    // A table read failure must NOT break resolution — degrade to the mirrors.
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err), providerId },
+      'catalog-resolver: models_catalog read failed; falling back to disk cache',
+    );
+  }
+
+  // 2. Disk-cache mirror.
+  const cacheDir = deps?.cacheDir ?? getCatalogDir();
+  const latest = findLatestCacheFile(cacheDir);
+  if (latest) {
+    const cache = readCacheFile(latest);
+    const provider = cache?.[providerId];
+    if (provider?.models) {
+      const fromCache = latestFromModelMap(provider.models, providerId, 'disk-cache');
+      if (fromCache) return fromCache;
+    }
+  }
+
+  // 3. Shipped-seed floor (always present in the package).
+  const seed = loadShippedSeed();
+  const seedModels = seed?.models?.[providerId];
+  if (seedModels) {
+    const fromSeed = latestFromModelMap(seedModels, providerId, 'shipped-seed');
+    if (fromSeed) return fromSeed;
+  }
+
+  return null;
+}
+
+/**
+ * Reset the in-memory shipped-seed cache.
+ *
+ * @internal — for use in unit tests only.
+ */
+export function _resetCatalogResolverCache(): void {
+  _seed = undefined;
+}

--- a/packages/core/src/llm/catalog-seeder.ts
+++ b/packages/core/src/llm/catalog-seeder.ts
@@ -1,0 +1,245 @@
+/**
+ * Catalog seeder — populates `models_catalog` from the shipped offline seed (T11734).
+ *
+ * ## What it does
+ *
+ * {@link seedModelsCatalog} reads the bundled `curated-catalog.json`, validates it
+ * against the contract zod schema ({@link curatedCatalogSchema}), flattens every
+ * provider→model entry into a `models_catalog` row, and UPSERTS each via
+ * {@link openDualScopeDb}`('global')`. Seeding is the offline bootstrap of the
+ * catalog SSoT — NO network is touched (the network refresh op is a separate leaf).
+ *
+ * ## Idempotent (AC2) + version-skip (AC4)
+ *
+ * The seed carries a semver `version`. The seeder records the seeded version in the
+ * global key-value `__catalog_meta` row and SKIPS a re-seed when the persisted
+ * version equals the shipped version (logged, not re-written). On a NEWER shipped
+ * version it re-seeds (upsert on the `(provider_id, models_dev_id)` natural key, so
+ * a re-seed never duplicates rows — running twice yields the same row count).
+ *
+ * @module llm/catalog-seeder
+ * @task T11734
+ * @epic T11694 (E8-CATALOG-CURATION)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { type CuratedCatalog, curatedCatalogSchema } from '@cleocode/contracts';
+import { sql } from 'drizzle-orm';
+import { getLogger } from '../logger.js';
+import {
+  type CleoGlobalDb,
+  openDualScopeDb,
+  openDualScopeDbAtPath,
+} from '../store/dual-scope-db.js';
+import {
+  modelsCatalog,
+  type NewModelsCatalogRow,
+} from '../store/schema/cleo-global/models-catalog.js';
+
+const logger = getLogger('llm-catalog-seeder');
+
+/** Result of a {@link seedModelsCatalog} run. */
+export interface SeedCatalogResult {
+  /** Whether rows were written this run (`false` on a version-skip). */
+  readonly seeded: boolean;
+  /** The seed version applied (or already persisted on a skip). */
+  readonly version: string;
+  /** Number of rows upserted (0 on a skip). */
+  readonly rowCount: number;
+  /** Why the run behaved as it did. */
+  readonly reason: 'seeded' | 'version-skip' | 'reseeded-newer';
+}
+
+/** Injectable seam for {@link seedModelsCatalog} (tests pass a temp-DB handle + fixture). */
+export interface SeedCatalogDeps {
+  /**
+   * An already-open global Drizzle handle. When omitted the seeder opens via
+   * {@link openDualScopeDb}`('global')`. Tests pass a temp-DB handle (opened via
+   * {@link openSeederAtPath}) to stay off `.cleo/*.db`.
+   */
+  readonly db?: CleoGlobalDb;
+  /**
+   * A catalog object to seed from, bypassing the bundled `curated-catalog.json`
+   * (tests pass a fixture). When omitted the shipped seed is read + validated.
+   */
+  readonly catalog?: CuratedCatalog;
+}
+
+/**
+ * Open the global seeder handle at an EXPLICIT path (test seam).
+ *
+ * @param dbPath - Absolute path to the temp `cleo.db`.
+ * @task T11734
+ */
+export async function openSeederAtPath(dbPath: string): Promise<CleoGlobalDb> {
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return handle.db;
+}
+
+/**
+ * Read + validate the shipped seed (`curated-catalog.json`) — no network.
+ *
+ * Throws a descriptive error when the bundled file is missing or fails schema
+ * validation, so a malformed seed fails the build/seed loudly rather than silently
+ * persisting garbage.
+ *
+ * @task T11734
+ */
+export function loadAndValidateSeed(): CuratedCatalog {
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  const jsonPath = join(thisDir, 'curated-catalog.json');
+  const raw = JSON.parse(readFileSync(jsonPath, 'utf-8')) as unknown;
+  return curatedCatalogSchema.parse(raw);
+}
+
+/**
+ * Flatten a {@link CuratedCatalog} into `models_catalog` INSERT rows.
+ *
+ * Each provider→model entry becomes one row; nested `modalities` / `cost` are
+ * JSON-serialized into their TEXT columns. `id` and `models_dev_id` both take the
+ * entry id (the latter anchors the `(provider_id, models_dev_id)` upsert key).
+ *
+ * @task T11734
+ */
+export function flattenCatalogToRows(catalog: CuratedCatalog): NewModelsCatalogRow[] {
+  const rows: NewModelsCatalogRow[] = [];
+  for (const [providerId, models] of Object.entries(catalog.models)) {
+    for (const [modelId, entry] of Object.entries(models)) {
+      rows.push({
+        id: modelId,
+        providerId,
+        name: entry.name,
+        family: entry.family,
+        attachment: entry.attachment,
+        reasoning: entry.reasoning,
+        temperature: entry.temperature,
+        interleaved: entry.interleaved,
+        toolCall: entry.tool_call,
+        modalities: JSON.stringify(entry.modalities),
+        cost: JSON.stringify(entry.cost),
+        contextLimit: entry.limit.context,
+        outputLimit: entry.limit.output,
+        status: entry.status,
+        releaseDate: entry.release_date,
+        modelsDevId: entry.id,
+        source: 'seed',
+      });
+    }
+  }
+  return rows;
+}
+
+/** Resolve the global Drizzle handle — injected, else canonical open. */
+async function resolveDb(deps?: SeedCatalogDeps): Promise<CleoGlobalDb> {
+  if (deps?.db !== undefined) return deps.db;
+  const handle = await openDualScopeDb('global');
+  return handle.db;
+}
+
+/** The KV key under which the seeded catalog version is persisted. */
+const CATALOG_VERSION_KEY = 'catalog.seed.version';
+
+/**
+ * Read the persisted seeded-catalog version from the lightweight `__catalog_meta`
+ * KV table (created on demand), or `null` when never seeded.
+ *
+ * @internal
+ */
+async function readPersistedVersion(db: CleoGlobalDb): Promise<string | null> {
+  db.run(
+    sql`CREATE TABLE IF NOT EXISTS __catalog_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+  );
+  const rows = (await db.all(
+    sql`SELECT value FROM __catalog_meta WHERE key = ${CATALOG_VERSION_KEY} LIMIT 1`,
+  )) as Array<{ value: string }>;
+  return rows[0]?.value ?? null;
+}
+
+/** Persist the seeded-catalog version into `__catalog_meta`. @internal */
+async function writePersistedVersion(db: CleoGlobalDb, version: string): Promise<void> {
+  db.run(
+    sql`INSERT INTO __catalog_meta (key, value) VALUES (${CATALOG_VERSION_KEY}, ${version})
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  );
+}
+
+/** Compare two semver strings — `a > b`? Padded numeric per-segment compare. @internal */
+function semverGreater(a: string, b: string): boolean {
+  const pa = a.split('.').map((n) => Number.parseInt(n, 10));
+  const pb = b.split('.').map((n) => Number.parseInt(n, 10));
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da > db) return true;
+    if (da < db) return false;
+  }
+  return false;
+}
+
+/**
+ * Seed `models_catalog` from the shipped offline seed — idempotent, offline-first.
+ *
+ * Behaviour:
+ *   - First run (no persisted version): upsert every row, persist the version. (AC1)
+ *   - Re-run with the SAME version: SKIP (logged, not re-written). (AC4)
+ *   - Re-run with a NEWER shipped version: re-seed (upsert, no duplicates). (AC3)
+ *
+ * The upsert is on the `(provider_id, models_dev_id)` natural key, so running twice
+ * yields the same row count and never duplicates (AC2). NO network is touched.
+ *
+ * @param deps - Optional injected DB handle / fixture catalog (tests).
+ * @returns A {@link SeedCatalogResult} describing what happened.
+ *
+ * @task T11734
+ */
+export async function seedModelsCatalog(deps?: SeedCatalogDeps): Promise<SeedCatalogResult> {
+  const catalog = deps?.catalog ?? loadAndValidateSeed();
+  const db = await resolveDb(deps);
+
+  const persisted = await readPersistedVersion(db);
+  if (persisted !== null && !semverGreater(catalog.version, persisted)) {
+    logger.debug(
+      { persisted, shipped: catalog.version },
+      'catalog-seeder: persisted version >= shipped; skipping re-seed',
+    );
+    return { seeded: false, version: persisted, rowCount: 0, reason: 'version-skip' };
+  }
+
+  const rows = flattenCatalogToRows(catalog);
+  for (const row of rows) {
+    await db
+      .insert(modelsCatalog)
+      .values(row)
+      .onConflictDoUpdate({
+        target: [modelsCatalog.providerId, modelsCatalog.modelsDevId],
+        set: {
+          id: row.id,
+          name: row.name,
+          family: row.family,
+          attachment: row.attachment,
+          reasoning: row.reasoning,
+          temperature: row.temperature,
+          interleaved: row.interleaved,
+          toolCall: row.toolCall,
+          modalities: row.modalities,
+          cost: row.cost,
+          contextLimit: row.contextLimit,
+          outputLimit: row.outputLimit,
+          status: row.status,
+          releaseDate: row.releaseDate,
+          source: row.source,
+          seededAt: sql`(datetime('now'))`,
+        },
+      });
+  }
+  await writePersistedVersion(db, catalog.version);
+
+  const reason: SeedCatalogResult['reason'] = persisted === null ? 'seeded' : 'reseeded-newer';
+  logger.debug(
+    { version: catalog.version, rowCount: rows.length, reason },
+    'catalog-seeder: models_catalog seeded',
+  );
+  return { seeded: true, version: catalog.version, rowCount: rows.length, reason };
+}

--- a/packages/core/src/llm/curated-catalog.json
+++ b/packages/core/src/llm/curated-catalog.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": "1.0.0",
+  "lastUpdated": "2026-06-09",
+  "providers": {
+    "anthropic": {
+      "id": "anthropic",
+      "endpoint": "https://api.anthropic.com",
+      "authTypes": ["api_key", "oauth"],
+      "npm": "@anthropic-ai/sdk"
+    },
+    "openai": {
+      "id": "openai",
+      "endpoint": "https://api.openai.com/v1",
+      "authTypes": ["api_key"],
+      "npm": "openai"
+    },
+    "google": {
+      "id": "google",
+      "endpoint": "https://generativelanguage.googleapis.com",
+      "authTypes": ["api_key", "vertex"],
+      "npm": "@google/genai"
+    }
+  },
+  "models": {
+    "anthropic": {
+      "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "family": "claude",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": true,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "cost": { "input": 1, "output": 5, "cache_read": 0.1, "cache_write": 1.25 },
+        "limit": { "context": 200000, "output": 64000 },
+        "status": "stable",
+        "release_date": "2025-10-01",
+        "provider": { "npm": "@anthropic-ai/sdk", "api": "anthropic_messages" }
+      },
+      "claude-sonnet-4-6-20251001": {
+        "id": "claude-sonnet-4-6-20251001",
+        "name": "Claude Sonnet 4.6",
+        "family": "claude",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": true,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "cost": { "input": 3, "output": 15, "cache_read": 0.3, "cache_write": 3.75 },
+        "limit": { "context": 200000, "output": 64000 },
+        "status": "stable",
+        "release_date": "2025-10-01",
+        "provider": { "npm": "@anthropic-ai/sdk", "api": "anthropic_messages" }
+      },
+      "claude-opus-4-8-20260115": {
+        "id": "claude-opus-4-8-20260115",
+        "name": "Claude Opus 4.8",
+        "family": "claude",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": true,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "cost": { "input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25 },
+        "limit": { "context": 200000, "output": 64000 },
+        "status": "stable",
+        "release_date": "2026-01-15",
+        "provider": { "npm": "@anthropic-ai/sdk", "api": "anthropic_messages" }
+      }
+    },
+    "openai": {
+      "gpt-5.1": {
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": false,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "cost": { "input": 2.5, "output": 10 },
+        "limit": { "context": 400000, "output": 128000 },
+        "status": "stable",
+        "release_date": "2025-11-10",
+        "provider": { "npm": "openai", "api": "codex_responses" }
+      },
+      "gpt-5.5": {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": false,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "cost": { "input": 3, "output": 12 },
+        "limit": { "context": 400000, "output": 128000 },
+        "status": "stable",
+        "release_date": "2026-02-20",
+        "provider": { "npm": "openai", "api": "codex_responses" }
+      }
+    },
+    "google": {
+      "gemini-2.5-pro": {
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "family": "gemini",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": false,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image", "audio", "video"], "output": ["text"] },
+        "cost": { "input": 1.25, "output": 10 },
+        "limit": { "context": 1048576, "output": 65536 },
+        "status": "stable",
+        "release_date": "2025-09-01",
+        "provider": { "npm": "@google/genai", "api": "chat_completions" }
+      },
+      "gemini-3.0-pro": {
+        "id": "gemini-3.0-pro",
+        "name": "Gemini 3.0 Pro",
+        "family": "gemini",
+        "attachment": true,
+        "reasoning": true,
+        "temperature": true,
+        "interleaved": false,
+        "tool_call": true,
+        "modalities": { "input": ["text", "image", "audio", "video"], "output": ["text"] },
+        "cost": { "input": 2, "output": 12 },
+        "limit": { "context": 2097152, "output": 65536 },
+        "status": "stable",
+        "release_date": "2026-03-10",
+        "provider": { "npm": "@google/genai", "api": "chat_completions" }
+      }
+    }
+  }
+}

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -59,6 +59,26 @@ export {
   resolveProviderDefaultModel,
   validateModelForProvider,
 } from './catalog-model-resolver.js';
+// Table-first catalog read chokepoint — models_catalog SSoT → disk → seed (T11737 · E8)
+export type {
+  CatalogResolutionSource,
+  CatalogResolverDeps,
+  ResolvedCatalogEntry,
+} from './catalog-resolver.js';
+export {
+  _resetCatalogResolverCache,
+  loadShippedSeed,
+  openCatalogAtPath,
+  resolveCatalogEntry,
+} from './catalog-resolver.js';
+// Catalog seeder — populates models_catalog from the shipped offline seed (T11734 · E8)
+export type { SeedCatalogDeps, SeedCatalogResult } from './catalog-seeder.js';
+export {
+  flattenCatalogToRows,
+  loadAndValidateSeed,
+  openSeederAtPath,
+  seedModelsCatalog,
+} from './catalog-seeder.js';
 // `cleo llm` CLI / dispatch engine ops (T9258 — T-LLM-CRED Phase 2 / T-llm-4)
 export {
   llmAdd,

--- a/packages/core/src/llm/system-resolver.ts
+++ b/packages/core/src/llm/system-resolver.ts
@@ -138,16 +138,30 @@ function deriveRole(
 }
 
 /**
- * When `resolveLLMForRole` returns `source === 'implicit-fallback'`, the
- * model is the hardcoded `IMPLICIT_FALLBACK_MODEL` literal. This function
- * replaces it with the SSoT `defaultModel` from the provider registry so
- * the resolved model tracks catalog updates rather than a frozen constant.
+ * When `resolveLLMForRole` returns `source === 'implicit-fallback'`, the model is
+ * the hardcoded `IMPLICIT_FALLBACK_MODEL` literal. This function derives the
+ * default from the **`models_catalog` SSoT** (latest `release_date` for the
+ * provider) so the resolved model tracks the catalog rather than a frozen
+ * constant — the "catalog-driven models, NO hardcoded" North Star (E8 · T11944).
  *
- * On any lookup error the original `resolved` envelope is returned unchanged
- * so the caller is never blocked — graceful degradation is preserved.
+ * ## Resolution order (offline-first degrade — T11944 AC1/AC2)
+ *
+ *   1. **`models_catalog` table** (via the {@link resolveCatalogEntry} table-first
+ *      chokepoint — T11737): newest `release_date` row for the provider. When the
+ *      table is seeded this WINS and the static builtin literal is never reached.
+ *   2. **provider-registry `defaultModel`** (the static builtin
+ *      `ProviderDef.defaultModel`) — reached ONLY when the catalog (table + disk
+ *      cache + shipped seed) yields nothing for the provider.
+ *   3. **the existing `IMPLICIT_FALLBACK_MODEL` literal** already on `resolved` —
+ *      the absolute offline floor, preserved for a fresh/offline install with no
+ *      catalog AND no provider profile (degrade does NOT break — AC2).
+ *
+ * NO network is issued at resolve time (table-or-cache only — AC4). On any lookup
+ * error the original `resolved` envelope is returned unchanged so the caller is
+ * never blocked.
  *
  * @param resolved - The envelope returned by `resolveLLMForRole`.
- * @returns The same envelope, possibly with `model` replaced from the registry.
+ * @returns The same envelope, possibly with `model` replaced from the catalog SSoT.
  */
 async function upgradeCatalogDefault(resolved: ResolvedLLM): Promise<ResolvedLLM> {
   if (resolved.source !== 'implicit-fallback') {
@@ -156,22 +170,40 @@ async function upgradeCatalogDefault(resolved: ResolvedLLM): Promise<ResolvedLLM
   }
 
   try {
-    // Lazy import to avoid pulling the full registry chain at module-init time.
+    // Lazy imports to avoid pulling the full registry/catalog chain at module-init.
+    const { resolveCatalogEntry } = await import('./catalog-resolver.js');
+    const { catalogKeyForProvider } = await import('./catalog-model-resolver.js');
+
+    // 1. Table-first catalog SSoT (release_date DESC) — the canonical default.
+    const catalogKey = catalogKeyForProvider(resolved.provider);
+    const entry = await resolveCatalogEntry(catalogKey);
+    if (entry?.id && entry.id !== resolved.model) {
+      logger.debug(
+        { provider: resolved.provider, from: resolved.model, to: entry.id, source: entry.source },
+        'system-resolver: upgrading implicit-fallback model to models_catalog default',
+      );
+      return { ...resolved, model: entry.id };
+    }
+    if (entry?.id) {
+      // Catalog already agrees with the resolved model — no mutation needed.
+      return resolved;
+    }
+
+    // 2. OFFLINE FLOOR: catalog empty/unseeded (fresh/offline install). Fall back to
+    //    the static builtin provider-registry default so degrade never breaks.
     const { getProviderProfile } = await import('./provider-registry/index.js');
     const profile = await getProviderProfile(resolved.provider);
-    if (!profile?.defaultModel) {
-      // Registry has no default for this provider — fall back to the existing model.
-      return resolved;
+    if (profile?.defaultModel && profile.defaultModel !== resolved.model) {
+      logger.debug(
+        { provider: resolved.provider, from: resolved.model, to: profile.defaultModel },
+        'system-resolver: catalog empty — degrading to static builtin defaultModel floor',
+      );
+      return { ...resolved, model: profile.defaultModel };
     }
-    if (profile.defaultModel === resolved.model) {
-      // Already the same — no mutation needed.
-      return resolved;
-    }
-    logger.debug(
-      { provider: resolved.provider, from: resolved.model, to: profile.defaultModel },
-      'system-resolver: upgrading implicit-fallback model to catalog default',
-    );
-    return { ...resolved, model: profile.defaultModel };
+
+    // 3. Neither catalog nor profile yielded a model — keep the existing
+    //    IMPLICIT_FALLBACK_MODEL literal already on `resolved` (the last floor).
+    return resolved;
   } catch (err) {
     logger.warn(
       { err: err instanceof Error ? err.message : String(err) },

--- a/packages/core/src/store/__tests__/models-catalog.test.ts
+++ b/packages/core/src/store/__tests__/models-catalog.test.ts
@@ -1,0 +1,204 @@
+/**
+ * T11733 — `models_catalog` catalog SSoT table on the GLOBAL cleo.db.
+ *
+ * Proves the AC: opening the consolidated global `cleo.db` (which applies the
+ * `drizzle-cleo-global` migration set, including the new
+ * `…_t11733-models-catalog` forward migration) materialises the `models_catalog`
+ * table, that a row inserts + selects cleanly (capabilities round-trip), that the
+ * migration is idempotent (re-open is a no-op, table still present), and that the
+ * `(provider_id, models_dev_id)` unique index + status CHECK + date GLOB hold.
+ *
+ * Every test runs against a TEMP-DIR cleo.db — never `.cleo/*.db`.
+ *
+ * @task T11733
+ * @epic T11694
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from '../dual-scope-db.js';
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `models-catalog-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+/** Open + migrate an isolated temp GLOBAL cleo.db; return its native handle. */
+async function openGlobalTemp(): Promise<DatabaseSync> {
+  const dbPath = join(testRoot, 'cleo.db');
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return (handle.db as unknown as { $client: DatabaseSync }).$client;
+}
+
+describe('models_catalog (catalog SSoT) — global cleo.db migration', () => {
+  it('migration materialises the `models_catalog` table', async () => {
+    const db = await openGlobalTemp();
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='models_catalog'")
+      .get() as { name: string } | undefined;
+    expect(row?.name).toBe('models_catalog');
+  }, 30_000);
+
+  it('inserts and selects a model row round-trip (capability fields)', async () => {
+    const db = await openGlobalTemp();
+    db.prepare(
+      `INSERT INTO models_catalog
+         (id, provider_id, name, family, attachment, reasoning, temperature, interleaved,
+          tool_call, modalities, cost, context_limit, output_limit, status, release_date,
+          models_dev_id, source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'claude-haiku-4-5',
+      'anthropic',
+      'Claude Haiku 4.5',
+      'claude',
+      1,
+      1,
+      1,
+      1,
+      1,
+      '{"input":["text","image"],"output":["text"]}',
+      '{"input":1,"output":5}',
+      200000,
+      64000,
+      'stable',
+      '2025-10-01',
+      'claude-haiku-4-5',
+      'seed',
+    );
+
+    const got = db
+      .prepare(
+        `SELECT id, provider_id, name, family, attachment, reasoning, tool_call,
+                modalities, cost, context_limit, status, release_date, models_dev_id, source
+           FROM models_catalog WHERE id = ?`,
+      )
+      .get('claude-haiku-4-5') as Record<string, unknown> | undefined;
+
+    expect(got).toBeDefined();
+    expect(got?.provider_id).toBe('anthropic');
+    expect(got?.family).toBe('claude');
+    expect(got?.attachment).toBe(1);
+    expect(got?.reasoning).toBe(1);
+    expect(got?.tool_call).toBe(1);
+    expect(got?.context_limit).toBe(200000);
+    expect(got?.status).toBe('stable');
+    expect(got?.release_date).toBe('2025-10-01');
+    expect(got?.source).toBe('seed');
+    // JSON blobs round-trip exactly.
+    expect(JSON.parse(got?.modalities as string)).toEqual({
+      input: ['text', 'image'],
+      output: ['text'],
+    });
+    expect(JSON.parse(got?.cost as string)).toEqual({ input: 1, output: 5 });
+  }, 30_000);
+
+  it('applies column defaults (temperature=1, status=stable, source=seed, seeded_at)', async () => {
+    const db = await openGlobalTemp();
+    db.prepare(
+      `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('m1', 'openai', 'M1', 'gpt', '2025-01-01', 'm1');
+    const got = db
+      .prepare(
+        `SELECT attachment, reasoning, temperature, interleaved, tool_call,
+                status, source, seeded_at, modalities, cost
+           FROM models_catalog WHERE id = 'm1'`,
+      )
+      .get() as Record<string, unknown> | undefined;
+    expect(got?.attachment).toBe(0);
+    expect(got?.temperature).toBe(1);
+    expect(got?.status).toBe('stable');
+    expect(got?.source).toBe('seed');
+    expect(got?.modalities).toBe('{"input":["text"],"output":["text"]}');
+    expect(got?.cost).toBe('{}');
+    expect(got?.seeded_at).toMatch(/^\d{4}-\d{2}-\d{2} /);
+  }, 30_000);
+
+  it('the `(provider_id, models_dev_id)` unique index forbids a duplicate within a provider', async () => {
+    const db = await openGlobalTemp();
+    db.prepare(
+      `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('a', 'anthropic', 'A', 'claude', '2025-01-01', 'dup');
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run('b', 'anthropic', 'B', 'claude', '2025-02-01', 'dup'),
+    ).toThrow();
+    // Same models_dev_id under a DIFFERENT provider is allowed.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run('c', 'openai', 'C', 'gpt', '2025-02-01', 'dup'),
+    ).not.toThrow();
+  }, 30_000);
+
+  it('the `status` CHECK rejects an out-of-enum value; the date GLOB rejects a bad date', async () => {
+    const db = await openGlobalTemp();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run('x', 'anthropic', 'X', 'claude', '2025-01-01', 'x', 'zombie'),
+    ).toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run('y', 'anthropic', 'Y', 'claude', 'not-a-date', 'y'),
+    ).toThrow();
+  }, 30_000);
+
+  it('migration is idempotent — re-opening the same DB is a no-op and the table persists', async () => {
+    const dbPath = join(testRoot, 'cleo.db');
+    const h1 = await openDualScopeDbAtPath('global', dbPath);
+    (h1.db as unknown as { $client: DatabaseSync }).$client
+      .prepare(
+        `INSERT INTO models_catalog (id, provider_id, name, family, release_date, models_dev_id)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run('persist', 'anthropic', 'P', 'claude', '2025-01-01', 'persist');
+
+    // Re-open (drops the cache first so a fresh migrate pass runs against the same file).
+    _resetDualScopeDbCache();
+    const h2 = await openDualScopeDbAtPath('global', dbPath);
+    const db2 = (h2.db as unknown as { $client: DatabaseSync }).$client;
+    const tbl = db2
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='models_catalog'")
+      .get() as { name: string } | undefined;
+    expect(tbl?.name).toBe('models_catalog');
+    // The row written before re-open is still there (no destructive re-create).
+    const row = db2.prepare('SELECT id FROM models_catalog WHERE id = ?').get('persist') as
+      | { id: string }
+      | undefined;
+    expect(row?.id).toBe('persist');
+  }, 30_000);
+});

--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -95,6 +95,8 @@
 export * from '../cleo-shared/index.js';
 export * from './accounts.js';
 export * from './agent-registry.js';
+// E8-CATALOG-CURATION (T11733) — the models.dev catalog SSoT (`models_catalog`).
+export * from './models-catalog.js';
 export * from './nexus.js';
 export * from './services.js';
 export * from './session-manifest.js';

--- a/packages/core/src/store/schema/cleo-global/models-catalog.ts
+++ b/packages/core/src/store/schema/cleo-global/models-catalog.ts
@@ -1,0 +1,124 @@
+/**
+ * Global-scope `cleo.db` — **models.dev catalog SSoT** (`models_catalog`, 1 table).
+ *
+ * E8-CATALOG-CURATION (epic T11694 · task T11733). This table is the queryable,
+ * `cleo health`-visible home for the **provider+model capability catalog** that
+ * today lives only as a disk JSON cache (`llm-catalog/`) and a tiny bundled
+ * `curated-models.json`. Each row is ONE model — its full models.dev wire
+ * capability set (modalities, cost, limits, reasoning/tool-call flags, status,
+ * release date) — so the catalog becomes the SSoT (DB table) with the disk cache
+ * demoted to an offline/degraded fallback MIRROR (T11737).
+ *
+ * It is the catalog half of the "catalog-driven models, NO hardcoded" North Star
+ * spine: the resolver default model derives from this table sorted by
+ * `release_date` DESC (T11944), killing the hardcoded `claude-haiku-4-5` literal —
+ * the static literal survives ONLY as the offline-only last-resort floor when this
+ * table is empty/unseeded.
+ *
+ * ## NOT the `accounts` credential pool — do not confuse the two
+ *
+ * `accounts` (T11709) holds machine-wide LLM CREDENTIALS (the pool the runner picks
+ * from). THIS table holds CATALOG DATA (model capabilities) — no secrets, no
+ * encryption. They share the cleo-global scope and the E10 typing conventions, but
+ * carry orthogonal data. The catalog is freely readable; credentials are sealed.
+ *
+ * ## E10 typing (mirrors sibling `accounts.ts` / `services.ts`)
+ *
+ * - Booleans (`attachment`/`reasoning`/`temperature`/`interleaved`/`tool_call`) use
+ *   `integer({mode:'boolean'})` (CHECK `(0, 1)` in the migration).
+ * - `modalities` / `cost` are JSON blobs serialized to TEXT (documented json pattern).
+ * - `release_date` is TEXT `YYYY-MM-DD` with a GLOB date check; `seeded_at` is a TEXT
+ *   ISO-8601 timestamp.
+ * - `status` is a named enum ({@link CATALOG_MODEL_STATUSES}, minted in contracts).
+ *
+ * ## Active selection — `release_date`-sorted, latest wins
+ *
+ * The resolver default and any "newest model for provider X" query reads this table
+ * ordered by `(provider_id, release_date DESC)` — the `idx_models_catalog_provider_release`
+ * index backs that scan. No raw partial unique index is required (unlike `accounts`'
+ * active-pointer); `id` is the natural PK and `(provider_id, models_dev_id)` is a
+ * natural unique key for the upsert.
+ *
+ * @task T11733
+ * @epic T11694
+ * @see ../../../../migrations/drizzle-cleo-global — the forward migration
+ * @see ../../../llm/catalog-seeder.ts — the seeder that populates this table (T11734)
+ * @see ../../../llm/catalog-resolver.ts — the table-first read chokepoint (T11737)
+ * @see ./accounts.ts — the sibling credential-pool table this directory mirrors
+ */
+
+import { CATALOG_MODEL_STATUSES } from '@cleocode/contracts';
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
+/**
+ * `models_catalog` — the machine-wide provider+model capability catalog table.
+ *
+ * One row per model. The catalog SSoT: seeded from the shipped offline
+ * `curated-catalog.json` (T11734), read table-first via `resolveCatalogEntry()`
+ * (T11737), and consulted by the resolver default (latest `release_date` wins —
+ * T11944). `id` is the model id (PK); `(provider_id, models_dev_id)` is the natural
+ * upsert key.
+ *
+ * @task T11733
+ */
+export const modelsCatalog = sqliteTable(
+  'models_catalog',
+  {
+    /** Model id — the catalog key (e.g. `claude-haiku-4-5-20251001`). Natural PK. */
+    id: text('id').primaryKey(),
+    /** Provider key (models.dev id, e.g. `anthropic` | `openai` | `google`). */
+    providerId: text('provider_id').notNull(),
+    /** Human-readable display name (e.g. `Claude Haiku 4.5`). */
+    name: text('name').notNull(),
+    /** Model family (e.g. `claude` | `gpt` | `gemini`). */
+    family: text('family').notNull(),
+    /** Supports file/image attachments. */
+    attachment: integer('attachment', { mode: 'boolean' }).notNull().default(false),
+    /** Supports extended reasoning / thinking. */
+    reasoning: integer('reasoning', { mode: 'boolean' }).notNull().default(false),
+    /** Honours a temperature parameter. */
+    temperature: integer('temperature', { mode: 'boolean' }).notNull().default(true),
+    /** Supports interleaved thinking blocks. */
+    interleaved: integer('interleaved', { mode: 'boolean' }).notNull().default(false),
+    /** Supports tool / function calling. */
+    toolCall: integer('tool_call', { mode: 'boolean' }).notNull().default(false),
+    /** JSON blob: `{ input: string[]; output: string[] }` modalities (serialized TEXT). */
+    modalities: text('modalities').notNull().default('{"input":["text"],"output":["text"]}'),
+    /** JSON blob: per-1M-token cost facets `{ input?, output?, cache_read?, … }` (serialized TEXT). */
+    cost: text('cost').notNull().default('{}'),
+    /** Max context window (tokens); NULL when the catalog entry omits a limit. */
+    contextLimit: integer('context_limit'),
+    /** Max output tokens; NULL when the catalog entry omits a limit. */
+    outputLimit: integer('output_limit'),
+    /**
+     * Availability lifecycle — `stable` | `beta` | `preview` | `deprecated` | `retired`
+     * ({@link CATALOG_MODEL_STATUSES}, minted in contracts).
+     */
+    status: text('status', { enum: CATALOG_MODEL_STATUSES }).notNull().default('stable'),
+    /**
+     * ISO release date `YYYY-MM-DD` (GLOB-checked in the migration). The SSoT sort key —
+     * the resolver default picks the row with the LATEST `release_date` for a provider.
+     */
+    releaseDate: text('release_date').notNull(),
+    /** The models.dev entry id (mirrors `id`; kept distinct for the natural upsert key). */
+    modelsDevId: text('models_dev_id').notNull(),
+    /** Provenance — where this row came from (e.g. `seed` | `refresh` | `import`). */
+    source: text('source').notNull().default('seed'),
+    /** ISO-8601 UTC instant this row was seeded/last upserted. Defaults to write time. */
+    seededAt: text('seeded_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // The natural upsert key — a models.dev id is unique within a provider.
+    unique('ux_models_catalog_provider_modeldev').on(table.providerId, table.modelsDevId),
+    // The default-resolution scan — newest model per provider (release_date DESC).
+    index('idx_models_catalog_provider_release').on(table.providerId, table.releaseDate),
+    // Lifecycle scans (e.g. exclude retired) per provider.
+    index('idx_models_catalog_provider_status').on(table.providerId, table.status),
+  ],
+);
+
+/** Row type for `models_catalog` SELECT queries. */
+export type ModelsCatalogRow = typeof modelsCatalog.$inferSelect;
+/** Row type for `models_catalog` INSERT/UPSERT operations. */
+export type NewModelsCatalogRow = typeof modelsCatalog.$inferInsert;


### PR DESCRIPTION
## M3 — catalog-driven models, NO hardcoded

Builds the E8 catalog foundation (epic **T11694**) as one coherent increment: the
`models_catalog` DB SSoT + a table-first read chokepoint + a resolver default that
derives from the catalog (latest `release_date` wins), **killing the hardcoded
`claude-haiku-4-5` default** at the resolution surface. Offline-first throughout —
NO network at build or resolve time.

### Tasks mapped
| Task | Deliverable |
|------|-------------|
| **T11731** (schema) | `packages/contracts/src/llm/catalog-schema.{json,ts}` — draft-2020-12 JSON Schema + zod mirror (`CuratedCatalog`) + `modelsCatalogRow{Insert,Select}Schema` row parity |
| **T11732** (seed) | `packages/core/src/llm/curated-catalog.json` — shipped **offline** seed (anthropic/openai/google, dated). The network generator is a separate leaf, intentionally out of scope |
| **T11733** (table) | `models_catalog` Drizzle table in cleo-global + forward migration `20260609010000_t11733-models-catalog` |
| **T11734** (seeder) | `catalog-seeder.ts` — `seedModelsCatalog()` reads+validates the seed, idempotent upsert, version-skip; wired into `cleo init` |
| **T11737** (chokepoint) | `catalog-resolver.ts` — `resolveCatalogEntry()` table-first read: **table → disk cache → shipped seed** |
| **T11944** (resolver default) | `system-resolver.ts` `upgradeCatalogDefault()` derives the default from the catalog SSoT (release_date DESC), static literal kept as offline floor |

### Table + seeder + chokepoint design
- **Table** mirrors the `accounts` (T11709) / `services` (T11937) precedent: `openDualScopeDb('global')` only, `integer({mode:'boolean'})` flags, JSON-as-TEXT (`modalities`/`cost`), TEXT `release_date` with GLOB date check, named `status` enum minted in contracts. Natural PK `id`; natural upsert key `(provider_id, models_dev_id)`; `idx_models_catalog_provider_release` backs the release_date-DESC scan. Migration is `IF NOT EXISTS` + `--> statement-breakpoint`, page-2-safe (never the first CREATE).
- **Seeder** flattens `CuratedCatalog` → rows, `onConflictDoUpdate` on the natural key (running twice = same row count, no dupes), persists the seed version in `__catalog_meta` and skips a same-version re-seed.
- **Chokepoint** `resolveCatalogEntry(providerKey)` returns the newest-release_date entry from the **table first**, falling back to the disk-cache mirror then the shipped seed — one reader, table-or-fallback, so the table and cache can never silently diverge.

### Offline-first degrade proof
`resolveCatalogEntry()` and the resolver default both work with **no network**:
1. seeded table → newest table row wins;
2. empty table → newest disk-cache entry;
3. empty table + empty cache → shipped seed floor;
4. nothing anywhere → `null`, and the resolver then degrades to the static builtin `defaultModel`, then to `IMPLICIT_FALLBACK_MODEL` — a fresh/offline install does **not** break (asserted).

### How the resolver default now derives from the catalog
`upgradeCatalogDefault()` (only on `source === 'implicit-fallback'`): (1) `resolveCatalogEntry(catalogKeyForProvider(provider))` table-first; when seeded this **wins** and the hardcoded literal is never reached; (2) else the static builtin `ProviderDef.defaultModel`; (3) else the existing `IMPLICIT_FALLBACK_MODEL` already on the envelope. No network (table-or-cache only).

### Hardcoded literals killed / kept as floor
- **Killed at the resolution surface:** `claude-haiku-4-5-20251001` is no longer the resolved default when the catalog is seeded — the test proves a `2099-12-31` catalog row drives the default instead of the frozen literal.
- **Kept as offline-only floor:** `fallback-model.ts:24` `IMPLICIT_FALLBACK_MODEL` and the builtin `anthropic.ts` `defaultModel` survive untouched as the last-resort degrade path (reached only when table + disk + seed all yield nothing).

### Quality gates
- FULL `pnpm run typecheck` (`tsc -b`) clean across all packages.
- `pnpm biome check --write` clean.
- **17 new in-process tests** pass (cgroup-capped, `--maxWorkers=2`): migration idempotency + round-trip + CHECKs + unique index; seeder seed/idempotency/version-skip/upsert + schema-validate; chokepoint table-first/disk/seed/null; resolver default newer-wins + offline floor + `skipCatalogDefault`. Never `.all()` a large table (table reads are `LIMIT 1` / `COUNT(*)`).
- **Zero regression:** 79 adjacent llm/store tests + 50 migration tests pass.
- `cleo check arch` baseline: **DB-Open-Guard strict** OK (zero raw `DatabaseSync`), **LLM-chokepoint** OK (no net-new — catalog data + resolution, no transport/client construction), **contracts-purity** OK (zod values only), **fan-out** OK. No canon `.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)