### PR TITLE
fix(T11733): unbreak no-hardcoded-models guard — remove model literal from models-catalog TSDoc

### DIFF
--- a/packages/core/src/store/schema/cleo-global/models-catalog.ts
+++ b/packages/core/src/store/schema/cleo-global/models-catalog.ts
@@ -65,7 +65,7 @@ import { index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-co
 export const modelsCatalog = sqliteTable(
   'models_catalog',
   {
-    /** Model id — the catalog key (e.g. `claude-haiku-4-5-20251001`). Natural PK. */
+    /** Model id — the catalog key (a models.dev id, e.g. `openai/gpt-5.5`). Natural PK. */
     id: text('id').primaryKey(),
     /** Provider key (models.dev id, e.g. `anthropic` | `openai` | `google`). */
     providerId: text('provider_id').notNull(),


### PR DESCRIPTION
## Regression fix (from this session's #1037)

The M3 catalog PR (#1037) left `claude-haiku-4-5-20251001` in a TSDoc **example** inside `packages/core/src/store/schema/cleo-global/models-catalog.ts:68` — outside the `src/llm/` scope the `no-hardcoded-models` drift guard allows. That guard (`packages/core/src/llm/__tests__/no-hardcoded-models.test.ts`) therefore fails on `main` (Unit Tests shard).

**Fix:** swap the TSDoc example for a models.dev id (`openai/gpt-5.5`) — one-line doc-comment change, zero behaviour. Verified no other instance of the full literal remains outside the allowed scope.

This was caught by a peer build agent inheriting the red shard; surfaced + fixed CORE-first per the DHQ mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)