### PR TITLE
feat(T1944): PlaybookAgenticNode.inputs → AgentDispatchInput.bindings + mustache resolution (M4)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -727,6 +727,14 @@ export { updateTask } from './tasks/update.js';
 // can import them without violating lint-core-first RULE-3 (which bans
 // `@cleocode/core/internal` from CLI command files).
 
+// T1944 (M4 cantbook done-gate) — canonical mustache `{{var}}` resolver
+// (T1238 SSoT). Re-exported from the main entrypoint so the playbook runtime
+// can resolve `PlaybookAgenticNode.inputs` templates at the dispatch boundary
+// without reaching into `@cleocode/core/internal` (lint-core-first RULE-3).
+export {
+  DefaultVariableResolver,
+  defaultResolver as defaultVariableResolver,
+} from './agents/variable-substitution.js';
 // T11917 (M5/AC3 · EP-API-STANDARD-FOUNDATION T11769) — config-as-domain handler
 // routing config.{get,list,validate,unset} to the ConfigManifest cascade resolver.
 export {

--- a/packages/playbooks/src/__tests__/inputs-bindings.test.ts
+++ b/packages/playbooks/src/__tests__/inputs-bindings.test.ts
@@ -1,0 +1,250 @@
+/**
+ * T1944 (M4 cantbook done-gate) — `PlaybookAgenticNode.inputs` →
+ * `AgentDispatchInput.bindings` wiring + mustache resolution at the dispatch
+ * boundary.
+ *
+ * Two layers of coverage:
+ *
+ *  1. Pure-unit tests of {@link resolveStepBindings} — precedence, shadowing,
+ *     dot-path resolution, and the lenient missing-key rule, exercised in
+ *     isolation with no DB.
+ *  2. In-process `executePlaybook` end-to-end — a `.cantbook`-equivalent node
+ *     with `inputs: { topic: '{{inputs.epicId}}' }` resolves and the bound
+ *     value reaches {@link AgentDispatchInput.bindings} at dispatch time.
+ *
+ * No `@cleocode/*` module is mocked — the resolver is the real canonical
+ * T1238 engine and the runtime runs against an in-memory `node:sqlite` DB.
+ *
+ * @task T1944 — wire PlaybookAgenticNode.inputs → AgentDispatchInput.bindings
+ */
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import type { PlaybookAgenticNode, PlaybookDefinition } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type AgentDispatcher,
+  type AgentDispatchInput,
+  type AgentDispatchResult,
+  executePlaybook,
+  resolveStepBindings,
+} from '../runtime.js';
+
+const _require = createRequire(import.meta.url);
+type DatabaseSync = _DatabaseSyncType;
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => DatabaseSync;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_SQL = resolve(
+  __dirname,
+  '../../../core/migrations/drizzle-tasks/20260417220000_t889-playbook-tables/migration.sql',
+);
+
+function applyMigration(db: DatabaseSync, sql: string): void {
+  const statements = sql
+    .split(/--> statement-breakpoint/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of statements) {
+    const lines = stmt.split('\n');
+    const hasSql = lines.some((l) => l.trim().length > 0 && !l.trim().startsWith('--'));
+    if (hasSql) db.exec(stmt);
+  }
+}
+
+function agenticNode(
+  id: string,
+  overrides: Partial<PlaybookAgenticNode> = {},
+): PlaybookAgenticNode {
+  return { id, type: 'agentic', skill: `skill-${id}`, ...overrides };
+}
+
+/** Dispatcher that records the full {@link AgentDispatchInput} per call. */
+function makeBindingRecorder(
+  handler: (input: AgentDispatchInput) => AgentDispatchResult,
+): AgentDispatcher & { calls: AgentDispatchInput[] } {
+  const calls: AgentDispatchInput[] = [];
+  return {
+    calls,
+    async dispatch(input: AgentDispatchInput): Promise<AgentDispatchResult> {
+      // Snapshot bindings/context so later mutation cannot taint the assertion.
+      calls.push({
+        ...input,
+        context: { ...input.context },
+        bindings: input.bindings === undefined ? undefined : { ...input.bindings },
+      });
+      return handler(input);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveStepBindings — pure unit
+// ---------------------------------------------------------------------------
+
+describe('T1944: resolveStepBindings (pure)', () => {
+  it('AC5: resolves a {{inputs.epicId}} template from the run context', () => {
+    const node = agenticNode('research', { inputs: { topic: '{{inputs.epicId}}' } });
+    const context = { inputs: { epicId: 'T1942' } };
+
+    const bound = resolveStepBindings(node, context);
+
+    expect(bound['topic']).toBe('T1942');
+    // Original context keys remain present.
+    expect(bound['inputs']).toEqual({ epicId: 'T1942' });
+  });
+
+  it('AC5: resolves a flat {{epicId}} single-segment template', () => {
+    const node = agenticNode('research', { inputs: { topic: '{{epicId}}' } });
+    const bound = resolveStepBindings(node, { epicId: 'T1942' });
+    expect(bound['topic']).toBe('T1942');
+  });
+
+  it('AC6: step bindings shadow playbook bindings for the same key', () => {
+    // The run context already carries `topic`; the step input MUST win.
+    const node = agenticNode('research', { inputs: { topic: '{{inputs.epicId}}' } });
+    const context = { topic: 'stale-context-value', inputs: { epicId: 'T1942' } };
+
+    const bound = resolveStepBindings(node, context);
+
+    expect(bound['topic']).toBe('T1942');
+    expect(bound['topic']).not.toBe('stale-context-value');
+  });
+
+  it('missing-key rule: unresolved {{path}} is left as a literal placeholder', () => {
+    const node = agenticNode('research', { inputs: { topic: '{{inputs.nope}}' } });
+    const bound = resolveStepBindings(node, { inputs: { epicId: 'T1942' } });
+    expect(bound['topic']).toBe('{{inputs.nope}}');
+  });
+
+  it('resolves dot-path nesting deeper than one level', () => {
+    const node = agenticNode('research', { inputs: { fw: '{{project.testing.framework}}' } });
+    const bound = resolveStepBindings(node, {
+      project: { testing: { framework: 'vitest' } },
+    });
+    expect(bound['fw']).toBe('vitest');
+  });
+
+  it('passes literal (non-template) input values through unchanged', () => {
+    const node = agenticNode('research', { inputs: { mode: 'fast' } });
+    const bound = resolveStepBindings(node, { x: 1 });
+    expect(bound['mode']).toBe('fast');
+  });
+
+  it('returns a shallow copy of context when the node declares no inputs', () => {
+    const node = agenticNode('research');
+    const context = { taskId: 'T123', a: 1 };
+    const bound = resolveStepBindings(node, context);
+    expect(bound).toEqual(context);
+    expect(bound).not.toBe(context);
+  });
+
+  it('returns a shallow copy of context for an empty inputs map', () => {
+    const node = agenticNode('research', { inputs: {} });
+    const context = { taskId: 'T123' };
+    expect(resolveStepBindings(node, context)).toEqual(context);
+  });
+
+  it('does not mutate the source context', () => {
+    const node = agenticNode('research', { inputs: { topic: '{{epicId}}' } });
+    const context = { epicId: 'T1942' };
+    resolveStepBindings(node, context);
+    expect(context).toEqual({ epicId: 'T1942' });
+    expect(context).not.toHaveProperty('topic');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executePlaybook — bindings reach the dispatch boundary (in-process e2e)
+// ---------------------------------------------------------------------------
+
+describe('T1944: AgentDispatchInput.bindings (in-process)', () => {
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys=ON');
+    applyMigration(db, readFileSync(MIGRATION_SQL, 'utf8'));
+  });
+  afterEach(() => db.close());
+
+  it('AC2: resolved step input reaches AgentDispatchInput.bindings at dispatch', async () => {
+    const playbook: PlaybookDefinition = {
+      version: '1.0',
+      name: 'inputs-bindings',
+      nodes: [agenticNode('research', { inputs: { topic: '{{inputs.epicId}}' } })],
+      edges: [],
+    };
+    const dispatcher = makeBindingRecorder(() => ({ status: 'success', output: {} }));
+
+    const result = await executePlaybook({
+      db,
+      playbook,
+      playbookHash: 'hash-t1944',
+      initialContext: { inputs: { epicId: 'T1942' } },
+      dispatcher,
+    });
+
+    expect(result.terminalStatus).toBe('completed');
+    expect(dispatcher.calls).toHaveLength(1);
+    // The resolved binding (NOT the raw template) reaches the dispatcher.
+    expect(dispatcher.calls[0]?.bindings?.['topic']).toBe('T1942');
+    // The raw accumulated context still carries the source object.
+    expect(dispatcher.calls[0]?.context['inputs']).toEqual({ epicId: 'T1942' });
+  });
+
+  it('AC2: bindings is always populated even when the node declares no inputs', async () => {
+    const playbook: PlaybookDefinition = {
+      version: '1.0',
+      name: 'no-inputs',
+      nodes: [agenticNode('plain')],
+      edges: [],
+    };
+    const dispatcher = makeBindingRecorder(() => ({ status: 'success', output: {} }));
+
+    await executePlaybook({
+      db,
+      playbook,
+      playbookHash: 'hash-t1944-b',
+      initialContext: { taskId: 'T123' },
+      dispatcher,
+    });
+
+    expect(dispatcher.calls[0]?.bindings).toMatchObject({ taskId: 'T123' });
+  });
+
+  it('AC6: step binding shadows a same-named accumulated context key end-to-end', async () => {
+    // Node `a` emits `topic`; node `b` declares an `inputs.topic` template that
+    // MUST shadow the inherited context value when dispatched.
+    const playbook: PlaybookDefinition = {
+      version: '1.0',
+      name: 'shadowing',
+      nodes: [agenticNode('a'), agenticNode('b', { inputs: { topic: '{{inputs.epicId}}' } })],
+      edges: [{ from: 'a', to: 'b' }],
+    };
+    const dispatcher = makeBindingRecorder((input) =>
+      input.nodeId === 'a'
+        ? { status: 'success', output: { topic: 'from-node-a' } }
+        : { status: 'success', output: {} },
+    );
+
+    await executePlaybook({
+      db,
+      playbook,
+      playbookHash: 'hash-t1944-c',
+      initialContext: { inputs: { epicId: 'T1942' } },
+      dispatcher,
+    });
+
+    const callB = dispatcher.calls.find((c) => c.nodeId === 'b');
+    // Accumulated context still has node-a's value...
+    expect(callB?.context['topic']).toBe('from-node-a');
+    // ...but the step binding shadows it.
+    expect(callB?.bindings?.['topic']).toBe('T1942');
+  });
+});

--- a/packages/playbooks/src/index.ts
+++ b/packages/playbooks/src/index.ts
@@ -79,6 +79,8 @@ export {
   executePlaybook,
   type PlaybookTerminalStatus,
   type ResumePlaybookOptions,
+  // T1944 (M4): per-step `node.inputs` → dispatch-boundary binding resolver.
+  resolveStepBindings,
   resumePlaybook,
 } from './runtime.js';
 // W4-8: state layer CRUD for playbook_runs + playbook_approvals

--- a/packages/playbooks/src/runtime.ts
+++ b/packages/playbooks/src/runtime.ts
@@ -48,13 +48,17 @@ import type {
   PlaybookNode,
   PlaybookRun,
   PlaybookRunStatus,
+  SubstitutionContext,
 } from '@cleocode/contracts';
 // T11762 ST-2: registry-driven ensures.schema resolution. The bodied accessors
 // live in `@cleocode/core` (Gate-10 contracts-purity forbids them in the
 // contracts leaf); core does NOT depend on playbooks, so this import direction
 // is cycle-free (mirrors the existing `@cleocode/core/store/schema` import in
 // `./schema.ts`).
-import { getEnsuresSchema, listEnsuresSchemaNames } from '@cleocode/core';
+// T1944 (M4): `defaultVariableResolver` is the canonical T1238 mustache engine,
+// re-used here (DRY) to resolve `PlaybookAgenticNode.inputs` `{{path}}`
+// templates at the dispatch boundary rather than re-implementing substitution.
+import { defaultVariableResolver, getEnsuresSchema, listEnsuresSchemaNames } from '@cleocode/core';
 import { createApprovalGate, getPlaybookSecret } from './approval.js';
 import {
   createPlaybookApproval,
@@ -84,6 +88,24 @@ export interface AgentDispatchInput {
   taskId: string;
   /** Snapshot of the accumulated bindings at dispatch time. */
   context: Record<string, unknown>;
+  /**
+   * Per-step resolved bindings for this node (T1944 · M4 cantbook done-gate).
+   *
+   * Additive field. Built by {@link resolveStepBindings} from
+   * {@link PlaybookAgenticNode.inputs} — each declared input is a mustache
+   * `{{path}}` template resolved against the accumulated run `context` (via the
+   * canonical T1238 {@link DefaultVariableResolver}), then layered ON TOP of
+   * that context so a step input SHADOWS a same-named context key.
+   *
+   * The runtime always populates this when dispatching an agentic node (it is a
+   * shallow copy of `context` when the node declares no `inputs`). It is typed
+   * optional only to keep the change strictly additive for any out-of-tree
+   * dispatcher that constructs an {@link AgentDispatchInput} directly.
+   *
+   * Resolver precedence (highest → lowest):
+   * `step bindings ⊳ playbook bindings (run context) ⊳ session ⊳ project-context ⊳ env ⊳ default`.
+   */
+  bindings?: Record<string, unknown>;
   /** 1-based iteration counter for this specific node (retry-aware). */
   iteration: number;
 }
@@ -501,6 +523,75 @@ function resolveNode(nodeId: string, idx: NodeIndex): PlaybookNode {
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve a {@link PlaybookAgenticNode}'s declared `inputs` into the per-step
+ * binding map handed to the dispatcher (T1944 · M4 cantbook done-gate).
+ *
+ * Each `inputs` value is a mustache `{{path}}` template. Templates are resolved
+ * against the accumulated run `context` using the canonical T1238
+ * {@link DefaultVariableResolver} (no second substitution engine — DRY) and the
+ * resolved key/value pairs are then layered ON TOP of the run context. The
+ * result is the dispatch-time binding map.
+ *
+ * ## Canonical resolver precedence (highest → lowest)
+ *
+ * 1. **step bindings** — the resolved `node.inputs` themselves. They are merged
+ *    LAST over the run context, so a step input always SHADOWS a same-named
+ *    context key (AC3 / AC6).
+ * 2. **playbook bindings** — the accumulated run `context` (seeded from the
+ *    playbook's declared inputs + every prior node's merged output).
+ * 3. **session / project-context / env / default** — supplied to the underlying
+ *    {@link DefaultVariableResolver} via the {@link SubstitutionContext} below.
+ *
+ * The run `context` is exposed to the resolver through BOTH the `projectContext`
+ * tier (which supports dot-notation, so `{{inputs.epicId}}` and `{{context.foo}}`
+ * resolve into nested objects) and `process.env` (the `env` tier). The
+ * resolver runs in lenient mode.
+ *
+ * ## Missing-key rule
+ *
+ * Lenient. When a `{{path}}` template references a value that resolves through
+ * NO tier, the literal placeholder text is left intact in the bound value (e.g.
+ * `{{missing}}` stays `"{{missing}}"`). This mirrors the canonical T1238
+ * lenient posture — a missing input never aborts the dispatch; the agent
+ * receives the literal placeholder and can fail loudly downstream if required.
+ *
+ * @param node - The agentic node whose `inputs` are resolved.
+ * @param context - The accumulated run bindings at dispatch time.
+ * @returns A new binding map = `{ ...context, ...resolvedStepInputs }`. When the
+ *   node declares no `inputs`, this is a shallow copy of `context`.
+ */
+export function resolveStepBindings(
+  node: PlaybookAgenticNode,
+  context: Record<string, unknown>,
+): Record<string, unknown> {
+  // No declared inputs — bindings are just a snapshot of the run context.
+  if (node.inputs === undefined || Object.keys(node.inputs).length === 0) {
+    return { ...context };
+  }
+
+  // Expose the run context to the canonical resolver. `projectContext` is the
+  // dot-notation-capable tier, so `{{inputs.epicId}}` / `{{context.foo.bar}}`
+  // walk into nested objects; flat keys (`{{epicId}}`) resolve via a
+  // single-segment walk on the same tier.
+  const substitutionContext: SubstitutionContext = {
+    projectContext: context,
+    env: process.env,
+  };
+
+  const resolvedInputs: Record<string, unknown> = {};
+  for (const [key, template] of Object.entries(node.inputs)) {
+    // Lenient resolve — missing placeholders are left literal (see TSDoc).
+    const result = defaultVariableResolver.resolve(template, substitutionContext, {
+      strict: false,
+    });
+    resolvedInputs[key] = result.text;
+  }
+
+  // Step bindings shadow the run context for same-named keys (AC3 / AC6).
+  return { ...context, ...resolvedInputs };
+}
+
+/**
  * Execute a single `agentic` node via the injected {@link AgentDispatcher}.
  * The dispatcher receives the current context and must return a success /
  * failure envelope — any thrown exception is normalized into a failure.
@@ -523,6 +614,10 @@ async function executeAgenticNode(
   const taskIdRaw = context['taskId'];
   const taskId = typeof taskIdRaw === 'string' && taskIdRaw.length > 0 ? taskIdRaw : runId;
 
+  // T1944 (M4): resolve `node.inputs` `{{path}}` templates against the run
+  // context and layer them on top so step inputs shadow context (AC1/AC2/AC3).
+  const bindings = resolveStepBindings(node, context);
+
   try {
     const result = await dispatcher.dispatch({
       runId,
@@ -530,6 +625,7 @@ async function executeAgenticNode(
       agentId,
       taskId,
       context: { ...context },
+      bindings,
       iteration,
     });
     if (result.status === 'success') {


### PR DESCRIPTION
## T1944 — wire `PlaybookAgenticNode.inputs` → `AgentDispatchInput.bindings` + mustache resolution at the dispatch boundary (M4 cantbook done-gate)

Builds off latest `origin/main` (includes #1040, the T11945 cantbook-Pi wiring).

The playbook runtime parsed `PlaybookAgenticNode.inputs` but `executeAgenticNode()` never read it — every agentic node was dispatched with only the raw accumulated `context`. This wires those declared step inputs into a resolved per-step binding map handed to the dispatcher, reusing the canonical T1238 mustache engine (no second substitution engine — DRY).

### Acceptance criteria
- **AC1** — `executeAgenticNode()` now consumes `node.inputs` (previously parsed-but-ignored). `packages/playbooks/src/runtime.ts`.
- **AC2** — Step inputs are resolved and bound to `AgentDispatchInput.bindings` **before** dispatch. Proven in-process: a `{{inputs.epicId}}` step input reaches `input.bindings.topic === 'T1942'` at the dispatcher.
- **AC3** — Mustache substitution applied at the dispatch boundary via the canonical `DefaultVariableResolver` (T1238). See precedence below.
- **AC4** — `AgentDispatchInput` extended with additive `bindings?: Record<string, unknown>` (typed optional to stay strictly additive; the runtime always populates it).
- **AC5/AC6** — Tests: `inputs: { topic: '{{inputs.epicId}}' }` resolves from the run context; step bindings shadow same-named playbook/context keys (unit + in-process e2e).
- **AC7** — Existing rcasd/ivtr/release runtime + `starter.e2e` suites still green — **156/156 playbook tests pass**.
- **AC8** — biome + tests green.

### Resolver precedence (highest → lowest)
`step bindings  ⊳  playbook bindings (run context)  ⊳  session  ⊳  project-context  ⊳  env  ⊳  default`

Implemented by `resolveStepBindings(node, context)` (new pure, exported, unit-tested helper):
1. Each `node.inputs` value is a `{{path}}` template, resolved against the run `context` exposed to the canonical resolver through the dot-notation-capable `projectContext` tier (so `{{inputs.epicId}}`, `{{context.foo.bar}}`, and flat `{{epicId}}` all resolve) plus `process.env` (the `env` tier).
2. The resolved key/value pairs are merged **LAST** over the run context — `{ ...context, ...resolvedInputs }` — so a step input always **shadows** a same-named context key.

### Missing-key rule
**Lenient.** An unresolved `{{path}}` is left as a literal placeholder in the bound value (e.g. `{{missing}}` stays `"{{missing}}"`) — mirroring the canonical T1238 posture. A missing input never aborts the dispatch; the agent receives the literal placeholder and can fail loudly downstream if it is required.

### Design notes
- Reuses the canonical T1238 `DefaultVariableResolver` rather than introducing a second `{{}}` resolver. Re-exported `defaultVariableResolver` from the `@cleocode/core` main index so the runtime avoids `@cleocode/core/internal` (lint-core-first RULE-3) — mirrors the existing `getEnsuresSchema` import path.
- `node.inputs`-free nodes get a shallow copy of `context` as `bindings`, so the field is always a usable map (never `undefined` at runtime).
- No source-context mutation (asserted in tests).

### Gates (all run cgroup-capped, daemon-OFF)
- `pnpm biome check` — clean.
- Full workspace build — success.
- **FULL `pnpm run typecheck` (`tsc -b`, all packages)** — clean (exit 0).
- `pnpm --filter @cleocode/playbooks run test` — **156 passed / 11 files**.
- Arch gates (baseline): contracts-purity ✓ (no net-new runtime, baseline 53) · contracts fan-out ✓ · CLI boundary ✓ (33=33, untouched).
- No new canon `.md`; no lockfile change.

### Files changed
- `packages/playbooks/src/runtime.ts` — `resolveStepBindings()` helper; `AgentDispatchInput.bindings`; `executeAgenticNode` wiring.
- `packages/playbooks/src/index.ts` — export `resolveStepBindings`.
- `packages/core/src/index.ts` — re-export `defaultVariableResolver` (T1238 SSoT).
- `packages/playbooks/src/__tests__/inputs-bindings.test.ts` — new (pure unit + in-process e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)