### PR TITLE
feat(T11702): Provider SSoT — ProviderDef contract + providers table/seed + alias resolution (M3 5-entity foundation)

### DIFF
--- a/packages/contracts/src/__tests__/provider-def.test.ts
+++ b/packages/contracts/src/__tests__/provider-def.test.ts
@@ -1,0 +1,93 @@
+/**
+ * T11702 — `ProviderDef` declarative contract shape.
+ *
+ * Type-level + value-level assertions that the contract is a closed, discriminated,
+ * serializable shape (the endpoint union is keyed on the `transport` literal, no
+ * `any`/`unknown` shortcut). No DB, no network.
+ *
+ * @task T11702
+ * @epic T11667
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PROVIDER_TRANSPORTS,
+  type ProviderDef,
+  type ProviderEndpoint,
+  REQUEST_QUIRK_KINDS,
+} from '../llm/provider-def.js';
+
+describe('ProviderDef contract (T11702)', () => {
+  it('exposes the closed transport discriminant set', () => {
+    expect([...PROVIDER_TRANSPORTS]).toEqual([
+      'openai-completions',
+      'openai-responses',
+      'anthropic-messages',
+      'aisdk',
+    ]);
+  });
+
+  it('exposes the closed request-quirk-kind set', () => {
+    expect(REQUEST_QUIRK_KINDS).toContain('grok-conv-id');
+    expect(REQUEST_QUIRK_KINDS).toContain('gemini-thinking-config');
+    expect(REQUEST_QUIRK_KINDS).toContain('moonshot-schema-sanitize');
+  });
+
+  it('accepts a fully-populated declarative provider def with an OAuth flow + alt endpoint', () => {
+    const def: ProviderDef = {
+      id: 'openai',
+      displayName: 'OpenAI Codex (ChatGPT)',
+      aliases: ['codex', 'chatgpt', 'openai-codex'],
+      authMethods: ['api_key', 'oauth'],
+      endpoint: { transport: 'openai-completions', baseUrl: 'https://api.openai.com/v1' },
+      altEndpoints: [{ transport: 'openai-responses', baseUrl: 'https://api.openai.com/v1' }],
+      modelsDevId: 'openai',
+      oauth: {
+        mode: 'pkce',
+        clientId: 'app_test',
+        tokenEndpoint: 'https://auth.openai.com/oauth/token',
+        authorizationEndpoint: 'https://auth.openai.com/oauth/authorize',
+      },
+      requestQuirks: [{ kind: 'openrouter-pareto' }],
+    };
+    // Round-trips through JSON — the shape is serializable (no closures).
+    const roundTripped = JSON.parse(JSON.stringify(def)) as ProviderDef;
+    expect(roundTripped.id).toBe('openai');
+    expect(roundTripped.endpoint.transport).toBe('openai-completions');
+    expect(roundTripped.altEndpoints?.[0]?.transport).toBe('openai-responses');
+    expect(roundTripped.oauth?.mode).toBe('pkce');
+  });
+
+  it('narrows the endpoint discriminated union on the transport literal', () => {
+    const endpoints: ProviderEndpoint[] = [
+      { transport: 'anthropic-messages', baseUrl: 'https://api.anthropic.com' },
+      { transport: 'aisdk', baseUrl: 'https://example.com', aiSdkProvider: 'google' },
+    ];
+    for (const ep of endpoints) {
+      if (ep.transport === 'aisdk') {
+        // Only the aisdk variant carries aiSdkProvider — narrowing proves the union.
+        expect(ep.aiSdkProvider).toBe('google');
+      } else {
+        expect(ep.baseUrl.startsWith('https://')).toBe(true);
+      }
+    }
+  });
+
+  it('accepts a minimal def (no optional fields)', () => {
+    const def: ProviderDef = {
+      id: 'bedrock',
+      displayName: 'AWS Bedrock',
+      aliases: ['aws-bedrock'],
+      authMethods: ['aws_sdk'],
+      endpoint: {
+        transport: 'aisdk',
+        baseUrl: 'https://bedrock.example',
+        aiSdkProvider: 'bedrock',
+      },
+      modelsDevId: 'bedrock',
+    };
+    expect(def.oauth).toBeUndefined();
+    expect(def.requestQuirks).toBeUndefined();
+    expect(def.altEndpoints).toBeUndefined();
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -865,6 +865,23 @@ export {
   PluginModelGateError,
   PluginRateLimitedError,
 } from './llm/plugin-llm.js';
+export type {
+  AiSdkEndpoint,
+  AnthropicMessagesEndpoint,
+  OAuthFlowDef,
+  OpenAICompletionsEndpoint,
+  OpenAIResponsesEndpoint,
+  ProviderDef,
+  ProviderEndpoint,
+  ProviderTransport,
+  RequestQuirk,
+  RequestQuirkKind,
+} from './llm/provider-def.js';
+// === M3 Provider SSoT (T11702 · epic T11667) — declarative ProviderDef ===
+export {
+  PROVIDER_TRANSPORTS,
+  REQUEST_QUIRK_KINDS,
+} from './llm/provider-def.js';
 // === Phase 4 Unified Architecture (T9281 / ADR-072) — Provider identity ===
 export type { ApiMode, BuiltinProviderId, ProviderId } from './llm/provider-id.js';
 // === Provider Profile + Plugin Contracts (T9262 — Phase 3 T-LLM-CRED) ===

--- a/packages/contracts/src/llm/index.ts
+++ b/packages/contracts/src/llm/index.ts
@@ -1,0 +1,29 @@
+/**
+ * `@cleocode/contracts/llm` — LLM contract subpath barrel.
+ *
+ * Re-exports the declarative provider contracts so consumers can import from the
+ * `./llm` subpath (`@cleocode/contracts/llm`) in addition to the package root.
+ * Currently fronts the M3 Provider SSoT {@link ProviderDef} contract (T11702);
+ * other `llm/*` modules continue to export from the package root barrel.
+ *
+ * @module llm
+ * @task T11702
+ * @epic T11667
+ */
+
+export type {
+  AiSdkEndpoint,
+  AnthropicMessagesEndpoint,
+  OAuthFlowDef,
+  OpenAICompletionsEndpoint,
+  OpenAIResponsesEndpoint,
+  ProviderDef,
+  ProviderEndpoint,
+  ProviderTransport,
+  RequestQuirk,
+  RequestQuirkKind,
+} from './provider-def.js';
+export {
+  PROVIDER_TRANSPORTS,
+  REQUEST_QUIRK_KINDS,
+} from './provider-def.js';

--- a/packages/contracts/src/llm/provider-def.ts
+++ b/packages/contracts/src/llm/provider-def.ts
@@ -1,0 +1,291 @@
+/**
+ * Declarative `ProviderDef` contract — the DATA shape of one LLM provider.
+ *
+ * M3 Provider SSoT (epic T11667 · task T11702). `ProviderDef` is the DECLARATIVE,
+ * serializable description of a provider: its identity, aliases, auth methods, wire
+ * endpoint (a discriminated union keyed on the `transport` literal), models.dev
+ * catalog key, default headers, optional OAuth flow, and a single request-quirk hook
+ * signature. It is the contract the `providers` global-DB table (T11703) persists and
+ * the alias resolver (T11704) reads.
+ *
+ * ## ProviderDef vs {@link ProviderProfile} — declarative DATA vs runtime BEHAVIOUR
+ *
+ * The pre-existing {@link ProviderProfile} (T9262 · T11756) is the RUNTIME provider
+ * shape carried in the in-process registry: it bundles live hook FUNCTIONS
+ * (`prepareMessages`, `buildExtraBody`, `buildApiKwargsExtras`, `fetchModels`) that
+ * cannot be serialized into a DB row. `ProviderDef` is the DECLARATIVE projection of
+ * the same provider — only serializable DATA — so it can be a `providers` table row,
+ * shipped as a seed, diffed, and resolved without importing provider-specific code.
+ * The builtin `ProviderProfile` set is the SEED SOURCE for the builtin `ProviderDef`
+ * set (the core mapper derives one from the other); the non-serializable hooks stay
+ * on `ProviderProfile`, reduced here to the single declarative {@link RequestQuirk}
+ * descriptor that records WHICH quirk a provider needs without embedding a closure.
+ *
+ * ## Endpoint is a discriminated union (AC5)
+ *
+ * {@link ProviderEndpoint} is a closed discriminated union keyed on the literal
+ * `transport` field — one variant per wire protocol CLEO knows how to speak. No
+ * `any`/`unknown` shortcut: every variant carries its own typed fields. This is the
+ * declarative analog of {@link ApiMode}; the core transport adapter table (T11767)
+ * maps a `transport` value to its `Transport` constructor.
+ *
+ * ## Contracts purity (Gate 10)
+ *
+ * This module is TYPES ONLY — interfaces, type aliases, and `as const` literal arrays.
+ * It exports NO bodied runtime helper. The builtin-set construction and the seed/upsert
+ * logic live in `@cleocode/core` (T11703 · T11704), never here.
+ *
+ * @module llm/provider-def
+ * @task T11702
+ * @epic T11667
+ * @see ./provider-profile.ts — the RUNTIME provider shape (hooks) this projects from
+ * @see ./provider-id.ts — {@link ApiMode} / {@link BuiltinProviderId} the transport mirrors
+ * @see ./oauth.ts — {@link ProviderOAuthConfig} the OAuth flow placeholder reuses
+ * @see ../../../core/src/store/schema/cleo-global/providers.ts — the persisted table (T11703)
+ */
+
+import type { StoredAuthTypeWire } from '../operations/llm.js';
+import type { ProviderOAuthConfig } from './oauth.js';
+import type { ProviderId } from './provider-id.js';
+
+/**
+ * Wire-transport discriminant for a {@link ProviderEndpoint} variant.
+ *
+ * Closed union — one literal per protocol CLEO has a transport for. The
+ * declarative analog of {@link import('./provider-id.js').ApiMode}:
+ *
+ * - `openai-completions` — OpenAI `/chat/completions` shape (OpenAI, OpenRouter,
+ *   Moonshot, Kimi, xAI, Gemini-via-OpenAI-compat) — `ApiMode 'chat_completions'`.
+ * - `openai-responses` — OpenAI Responses API (Codex backend, xAI-responses) —
+ *   `ApiMode 'codex_responses'`.
+ * - `anthropic-messages` — native Anthropic Messages API (prompt-cache + thinking) —
+ *   `ApiMode 'anthropic_messages'`.
+ * - `aisdk` — routed through the Vercel AI-SDK provider factory (the data-driven
+ *   `apiMode → provider` adapter, T11767) rather than a bespoke CLEO transport.
+ *
+ * @task T11702
+ */
+export const PROVIDER_TRANSPORTS = [
+  'openai-completions',
+  'openai-responses',
+  'anthropic-messages',
+  'aisdk',
+] as const;
+
+/** TypeScript union derived from {@link PROVIDER_TRANSPORTS}. */
+export type ProviderTransport = (typeof PROVIDER_TRANSPORTS)[number];
+
+/**
+ * Endpoint for the `openai-completions` transport — the OpenAI
+ * `/chat/completions` wire shape (OpenAI, OpenRouter, Moonshot, Kimi, xAI,
+ * Gemini-via-compat). `baseUrl` has NO trailing slash.
+ *
+ * @task T11702
+ */
+export interface OpenAICompletionsEndpoint {
+  /** Discriminant — the OpenAI chat-completions wire protocol. */
+  readonly transport: 'openai-completions';
+  /** Base URL for the provider's API — no trailing slash. */
+  readonly baseUrl: string;
+}
+
+/**
+ * Endpoint for the `openai-responses` transport — the OpenAI Responses API
+ * (Codex backend, xAI-responses). `baseUrl` has NO trailing slash.
+ *
+ * @task T11702
+ */
+export interface OpenAIResponsesEndpoint {
+  /** Discriminant — the OpenAI Responses wire protocol. */
+  readonly transport: 'openai-responses';
+  /** Base URL for the Responses endpoint — no trailing slash. */
+  readonly baseUrl: string;
+}
+
+/**
+ * Endpoint for the `anthropic-messages` transport — the native Anthropic
+ * Messages API (full prompt-cache + extended thinking). `baseUrl` has NO
+ * trailing slash.
+ *
+ * @task T11702
+ */
+export interface AnthropicMessagesEndpoint {
+  /** Discriminant — the native Anthropic Messages wire protocol. */
+  readonly transport: 'anthropic-messages';
+  /** Base URL for the Anthropic API — no trailing slash. */
+  readonly baseUrl: string;
+}
+
+/**
+ * Endpoint for the `aisdk` transport — the provider is reached through the
+ * Vercel AI-SDK provider factory (the data-driven adapter table, T11767) keyed
+ * by `aiSdkProvider`, rather than a bespoke CLEO transport.
+ *
+ * @task T11702
+ */
+export interface AiSdkEndpoint {
+  /** Discriminant — routed through the AI-SDK provider factory. */
+  readonly transport: 'aisdk';
+  /** Base URL passed to the AI-SDK provider factory — no trailing slash. */
+  readonly baseUrl: string;
+  /**
+   * The AI-SDK provider-factory key (e.g. `openai-compatible` | `google` |
+   * `bedrock`) the adapter table maps to a `create*` factory. NEVER an inline
+   * client construction — the factory call is the LLM chokepoint (T11783).
+   */
+  readonly aiSdkProvider: string;
+}
+
+/**
+ * A provider's wire endpoint — a discriminated union keyed on the `transport`
+ * literal (AC5). Exactly one variant per {@link ProviderTransport}; each carries
+ * its own typed fields, with no `any`/`unknown` shortcut.
+ *
+ * @task T11702
+ */
+export type ProviderEndpoint =
+  | OpenAICompletionsEndpoint
+  | OpenAIResponsesEndpoint
+  | AnthropicMessagesEndpoint
+  | AiSdkEndpoint;
+
+/**
+ * Known request-quirk kinds — the DECLARATIVE record of WHICH provider-specific
+ * request adjustment a provider needs, WITHOUT embedding the closure.
+ *
+ * The live closures stay on {@link ProviderProfile} (`buildExtraBody` /
+ * `buildApiKwargsExtras` / `prepareMessages`); a `ProviderDef` row records only
+ * the quirk's stable kind so the table/seed stays serializable. The runtime maps
+ * a {@link RequestQuirk} `kind` back to its hook implementation.
+ *
+ * - `grok-conv-id` — inject the process-scoped `x-grok-conv-id` header (xAI).
+ * - `gemini-thinking-config` — inject `thinking_config` in `extra_body` (Gemini).
+ * - `kimi-reasoning-effort` — top-level `reasoning_effort` kwarg (Kimi Code).
+ * - `moonshot-schema-sanitize` — shallow tool-schema sanitization (Moonshot).
+ * - `openrouter-pareto` — inject the Pareto price-router plugin (OpenRouter).
+ *
+ * @task T11702
+ */
+export const REQUEST_QUIRK_KINDS = [
+  'grok-conv-id',
+  'gemini-thinking-config',
+  'kimi-reasoning-effort',
+  'moonshot-schema-sanitize',
+  'openrouter-pareto',
+] as const;
+
+/** TypeScript union derived from {@link REQUEST_QUIRK_KINDS}. */
+export type RequestQuirkKind = (typeof REQUEST_QUIRK_KINDS)[number];
+
+/**
+ * A single declarative request-quirk descriptor (AC4 — the "request-quirk hook
+ * signature"). Records the quirk's stable {@link RequestQuirkKind} so a
+ * `ProviderDef` row stays serializable; the runtime resolves the `kind` to its
+ * hook implementation on {@link ProviderProfile}. The signature the hook MUST
+ * satisfy is `(model: string) => Record<string, unknown>` (the declarative shape
+ * of `buildExtraBody` / `buildApiKwargsExtras`), captured here only as the
+ * documented contract — never as an embedded closure.
+ *
+ * @task T11702
+ */
+export interface RequestQuirk {
+  /** The stable quirk kind this provider needs. */
+  readonly kind: RequestQuirkKind;
+}
+
+/**
+ * OAuth flow placeholder embedded on a {@link ProviderDef} (AC4).
+ *
+ * For M3 this is the existing {@link ProviderOAuthConfig} shape (PKCE / device-code
+ * endpoints + client id), aliased so the M4 vault work (T10409) can widen it without
+ * a contract rename. A `ProviderDef` carries `oauth` only when the provider supports
+ * an OAuth login flow (anthropic, openai, kimi-code); it is omitted otherwise.
+ *
+ * @task T11702
+ */
+export type OAuthFlowDef = ProviderOAuthConfig;
+
+/**
+ * Declarative description of one LLM provider — the serializable DATA SSoT.
+ *
+ * The contract persisted as a `providers` table row (T11703) and read by the alias
+ * resolver (T11704). Derived from the runtime {@link ProviderProfile} set: identity
+ * + aliases + auth + endpoint + catalog key + headers + optional OAuth + the
+ * declarative request quirks. Carries NO closures — only serializable DATA.
+ *
+ * @task T11702
+ */
+export interface ProviderDef {
+  /**
+   * Canonical provider id (lower-cased). For builtins this is a
+   * {@link BuiltinProviderId}; plugin providers may use any non-empty string.
+   */
+  readonly id: ProviderId;
+
+  /** Human-readable display name shown in pickers and diagnostic output. */
+  readonly displayName: string;
+
+  /**
+   * Alternate names that resolve to this provider (case-insensitive). The SINGLE
+   * source the alias resolver (T11704) reads — `codex`/`chatgpt` → `openai`,
+   * `claude` → `anthropic`, `google` → `gemini`, … An alias colliding with another
+   * provider's primary `id` is a resolution error (T11704 AC2).
+   */
+  readonly aliases: ReadonlyArray<string>;
+
+  /**
+   * Authentication mechanisms this provider supports (`api_key` | `oauth` |
+   * `aws_sdk`). The {@link StoredAuthTypeWire} wire enum.
+   */
+  readonly authMethods: ReadonlyArray<StoredAuthTypeWire>;
+
+  /**
+   * The provider's wire endpoint — a discriminated union keyed on `transport`
+   * (AC5). A provider that speaks multiple protocols (e.g. xAI completions +
+   * responses) carries the multiple variants in {@link altEndpoints}.
+   */
+  readonly endpoint: ProviderEndpoint;
+
+  /**
+   * Additional wire endpoints this provider also speaks, beyond the primary
+   * {@link endpoint}. Collapses the prior per-ApiMode profile duplication into ONE
+   * row (T11703 AC4 — xAI's completions + responses become one `ProviderDef`).
+   * Empty/omitted for single-protocol providers.
+   */
+  readonly altEndpoints?: ReadonlyArray<ProviderEndpoint>;
+
+  /**
+   * The models.dev catalog provider key joining this provider to the
+   * `models_catalog` table (T11733). Usually equals {@link id}; carried distinctly
+   * because a provider id and its catalog key can differ (e.g. `kimi-code` →
+   * `moonshot`).
+   */
+  readonly modelsDevId: string;
+
+  /**
+   * HTTP headers sent with every request to this provider, merged into the
+   * client's `defaultHeaders` (e.g. `{ 'anthropic-version': '2023-06-01' }`).
+   * Omitted when the provider needs no pinned headers.
+   */
+  readonly defaultHeaders?: Readonly<Record<string, string>>;
+
+  /**
+   * Environment variable names that may supply this provider's API key (e.g.
+   * `['ANTHROPIC_API_KEY']`). Resolver chains may check these before the vault.
+   * Omitted when the provider has no env-var credential path.
+   */
+  readonly envVars?: ReadonlyArray<string>;
+
+  /**
+   * OAuth flow placeholder (AC4) — present only when the provider supports an
+   * OAuth login flow (anthropic, openai, kimi-code). See {@link OAuthFlowDef}.
+   */
+  readonly oauth?: OAuthFlowDef;
+
+  /**
+   * Declarative request quirks this provider needs (AC4) — the stable
+   * {@link RequestQuirk} descriptors WITHOUT the closures (those stay on
+   * {@link ProviderProfile}). Empty/omitted when the provider needs no quirk.
+   */
+  readonly requestQuirks?: ReadonlyArray<RequestQuirk>;
+}

--- a/packages/core/migrations/drizzle-cleo-global/20260609020000_t11703-providers/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260609020000_t11703-providers/migration.sql
@@ -1,0 +1,52 @@
+-- T11703 (M3 Provider SSoT · epic T11667) — the `providers` declarative-provider
+-- SSoT table in the consolidated GLOBAL cleo.db (drizzle-cleo-global scope ONLY —
+-- the provider definition set is a cross-project, machine-wide signal with no
+-- project-tier analog, so it is NOT mirrored into drizzle-cleo-project).
+--
+-- One row per provider: the serializable ProviderDef (T11702) — identity, aliases,
+-- auth methods, wire endpoint(s) (tagged-union JSON discriminated on `transport`),
+-- models.dev catalog key, default headers, optional OAuth flow, declarative request
+-- quirks. This table is the provider SSoT — seeded from the builtin ProviderDef set
+-- derived from the in-process ProviderProfile builtins (T11703), and read by the
+-- resolver / CLI / alias resolver (T11704). The non-serializable runtime hooks stay
+-- on ProviderProfile; a row carries only DATA.
+--
+-- This carries NO secrets and NO encryption — it is declarative config DATA, distinct
+-- from the `accounts` LLM-credential pool (T11709), the `service_*` vault (T11937),
+-- and the `models_catalog` catalog (T11733). The OAuth `client_id` it stores is the
+-- provider's PUBLIC first-party id; client SECRETS live in the service vault.
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-global) and many subsequent migrations, so `providers` is NEVER the first
+-- CREATE on a fresh DB — rootpage 2 is already owned by `__drizzle_migrations` /
+-- the baseline tables. No journal pre-create is required.
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op (idempotent).
+-- Each statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11703
+-- @epic T11667
+
+CREATE TABLE IF NOT EXISTS `providers` (
+  `id` text PRIMARY KEY NOT NULL,
+  `display_name` text NOT NULL,
+  `aliases` text NOT NULL DEFAULT '[]',
+  `auth_methods` text NOT NULL DEFAULT '[]',
+  `endpoint` text NOT NULL,
+  `alt_endpoints` text NOT NULL DEFAULT '[]',
+  `models_dev_id` text NOT NULL,
+  `default_headers` text NOT NULL DEFAULT '{}',
+  `env_vars` text NOT NULL DEFAULT '[]',
+  `oauth` text,
+  `request_quirks` text NOT NULL DEFAULT '[]',
+  `source` text NOT NULL DEFAULT 'seed',
+  `seeded_at` text NOT NULL DEFAULT (datetime('now')),
+  CHECK ("seeded_at" IS NULL OR "seeded_at" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*')
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_providers_models_dev` ON `providers` (`models_dev_id`);

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -1209,6 +1209,20 @@ export async function initProject(opts: InitOptions = {}): Promise<InitResult> {
     );
   }
 
+  // M3 (T11703): seed the `providers` declarative-provider SSoT from the builtin
+  // ProviderDef set (derived from the in-process ProviderProfile builtins). Idempotent
+  // (upsert on `id`) + plugin-safe (never touches user provider rows) — no network.
+  // Non-fatal: a fresh install still resolves providers from the in-process registry.
+  try {
+    const { seedProviders } = await import('./llm/provider-registry/provider-seed.js');
+    const seedResult = await seedProviders();
+    if (seedResult.seeded) {
+      created.push(`providers: seeded ${seedResult.rowCount} builtin providers`);
+    }
+  } catch (err) {
+    warnings.push(`providers seed failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   // Context anchoring: when brownfield and --map-codebase was NOT already run,
   // surface a hint so the operator knows they can anchor the baseline in BRAIN.
   // (We do NOT auto-run mapCodebase here — it's opt-in to avoid blocking init.)

--- a/packages/core/src/llm/__tests__/provider-alias.test.ts
+++ b/packages/core/src/llm/__tests__/provider-alias.test.ts
@@ -1,0 +1,130 @@
+/**
+ * T11704 — pure provider-alias resolution over `ProviderDef.aliases`.
+ *
+ * No DB, no network — `resolveProviderId` is a pure function of `(input, defs)`.
+ *
+ * @task T11704
+ * @epic T11667
+ */
+
+import type { ProviderDef } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { buildAliasIndex, resolveProviderId } from '../provider-registry/provider-alias.js';
+import { builtinProviderDefs } from '../provider-registry/provider-defs.js';
+
+describe('resolveProviderId (T11704)', () => {
+  it('resolves codex and chatgpt to openai (from the builtin set)', () => {
+    expect(resolveProviderId('codex')).toBe('openai');
+    expect(resolveProviderId('chatgpt')).toBe('openai');
+    expect(resolveProviderId('openai-codex')).toBe('openai');
+  });
+
+  it('resolves claude → anthropic and google → gemini', () => {
+    expect(resolveProviderId('claude')).toBe('anthropic');
+    expect(resolveProviderId('google')).toBe('gemini');
+  });
+
+  it('resolves a primary id to itself', () => {
+    expect(resolveProviderId('anthropic')).toBe('anthropic');
+    expect(resolveProviderId('openai')).toBe('openai');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(resolveProviderId('  CODEX ')).toBe('openai');
+    expect(resolveProviderId('Claude')).toBe('anthropic');
+  });
+
+  it('returns null for an unknown name', () => {
+    expect(resolveProviderId('definitely-not-a-provider')).toBeNull();
+    expect(resolveProviderId('')).toBeNull();
+  });
+
+  it('is deterministic — same input yields the same output across calls', () => {
+    expect(resolveProviderId('codex')).toBe(resolveProviderId('codex'));
+  });
+
+  it('accepts a prebuilt index (hot-loop seam)', () => {
+    const index = buildAliasIndex(builtinProviderDefs());
+    expect(resolveProviderId('codex', index)).toBe('openai');
+    expect(resolveProviderId('nope', index)).toBeNull();
+  });
+
+  it('throws when an alias collides with another provider primary id', () => {
+    const defs: ProviderDef[] = [
+      {
+        id: 'openai',
+        displayName: 'OpenAI',
+        aliases: [],
+        authMethods: ['api_key'],
+        endpoint: { transport: 'openai-completions', baseUrl: 'https://api.openai.com' },
+        modelsDevId: 'openai',
+      },
+      {
+        id: 'anthropic',
+        displayName: 'Anthropic',
+        // 'openai' is openai's PRIMARY id — declaring it as an alias is a collision.
+        aliases: ['openai'],
+        authMethods: ['api_key'],
+        endpoint: { transport: 'anthropic-messages', baseUrl: 'https://api.anthropic.com' },
+        modelsDevId: 'anthropic',
+      },
+    ];
+    expect(() => buildAliasIndex(defs)).toThrow(/collides/);
+  });
+
+  it('throws when two providers declare the same alias (ambiguous)', () => {
+    const defs: ProviderDef[] = [
+      {
+        id: 'p1',
+        displayName: 'P1',
+        aliases: ['shared'],
+        authMethods: ['api_key'],
+        endpoint: { transport: 'openai-completions', baseUrl: 'https://p1.example' },
+        modelsDevId: 'p1',
+      },
+      {
+        id: 'p2',
+        displayName: 'P2',
+        aliases: ['shared'],
+        authMethods: ['api_key'],
+        endpoint: { transport: 'openai-completions', baseUrl: 'https://p2.example' },
+        modelsDevId: 'p2',
+      },
+    ];
+    expect(() => buildAliasIndex(defs)).toThrow(/ambiguous/);
+  });
+});
+
+describe('builtinProviderDefs derivation (T11703)', () => {
+  it('derives one ProviderDef per provider id (xai collapsed to one row)', () => {
+    const defs = builtinProviderDefs();
+    const ids = defs.map((d) => d.id);
+    // No duplicate ids — the xai completions + responses profiles collapse to one.
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain('xai');
+    expect(ids.filter((id) => id === 'xai')).toHaveLength(1);
+  });
+
+  it('folds the xai Responses endpoint into the single xai row altEndpoints (AC4)', () => {
+    const xai = builtinProviderDefs().find((d) => d.id === 'xai');
+    expect(xai).toBeDefined();
+    expect(xai?.endpoint.transport).toBe('openai-completions');
+    expect(xai?.altEndpoints?.some((e) => e.transport === 'openai-responses')).toBe(true);
+  });
+
+  it('maps anthropic + kimi-code to the anthropic-messages transport', () => {
+    const defs = builtinProviderDefs();
+    expect(defs.find((d) => d.id === 'anthropic')?.endpoint.transport).toBe('anthropic-messages');
+    expect(defs.find((d) => d.id === 'kimi-code')?.endpoint.transport).toBe('anthropic-messages');
+  });
+
+  it('maps kimi-code to its moonshot models.dev catalog key', () => {
+    expect(builtinProviderDefs().find((d) => d.id === 'kimi-code')?.modelsDevId).toBe('moonshot');
+  });
+
+  it('carries the OAuth flow placeholder for anthropic + openai', () => {
+    const defs = builtinProviderDefs();
+    expect(defs.find((d) => d.id === 'anthropic')?.oauth?.mode).toBe('pkce');
+    expect(defs.find((d) => d.id === 'openai')?.oauth?.mode).toBe('pkce');
+  });
+});

--- a/packages/core/src/llm/__tests__/provider-seed.test.ts
+++ b/packages/core/src/llm/__tests__/provider-seed.test.ts
@@ -1,0 +1,133 @@
+/**
+ * T11703 — `seedProviders` populates the `providers` table from the builtin
+ * ProviderDef set, idempotently (re-open is a no-op), without clobbering user rows.
+ *
+ * Every test seeds a TEMP-DIR global cleo.db — never `.cleo/*.db` and NO network.
+ *
+ * @task T11703
+ * @epic T11667
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import type { ProviderDef } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CleoGlobalDb } from '../../store/dual-scope-db.js';
+import { _resetDualScopeDbCache } from '../../store/dual-scope-db.js';
+import { builtinProviderDefs } from '../provider-registry/provider-defs.js';
+import {
+  openProviderSeederAtPath,
+  providerDefToRow,
+  seedProviders,
+} from '../provider-registry/provider-seed.js';
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `provider-seed-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+async function open(): Promise<{ db: CleoGlobalDb; native: DatabaseSync }> {
+  const db = await openProviderSeederAtPath(join(testRoot, 'cleo.db'));
+  const native = (db as unknown as { $client: DatabaseSync }).$client;
+  return { db, native };
+}
+
+function rowCount(native: DatabaseSync): number {
+  const r = native.prepare('SELECT COUNT(*) AS c FROM providers').get() as { c: number };
+  return r.c;
+}
+
+describe('seedProviders (T11703)', () => {
+  it('seeds the builtin provider set and round-trips the declarative JSON columns', async () => {
+    const { db, native } = await open();
+    const defs = builtinProviderDefs();
+    const result = await seedProviders({ db, defs });
+
+    expect(result.seeded).toBe(true);
+    expect(result.rowCount).toBe(defs.length);
+    expect(rowCount(native)).toBe(defs.length);
+
+    const anthropic = native
+      .prepare('SELECT id, display_name, aliases, endpoint, oauth FROM providers WHERE id = ?')
+      .get('anthropic') as Record<string, unknown>;
+    expect(anthropic.id).toBe('anthropic');
+    expect(JSON.parse(anthropic.aliases as string)).toContain('claude');
+    expect(JSON.parse(anthropic.endpoint as string)).toMatchObject({
+      transport: 'anthropic-messages',
+    });
+    expect(JSON.parse(anthropic.oauth as string)).toMatchObject({ mode: 'pkce' });
+  }, 30_000);
+
+  it('is idempotent — running twice yields the same row count and no duplicates', async () => {
+    const { db, native } = await open();
+    const defs = builtinProviderDefs();
+    await seedProviders({ db, defs });
+    const first = rowCount(native);
+
+    const second = await seedProviders({ db, defs });
+    expect(second.seeded).toBe(true);
+    expect(rowCount(native)).toBe(first);
+  }, 30_000);
+
+  it('re-opening the migrated DB is a no-op (migration IF NOT EXISTS)', async () => {
+    {
+      const { db, native } = await open();
+      await seedProviders({ db, defs: builtinProviderDefs() });
+      expect(rowCount(native)).toBeGreaterThan(0);
+    }
+    _resetDualScopeDbCache();
+    // Re-open the SAME on-disk DB — the migration is a no-op, rows persist.
+    const { native } = await open();
+    expect(rowCount(native)).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('does not clobber a user plugin provider row on re-seed (AC5)', async () => {
+    const { db, native } = await open();
+    // Insert a user plugin provider row (a non-builtin id) directly.
+    const pluginRow = providerDefToRow({
+      id: 'my-plugin-provider',
+      displayName: 'My Plugin Provider',
+      aliases: ['mpp'],
+      authMethods: ['api_key'],
+      endpoint: { transport: 'openai-completions', baseUrl: 'https://plugin.example' },
+      modelsDevId: 'my-plugin-provider',
+    } satisfies ProviderDef);
+    native
+      .prepare(
+        'INSERT INTO providers (id, display_name, aliases, auth_methods, endpoint, models_dev_id, source) VALUES (?,?,?,?,?,?,?)',
+      )
+      .run(
+        pluginRow.id,
+        pluginRow.displayName,
+        pluginRow.aliases,
+        pluginRow.authMethods,
+        pluginRow.endpoint,
+        pluginRow.modelsDevId,
+        'plugin',
+      );
+
+    await seedProviders({ db, defs: builtinProviderDefs() });
+
+    const survived = native
+      .prepare('SELECT id, source FROM providers WHERE id = ?')
+      .get('my-plugin-provider') as Record<string, unknown> | undefined;
+    expect(survived).toBeDefined();
+    expect(survived?.source).toBe('plugin');
+  }, 30_000);
+});

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -136,6 +136,22 @@ export {
   suppressionStatePath,
   writeSuppressionFile,
 } from './credential-removal.js';
+// M3 Provider SSoT (T11702/T11703/T11704 · epic T11667) — declarative providers
+export type { ProviderAliasIndex } from './provider-registry/provider-alias.js';
+export {
+  buildAliasIndex,
+  resolveProviderId,
+} from './provider-registry/provider-alias.js';
+export {
+  builtinProviderDefs,
+  toProviderDef,
+} from './provider-registry/provider-defs.js';
+export type { SeedProvidersDeps, SeedProvidersResult } from './provider-registry/provider-seed.js';
+export {
+  openProviderSeederAtPath,
+  providerDefToRow,
+  seedProviders,
+} from './provider-registry/provider-seed.js';
 // Credential seeders — unified pool foundation (E-CONFIG-AUTH-UNIFY E2a / T9408)
 // T9409 adds the concrete `EnvSeeder` and the `./register.js` barrel that
 // populates `BUILTIN_SEEDERS` at module load. Importing this `llm/index.js`

--- a/packages/core/src/llm/provider-registry/provider-alias.ts
+++ b/packages/core/src/llm/provider-registry/provider-alias.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure provider-alias resolution over {@link ProviderDef.aliases} (T11704).
+ *
+ * M3 Provider SSoT (epic T11667 · task T11704). {@link resolveProviderId} maps a name
+ * OR an alias to its canonical provider id, reading the {@link ProviderDef} set's
+ * `aliases` arrays as the SINGLE source — `codex`/`chatgpt` → `openai`,
+ * `claude` → `anthropic`, `google` → `gemini`, … It is the declarative replacement
+ * for the ad-hoc `_aliases` Map the in-process registry populates imperatively.
+ *
+ * ## Pure + deterministic + side-effect-free (AC2 · AC5)
+ *
+ * The resolver is a pure function of `(input, defs)`: no DB, no network, no module
+ * state. {@link buildAliasIndex} folds the provider set into an immutable
+ * `alias → id` index once; {@link resolveProviderId} is a single case-insensitive
+ * lookup. An alias that collides with ANOTHER provider's primary id is rejected at
+ * index-build time (a hard error) so a mis-declared alias can never silently
+ * mis-route. Unknown input returns `null`.
+ *
+ * @module llm/provider-registry/provider-alias
+ * @task T11704
+ * @epic T11667
+ * @see @cleocode/contracts — {@link ProviderDef} (the declarative contract, T11702)
+ * @see ./provider-defs.ts — {@link builtinProviderDefs} (the default provider set)
+ */
+
+import type { ProviderDef } from '@cleocode/contracts';
+import { builtinProviderDefs } from './provider-defs.js';
+
+/**
+ * An immutable case-insensitive `alias-or-id → canonical-id` index built from a
+ * provider set. Every provider's own id maps to itself; every alias maps to its
+ * provider's id.
+ *
+ * @task T11704
+ */
+export type ProviderAliasIndex = ReadonlyMap<string, string>;
+
+/**
+ * Build the immutable {@link ProviderAliasIndex} from a provider set.
+ *
+ * Every provider's lower-cased `id` maps to itself; every lower-cased alias maps to
+ * its provider's id. Pure + deterministic.
+ *
+ * @param defs - The provider definitions (defaults to {@link builtinProviderDefs}).
+ * @returns The case-insensitive alias index.
+ * @throws {Error} When an alias collides with ANOTHER provider's primary id, or two
+ *   providers declare the SAME alias (ambiguous resolution — AC2).
+ * @task T11704
+ */
+export function buildAliasIndex(
+  defs: ReadonlyArray<ProviderDef> = builtinProviderDefs(),
+): ProviderAliasIndex {
+  const ids = new Set<string>();
+  for (const def of defs) ids.add(def.id.toLowerCase());
+
+  const index = new Map<string, string>();
+  // Primary ids first — an id always resolves to itself.
+  for (const id of ids) index.set(id, id);
+
+  for (const def of defs) {
+    const canonical = def.id.toLowerCase();
+    for (const alias of def.aliases) {
+      const key = alias.toLowerCase();
+      // An alias that IS another provider's primary id is a hard collision.
+      if (ids.has(key) && key !== canonical) {
+        throw new Error(
+          `[provider-alias] Alias "${alias}" for provider "${def.id}" collides with the ` +
+            `primary id of another provider.`,
+        );
+      }
+      const existing = index.get(key);
+      if (existing !== undefined && existing !== canonical) {
+        throw new Error(
+          `[provider-alias] Alias "${alias}" is declared by both "${existing}" and ` +
+            `"${def.id}" — ambiguous resolution.`,
+        );
+      }
+      index.set(key, canonical);
+    }
+  }
+  return index;
+}
+
+/**
+ * Resolve a provider name or alias to its canonical provider id (case-insensitive).
+ *
+ * Pure + deterministic + side-effect-free. `codex`/`chatgpt` → `openai`,
+ * `claude` → `anthropic`, an exact provider id → itself. Returns `null` for an
+ * unknown name (callers handle the generic/fallback case).
+ *
+ * @param input - The provider name or alias to resolve.
+ * @param indexOrDefs - An already-built {@link ProviderAliasIndex}, OR the provider
+ *   set to build one from (defaults to {@link builtinProviderDefs}). Pass the prebuilt
+ *   index in a hot loop to avoid rebuilding per call.
+ * @returns The canonical provider id, or `null` when `input` matches no id/alias.
+ * @task T11704
+ */
+export function resolveProviderId(
+  input: string,
+  indexOrDefs: ProviderAliasIndex | ReadonlyArray<ProviderDef> = builtinProviderDefs(),
+): string | null {
+  // Discriminate on the Map's `get` method — an already-built ProviderAliasIndex
+  // (a ReadonlyMap) has it; a provider-set array does not (build the index from it).
+  const index: ProviderAliasIndex =
+    'get' in indexOrDefs ? indexOrDefs : buildAliasIndex(indexOrDefs);
+  return index.get(input.trim().toLowerCase()) ?? null;
+}

--- a/packages/core/src/llm/provider-registry/provider-defs.ts
+++ b/packages/core/src/llm/provider-registry/provider-defs.ts
@@ -1,0 +1,201 @@
+/**
+ * Builtin {@link ProviderDef} set — the SEED SOURCE for the `providers` table.
+ *
+ * M3 Provider SSoT (epic T11667 · task T11703). The DECLARATIVE provider definitions
+ * are DERIVED from the existing runtime {@link ProviderProfile} builtins (the in-process
+ * registry SSoT) rather than re-declared — so the two never drift and there is one
+ * place to add a provider (the profile). `toProviderDef` projects a `ProviderProfile`
+ * (which bundles non-serializable hook closures) down to the serializable `ProviderDef`
+ * shape (DATA only): identity + aliases + auth + endpoint(s) + catalog key + headers +
+ * env vars + OAuth placeholder + the declarative request quirks.
+ *
+ * ## Why this lives under `provider-registry/`
+ *
+ * The builtin profiles are model-data SSoT (the LLM-chokepoint lint exempts this
+ * directory for model-id literals). This module reads their declarative DATA and
+ * never constructs a transport/client — it carries no model-id literals of its own.
+ *
+ * @module llm/provider-registry/provider-defs
+ * @task T11703
+ * @epic T11667
+ * @see @cleocode/contracts — {@link ProviderDef} (the declarative contract, T11702)
+ * @see ./index.ts — the in-process {@link ProviderProfile} registry (runtime SSoT)
+ * @see ./provider-seed.ts — the seeder that upserts these rows into `providers`
+ */
+
+import type {
+  ProviderDef,
+  ProviderEndpoint,
+  ProviderProfile,
+  ProviderTransport,
+  RequestQuirk,
+  RequestQuirkKind,
+} from '@cleocode/contracts';
+import { anthropicProfile } from './builtin/anthropic.js';
+import { bedrockProfile } from './builtin/bedrock.js';
+import { geminiProfile } from './builtin/gemini.js';
+import { kimiCodeProfile } from './builtin/kimi-code.js';
+import { moonshotProfile } from './builtin/moonshot.js';
+import { ollamaProfile } from './builtin/ollama.js';
+import { openaiProfile } from './builtin/openai.js';
+import { openrouterProfile } from './builtin/openrouter.js';
+import { xaiProfile } from './builtin/xai.js';
+
+/**
+ * Declarative per-builtin overlay applied during projection — the bits of a
+ * {@link ProviderDef} that are NOT directly carried on a {@link ProviderProfile}:
+ * the wire {@link ProviderTransport}, the models.dev catalog key (when it differs
+ * from the provider id), any extra (alternate) endpoints, and the declarative
+ * {@link RequestQuirk} kinds standing in for the profile's hook closures.
+ *
+ * Keyed by the profile's canonical `name`. A provider absent from this table
+ * projects with the default `openai-completions` transport, `modelsDevId = id`,
+ * no alt endpoints, and no quirks.
+ *
+ * @task T11703
+ */
+interface ProviderDefOverlay {
+  /** Primary wire transport (the declarative analog of the provider's ApiMode). */
+  readonly transport: ProviderTransport;
+  /** AI-SDK provider-factory key — required iff `transport === 'aisdk'`. */
+  readonly aiSdkProvider?: string;
+  /** models.dev catalog key when it differs from the provider id (else id). */
+  readonly modelsDevId?: string;
+  /**
+   * Additional wire transports this provider also speaks — collapses the prior
+   * per-ApiMode profile duplication into one row (AC4 — xAI completions + responses).
+   * Each entry reuses the primary `baseUrl` unless an explicit baseUrl is given.
+   */
+  readonly altTransports?: ReadonlyArray<{
+    readonly transport: ProviderTransport;
+    readonly aiSdkProvider?: string;
+    readonly baseUrl?: string;
+  }>;
+  /** Declarative request-quirk kinds standing in for the profile's hook closures. */
+  readonly quirks?: ReadonlyArray<RequestQuirkKind>;
+}
+
+/**
+ * Per-builtin projection overlay (the non-`ProviderProfile` declarative DATA).
+ *
+ * Transport mapping mirrors `deriveApiMode` (api-mode.ts):
+ *  - `anthropic` / `kimi-code` → `anthropic-messages` (kimi speaks Anthropic wire)
+ *  - `openai` → `openai-completions` primary + `openai-responses` alt (Codex OAuth)
+ *  - `gemini` / `bedrock` / `ollama` → `aisdk` (reached via AI-SDK provider factory)
+ *  - `xai` → `openai-completions` primary + `openai-responses` alt (collapses the
+ *    prior `xaiProfile` / `xaiResponsesProfile` duplication into ONE row — AC4)
+ *  - `openrouter` / `moonshot` → `openai-completions`
+ *
+ * @task T11703
+ */
+const OVERLAYS: Readonly<Record<string, ProviderDefOverlay>> = {
+  anthropic: { transport: 'anthropic-messages' },
+  openai: {
+    transport: 'openai-completions',
+    altTransports: [{ transport: 'openai-responses' }],
+  },
+  gemini: { transport: 'aisdk', aiSdkProvider: 'google' },
+  moonshot: { transport: 'openai-completions' },
+  'kimi-code': {
+    transport: 'anthropic-messages',
+    modelsDevId: 'moonshot',
+    quirks: ['kimi-reasoning-effort'],
+  },
+  openrouter: { transport: 'openai-completions', quirks: ['openrouter-pareto'] },
+  bedrock: { transport: 'aisdk', aiSdkProvider: 'bedrock' },
+  xai: {
+    transport: 'openai-completions',
+    altTransports: [{ transport: 'openai-responses' }],
+    quirks: ['grok-conv-id'],
+  },
+  ollama: { transport: 'aisdk', aiSdkProvider: 'openai-compatible' },
+};
+
+/**
+ * Build a {@link ProviderEndpoint} from a transport + base URL (+ AI-SDK key).
+ *
+ * @internal
+ */
+function makeEndpoint(
+  transport: ProviderTransport,
+  baseUrl: string,
+  aiSdkProvider?: string,
+): ProviderEndpoint {
+  if (transport === 'aisdk') {
+    // The aisdk variant REQUIRES an aiSdkProvider; default to the OpenAI-compatible
+    // factory when an overlay omits it (the generic compat path).
+    return { transport: 'aisdk', baseUrl, aiSdkProvider: aiSdkProvider ?? 'openai-compatible' };
+  }
+  return { transport, baseUrl };
+}
+
+/**
+ * Project a runtime {@link ProviderProfile} down to the serializable
+ * {@link ProviderDef} (DATA only — drops the hook closures, keeps their declarative
+ * {@link RequestQuirk} kinds). Pure + deterministic.
+ *
+ * @param profile - The runtime profile (in-process registry SSoT).
+ * @returns The declarative provider definition.
+ * @task T11703
+ */
+export function toProviderDef(profile: ProviderProfile): ProviderDef {
+  const overlay = OVERLAYS[profile.name.toLowerCase()];
+  const transport: ProviderTransport = overlay?.transport ?? 'openai-completions';
+  const endpoint = makeEndpoint(transport, profile.baseUrl, overlay?.aiSdkProvider);
+
+  const altEndpoints: ProviderEndpoint[] = (overlay?.altTransports ?? []).map((alt) =>
+    makeEndpoint(alt.transport, alt.baseUrl ?? profile.baseUrl, alt.aiSdkProvider),
+  );
+
+  const requestQuirks: RequestQuirk[] = (overlay?.quirks ?? []).map((kind) => ({ kind }));
+
+  const def: ProviderDef = {
+    id: profile.name,
+    displayName: profile.displayName,
+    aliases: [...(profile.aliases ?? [])],
+    authMethods: [...profile.authTypes],
+    endpoint,
+    ...(altEndpoints.length > 0 ? { altEndpoints } : {}),
+    modelsDevId: overlay?.modelsDevId ?? profile.name,
+    ...(profile.defaultHeaders !== undefined
+      ? { defaultHeaders: { ...profile.defaultHeaders } }
+      : {}),
+    ...(profile.envVars !== undefined ? { envVars: [...profile.envVars] } : {}),
+    ...(profile.oauth !== undefined ? { oauth: profile.oauth } : {}),
+    ...(requestQuirks.length > 0 ? { requestQuirks } : {}),
+  };
+  return def;
+}
+
+/**
+ * Runtime profiles that seed the builtin {@link ProviderDef} set.
+ *
+ * The `xai` Responses profile (`xaiResponsesProfile`) is intentionally OMITTED — its
+ * Responses endpoint is folded into the single `xai` row's `altEndpoints` (AC4). The
+ * dual-ApiMode duplication collapses to one declarative row per provider id.
+ *
+ * @task T11703
+ */
+const SEED_PROFILES: ReadonlyArray<ProviderProfile> = [
+  anthropicProfile,
+  openaiProfile,
+  geminiProfile,
+  moonshotProfile,
+  kimiCodeProfile,
+  openrouterProfile,
+  bedrockProfile,
+  xaiProfile,
+  ollamaProfile,
+];
+
+/**
+ * The builtin {@link ProviderDef} set — DERIVED from the runtime
+ * {@link ProviderProfile} builtins. The SSoT-seed source for the `providers`
+ * table (T11703) and the input to the pure alias resolver (T11704).
+ *
+ * @returns Builtin provider definitions (one per provider id; xai collapsed to one).
+ * @task T11703
+ */
+export function builtinProviderDefs(): ReadonlyArray<ProviderDef> {
+  return SEED_PROFILES.map(toProviderDef);
+}

--- a/packages/core/src/llm/provider-registry/provider-seed.ts
+++ b/packages/core/src/llm/provider-registry/provider-seed.ts
@@ -1,0 +1,147 @@
+/**
+ * Provider seeder — populates the `providers` table from the builtin ProviderDef set.
+ *
+ * M3 Provider SSoT (epic T11667 · task T11703). {@link seedProviders} takes the builtin
+ * {@link ProviderDef} set (derived from the runtime {@link ProviderProfile} builtins by
+ * {@link builtinProviderDefs}), serializes each declarative field to its TEXT column,
+ * and UPSERTS each row via {@link openDualScopeDb}`('global')`. Seeding is the offline
+ * bootstrap of the provider SSoT — NO network is touched.
+ *
+ * ## Idempotent (AC5) + does NOT clobber user plugin providers
+ *
+ * The upsert targets the `id` primary key, so re-running yields the same row count and
+ * never duplicates (running twice = same rows). Only BUILTIN ids are touched — a user
+ * plugin provider row (a different id) is never read or written, so a re-seed cannot
+ * clobber it. `source` is stamped `seed` for these rows; plugin rows carry their own
+ * `source`.
+ *
+ * @module llm/provider-registry/provider-seed
+ * @task T11703
+ * @epic T11667
+ * @see ./provider-defs.ts — the builtin ProviderDef set (seed source)
+ * @see ../../store/schema/cleo-global/providers.ts — the persisted table
+ * @see ../catalog-seeder.ts — the sibling seeder this mirrors
+ */
+
+import type { ProviderDef } from '@cleocode/contracts';
+import { sql } from 'drizzle-orm';
+import { getLogger } from '../../logger.js';
+import {
+  type CleoGlobalDb,
+  openDualScopeDb,
+  openDualScopeDbAtPath,
+} from '../../store/dual-scope-db.js';
+import { type NewProviderRow, providers } from '../../store/schema/cleo-global/providers.js';
+import { builtinProviderDefs } from './provider-defs.js';
+
+const logger = getLogger('llm-provider-seeder');
+
+/** Result of a {@link seedProviders} run. */
+export interface SeedProvidersResult {
+  /** Whether rows were written this run. */
+  readonly seeded: boolean;
+  /** Number of builtin provider rows upserted. */
+  readonly rowCount: number;
+}
+
+/** Injectable seam for {@link seedProviders} (tests pass a temp-DB handle + defs). */
+export interface SeedProvidersDeps {
+  /**
+   * An already-open global Drizzle handle. When omitted the seeder opens via
+   * {@link openDualScopeDb}`('global')`. Tests pass a temp-DB handle (opened via
+   * {@link openProviderSeederAtPath}) to stay off `.cleo/*.db`.
+   */
+  readonly db?: CleoGlobalDb;
+  /**
+   * The provider definitions to seed, bypassing {@link builtinProviderDefs} (tests
+   * pass a fixture). When omitted the builtin set is used.
+   */
+  readonly defs?: ReadonlyArray<ProviderDef>;
+}
+
+/**
+ * Open the global seeder handle at an EXPLICIT path (test seam).
+ *
+ * @param dbPath - Absolute path to the temp `cleo.db`.
+ * @task T11703
+ */
+export async function openProviderSeederAtPath(dbPath: string): Promise<CleoGlobalDb> {
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return handle.db;
+}
+
+/**
+ * Serialize one {@link ProviderDef} into a `providers` INSERT row. JSON columns are
+ * `JSON.stringify`-serialized; `oauth` is NULL when the provider has no OAuth flow.
+ *
+ * @param def - The declarative provider definition.
+ * @returns The flattened `providers` row.
+ * @task T11703
+ */
+export function providerDefToRow(def: ProviderDef): NewProviderRow {
+  return {
+    id: def.id,
+    displayName: def.displayName,
+    aliases: JSON.stringify(def.aliases),
+    authMethods: JSON.stringify(def.authMethods),
+    endpoint: JSON.stringify(def.endpoint),
+    altEndpoints: JSON.stringify(def.altEndpoints ?? []),
+    modelsDevId: def.modelsDevId,
+    defaultHeaders: JSON.stringify(def.defaultHeaders ?? {}),
+    envVars: JSON.stringify(def.envVars ?? []),
+    oauth: def.oauth !== undefined ? JSON.stringify(def.oauth) : null,
+    requestQuirks: JSON.stringify(def.requestQuirks ?? []),
+    source: 'seed',
+  };
+}
+
+/** Resolve the global Drizzle handle — injected, else canonical open. @internal */
+async function resolveDb(deps?: SeedProvidersDeps): Promise<CleoGlobalDb> {
+  if (deps?.db !== undefined) return deps.db;
+  const handle = await openDualScopeDb('global');
+  return handle.db;
+}
+
+/**
+ * Seed the `providers` table from the builtin {@link ProviderDef} set — idempotent,
+ * offline-first, plugin-safe.
+ *
+ * Upserts on the `id` primary key, so running twice yields the same row count and
+ * never duplicates (AC5). Only builtin ids are written; user plugin provider rows
+ * (other ids) are never touched. NO network is touched.
+ *
+ * @param deps - Optional injected DB handle / fixture defs (tests).
+ * @returns A {@link SeedProvidersResult} describing what happened.
+ * @task T11703
+ */
+export async function seedProviders(deps?: SeedProvidersDeps): Promise<SeedProvidersResult> {
+  const defs = deps?.defs ?? builtinProviderDefs();
+  const db = await resolveDb(deps);
+
+  for (const def of defs) {
+    const row = providerDefToRow(def);
+    await db
+      .insert(providers)
+      .values(row)
+      .onConflictDoUpdate({
+        target: providers.id,
+        set: {
+          displayName: row.displayName,
+          aliases: row.aliases,
+          authMethods: row.authMethods,
+          endpoint: row.endpoint,
+          altEndpoints: row.altEndpoints,
+          modelsDevId: row.modelsDevId,
+          defaultHeaders: row.defaultHeaders,
+          envVars: row.envVars,
+          oauth: row.oauth,
+          requestQuirks: row.requestQuirks,
+          source: row.source,
+          seededAt: sql`(datetime('now'))`,
+        },
+      });
+  }
+
+  logger.debug({ rowCount: defs.length }, 'provider-seeder: providers seeded');
+  return { seeded: defs.length > 0, rowCount: defs.length };
+}

--- a/packages/core/src/store/__tests__/providers-table.test.ts
+++ b/packages/core/src/store/__tests__/providers-table.test.ts
@@ -1,0 +1,160 @@
+/**
+ * T11703 — `providers` declarative-provider SSoT table on the GLOBAL cleo.db.
+ *
+ * Proves the AC: opening the consolidated global `cleo.db` (which applies the
+ * `drizzle-cleo-global` migration set, including the new `…_t11703-providers`
+ * forward migration) materialises the `providers` table, that a row inserts +
+ * selects cleanly (JSON columns round-trip), that the column defaults apply, that
+ * the `seeded_at` date GLOB CHECK holds, and that the migration is idempotent
+ * (re-open is a no-op, table + rows persist).
+ *
+ * Every test runs against a TEMP-DIR cleo.db — never `.cleo/*.db`.
+ *
+ * @task T11703
+ * @epic T11667
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from '../dual-scope-db.js';
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = join(
+    tmpdir(),
+    `providers-table-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+/** Open + migrate an isolated temp GLOBAL cleo.db; return its native handle. */
+async function openGlobalTemp(): Promise<DatabaseSync> {
+  const dbPath = join(testRoot, 'cleo.db');
+  const handle = await openDualScopeDbAtPath('global', dbPath);
+  return (handle.db as unknown as { $client: DatabaseSync }).$client;
+}
+
+describe('providers (declarative provider SSoT) — global cleo.db migration', () => {
+  it('migration materialises the `providers` table', async () => {
+    const db = await openGlobalTemp();
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='providers'")
+      .get() as { name: string } | undefined;
+    expect(row?.name).toBe('providers');
+  }, 30_000);
+
+  it('inserts and selects a provider row round-trip (JSON columns)', async () => {
+    const db = await openGlobalTemp();
+    db.prepare(
+      `INSERT INTO providers
+         (id, display_name, aliases, auth_methods, endpoint, alt_endpoints,
+          models_dev_id, default_headers, env_vars, oauth, request_quirks, source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'openai',
+      'OpenAI Codex (ChatGPT)',
+      '["codex","chatgpt"]',
+      '["api_key","oauth"]',
+      '{"transport":"openai-completions","baseUrl":"https://api.openai.com/v1"}',
+      '[{"transport":"openai-responses","baseUrl":"https://api.openai.com/v1"}]',
+      'openai',
+      '{}',
+      '[]',
+      '{"mode":"pkce","clientId":"app_x","tokenEndpoint":"https://auth.openai.com/oauth/token"}',
+      '[]',
+      'seed',
+    );
+
+    const got = db
+      .prepare(
+        `SELECT id, display_name, aliases, endpoint, alt_endpoints, oauth, source
+           FROM providers WHERE id = ?`,
+      )
+      .get('openai') as Record<string, unknown> | undefined;
+
+    expect(got).toBeDefined();
+    expect(got?.display_name).toBe('OpenAI Codex (ChatGPT)');
+    expect(JSON.parse(got?.aliases as string)).toEqual(['codex', 'chatgpt']);
+    expect(JSON.parse(got?.endpoint as string)).toMatchObject({ transport: 'openai-completions' });
+    expect(JSON.parse(got?.alt_endpoints as string)[0]).toMatchObject({
+      transport: 'openai-responses',
+    });
+    expect(JSON.parse(got?.oauth as string)).toMatchObject({ mode: 'pkce' });
+    expect(got?.source).toBe('seed');
+  }, 30_000);
+
+  it('applies column defaults (aliases=[], source=seed, seeded_at, oauth NULL)', async () => {
+    const db = await openGlobalTemp();
+    db.prepare(
+      `INSERT INTO providers (id, display_name, endpoint, models_dev_id) VALUES (?, ?, ?, ?)`,
+    ).run(
+      'ollama',
+      'Ollama',
+      '{"transport":"aisdk","baseUrl":"http://localhost:11434","aiSdkProvider":"openai-compatible"}',
+      'ollama',
+    );
+    const got = db
+      .prepare(
+        `SELECT aliases, auth_methods, alt_endpoints, default_headers, env_vars,
+                request_quirks, oauth, source, seeded_at
+           FROM providers WHERE id = 'ollama'`,
+      )
+      .get() as Record<string, unknown> | undefined;
+    expect(got?.aliases).toBe('[]');
+    expect(got?.auth_methods).toBe('[]');
+    expect(got?.alt_endpoints).toBe('[]');
+    expect(got?.default_headers).toBe('{}');
+    expect(got?.env_vars).toBe('[]');
+    expect(got?.request_quirks).toBe('[]');
+    expect(got?.oauth).toBeNull();
+    expect(got?.source).toBe('seed');
+    expect(got?.seeded_at).toMatch(/^\d{4}-\d{2}-\d{2} /);
+  }, 30_000);
+
+  it('the `seeded_at` date GLOB CHECK rejects a malformed timestamp', async () => {
+    const db = await openGlobalTemp();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO providers (id, display_name, endpoint, models_dev_id, seeded_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('bad', 'Bad', '{"transport":"openai-completions","baseUrl":"x"}', 'bad', 'not-a-date'),
+    ).toThrow();
+  }, 30_000);
+
+  it('migration is idempotent — re-opening the same DB is a no-op and the table + row persist', async () => {
+    const dbPath = join(testRoot, 'cleo.db');
+    const h1 = await openDualScopeDbAtPath('global', dbPath);
+    (h1.db as unknown as { $client: DatabaseSync }).$client
+      .prepare(
+        `INSERT INTO providers (id, display_name, endpoint, models_dev_id) VALUES (?, ?, ?, ?)`,
+      )
+      .run('persist', 'P', '{"transport":"openai-completions","baseUrl":"x"}', 'persist');
+
+    _resetDualScopeDbCache();
+    const h2 = await openDualScopeDbAtPath('global', dbPath);
+    const db2 = (h2.db as unknown as { $client: DatabaseSync }).$client;
+    const tbl = db2
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='providers'")
+      .get() as { name: string } | undefined;
+    expect(tbl?.name).toBe('providers');
+    const row = db2.prepare('SELECT id FROM providers WHERE id = ?').get('persist') as
+      | { id: string }
+      | undefined;
+    expect(row?.id).toBe('persist');
+  }, 30_000);
+});

--- a/packages/core/src/store/schema/cleo-global/index.ts
+++ b/packages/core/src/store/schema/cleo-global/index.ts
@@ -98,6 +98,8 @@ export * from './agent-registry.js';
 // E8-CATALOG-CURATION (T11733) — the models.dev catalog SSoT (`models_catalog`).
 export * from './models-catalog.js';
 export * from './nexus.js';
+// M3 Provider SSoT (T11703 · epic T11667) — the declarative provider table (`providers`).
+export * from './providers.js';
 export * from './services.js';
 export * from './session-manifest.js';
 export * from './skills.js';

--- a/packages/core/src/store/schema/cleo-global/providers.ts
+++ b/packages/core/src/store/schema/cleo-global/providers.ts
@@ -1,0 +1,104 @@
+/**
+ * Global-scope `cleo.db` — **declarative provider SSoT** (`providers`, 1 table).
+ *
+ * M3 Provider SSoT (epic T11667 · task T11703). This table is the queryable,
+ * `cleo health`-visible home for the **declarative provider definitions** that today
+ * live only as hand-written {@link ProviderProfile} modules in the in-process registry.
+ * Each row is ONE provider's serializable {@link ProviderDef} (T11702) — identity,
+ * aliases, auth methods, wire endpoint(s), models.dev catalog key, default headers,
+ * optional OAuth flow, declarative request quirks — so the provider set becomes the
+ * SSoT (DB table) the resolver, the CLI, and the alias resolver (T11704) read.
+ *
+ * The non-serializable RUNTIME hooks (`buildExtraBody` / `prepareMessages` / …) stay
+ * on {@link ProviderProfile}; a `providers` row carries only DATA, with the quirk
+ * closures reduced to declarative `request_quirks` descriptors.
+ *
+ * ## NOT the `accounts` credential pool / `models_catalog` — do not confuse them
+ *
+ * `accounts` (T11709) holds machine-wide LLM CREDENTIALS (the pool the runner picks
+ * from); `models_catalog` (T11733) holds per-MODEL capability DATA. THIS table holds
+ * per-PROVIDER declarative config (endpoints, aliases, auth methods). All three share
+ * the cleo-global scope + E10 typing conventions but carry orthogonal data. The
+ * provider set is freely readable (no secrets, no encryption — the OAuth `client_id`
+ * is public; client SECRETS live in the `service_*` vault, T11937).
+ *
+ * ## E10 typing (mirrors sibling `accounts.ts` / `services.ts` / `models-catalog.ts`)
+ *
+ * - JSON-as-TEXT for the array/object fields (`aliases`, `auth_methods`, `endpoint`,
+ *   `alt_endpoints`, `default_headers`, `env_vars`, `oauth`, `request_quirks`) — each
+ *   serialized to its TEXT column (the documented json pattern).
+ * - `seeded_at` is a TEXT ISO-8601 timestamp (GLOB-checked in the migration).
+ * - No booleans/enums (the declarative shape is all id/JSON), so the only CHECKs the
+ *   schema-parity gate (T11364) re-derives are the timestamp GLOB + the JSON columns'
+ *   NOT NULL defaults.
+ *
+ * ## Active selection — natural PK `id`, no partial index
+ *
+ * `id` is the provider id (PK); a provider is looked up by `id` or resolved from an
+ * alias (T11704 reads the `aliases` JSON). No raw partial unique index is required
+ * (unlike `accounts`' active-pointer) — there is exactly one row per provider id.
+ *
+ * @task T11703
+ * @epic T11667
+ * @see ../../../../migrations/drizzle-cleo-global — the forward migration
+ * @see ../../../llm/provider-registry/provider-seed.ts — the seeder that populates this table (T11703)
+ * @see ../../../llm/provider-registry/provider-defs.ts — the builtin ProviderDef set (seed source)
+ * @see ./accounts.ts — the sibling credential-pool table this directory mirrors
+ * @see ./models-catalog.ts — the sibling catalog table this directory mirrors
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * `providers` — the machine-wide declarative provider-definition table.
+ *
+ * One row per provider. The provider SSoT: seeded from the builtin
+ * {@link ProviderDef} set (T11703 · derived from the in-process
+ * {@link ProviderProfile} builtins), read by the resolver/CLI/alias resolver
+ * (T11704). `id` is the provider id (PK); JSON columns hold the serialized
+ * declarative fields. The seeder upserts on `id` (idempotent — re-open is a no-op).
+ *
+ * @task T11703
+ */
+export const providers = sqliteTable(
+  'providers',
+  {
+    /** Provider id — the canonical lower-cased key (e.g. `anthropic`). Natural PK. */
+    id: text('id').primaryKey(),
+    /** Human-readable display name (e.g. `Anthropic Claude`). */
+    displayName: text('display_name').notNull(),
+    /** JSON array of case-insensitive aliases (the alias-resolver source). Serialized TEXT; defaults `[]`. */
+    aliases: text('aliases').notNull().default('[]'),
+    /** JSON array of `StoredAuthTypeWire` auth methods (`api_key`|`oauth`|`aws_sdk`). Serialized TEXT; defaults `[]`. */
+    authMethods: text('auth_methods').notNull().default('[]'),
+    /** JSON object — the primary `ProviderEndpoint` tagged union (discriminant `transport`). Serialized TEXT. */
+    endpoint: text('endpoint').notNull(),
+    /** JSON array of additional `ProviderEndpoint` variants (multi-protocol providers). Serialized TEXT; defaults `[]`. */
+    altEndpoints: text('alt_endpoints').notNull().default('[]'),
+    /** The models.dev catalog provider key (joins `models_catalog.provider_id`). */
+    modelsDevId: text('models_dev_id').notNull(),
+    /** JSON object of pinned default HTTP headers. Serialized TEXT; defaults `{}`. */
+    defaultHeaders: text('default_headers').notNull().default('{}'),
+    /** JSON array of credential env-var names. Serialized TEXT; defaults `[]`. */
+    envVars: text('env_vars').notNull().default('[]'),
+    /** JSON object — the optional `OAuthFlowDef` placeholder; NULL when the provider has no OAuth flow. */
+    oauth: text('oauth'),
+    /** JSON array of declarative `RequestQuirk` descriptors. Serialized TEXT; defaults `[]`. */
+    requestQuirks: text('request_quirks').notNull().default('[]'),
+    /** Provenance — where this row came from (e.g. `seed` | `plugin` | `import`). */
+    source: text('source').notNull().default('seed'),
+    /** ISO-8601 UTC instant this row was seeded/last upserted. Defaults to write time. */
+    seededAt: text('seeded_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // Lookup index — resolve providers by their models.dev catalog key (join to
+    // models_catalog). `id` is already the PK, so no extra unique is needed.
+    index('idx_providers_models_dev').on(table.modelsDevId),
+  ],
+);
+
+/** Row type for `providers` SELECT queries. */
+export type ProviderRow = typeof providers.$inferSelect;
+/** Row type for `providers` INSERT/UPSERT operations. */
+export type NewProviderRow = typeof providers.$inferInsert;


### PR DESCRIPTION
## M3 Provider SSoT — the declarative 5-entity foundation

One coherent increment landing the first three M3 tasks (epic T11667). Mirrors the proven cleo-global table pattern (accounts T11709 · services T11937 · models-catalog T11733). Daemon-OFF, contained, in-process tests, no merge/tag.

### T11702 — `ProviderDef` declarative contract
`packages/contracts/src/llm/provider-def.ts` exports a **types-only** `ProviderDef`:
- `id` · `displayName` · `aliases[]` · `authMethods[]` (`StoredAuthTypeWire`)
- `endpoint` — a **discriminated union keyed on the `transport` literal** (AC5): `openai-completions` | `openai-responses` | `anthropic-messages` | `aisdk` — no `any`/`unknown` shortcut, every variant typed
- `altEndpoints[]` (multi-protocol providers) · `modelsDevId` · `defaultHeaders?` · `envVars?` · `oauth?: OAuthFlowDef` (placeholder reusing `ProviderOAuthConfig`) · `requestQuirks[]` (declarative `RequestQuirk` descriptors)
- Re-exported from `contracts/src/index.ts` **and** the new `contracts/src/llm/index.ts` barrel (AC6); full TSDoc (AC7)

### T11703 — `providers` table + migration + seed
- `packages/core/src/store/schema/cleo-global/providers.ts` — `providers` sqliteTable (id PK, JSON-as-TEXT for aliases/auth_methods/endpoint/alt_endpoints/default_headers/env_vars/oauth/request_quirks, E10 ISO `seeded_at`), exported from the cleo-global barrel
- `packages/core/migrations/drizzle-cleo-global/20260609020000_t11703-providers/migration.sql` — `IF NOT EXISTS` + `--> statement-breakpoint`, **page-2-safe** (runs after the consolidation baseline, never the first CREATE), `seeded_at` GLOB CHECK
- `provider-registry/provider-seed.ts` — idempotent `onConflictDoUpdate(id)` seeder wired **non-fatally** into `cleo init` (mirrors the catalog seeder). **Plugin-safe**: only builtin ids are upserted; a user plugin row (other id) is never touched (AC5)
- `provider-registry/provider-defs.ts` — the builtin `ProviderDef` set is **derived** from the existing `ProviderProfile` builtins; **xAI's completions + responses profiles collapse into ONE row's `altEndpoints`** (AC4)

### T11704 — pure alias resolution
`provider-registry/provider-alias.ts` — `resolveProviderId(name) -> id | null` over `ProviderDef.aliases` as the single source: `codex`/`chatgpt` → `openai`, `claude` → `anthropic`, unknown → `null`. Deterministic, side-effect-free, no DB/network; an alias colliding with another provider's primary id throws at index-build (AC2).

### ProviderDef ↔ ProviderProfile reconciliation
`ProviderDef` is the **serializable DECLARATIVE projection** of the runtime `ProviderProfile`. `ProviderProfile` keeps the non-serializable hook closures (`buildExtraBody`/`prepareMessages`/…); `ProviderDef` carries only DATA, reducing each hook to a declarative `RequestQuirk` kind. The profile set is the **single seed source** (`toProviderDef`), so the table and the in-process registry never drift.

### Migration safety
Forward-only, additive, `IF NOT EXISTS`, statement-breakpoint-separated (node:sqlite truncation guard), page-2-invariant respected. Re-open is a verified no-op (rows + table persist).

### Gates
- `pnpm biome check` clean · **full `pnpm run typecheck` (`tsc -b`) clean** · full root build green
- Tests: contracts shape **5/5** · core alias+derivation+seed+migration **23/23** · sibling provider-registry/models-catalog/service-vault/catalog-seeder **31/31** — all in-process, temp-DB, no `.all()` on large tables (cgroup-capped runs)
- Arch gates: DB-Open-Guard **strict OK** (openDualScopeDb only) · contracts-purity OK (provider-def is types-only) · contracts-fan-out OK · LLM-chokepoint OK (zero net-new violations) · SSoT-EXEMPT OK · CLI-boundary OK
- No canon `.md` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)