### PR TITLE
feat(T11802): M4 done-gate — route cantbook dispatch through guard.ts + prove rcasd.cantbook → ONE LAFS envelope, no GenKit

### DIFF
--- a/packages/cleo/src/dispatch/domains/playbook.ts
+++ b/packages/cleo/src/dispatch/domains/playbook.ts
@@ -50,6 +50,7 @@ import {
   type AgentDispatcher,
   type AgentDispatchInput,
   type AgentDispatchResult,
+  type DeterministicRunner,
   E_PLAYBOOK_RESUME_BLOCKED,
   E_PLAYBOOK_RUNTIME_INVALID,
   type ExecutePlaybookResult,
@@ -93,6 +94,12 @@ export interface PlaybookRuntimeOverrides {
   db?: _DatabaseSyncType;
   /** Dispatcher to invoke for `agentic` nodes. */
   dispatcher?: AgentDispatcher;
+  /**
+   * Runner to invoke for `deterministic` (shell/tool) nodes. When tests override
+   * this they bypass {@link buildDefaultDeterministicRunner} entirely. Production
+   * callers leave it unset and get the guard-routed runner (T11802).
+   */
+  deterministicRunner?: DeterministicRunner;
   /**
    * Directory resolver for starter playbooks. Defaults to
    * `packages/playbooks/starter` but tests can point to a fixture dir.
@@ -338,11 +345,19 @@ async function buildDefaultDispatcher(): Promise<AgentDispatcher> {
     maybeCreatePiRunner,
     resolveCantbookNodeProfile,
     hasCantbookProfilePin,
+    DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
   } = await import('@cleocode/core/internal');
   const projectRoot = getProjectRoot();
-  // In-process skill nodes execute over a deny-first guarded tool surface scoped
-  // to the project root (T11477 · AC4). Isolation/agent nodes keep spawning.
-  const tools = createToolGuard({ allowedRoots: [projectRoot] });
+  // In-process skill nodes (and, via buildDefaultDeterministicRunner, every
+  // `deterministic` shell step) execute over the SAME deny-first guarded tool
+  // surface scoped to the project root (T11477 · AC4 + T11802 · AC1). The shell
+  // denylist + `enforce` mode make a denied command reject BEFORE any process is
+  // spawned (T11802 · AC3). Isolation/agent nodes keep spawning subagents.
+  const tools = createToolGuard({
+    allowedRoots: [projectRoot],
+    deniedCommands: DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
+    mode: 'enforce',
+  });
   // M4 keystone (T11945): when CLEO_PI_RUNNER_ENABLED=1, route in-process skill
   // nodes THROUGH the Pi agent loop. Default-OFF → `undefined` → defaultSkillRunner
   // (zero behaviour change). The helper lazy-imports the Pi barrel only when enabled.
@@ -447,6 +462,46 @@ async function buildDefaultDispatcher(): Promise<AgentDispatcher> {
       }
     },
   };
+}
+
+/**
+ * Build the default {@link DeterministicRunner} for `deterministic` (shell/tool)
+ * nodes (T11802). Every command is routed through the guard.ts deny-first
+ * chokepoint — the SAME guard (`allowedRoots` + `deniedCommands` + `enforce`)
+ * the skill executor uses — so NO `.cantbook` shell step can bypass the policy
+ * point (AC1) and a denied command is rejected before any spawn (AC3).
+ *
+ * Returns `undefined` (the runtime then applies its own fallback) in two cases:
+ *  - a test sets {@link PlaybookRuntimeOverrides.dispatcher} but not
+ *    `deterministicRunner` — the test wants a fully hermetic run, so the
+ *    production guard (which would call `getProjectRoot()`) is NOT constructed;
+ *    the runtime's deterministic→agentic fallback keeps existing tests
+ *    behaviour-identical.
+ *
+ * @internal
+ */
+async function buildDefaultDeterministicRunner(): Promise<DeterministicRunner | undefined> {
+  if (__playbookRuntimeOverrides.deterministicRunner) {
+    return __playbookRuntimeOverrides.deterministicRunner;
+  }
+  // Hermetic-test mode: a dispatcher override with no deterministic runner means
+  // the caller wants no production side effects — defer to the runtime fallback.
+  if (__playbookRuntimeOverrides.dispatcher) {
+    return undefined;
+  }
+  const {
+    getProjectRoot,
+    createToolGuard,
+    createGuardedDeterministicRunner,
+    DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
+  } = await import('@cleocode/core/internal');
+  const projectRoot = getProjectRoot();
+  const tools = createToolGuard({
+    allowedRoots: [projectRoot],
+    deniedCommands: DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
+    mode: 'enforce',
+  });
+  return createGuardedDeterministicRunner({ tools });
 }
 
 /**
@@ -683,6 +738,9 @@ const _playbookTypedHandler = defineTypedHandler<PlaybookOps>('playbook', {
 
     const db = await acquireDb();
     const dispatcher = await buildDefaultDispatcher();
+    // T11802: route every `deterministic` (shell) node through the guard.ts
+    // deny-first chokepoint — no .cantbook shell step bypasses the policy point.
+    const deterministicRunner = await buildDefaultDeterministicRunner();
     let result: ExecutePlaybookResult;
     try {
       const { getProjectRoot } = await import('@cleocode/core/internal');
@@ -694,6 +752,7 @@ const _playbookTypedHandler = defineTypedHandler<PlaybookOps>('playbook', {
         dispatcher,
         projectRoot: getProjectRoot(),
       };
+      if (deterministicRunner !== undefined) opts.deterministicRunner = deterministicRunner;
       if (__playbookRuntimeOverrides.approvalSecret !== undefined) {
         opts.approvalSecret = __playbookRuntimeOverrides.approvalSecret;
       }
@@ -793,6 +852,7 @@ const _playbookTypedHandler = defineTypedHandler<PlaybookOps>('playbook', {
     }
 
     const dispatcher = await buildDefaultDispatcher();
+    const deterministicRunner = await buildDefaultDeterministicRunner();
     try {
       const opts: Parameters<typeof resumePlaybook>[0] = {
         db,
@@ -800,6 +860,7 @@ const _playbookTypedHandler = defineTypedHandler<PlaybookOps>('playbook', {
         approvalToken: latest.token,
         dispatcher,
       };
+      if (deterministicRunner !== undefined) opts.deterministicRunner = deterministicRunner;
       if (__playbookRuntimeOverrides.approvalSecret !== undefined) {
         opts.approvalSecret = __playbookRuntimeOverrides.approvalSecret;
       }

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1010,6 +1010,18 @@ export {
 export { listPhases, showPhase } from './pipeline/index.js';
 // Platform (additional)
 export { getNodeUpgradeInstructions, getNodeVersionInfo } from './platform.js';
+// Guarded deterministic runner — routes every `deterministic` (shell) node
+// dispatch in executePlaybook through the guard.ts deny-first chokepoint (T11802).
+export type {
+  GuardedDeterministicInput,
+  GuardedDeterministicResult,
+  GuardedDeterministicRunner,
+  GuardedDeterministicRunnerOptions,
+} from './playbooks/guarded-deterministic-runner.js';
+export {
+  createGuardedDeterministicRunner,
+  DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
+} from './playbooks/guarded-deterministic-runner.js';
 // Skill-node routing — in-process skill execution + retained subprocess spawn (T11477).
 export type { SkillNodeDispatchInput } from './playbooks/skill-node-executor.js';
 export { ISOLATION_CONTEXT_KEY, runSkillNodeOrSpawn } from './playbooks/skill-node-executor.js';

--- a/packages/core/src/playbooks/guarded-deterministic-runner.ts
+++ b/packages/core/src/playbooks/guarded-deterministic-runner.ts
@@ -1,0 +1,222 @@
+/**
+ * Guarded deterministic-node runner — routes EVERY `deterministic` (shell/tool)
+ * dispatch in `executePlaybook` through the `guard.ts` deny-first chokepoint
+ * (T11802 · M4 cantbook done-gate).
+ *
+ * ## The gap this closes (AC1)
+ *
+ * The playbook runtime (`@cleocode/playbooks/runtime`) executes `deterministic`
+ * nodes through an INJECTED `DeterministicRunner`. When no runner is injected it
+ * degrades to `AgentDispatcher.dispatch` with a synthetic `deterministic:<cmd>`
+ * agent id — a path that NEVER touches the `guard.ts` shell denylist. So a
+ * `.cantbook` shell step could spawn a subprocess that bypasses the single
+ * policy point.
+ *
+ * This factory builds the CANONICAL production `DeterministicRunner`: every
+ * command is funnelled through the injected {@link GuardedToolSurface}'s
+ * `executeShell` — the SAME deny-first command policy + env-scrub chokepoint
+ * (`createToolGuard`) that in-process skill nodes already use (T11477). There is
+ * NO second subprocess code path: shell steps and skill→tool calls share ONE
+ * guard. The runtime stays a pure state machine (it imports no `child_process`);
+ * the guard owns the spawn (AC1).
+ *
+ * ## Deny semantics (AC3)
+ *
+ * The guard's `executeShell` checks the command basename against the policy
+ * denylist BEFORE any process is spawned. In `mode: 'enforce'` a denied command
+ * rejects with {@link GuardDeniedError} (`E_TOOL_GUARD_DENIED`); this runner
+ * catches that rejection and maps it to a contract-clean
+ * `{ status: 'failure', error }` envelope so the runtime's retry / escalation
+ * semantics stay intact (the runtime contract is non-throwing). In `mode: 'warn'`
+ * the guard logs-and-proceeds — the denylist is advisory — so a guarded runner
+ * built for enforcement MUST be constructed from an `enforce`-mode guard.
+ *
+ * ## Why a factory over a guard (DIP)
+ *
+ * The runner depends on the abstract {@link GuardedToolSurface} (the contract
+ * shape of `createToolGuard()`), NOT on the concrete guard — so the policy point
+ * is injected, exactly mirroring {@link createSkillNodeExecutor}. `core` builds
+ * the guard once (`createToolGuard({ allowedRoots, deniedCommands, mode })`) and
+ * hands the same surface to BOTH the skill executor and this deterministic
+ * runner.
+ *
+ * @epic T11391
+ * @task T11802
+ * @saga T11387
+ * @see ../tools/guard.ts — the deny-first chokepoint
+ * @see ./skill-node-executor.ts — the sibling in-process skill path
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+
+/**
+ * Canonical deny-list of destructive command basenames a `.cantbook`
+ * `deterministic` node may NOT run (T11802 · AC3). This is the SSoT the
+ * production dispatcher hands to `createToolGuard({ deniedCommands })` so the
+ * SAME chokepoint that guards in-process skill→tool calls also rejects a
+ * dangerous shell step. Matched against the command's last path segment by the
+ * guard, so `/bin/rm` and `rm` are both denied.
+ *
+ * Intentionally conservative — destructive disk / process / system operations a
+ * planning playbook should never invoke. Extend deliberately; every addition is
+ * a policy decision.
+ */
+export const DEFAULT_DETERMINISTIC_DENIED_COMMANDS: readonly string[] = Object.freeze([
+  'rm',
+  'rmdir',
+  'shutdown',
+  'reboot',
+  'mkfs',
+  'dd',
+  'shred',
+  'fdisk',
+  'mkswap',
+  'kill',
+  'killall',
+]);
+
+/**
+ * Minimal projection of the playbook runtime's `DeterministicRunInput` that the
+ * guarded runner consumes. Declared structurally so `@cleocode/core` does NOT
+ * import `@cleocode/playbooks` (preserves the directed layering
+ * `contracts → core → playbooks`). The runtime's input is structurally
+ * assignable to this shape.
+ */
+export interface GuardedDeterministicInput {
+  /** Playbook run identifier (FK into `playbook_runs.run_id`). */
+  readonly runId: string;
+  /** Node identifier within the run graph. */
+  readonly nodeId: string;
+  /** Executable to run (NOT a shell string — args are passed separately). */
+  readonly command: string;
+  /** Arguments passed to {@link GuardedDeterministicInput.command}. */
+  readonly args: readonly string[];
+  /** Working directory. Defaults to `process.cwd()` in the shell primitive. */
+  readonly cwd?: string;
+  /** Extra environment variables merged (and scrubbed) over the child env. */
+  readonly env?: Readonly<Record<string, string>>;
+  /** Hard timeout in milliseconds; the process is killed when exceeded. */
+  readonly timeout_ms?: number;
+}
+
+/**
+ * Terminal output of a guarded deterministic execution. Structurally identical
+ * to the runtime's `DeterministicRunResult` so this runner is assignable to the
+ * runtime's `DeterministicRunner` interface without a wrapper.
+ */
+export interface GuardedDeterministicResult {
+  status: 'success' | 'failure';
+  /** Key-value pairs merged into the run context on success. */
+  output: Record<string, unknown>;
+  /** Human-readable failure reason on `status === 'failure'`. */
+  error?: string;
+}
+
+/**
+ * Structural match for the playbook runtime's `DeterministicRunner` interface.
+ * Re-declared here (not imported) for the same directed-layering reason as
+ * {@link GuardedDeterministicInput}.
+ */
+export interface GuardedDeterministicRunner {
+  run(input: GuardedDeterministicInput): Promise<GuardedDeterministicResult>;
+}
+
+/**
+ * Options accepted by {@link createGuardedDeterministicRunner}.
+ *
+ * @task T11802
+ */
+export interface GuardedDeterministicRunnerOptions {
+  /**
+   * The deny-first guarded tool surface every deterministic command is routed
+   * through. Typically the SAME `createToolGuard({ allowedRoots, deniedCommands,
+   * mode })` result handed to the in-process skill executor — so shell steps and
+   * skill→tool calls share ONE policy point. Injected (DIP) — the runner never
+   * constructs its own guard.
+   */
+  readonly tools: GuardedToolSurface;
+}
+
+/**
+ * Build a {@link GuardedDeterministicRunner} that routes EVERY `deterministic`
+ * node command through the injected guard's `executeShell` (T11802 · AC1).
+ *
+ * Inject the result as `deterministicRunner` when calling `executePlaybook`:
+ *
+ * @example
+ * ```ts
+ * import { createToolGuard } from '@cleocode/core/internal';
+ *
+ * const tools = createToolGuard({
+ *   allowedRoots: [projectRoot],
+ *   deniedCommands: ['rm', 'shutdown', 'mkfs'],
+ *   mode: 'enforce',
+ * });
+ * await executePlaybook({
+ *   db, playbook, playbookHash, initialContext, dispatcher,
+ *   deterministicRunner: createGuardedDeterministicRunner({ tools }),
+ * });
+ * // A `deterministic` node running `rm` → guard rejects → { status: 'failure' }
+ * ```
+ *
+ * The returned runner NEVER throws — a guard `enforce`-mode rejection
+ * ({@link import('../tools/guard.js').GuardDeniedError}) is caught and mapped to
+ * a `{ status: 'failure', error }` envelope so the runtime's retry / escalation
+ * stays intact (the runtime's `DeterministicRunner` contract is non-throwing).
+ *
+ * @param opts - The injected guarded tool surface.
+ * @returns A runner assignable to the runtime's `DeterministicRunner`.
+ * @task T11802
+ */
+export function createGuardedDeterministicRunner(
+  opts: GuardedDeterministicRunnerOptions,
+): GuardedDeterministicRunner {
+  const { tools } = opts;
+  return {
+    async run(input: GuardedDeterministicInput): Promise<GuardedDeterministicResult> {
+      try {
+        // The guard checks the command basename against the denylist BEFORE
+        // spawning (deny → reject in enforce mode), then scrubs the child env at
+        // the chokepoint. This is the ONLY shell-spawn path for deterministic
+        // nodes — there is no bypass.
+        const result = await tools.executeShell({
+          command: input.command,
+          args: [...input.args],
+          ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+          ...(input.env !== undefined ? { env: input.env } : {}),
+          ...(input.timeout_ms !== undefined ? { timeoutMs: input.timeout_ms } : {}),
+        });
+        // A non-zero exit is a node failure, not a thrown error — mirror the
+        // shell primitive's "exit code is the result" contract.
+        if (result.code === 0) {
+          return {
+            status: 'success',
+            output: {
+              [`${input.nodeId}_stdout`]: result.stdout,
+              [`${input.nodeId}_exitCode`]: result.code,
+            },
+          };
+        }
+        return {
+          status: 'failure',
+          output: {
+            [`${input.nodeId}_stdout`]: result.stdout,
+            [`${input.nodeId}_stderr`]: result.stderr,
+            [`${input.nodeId}_exitCode`]: result.code,
+          },
+          error:
+            `deterministic node "${input.nodeId}" command "${input.command}" exited ` +
+            `${result.code === null ? 'on signal/timeout' : `with code ${result.code}`}`,
+        };
+      } catch (err) {
+        // Guard-denied (enforce mode) or an unexpected spawn error — never let it
+        // escape; the runtime contract is non-throwing.
+        return {
+          status: 'failure',
+          output: {},
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  };
+}

--- a/packages/playbooks/src/__tests__/guarded-deterministic-dispatch.test.ts
+++ b/packages/playbooks/src/__tests__/guarded-deterministic-dispatch.test.ts
@@ -1,0 +1,225 @@
+/**
+ * T11802 (M4 cantbook done-gate) — every `deterministic` (shell) node dispatch in
+ * `executePlaybook` routes through the `guard.ts` deny-first chokepoint.
+ *
+ * ## What this proves
+ *
+ *  - **AC1 / AC2** — a minimal `.cantbook` with a `deterministic` shell step,
+ *    executed through the REAL {@link executePlaybook} runtime with the
+ *    production-shaped {@link createGuardedDeterministicRunner} wired to a real
+ *    {@link createToolGuard}, reaches the guard: the spawned command actually runs
+ *    THROUGH `guard.executeShell` (proven by captured stdout in the merged run
+ *    context). There is NO `child_process` import in the runtime call graph — the
+ *    guard owns the spawn.
+ *  - **AC3** — when the SAME runtime dispatches a `deterministic` node whose
+ *    command is on the guard's denylist (`enforce` mode), the guard REJECTS it
+ *    BEFORE any process is spawned; the node terminates as a contained failure
+ *    (the runtime contract is non-throwing) carrying the guard's
+ *    `E_TOOL_GUARD_DENIED` message.
+ *  - **AC5** — no new state machine: the runtime is unchanged; only the injected
+ *    `deterministicRunner` is the guard-routed one.
+ *
+ * ## Determinism + isolation
+ *
+ *  - IN-PROCESS only — vitest source, NO subprocess driver (tsx unresolvable in CI).
+ *  - daemon-OFF — an in-memory `node:sqlite` DB, no daemon.
+ *  - The allowed command is `node -e <print>` (always present on the test box, no
+ *    network, no filesystem mutation) so the "guard actually spawned" assertion is
+ *    portable and side-effect-free.
+ *  - A temp project root scopes the guard's `allowedRoots`; `cwd` is pinned to it.
+ *
+ * @epic T11391
+ * @task T11802
+ * @saga T11387
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import type { PlaybookDefinition, PlaybookDeterministicNode } from '@cleocode/contracts';
+import {
+  createGuardedDeterministicRunner,
+  createToolGuard,
+  DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
+} from '@cleocode/core/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type DeterministicRunner, executePlaybook } from '../runtime.js';
+
+const _require = createRequire(import.meta.url);
+type DatabaseSync = _DatabaseSyncType;
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => DatabaseSync;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the T889 playbook-tables migration SQL. */
+const MIGRATION_SQL = resolve(
+  __dirname,
+  '../../../core/migrations/drizzle-tasks/20260417220000_t889-playbook-tables/migration.sql',
+);
+
+/** Apply a multi-statement Drizzle migration (split on the breakpoint token). */
+function applyMigration(db: DatabaseSync, sql: string): void {
+  const statements = sql
+    .split(/--> statement-breakpoint/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of statements) {
+    const lines = stmt.split('\n');
+    const hasSql = lines.some((l) => l.trim().length > 0 && !l.trim().startsWith('--'));
+    if (hasSql) db.exec(stmt);
+  }
+}
+
+/** Build a single-node `deterministic` playbook (the entry node is terminal). */
+function singleDeterministicPlaybook(node: PlaybookDeterministicNode): PlaybookDefinition {
+  return { version: '1.0', name: 'guarded-shell', nodes: [node], edges: [] };
+}
+
+describe('T11802 (M4): deterministic node dispatch routes through guard.ts', () => {
+  let db: DatabaseSync;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys=ON');
+    applyMigration(db, readFileSync(MIGRATION_SQL, 'utf8'));
+    projectRoot = mkdtempSync(join(tmpdir(), 't11802-guarded-shell-'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  /**
+   * Build the production-shaped deterministic runner: the SAME guard the CLI's
+   * `buildDefaultDeterministicRunner` constructs (allowedRoots + denylist +
+   * enforce), wrapped by `createGuardedDeterministicRunner`.
+   */
+  function buildGuardedRunner(): DeterministicRunner {
+    const tools = createToolGuard({
+      allowedRoots: [projectRoot],
+      deniedCommands: DEFAULT_DETERMINISTIC_DENIED_COMMANDS,
+      mode: 'enforce',
+    });
+    // Structurally assignable to the runtime's DeterministicRunner.
+    return createGuardedDeterministicRunner({ tools });
+  }
+
+  it('AC2: a shell step is intercepted by the guard — the command runs THROUGH guard.executeShell', async () => {
+    // `node -e` prints a sentinel; capturing it proves the guard actually
+    // spawned the process (not a mock).
+    const SENTINEL = 'guard-intercepted-T11802';
+    const node: PlaybookDeterministicNode = {
+      id: 'shell',
+      type: 'deterministic',
+      command: process.execPath, // node — always present, never on the denylist
+      args: ['-e', `process.stdout.write(${JSON.stringify(SENTINEL)})`],
+      cwd: projectRoot,
+    };
+
+    const result = await executePlaybook({
+      db,
+      playbook: singleDeterministicPlaybook(node),
+      playbookHash: 'hash-allowed',
+      initialContext: { taskId: 'T11802' },
+      dispatcher: {
+        // The agentic dispatcher must NEVER be reached for a deterministic node.
+        async dispatch() {
+          return {
+            status: 'failure',
+            output: {},
+            error: 'agentic dispatcher reached for a deterministic node — guard bypassed!',
+          };
+        },
+      },
+      deterministicRunner: buildGuardedRunner(),
+    });
+
+    expect(result.terminalStatus).toBe('completed');
+    // The guard's executeShell captured the child's stdout into the merged
+    // context — dispositive that the command was spawned THROUGH the guard.
+    expect(result.finalContext['shell_stdout']).toBe(SENTINEL);
+    expect(result.finalContext['shell_exitCode']).toBe(0);
+  });
+
+  it('AC3: a denied command is rejected by the guard denylist when dispatched from executePlaybook', async () => {
+    // `rm` is on DEFAULT_DETERMINISTIC_DENIED_COMMANDS — the guard rejects it
+    // BEFORE any process is spawned (enforce mode).
+    expect(DEFAULT_DETERMINISTIC_DENIED_COMMANDS).toContain('rm');
+
+    const node: PlaybookDeterministicNode = {
+      id: 'danger',
+      type: 'deterministic',
+      command: 'rm',
+      args: ['-rf', join(projectRoot, 'anything')],
+      cwd: projectRoot,
+      // One attempt → first denial is terminal (no retry storms).
+      on_failure: { max_iterations: 1 },
+    };
+
+    const result = await executePlaybook({
+      db,
+      playbook: singleDeterministicPlaybook(node),
+      playbookHash: 'hash-denied',
+      initialContext: { taskId: 'T11802' },
+      dispatcher: {
+        async dispatch() {
+          return {
+            status: 'failure',
+            output: {},
+            error: 'agentic dispatcher reached for a deterministic node — guard bypassed!',
+          };
+        },
+      },
+      deterministicRunner: buildGuardedRunner(),
+      maxIterationsDefault: 1,
+    });
+
+    // The denial is a contained node failure (the runtime never throws).
+    expect(result.terminalStatus).toBe('exceeded_iteration_cap');
+    expect(result.exceededNodeId).toBe('danger');
+    // The guard's enforce-mode rejection message reached the runtime.
+    expect(result.errorContext ?? '').toMatch(/denylist|E_TOOL_GUARD_DENIED|"rm"/);
+  });
+
+  it('AC1: the guard is the ONLY spawn path — a denied command never spawns rm', async () => {
+    // Targeting a path INSIDE the project root so, IF the guard were bypassed,
+    // rm would actually delete it. The guard must stop it first. We assert the
+    // failure shape (no rm executed) rather than filesystem side effects so the
+    // test is hermetic even on a box without `rm`.
+    const node: PlaybookDeterministicNode = {
+      id: 'danger',
+      type: 'deterministic',
+      command: '/bin/rm', // absolute path — basename `rm` is still denied
+      args: ['-f', join(projectRoot, 'sentinel')],
+      cwd: projectRoot,
+      on_failure: { max_iterations: 1 },
+    };
+
+    let agenticReached = false;
+    const result = await executePlaybook({
+      db,
+      playbook: singleDeterministicPlaybook(node),
+      playbookHash: 'hash-abs-denied',
+      initialContext: { taskId: 'T11802' },
+      dispatcher: {
+        async dispatch() {
+          agenticReached = true;
+          return { status: 'success', output: { bypassed: true } };
+        },
+      },
+      deterministicRunner: buildGuardedRunner(),
+      maxIterationsDefault: 1,
+    });
+
+    expect(agenticReached).toBe(false); // never fell back to the agentic path
+    expect(result.terminalStatus).toBe('exceeded_iteration_cap');
+    expect(result.errorContext ?? '').toMatch(/denylist|E_TOOL_GUARD_DENIED|"rm"/);
+  });
+});

--- a/packages/playbooks/src/__tests__/rcasd-one-envelope.test.ts
+++ b/packages/playbooks/src/__tests__/rcasd-one-envelope.test.ts
@@ -1,0 +1,239 @@
+/**
+ * T11803 (M4 cantbook done-gate) — prove the vertical slice: `rcasd.cantbook`
+ * execution terminates with EXACTLY ONE LAFS `RenderableEnvelope`, and there is
+ * NO GenKit import anywhere in the execution call graph.
+ *
+ * ## What this proves
+ *
+ *  - **AC1** — the REAL starter `rcasd.cantbook` is parsed and driven end-to-end
+ *    through {@link executePlaybook} (parse → execute → terminal envelope). The
+ *    five agentic stages are stubbed by a DETERMINISTIC recording dispatcher (no
+ *    LLM backend authenticates on CI, and the point of this gate is the ENVELOPE
+ *    SHAPE + the import graph — NOT a live model round-trip).
+ *  - **AC2** — the terminal result is folded into exactly ONE LAFS envelope (the
+ *    ADR-077 `RenderableEnvelope<T>` `{ kind: 'single', data }` wrapped by the
+ *    canonical `createEnvelope` SSoT) and that envelope passes the
+ *    `@cleocode/lafs` `validateEnvelope` schema validator. Exactly one — the run
+ *    produces one `ExecutePlaybookResult`, which maps to one envelope.
+ *  - **AC3** — NO `@genkit-ai` / GenKit import in the execution call graph: a
+ *    static module-graph walk over every playbooks `src/` file reachable from
+ *    `runtime.ts` (the executePlaybook entry) via intra-package imports asserts
+ *    zero GenKit specifiers, and the runtime entry imports none directly.
+ *  - **AC5** — the test is NOT skipped (no `.skip`, no `it.skipIf`).
+ *
+ * ## Determinism + isolation
+ *
+ *  - IN-PROCESS only — vitest source, NO subprocess (tsx unresolvable in CI).
+ *  - daemon-OFF — an in-memory `node:sqlite` DB, no daemon, no live LLM.
+ *  - The dispatcher emits each stage's `ensures.schema`-satisfying output so the
+ *    rcasd contract gates pass and the run reaches `completed` — a faithful
+ *    full-pipeline traversal, deterministically.
+ *
+ * @epic T11391
+ * @task T11803
+ * @saga T11387
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import type { RenderableEnvelope } from '@cleocode/contracts';
+import { createEnvelope, validateEnvelope } from '@cleocode/lafs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parsePlaybook } from '../parser.js';
+import {
+  type AgentDispatcher,
+  type AgentDispatchInput,
+  type AgentDispatchResult,
+  type ExecutePlaybookResult,
+  executePlaybook,
+} from '../runtime.js';
+
+const _require = createRequire(import.meta.url);
+type DatabaseSync = _DatabaseSyncType;
+const { DatabaseSync } = _require('node:sqlite') as {
+  DatabaseSync: new (...args: ConstructorParameters<typeof _DatabaseSyncType>) => DatabaseSync;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PLAYBOOKS_SRC = resolve(__dirname, '..');
+
+const MIGRATION_SQL = resolve(
+  __dirname,
+  '../../../core/migrations/drizzle-tasks/20260417220000_t889-playbook-tables/migration.sql',
+);
+const RCASD_CANTBOOK = resolve(__dirname, '../../starter/rcasd.cantbook');
+
+function applyMigration(db: DatabaseSync, sql: string): void {
+  const statements = sql
+    .split(/--> statement-breakpoint/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of statements) {
+    const lines = stmt.split('\n');
+    const hasSql = lines.some((l) => l.trim().length > 0 && !l.trim().startsWith('--'));
+    if (hasSql) db.exec(stmt);
+  }
+}
+
+/**
+ * Deterministic recording dispatcher that emits each rcasd stage's
+ * `ensures.schema`-satisfying output + the `requires`/edge fields the next stage
+ * needs, so the full five-stage pipeline reaches `completed` with NO LLM. Keyed
+ * by `nodeId` (the rcasd stage names).
+ */
+function makeRcasdDispatcher(): AgentDispatcher & { nodes: string[] } {
+  const nodes: string[] = [];
+  // Per-stage outputs satisfying rcasd.cantbook ensures.schema + downstream
+  // requires/edge contracts. The first four stages' ensures.schema names
+  // (research_summary | consensus_decision | architecture_plan |
+  // specification_document) are registered passthrough; the terminal
+  // `decomposition` stage's `task_tree` is STRICT — it validates
+  // `context['task_tree']` as a non-empty array of { title, acceptance[] }
+  // entries — so we emit a conformant `task_tree` to clear the contract gate.
+  const STAGE_OUTPUT: Record<string, Record<string, unknown>> = {
+    research: {
+      summary: 'research summary for the epic',
+      risks: ['risk-a', 'risk-b'],
+    },
+    consensus: {
+      decision: 'proceed with approach X',
+    },
+    architecture: {
+      patterns: ['pattern-1', 'pattern-2'],
+      adrs: ['ADR-001'],
+    },
+    specification: {
+      acceptance: ['AC1', 'AC2'],
+      requirements: ['REQ-1'],
+    },
+    decomposition: {
+      // `children` satisfies the specification→decomposition edge.ensures.
+      children: ['T1001', 'T1002'],
+      acceptance: ['AC1'],
+      requirements: ['REQ-1'],
+      // `task_tree` satisfies the strict ensures.schema on the terminal stage.
+      task_tree: [
+        { id: 'T1001', title: 'Implement feature A', acceptance: ['AC1'] },
+        { id: 'T1002', title: 'Implement feature B', acceptance: ['AC2'] },
+      ],
+    },
+  };
+  return {
+    nodes,
+    async dispatch(input: AgentDispatchInput): Promise<AgentDispatchResult> {
+      nodes.push(input.nodeId);
+      return { status: 'success', output: STAGE_OUTPUT[input.nodeId] ?? {} };
+    },
+  };
+}
+
+/**
+ * Recursively collect every `*.ts` source file under `dir` (excluding tests),
+ * so the no-GenKit assertion covers the WHOLE playbooks runtime package surface
+ * reachable by the execution path — not just the entry file.
+ */
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue;
+      out.push(...collectSourceFiles(full));
+    } else if (entry.name.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('T11803 (M4): rcasd.cantbook → exactly ONE LAFS envelope, no GenKit', () => {
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys=ON');
+    applyMigration(db, readFileSync(MIGRATION_SQL, 'utf8'));
+  });
+  afterEach(() => db.close());
+
+  it('AC1+AC2: parse→execute→envelope yields exactly ONE valid LAFS RenderableEnvelope', async () => {
+    const { definition, sourceHash } = parsePlaybook(readFileSync(RCASD_CANTBOOK, 'utf8'));
+    expect(definition.name).toBe('rcasd');
+    expect(definition.nodes.map((n) => n.id)).toEqual([
+      'research',
+      'consensus',
+      'architecture',
+      'specification',
+      'decomposition',
+    ]);
+
+    const dispatcher = makeRcasdDispatcher();
+    const result: ExecutePlaybookResult = await executePlaybook({
+      db,
+      playbook: definition,
+      playbookHash: sourceHash,
+      initialContext: { taskId: 'T999', epicId: 'T999', scope: 'global' },
+      dispatcher,
+    });
+
+    // The full five-stage pipeline ran deterministically to completion.
+    expect(dispatcher.nodes).toEqual([
+      'research',
+      'consensus',
+      'architecture',
+      'specification',
+      'decomposition',
+    ]);
+    expect(result.terminalStatus).toBe('completed');
+    // No silent contract violation hid behind the completion.
+    expect(result.finalContext['__ensuresSchemaViolation']).toBeUndefined();
+    expect(result.finalContext['__contractViolation']).toBeUndefined();
+
+    // Fold the single terminal result into ONE ADR-077 RenderableEnvelope, then
+    // into ONE canonical LAFS envelope (the SSoT `createEnvelope`).
+    const renderable: RenderableEnvelope<ExecutePlaybookResult> = {
+      kind: 'single',
+      data: result,
+    };
+    const lafsEnvelope = createEnvelope({
+      success: true,
+      result: renderable as unknown as Record<string, unknown>,
+      meta: { operation: 'playbook.run', requestId: `rcasd-${result.runId}` },
+    });
+
+    // EXACTLY ONE — a single object, not an array of envelopes.
+    expect(Array.isArray(lafsEnvelope)).toBe(false);
+    expect(lafsEnvelope.success).toBe(true);
+    expect(lafsEnvelope.result).toMatchObject({ kind: 'single' });
+
+    // Validated by the @cleocode/lafs schema validator.
+    const validation = validateEnvelope(lafsEnvelope);
+    expect(validation.errors).toEqual([]);
+    expect(validation.valid).toBe(true);
+  });
+
+  it('AC3: NO @genkit-ai / GenKit import in the execution call graph', () => {
+    // The execution call graph for executePlaybook (runtime → state, approval,
+    // parser, schema) lives entirely under packages/playbooks/src. Walk every
+    // non-test source file and assert zero GenKit specifiers.
+    const files = collectSourceFiles(PLAYBOOKS_SRC);
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    const GENKIT_IMPORT =
+      /(?:import|from|require)\s*(?:\(\s*)?['"]@?genkit(?:-ai)?(?:\/[^'"]*)?['"]/;
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      if (GENKIT_IMPORT.test(src)) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+
+    // And the runtime entry — the executePlaybook module itself — imports no
+    // GenKit specifier directly (belt-and-suspenders against a future edit).
+    const runtimeSrc = readFileSync(resolve(PLAYBOOKS_SRC, 'runtime.ts'), 'utf8');
+    expect(runtimeSrc).not.toMatch(/@?genkit/i);
+  });
+});


### PR DESCRIPTION
Closes the **M4 cantbook done-gate** — tasks **T11802** + **T11803** (children of T11478). One coherent vertical-slice gate-close. Built off latest `origin/main` (incl. #1043). daemon-OFF, deterministic, no live LLM round-trip.

## T11802 — every skill-node / shell dispatch routes through `guard.ts`

| AC | How |
|----|-----|
| **AC1** all `deterministic`/shell dispatches in `executePlaybook` route through `guard.ts` (no direct `child_process`) | New canonical `createGuardedDeterministicRunner` (`packages/core/src/playbooks/guarded-deterministic-runner.ts`) wraps the injected `GuardedToolSurface` and funnels EVERY command through `guard.executeShell` — the SAME deny-first command policy + env-scrub chokepoint (`createToolGuard`) the in-process skill executor already uses (T11477). The runtime stays a pure state machine; the guard owns the spawn. Wired into the CLI via `buildDefaultDeterministicRunner` (passed to `executePlaybook`/`resumePlaybook`). |
| **AC2** integration test: minimal `.cantbook` shell step → guard intercept confirmed | `packages/playbooks/src/__tests__/guarded-deterministic-dispatch.test.ts` runs a `deterministic` shell node (`node -e <print>`) through the REAL `executePlaybook` + production-shaped guarded runner; the command runs THROUGH `guard.executeShell` (proven by captured stdout in the merged context). |
| **AC3** guard deny-list rejects a disallowed command from `executePlaybook` | New `DEFAULT_DETERMINISTIC_DENIED_COMMANDS` SSoT (`rm`/`shutdown`/`mkfs`/`dd`/…) + `enforce` mode → a denylisted command (`rm`, `/bin/rm`) is rejected BEFORE any spawn; the node terminates as a contained failure carrying `E_TOOL_GUARD_DENIED`. The agentic dispatcher is asserted never-reached. |
| **AC5** no new state machine | The runtime is unchanged — only the injected `deterministicRunner` is the guard-routed one. |

## T11803 — vertical slice: `rcasd.cantbook` → exactly ONE LAFS envelope, no GenKit

| AC | How |
|----|-----|
| **AC1** vitest integration test runs `rcasd.cantbook` parse→execute→envelope | `packages/playbooks/src/__tests__/rcasd-one-envelope.test.ts` drives the REAL starter `rcasd.cantbook` through `executePlaybook` with a deterministic recording dispatcher (no LLM backend authenticates on CI; the gate is the envelope SHAPE + import graph, not a live round-trip). Each stage emits its `ensures.schema`-satisfying output, incl. a conformant strict `task_tree`, so the full 5-stage pipeline reaches `completed` with no silent contract violation. |
| **AC2** terminal result is exactly ONE LAFS `RenderableEnvelope` (validated by `@cleocode/lafs`) | The single `ExecutePlaybookResult` folds into one ADR-077 `RenderableEnvelope<T>` (`{ kind: 'single', data }`), wrapped by the canonical `createEnvelope` SSoT, and passes `@cleocode/lafs` `validateEnvelope` (`valid: true`, zero errors). |
| **AC3** no GenKit import in the execution call graph | A static module-graph walk over every playbooks `src/` file asserts ZERO `@genkit-ai`/`genkit` import specifiers; the runtime entry (`runtime.ts`) imports none directly. |
| **AC4/AC5** test green, not skipped | In-process only (NOT subprocess — tsx unresolvable in CI); no `.skip`. |

## Gates (all cgroup-capped, MemoryMax=16G)
- Full `pnpm run build` green · full `pnpm run typecheck` green
- **173** playbooks tests (incl. 5 new across 2 new files) · **35** core-playbooks · **227** core-tools (incl. `guard.test.ts`) — all pass
- `cleo check arch` baselines: DB-open guard **strict OK**, CLI boundary **33=baseline (0 net-new)**, contracts purity/fan-out OK, LLM chokepoint OK, tools-vs-skills OK
- No canon `.md` added

> Note: the pre-existing single-file isolation failure of `packages/cleo/src/dispatch/domains/__tests__/playbook.test.ts` under `vitest -c …` (`Cannot find package '@cleocode/core/store/background-jobs.js'` from `@cleocode/runtime/src`) reproduces IDENTICALLY on pristine `origin/main` with this change stashed out — a worktree resolution artifact, not a regression. The full project run in CI uses the proper alias chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)