### PR TITLE
feat(T11945): wire PiAgentAdapter into production playbook dispatchers — cantbook runs via Pi (M4, default-OFF)

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/go-ivtr-runner.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/go-ivtr-runner.test.ts
@@ -29,6 +29,7 @@ const mockGetDb = vi.fn();
 const mockGetNativeDb = vi.fn();
 const mockCreateToolGuard = vi.fn();
 const mockRunSkillNodeOrSpawn = vi.fn();
+const mockMaybeCreatePiRunner = vi.fn();
 const mockOrchestrateSpawnExecute = vi.fn();
 
 // `resolvePlaybook` is re-exported from `@cleocode/core` (static import).
@@ -50,6 +51,9 @@ vi.mock('@cleocode/core/internal', () => ({
   getNativeDb: (...args: unknown[]) => mockGetNativeDb(...args),
   createToolGuard: (...args: unknown[]) => mockCreateToolGuard(...args),
   runSkillNodeOrSpawn: (...args: unknown[]) => mockRunSkillNodeOrSpawn(...args),
+  // T11945 (M4): default-OFF Pi runner wiring — returns undefined unless the flag
+  // is set, so the dispatcher keeps the defaultSkillRunner path (zero change).
+  maybeCreatePiRunner: (...args: unknown[]) => mockMaybeCreatePiRunner(...args),
 }));
 
 // Subprocess spawn gateway (dynamic import inside the dispatcher builder).

--- a/packages/cleo/src/cli/commands/go-ivtr-runner.ts
+++ b/packages/cleo/src/cli/commands/go-ivtr-runner.ts
@@ -158,11 +158,17 @@ const runIvtrPlaybookTurn: go.IvtrRunner = async (taskId, options) => {
  */
 const buildGoDispatcher = async (projectRoot: string): Promise<AgentDispatcher> => {
   const { orchestrateSpawnExecute } = await import('@cleocode/runtime/gateway');
-  const { createToolGuard, runSkillNodeOrSpawn } = await import('@cleocode/core/internal');
+  const { createToolGuard, runSkillNodeOrSpawn, maybeCreatePiRunner } = await import(
+    '@cleocode/core/internal'
+  );
 
   // In-process skill nodes execute over a deny-first guarded tool surface scoped
   // to the project root (mirrors playbook.ts AC4). Isolation/agent nodes spawn.
   const tools = createToolGuard({ allowedRoots: [projectRoot] });
+  // M4 keystone (T11945): when CLEO_PI_RUNNER_ENABLED=1, route in-process skill
+  // nodes THROUGH the Pi agent loop. Default-OFF → `undefined` → defaultSkillRunner
+  // (zero behaviour change). The helper lazy-imports the Pi barrel only when enabled.
+  const runner = await maybeCreatePiRunner({ system: 'task-executor', projectRoot });
 
   /** Subprocess-spawn fallback — retained for isolation/agent nodes. */
   const spawn = async (input: AgentDispatchInput): Promise<AgentDispatchResult> => {
@@ -194,9 +200,16 @@ const buildGoDispatcher = async (projectRoot: string): Promise<AgentDispatcher> 
   return {
     async dispatch(input: AgentDispatchInput): Promise<AgentDispatchResult> {
       try {
+        // With the Pi runner wired (T11945) the in-process node runs through the
+        // Pi loop; `runner: undefined` (default-OFF) keeps the defaultSkillRunner path.
         return await runSkillNodeOrSpawn(
           { nodeId: input.nodeId, agentId: input.agentId, context: input.context },
-          { tools, cwd: projectRoot, subprocessSpawn: () => spawn(input) },
+          {
+            tools,
+            cwd: projectRoot,
+            subprocessSpawn: () => spawn(input),
+            ...(runner !== undefined ? { runner } : {}),
+          },
         );
       } catch (err) {
         return {

--- a/packages/cleo/src/dispatch/domains/playbook.ts
+++ b/packages/cleo/src/dispatch/domains/playbook.ts
@@ -331,13 +331,16 @@ async function acquireDb(): Promise<_DatabaseSyncType> {
 async function buildDefaultDispatcher(): Promise<AgentDispatcher> {
   if (__playbookRuntimeOverrides.dispatcher) return __playbookRuntimeOverrides.dispatcher;
   const { orchestrateSpawnExecute } = await import('@cleocode/runtime/gateway');
-  const { getProjectRoot, createToolGuard, runSkillNodeOrSpawn } = await import(
-    '@cleocode/core/internal'
-  );
+  const { getProjectRoot, createToolGuard, runSkillNodeOrSpawn, maybeCreatePiRunner } =
+    await import('@cleocode/core/internal');
   const projectRoot = getProjectRoot();
   // In-process skill nodes execute over a deny-first guarded tool surface scoped
   // to the project root (T11477 · AC4). Isolation/agent nodes keep spawning.
   const tools = createToolGuard({ allowedRoots: [projectRoot] });
+  // M4 keystone (T11945): when CLEO_PI_RUNNER_ENABLED=1, route in-process skill
+  // nodes THROUGH the Pi agent loop. Default-OFF → `undefined` → defaultSkillRunner
+  // (zero behaviour change). The helper lazy-imports the Pi barrel only when enabled.
+  const runner = await maybeCreatePiRunner({ system: 'task-executor', projectRoot });
 
   /** Subprocess-spawn fallback — retained for isolation/agent nodes (AC3). */
   const spawn = async (input: AgentDispatchInput): Promise<AgentDispatchResult> => {
@@ -370,10 +373,17 @@ async function buildDefaultDispatcher(): Promise<AgentDispatcher> {
     async dispatch(input: AgentDispatchInput): Promise<AgentDispatchResult> {
       try {
         // In-process ct-* skill node → SkillExecutorAdapter (replaces spawn for
-        // those nodes, AC2); everything else → subprocess spawn (AC3).
+        // those nodes, AC2); everything else → subprocess spawn (AC3). With the
+        // Pi runner wired (T11945) the in-process node runs through the Pi loop;
+        // `runner: undefined` (default-OFF) keeps the defaultSkillRunner path.
         return await runSkillNodeOrSpawn(
           { nodeId: input.nodeId, agentId: input.agentId, context: input.context },
-          { tools, cwd: projectRoot, subprocessSpawn: () => spawn(input) },
+          {
+            tools,
+            cwd: projectRoot,
+            subprocessSpawn: () => spawn(input),
+            ...(runner !== undefined ? { runner } : {}),
+          },
         );
       } catch (err) {
         return {

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -33,6 +33,14 @@
 
 import './lib/suppress-sqlite-warning.js';
 
+// Pi in-process runner wiring — default-OFF, lazy-imported Pi `SkillRunner` the
+// production cantbook dispatchers pass into `runSkillNodeOrSpawn`'s `runner` slot
+// (T11945 · M4). Exported BEFORE the `export * from './index.js'` superset so the
+// live binding is established ahead of the index re-export cycle (vitest source
+// resolution otherwise leaves a late flat re-export of a fresh leaf undefined).
+export type { MaybePiRunnerDeps } from './playbooks/pi-runner-wiring.js';
+export { maybeCreatePiRunner } from './playbooks/pi-runner-wiring.js';
+
 // ---------------------------------------------------------------------------
 // Re-export the entire public API (superset)
 // ---------------------------------------------------------------------------

--- a/packages/core/src/playbooks/index.ts
+++ b/packages/core/src/playbooks/index.ts
@@ -23,7 +23,11 @@ export {
 } from './agent-dispatcher.js';
 
 export type { playbookCoreOps } from './ops.js';
-
+// Pi in-process runner wiring — default-OFF, lazy-imported Pi `SkillRunner` the
+// production cantbook dispatchers pass into `runSkillNodeOrSpawn`'s `runner`
+// slot (T11945 · M4). Exported here (the eager core graph) so its live binding
+// is initialised before `internal.ts` re-exports it.
+export { type MaybePiRunnerDeps, maybeCreatePiRunner } from './pi-runner-wiring.js';
 export {
   listPlaybooks,
   PlaybookNotFoundError,
@@ -32,7 +36,6 @@ export {
   type ResolvePlaybookOptions,
   resolvePlaybook,
 } from './playbook-resolver.js';
-
 // Skill-node executor — injects the in-process SkillExecutorAdapter as the
 // dispatcher's executor while retaining subprocess-spawn for isolation nodes
 // (T11477 · epic T11391).

--- a/packages/core/src/playbooks/pi-runner-wiring.ts
+++ b/packages/core/src/playbooks/pi-runner-wiring.ts
@@ -1,0 +1,107 @@
+/**
+ * Production wiring helper for the Pi in-process `SkillRunner` (T11945 · M4).
+ *
+ * THE M4 keystone seam: this is the single place the two production cantbook
+ * dispatchers (`buildDefaultDispatcher` in `playbook.ts` and `buildGoDispatcher`
+ * in `go-ivtr-runner.ts`) reach to obtain the Pi-backed `SkillRunner` they pass
+ * into {@link runSkillNodeOrSpawn}'s `runner` slot. When the runner is supplied,
+ * an in-process `ct-*` skill node routes THROUGH the {@link
+ * import('../llm/pi/pi-agent-adapter.js').PiAgentAdapter} (the Pi agent loop);
+ * when it is `undefined`, the adapter falls back to `defaultSkillRunner` — the
+ * pre-T11945 behaviour.
+ *
+ * ## Default-OFF + lazy-import (Gate-13 + OOM safety)
+ *
+ * The Pi embed is gated behind the **default-OFF** `CLEO_PI_RUNNER_ENABLED`
+ * flag. When the flag is unset (the default) this helper returns `undefined`
+ * WITHOUT importing the Pi barrel — so `@earendil-works/pi-ai`'s `register-
+ * builtins` side effect is never paid on the hot dispatch path, and there is
+ * ZERO behaviour change. Only when the flag is explicitly `'1'` do we
+ * dynamically import the barrel and construct the runner. The import is dynamic
+ * (not a top-level `import`) precisely so the heavy `pi-ai` dependency stays out
+ * of `@cleocode/core/internal`'s eager module graph (every CLI dispatcher loads
+ * `internal`, but must not load `pi-ai` unless Pi is enabled).
+ *
+ * Keeping this helper in `core` keeps the CLI dispatchers thin (CLI package
+ * boundary, Gate-6): each call site is a single `await maybeCreatePiRunner(...)`.
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11945
+ */
+
+import type { SystemOfUseLabel } from '@cleocode/contracts';
+import type { SkillRunner } from '../skills/skill-executor-adapter.js';
+
+/**
+ * The default-OFF env flag controlling the Pi in-process runner. Mirrors
+ * `isPiRunnerEnabled()` in the Pi barrel exactly (strict `'1'`), read here as a
+ * cheap pre-check so the heavy Pi/`pi-ai` barrel is only dynamically imported
+ * when Pi is actually enabled.
+ */
+const PI_RUNNER_FLAG = 'CLEO_PI_RUNNER_ENABLED';
+
+/**
+ * Resolution + project-root deps forwarded to `createPiSkillRunner` when the Pi
+ * runner is constructed. Mirrors the subset of `PiAgentAdapterDeps` the
+ * dispatchers can supply at their call site.
+ */
+export interface MaybePiRunnerDeps {
+  /**
+   * The system-of-use label the Pi adapter resolves its LLM through (E9). When
+   * omitted, `createPiSkillRunner` defaults to `'task-executor'`.
+   */
+  readonly system?: SystemOfUseLabel;
+  /**
+   * Project root for config + credential resolution. When omitted, resolution
+   * defaults to `process.cwd()` inside `resolveLLMForSystem`.
+   */
+  readonly projectRoot?: string;
+}
+
+/**
+ * Return the Pi-backed {@link SkillRunner} when `CLEO_PI_RUNNER_ENABLED=1`, else
+ * `undefined`.
+ *
+ * The two production cantbook dispatchers call this and pass the result into
+ * {@link runSkillNodeOrSpawn}'s `runner` slot:
+ *
+ * @example
+ * ```ts
+ * const runner = await maybeCreatePiRunner({ system: 'task-executor', projectRoot });
+ * await runSkillNodeOrSpawn(input, { tools, cwd: projectRoot, subprocessSpawn, runner });
+ * ```
+ *
+ * Default-OFF: when the flag is unset (the common case) this short-circuits to
+ * `undefined` before importing the Pi barrel, so `pi-ai`'s `register-builtins`
+ * is never loaded and the dispatcher behaves exactly as it did pre-T11945
+ * (`defaultSkillRunner` runs the in-process skill node).
+ *
+ * @param deps - Optional resolution system + project root forwarded to the Pi
+ *   adapter when the runner is constructed.
+ * @returns The Pi `SkillRunner` when enabled, otherwise `undefined`.
+ * @task T11945
+ */
+export async function maybeCreatePiRunner(
+  deps: MaybePiRunnerDeps = {},
+): Promise<SkillRunner | undefined> {
+  // Cheap default-OFF gate — read the raw flag WITHOUT importing the Pi barrel
+  // (which transitively pulls the heavy `pi-ai` dependency). This is the hot
+  // path on every dispatch when Pi is disabled.
+  if (process.env[PI_RUNNER_FLAG] !== '1') {
+    return undefined;
+  }
+
+  // Flag is on — lazy-import the Pi barrel (subpath, NOT via `internal`) so
+  // `pi-ai` stays out of the eager module graph. `isPiRunnerEnabled()` is the
+  // authoritative predicate; re-confirm in case the env changed between the
+  // raw pre-check and the import.
+  const { createPiSkillRunner, isPiRunnerEnabled } = await import('../llm/pi/index.js');
+  if (!isPiRunnerEnabled()) {
+    return undefined;
+  }
+  return createPiSkillRunner({
+    ...(deps.system !== undefined ? { system: deps.system } : {}),
+    ...(deps.projectRoot !== undefined ? { projectRoot: deps.projectRoot } : {}),
+  });
+}

--- a/packages/playbooks/src/__tests__/fixtures/pi-skill-only.cantbook
+++ b/packages/playbooks/src/__tests__/fixtures/pi-skill-only.cantbook
@@ -1,0 +1,26 @@
+version: "1.0"
+name: pi-skill-only
+description: >
+  T11945 (M4) deterministic e2e fixture — a single skill-only agentic node. The
+  node names a real `ct-*` skill so the production dispatcher's
+  `runSkillNodeOrSpawn` takes the IN-PROCESS skill path (findSkill resolves it)
+  and, when a Pi runner is injected, routes the node THROUGH the PiAgentAdapter.
+  No `requires`/`ensures` contracts so schema enforcement never interferes with
+  the dispatch-path assertion. With no LLM credential resolvable in CI the Pi
+  loop terminates with the cleo-owned no-credential failure — proving the call
+  reached the Pi streamFn (the E9 chokepoint), not a live round-trip.
+
+inputs:
+  - name: taskId
+    required: true
+    description: Task id being executed (seeds the run context).
+
+nodes:
+  - id: execute
+    type: agentic
+    skill: ct-task-executor
+    description: >
+      Single skill-only node — routes in-process through the SkillExecutorAdapter,
+      and through the PiAgentAdapter when the Pi runner is wired (T11945).
+
+edges: []

--- a/packages/playbooks/src/__tests__/pi-cantbook-e2e.test.ts
+++ b/packages/playbooks/src/__tests__/pi-cantbook-e2e.test.ts
@@ -1,0 +1,294 @@
+/**
+ * T11945 (M4) — deterministic in-process e2e: a skill-only `.cantbook` executes
+ * THROUGH the PiAgentAdapter when the Pi runner is wired into the production
+ * dispatcher.
+ *
+ * ## What this proves (the M4 keystone)
+ *
+ * The two production cantbook dispatchers (`buildDefaultDispatcher` in
+ * `packages/cleo/src/dispatch/domains/playbook.ts` and `buildGoDispatcher` in
+ * `packages/cleo/src/cli/commands/go-ivtr-runner.ts`) now pass
+ * `runner: await maybeCreatePiRunner({ system, projectRoot })` into
+ * {@link runSkillNodeOrSpawn}. This test reconstructs that EXACT production
+ * dispatcher shape (`createToolGuard` + `runSkillNodeOrSpawn` + the
+ * `maybeCreatePiRunner` wiring helper) and drives a single skill-only node
+ * through the real {@link executePlaybook} runtime state machine.
+ *
+ * With `CLEO_PI_RUNNER_ENABLED=1` the in-process skill node routes THROUGH the
+ * PiAgentAdapter. There is no working LLM backend on this box, so we do NOT
+ * assert a live round-trip — we assert the DISPATCH PATH reached the Pi adapter,
+ * proven by the **cleo-owned no-credential failure string**
+ * (`no credential resolved for system "task-executor"`) emitted by the Cleo
+ * streamFn (`createPiStreamFn`, the E9 chokepoint). A pi-ai-internal failure
+ * shape would not carry that exact cleo string. The Pi adapter NEVER throws —
+ * it returns a contained `{ status: 'failure' }` (pi-agent-adapter.test.ts:197
+ * precedent), so the run terminates cleanly.
+ *
+ * ## Determinism + isolation contract (AC3 · AC4)
+ *
+ *  - IN-PROCESS only — vitest source, NO subprocess (tsx unresolvable in CI).
+ *  - daemon-OFF — the runtime is the in-memory `node:sqlite` DB, no daemon.
+ *  - `CLEO_SESSION_ID` is stamped so the Pi runner's ZERO-authority guard passes
+ *    (production relies on the daemon stamping it; here the test stamps it).
+ *  - A real `ct-*` skill is materialised under a temp project root's
+ *    `.agents/skills/` dir so `findSkill` resolves it and the in-process skill
+ *    path (not subprocess spawn) is taken. `CLEO_PROJECT_ROOT` pins resolution
+ *    to that temp dir.
+ *  - `maxIterationsDefault: 1` so the failing node runs exactly once → the run
+ *    terminates as `exceeded_iteration_cap` with the Pi error in `errorContext`.
+ *
+ * @epic T10403
+ * @task T11761
+ * @task T11945
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import {
+  type AgentDispatcher,
+  type AgentDispatchInput,
+  type AgentDispatchResult,
+  createToolGuard,
+  maybeCreatePiRunner,
+  runSkillNodeOrSpawn,
+} from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parsePlaybook } from '../parser.js';
+import { executePlaybook } from '../runtime.js';
+import { getPlaybookRun } from '../state.js';
+
+const _require = createRequire(import.meta.url);
+type DatabaseSync = _DatabaseSyncType;
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => DatabaseSync;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the T889 playbook-tables migration SQL. */
+const MIGRATION_SQL_PATH = resolve(
+  __dirname,
+  '../../../core/migrations/drizzle-tasks/20260417220000_t889-playbook-tables/migration.sql',
+);
+
+/** The skill-only fixture cantbook materialised for this suite. */
+const FIXTURE_PATH = resolve(__dirname, 'fixtures/pi-skill-only.cantbook');
+
+/**
+ * Cleo-owned Pi failure markers that ONLY appear when a dispatch reached the
+ * PiAgentAdapter → Cleo streamFn (E9 chokepoint). A `defaultSkillRunner` would
+ * have SUCCEEDED (it does no LLM work), so seeing any of these proves the Pi
+ * route was taken:
+ *  - `no credential resolved for system` — the Cleo streamFn's no-credential
+ *    terminal error (`createPiStreamFn`), when NO key is reachable.
+ *  - `Pi loop failed:` — the Cleo `wrapPiCall` containment prefix
+ *    (`pi-errors.ts`), when a credential DID resolve and the real LLM transport
+ *    failed (e.g. an expired `sk-ant-oat` token → 401). Either way the call went
+ *    through the Pi adapter, never `defaultSkillRunner`.
+ *
+ * Mirrors the `pi-agent-adapter.test.ts:197` precedent
+ * (`/no credential resolved for system|pi loop error|error/i`).
+ */
+const PI_DISPATCH_MARKERS = /no credential resolved for system|Pi loop failed:/i;
+
+/**
+ * Apply a multi-statement Drizzle migration file (split on the
+ * `--> statement-breakpoint` token). Mirrors starter.e2e.test.ts.
+ */
+function applyMigration(db: DatabaseSync, sql: string): void {
+  const statements = sql
+    .split(/--> statement-breakpoint/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of statements) {
+    const lines = stmt.split('\n');
+    const hasSql = lines.some((l) => l.trim().length > 0 && !l.trim().startsWith('--'));
+    if (hasSql) db.exec(stmt);
+  }
+}
+
+/**
+ * Materialise a real `ct-task-executor` skill under `<projectRoot>/.agents/skills/`
+ * so {@link runSkillNodeOrSpawn}'s `findSkill(agentId, projectRoot)` resolves it
+ * via the `project-custom` search scope, taking the in-process skill path.
+ */
+function writeFixtureSkill(projectRoot: string): void {
+  const skillDir = join(projectRoot, '.agents', 'skills', 'ct-task-executor');
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    [
+      '---',
+      'name: ct-task-executor',
+      'description: T11945 e2e fixture skill — drives the in-process Pi dispatch path.',
+      '---',
+      '',
+      'Execute the assigned task.',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+}
+
+/**
+ * Build the EXACT production dispatcher shape from `buildDefaultDispatcher`:
+ * in-process `ct-*` skill nodes run over a deny-first guarded tool surface via
+ * {@link runSkillNodeOrSpawn} with the Pi runner injected; isolation/agent nodes
+ * fall back to the (here-unused) subprocess spawn. The `runner` is obtained from
+ * the M4 wiring helper {@link maybeCreatePiRunner}, exactly as production does.
+ */
+async function buildProductionShapedDispatcher(projectRoot: string): Promise<AgentDispatcher> {
+  const tools = createToolGuard({ allowedRoots: [projectRoot] });
+  // The M4 keystone wiring under test — with CLEO_PI_RUNNER_ENABLED=1 this is
+  // the Pi `SkillRunner`; with the flag unset it is `undefined`.
+  const runner = await maybeCreatePiRunner({ system: 'task-executor', projectRoot });
+
+  /** Subprocess fallback — never exercised by the skill-only fixture. */
+  const spawn = async (input: AgentDispatchInput): Promise<AgentDispatchResult> => ({
+    status: 'failure',
+    output: {},
+    error: `unexpected subprocess spawn for ${input.agentId}`,
+  });
+
+  return {
+    async dispatch(input: AgentDispatchInput): Promise<AgentDispatchResult> {
+      return runSkillNodeOrSpawn(
+        { nodeId: input.nodeId, agentId: input.agentId, context: input.context },
+        {
+          tools,
+          cwd: projectRoot,
+          subprocessSpawn: () => spawn(input),
+          ...(runner !== undefined ? { runner } : {}),
+        },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('T11945 (M4): skill-only .cantbook routes through the PiAgentAdapter', () => {
+  let db: DatabaseSync;
+  let projectRoot: string;
+
+  const SAVED = {
+    session: process.env['CLEO_SESSION_ID'],
+    flag: process.env['CLEO_PI_RUNNER_ENABLED'],
+    projectRoot: process.env['CLEO_PROJECT_ROOT'],
+    cleoRoot: process.env['CLEO_ROOT'],
+    anthropic: process.env['ANTHROPIC_API_KEY'],
+    anthropicOauth: process.env['ANTHROPIC_OAUTH_TOKEN'],
+  };
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys=ON');
+    applyMigration(db, readFileSync(MIGRATION_SQL_PATH, 'utf8'));
+
+    projectRoot = mkdtempSync(join(tmpdir(), 't11945-pi-e2e-'));
+    writeFixtureSkill(projectRoot);
+
+    // Pin skill + project resolution to the temp root (getProjectRoot honours
+    // CLEO_ROOT / CLEO_PROJECT_ROOT before any walk).
+    process.env['CLEO_PROJECT_ROOT'] = projectRoot;
+    process.env['CLEO_ROOT'] = projectRoot;
+    // Daemon-stamped identity — the Pi runner fails closed without it (ZERO authority).
+    process.env['CLEO_SESSION_ID'] = 'sess-t11945-e2e';
+    // No credential reachable → deterministic cleo-owned no-credential failure.
+    delete process.env['ANTHROPIC_API_KEY'];
+    delete process.env['ANTHROPIC_OAUTH_TOKEN'];
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(projectRoot, { recursive: true, force: true });
+    restoreEnv('CLEO_SESSION_ID', SAVED.session);
+    restoreEnv('CLEO_PI_RUNNER_ENABLED', SAVED.flag);
+    restoreEnv('CLEO_PROJECT_ROOT', SAVED.projectRoot);
+    restoreEnv('CLEO_ROOT', SAVED.cleoRoot);
+    restoreEnv('ANTHROPIC_API_KEY', SAVED.anthropic);
+    restoreEnv('ANTHROPIC_OAUTH_TOKEN', SAVED.anthropicOauth);
+  });
+
+  it('routes the in-process skill node THROUGH the Pi adapter (proven by the cleo no-credential failure)', async () => {
+    process.env['CLEO_PI_RUNNER_ENABLED'] = '1';
+
+    const { definition, sourceHash } = parsePlaybook(readFileSync(FIXTURE_PATH, 'utf8'));
+    expect(definition.name).toBe('pi-skill-only');
+    expect(definition.nodes).toHaveLength(1);
+
+    const dispatcher = await buildProductionShapedDispatcher(projectRoot);
+
+    const result = await executePlaybook({
+      db,
+      playbook: definition,
+      playbookHash: sourceHash,
+      initialContext: { taskId: 'T11945' },
+      dispatcher,
+      projectRoot,
+      // One attempt → the node fails once (no credential) and terminates.
+      maxIterationsDefault: 1,
+    });
+
+    // The Pi loop never throws — the run reaches a clean terminal state with the
+    // node failure recorded (not an uncaught exception).
+    expect(result.terminalStatus).toBe('exceeded_iteration_cap');
+    expect(result.exceededNodeId).toBe('execute');
+
+    // THE PROOF: the failure carries a cleo-owned Pi marker (streamFn
+    // no-credential error OR the wrapPiCall containment prefix). These ONLY
+    // appear when the dispatch reached the PiAgentAdapter → Cleo streamFn (the
+    // E9 chokepoint). A `defaultSkillRunner` would have SUCCEEDED (it does no LLM
+    // work, terminalStatus 'completed'), so an `exceeded_iteration_cap` carrying
+    // this marker is dispositive that the Pi route ran.
+    const errorContext = result.errorContext ?? '';
+    expect(errorContext).toMatch(PI_DISPATCH_MARKERS);
+
+    const run = getPlaybookRun(db, result.runId);
+    expect(run?.status).toBe('failed');
+  });
+
+  it('with CLEO_PI_RUNNER_ENABLED unset the node stays on defaultSkillRunner (zero behaviour change)', async () => {
+    // Flag deliberately NOT set → maybeCreatePiRunner returns undefined →
+    // runSkillNodeOrSpawn uses defaultSkillRunner, which resolves the skill and
+    // returns success WITHOUT any LLM work. The run completes; no Pi string.
+    delete process.env['CLEO_PI_RUNNER_ENABLED'];
+
+    const { definition, sourceHash } = parsePlaybook(readFileSync(FIXTURE_PATH, 'utf8'));
+    const dispatcher = await buildProductionShapedDispatcher(projectRoot);
+
+    const result = await executePlaybook({
+      db,
+      playbook: definition,
+      playbookHash: sourceHash,
+      initialContext: { taskId: 'T11945' },
+      dispatcher,
+      projectRoot,
+      maxIterationsDefault: 1,
+    });
+
+    expect(result.terminalStatus).toBe('completed');
+    // defaultSkillRunner echoes resolution metadata — never a Pi failure marker.
+    expect(result.errorContext ?? '').not.toMatch(PI_DISPATCH_MARKERS);
+    expect(result.finalContext).toMatchObject({ skillId: 'ct-task-executor', resolved: true });
+  });
+
+  it('maybeCreatePiRunner is default-OFF: undefined unless CLEO_PI_RUNNER_ENABLED=1', async () => {
+    delete process.env['CLEO_PI_RUNNER_ENABLED'];
+    expect(await maybeCreatePiRunner({ system: 'task-executor', projectRoot })).toBeUndefined();
+
+    process.env['CLEO_PI_RUNNER_ENABLED'] = '1';
+    const runner = await maybeCreatePiRunner({ system: 'task-executor', projectRoot });
+    expect(typeof runner).toBe('function');
+  });
+});
+
+/** Restore an env var to its saved value (delete when it was unset). */
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}


### PR DESCRIPTION
## T11945 — M4 keystone: a `.cantbook` executes end-to-end via Pi

The dispatch chain `CoreAgentDispatcher → runSkillNodeOrSpawn → SkillExecutorAdapter → SkillRunner` was fully plumbed (`runSkillNodeOrSpawn` already accepts a `runner` opt), but **neither production dispatcher passed `runner`** — so in-process skill nodes always fell back to `defaultSkillRunner` and the `PiAgentAdapter` was never invoked in production. This PR closes that one-line-per-site gap, behind a default-OFF flag.

### The 2 call-site wirings (both default-OFF)
| Dispatcher | Path | Change |
|---|---|---|
| `buildDefaultDispatcher` | `packages/cleo/src/dispatch/domains/playbook.ts` (`cleo playbook run`) | passes `runner: await maybeCreatePiRunner({ system: 'task-executor', projectRoot })` into `runSkillNodeOrSpawn` |
| `buildGoDispatcher` | `packages/cleo/src/cli/commands/go-ivtr-runner.ts` (`cleo go` IVTR) | same wiring |

When the runner is `undefined` (the default), `runSkillNodeOrSpawn` uses the existing `defaultSkillRunner` — **zero behaviour change**.

### The default-OFF flag + thin CLI (Gate-6)
New core helper `maybeCreatePiRunner` (`packages/core/src/playbooks/pi-runner-wiring.ts`):
- Returns `undefined` unless `CLEO_PI_RUNNER_ENABLED=1` (strict `'1'`, mirrors `isPiRunnerEnabled`).
- Reads the raw env flag as a cheap pre-check, then **dynamically imports** the Pi barrel only when enabled — keeping the heavy `@earendil-works/pi-ai` dependency out of `@cleocode/core/internal`'s eager module graph (OOM-safe, no `register-builtins` on the hot dispatch path).
- Exported from `internal.ts` **before** the `export * from './index.js'` superset so the live binding survives the `internal ↔ index` re-export cycle under vitest source resolution (real-node dist resolves it fine either way; verified).
- CLI dispatchers stay thin — a single `await maybeCreatePiRunner(...)` each.

### Deterministic in-process e2e (the proof)
`packages/playbooks/src/__tests__/pi-cantbook-e2e.test.ts` drives a skill-only fixture (`pi-skill-only.cantbook`, a single `ct-*` node) through the **real `executePlaybook` runtime** with a **production-shaped dispatcher whose `runner` IS `maybeCreatePiRunner`**:
- **Flag ON** → the in-process node routes **THROUGH the PiAgentAdapter**, proven by the cleo-owned Pi failure marker (streamFn `no credential resolved for system` OR the `wrapPiCall` `Pi loop failed:` containment prefix). A `defaultSkillRunner` would have **succeeded** (no LLM work) — so an `exceeded_iteration_cap` carrying that marker is dispositive that the Pi route ran. **NOT a live LLM round-trip** (no backend authes on CI; the Pi adapter returns a contained `{status:'failure'}`, never throws).
- **Flag unset** → stays on `defaultSkillRunner` (`completed`, no Pi marker).
- IN-PROCESS only (no subprocess), daemon-OFF, `CLEO_SESSION_ID` stamped so the Pi ZERO-authority guard passes.

### Gate-13
No new out-of-chokepoint LLM construction — the streamFn already routes through `resolveLLMForSystem`; this touches CLI dispatch wiring only. `go-ivtr-runner.test.ts` mock extended with `maybeCreatePiRunner` (returns `undefined` = default-OFF).

### Gates (all green, cgroup-capped)
- `pnpm biome check --write .` — clean
- full `pnpm run typecheck` (`tsc -b`) — clean
- `pnpm run build` — green
- e2e **3/3** + pi adapter & playbooks suites **288/288** pass
- `go-ivtr-runner.test.ts` **5/5** pass (mock updated)
- `cleo check arch` — **6/6** gates pass · Gate-13 LLM chokepoint — no new violations · define-command / CLI-boundary / contracts-fan-out — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)