### PR TITLE
feat(T11946): execute_code agent tool via PiExecutionEnv (Gondolin/in-process, M7)

### DIFF
--- a/packages/core/src/llm/pi/pi-gondolin-env.ts
+++ b/packages/core/src/llm/pi/pi-gondolin-env.ts
@@ -112,7 +112,7 @@ function execErr(code: string, message: string): PiResult<never, PiExecutionErro
  * two-token forms `git push` / `git remote` so a `git`-rooted egress is caught
  * even though `git`'s OWN basename is allowed (for `git diff` etc.).
  */
-const DENIED_EXEC_PREFIXES: readonly string[] = [
+export const DENIED_EXEC_PREFIXES: readonly string[] = [
   'gh',
   'npm publish',
   'cleo',
@@ -130,7 +130,7 @@ const DENIED_EXEC_PREFIXES: readonly string[] = [
  * @param command - The string command or argv array the env received.
  * @returns The matched denied prefix, or `null` when the command is allowed.
  */
-function deniedEgressVerb(command: string | readonly string[]): string | null {
+export function deniedEgressVerb(command: string | readonly string[]): string | null {
   const tokens = Array.isArray(command)
     ? [...command]
     : String(command)

--- a/packages/core/src/tools/__tests__/exec-code-agent-tool.test.ts
+++ b/packages/core/src/tools/__tests__/exec-code-agent-tool.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for the `execute_code` agent tool (T11946 · M7 · epic T11456).
+ *
+ * FULLY MOCKED — no real Gondolin VM, no QEMU, no `/dev/kvm`, no real subprocess.
+ * The execution env is supplied through an INJECTED fake selector that returns a
+ * fake {@link PiExecutionEnv}, so every assertion runs in-process with the optional
+ * `@earendil-works/gondolin` package ABSENT (the CI / most-developer-machines path).
+ *
+ * Covers:
+ *   - AC1 registered via the self-registering marker (not inline) + part of the
+ *     built-in catalog;
+ *   - AC2 resolves a PiExecutionEnv through `resolveExecutionEnv` and runs the
+ *     snippet via `env.exec` (selector IS called, output IS captured), with
+ *     gondolin ABSENT (the in-process path);
+ *   - availability mirrors browser_* — hidden unless `capabilities.codeExec === true`;
+ *   - egress verbs (gh / git push / npm publish / cleo) denied BEFORE `env.exec`;
+ *   - Zod schema validation (bad language / missing code → invalid-args);
+ *   - the dispatch engine's availability + timeout gating honored unchanged.
+ *
+ * @task T11946
+ * @epic T11456
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { describe, expect, it, vi } from 'vitest';
+import type { PiExecutionEnv } from '../../llm/pi/pi-execution-env.js';
+import type {
+  ResolveExecutionEnvOptions,
+  ResolveExecutionEnvSeams,
+} from '../../llm/pi/resolve-execution-env.js';
+import { AgentToolRegistry } from '../agent-registry.js';
+import { registerBuiltinAgentTools } from '../builtin-agent-tools.js';
+import { ToolCallBudget, ToolDispatchEngine } from '../dispatch.js';
+import {
+  buildExecCommand,
+  codeExecAvailable,
+  EXEC_CODE_LANGUAGES,
+  type ExecCodeResult,
+  type ExecutionEnvResolver,
+  registerExecCodeAgentTool,
+} from '../exec-code-agent-tool.js';
+import { createToolGuard } from '../guard.js';
+
+// ===========================================================================
+// Test doubles
+// ===========================================================================
+
+/** A captured `exec` call: the command line + the options the env received. */
+interface ExecCall {
+  readonly command: string;
+  readonly timeout: number | undefined;
+}
+
+/**
+ * Build a fake {@link PiExecutionEnv} that records every `exec` call and returns a
+ * canned process result. NO real VM / QEMU / subprocess — only the `exec` +
+ * `cleanup` members the tool touches are meaningful; the rest are inert stubs.
+ */
+function fakeEnv(canned: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  /** When set, `exec` returns a typed Result.err instead of a process result. */
+  err?: { code: string; message: string };
+}): { env: PiExecutionEnv; execCalls: ExecCall[]; cleanups: number } {
+  const execCalls: ExecCall[] = [];
+  const state = { cleanups: 0 };
+  const env: PiExecutionEnv = {
+    cwd: () => '/workspace',
+    absolutePath: (p) => p,
+    joinPath: (...s) => s.join('/'),
+    readTextFile: async () => ({ ok: true, value: '' }),
+    readTextLines: async () => ({ ok: true, value: [] }),
+    readBinaryFile: async () => ({ ok: true, value: new Uint8Array() }),
+    writeFile: async () => ({ ok: true, value: undefined }),
+    appendFile: async () => ({ ok: true, value: undefined }),
+    fileInfo: async () => ({ ok: true, value: { isFile: true, isDirectory: false } }),
+    listDir: async () => ({ ok: true, value: [] }),
+    canonicalPath: async () => ({ ok: true, value: '/workspace' }),
+    exists: async () => ({ ok: true, value: true }),
+    createDir: async () => ({ ok: true, value: undefined }),
+    remove: async () => ({ ok: true, value: undefined }),
+    createTempDir: async () => ({ ok: true, value: '/workspace' }),
+    createTempFile: async () => ({ ok: true, value: '/workspace' }),
+    exec: async (command, options) => {
+      execCalls.push({ command, timeout: options?.timeout });
+      if (canned.err !== undefined) {
+        return { ok: false, error: canned.err };
+      }
+      return {
+        ok: true,
+        value: {
+          stdout: canned.stdout ?? '',
+          stderr: canned.stderr ?? '',
+          exitCode: canned.exitCode ?? 0,
+        },
+      };
+    },
+    cleanup: async () => {
+      state.cleanups += 1;
+    },
+  };
+  return {
+    env,
+    execCalls,
+    get cleanups() {
+      return state.cleanups;
+    },
+  } as { env: PiExecutionEnv; execCalls: ExecCall[]; cleanups: number };
+}
+
+/** A guarded surface stub — the tool resolves its OWN env, so this is never used. */
+const noopGuardedSurface = {} as GuardedToolSurface;
+
+// ===========================================================================
+// AC1 — registration via the self-registering marker
+// ===========================================================================
+
+describe('execute_code — registration (AC1)', () => {
+  it('exports a self-registering marker that registers execute_code', async () => {
+    const mod = await import('../exec-code-agent-tool.js');
+    expect(typeof mod.registerAgentTools).toBe('function');
+    const registry = new AgentToolRegistry();
+    mod.registerAgentTools(registry);
+    expect(registry.get('execute_code')).toBeDefined();
+  });
+
+  it('is part of the built-in catalog with the right class/toolset', async () => {
+    const registry = new AgentToolRegistry();
+    registerBuiltinAgentTools(registry);
+    await registry.init({ skipBuiltins: true });
+    const tool = registry.get('execute_code');
+    expect(tool).toBeDefined();
+    expect(tool?.class).toBe('shell');
+    expect(tool?.toolset).toBe('agent');
+    expect(tool?.stateless).toBe(true);
+    // The tool lands in the `agent` toolset bucket (AC4).
+    expect(registry.byToolset('agent').some((t) => t.name === 'execute_code')).toBe(true);
+  });
+});
+
+// ===========================================================================
+// AC — availability mirrors browser_* (hidden unless capabilities.codeExec)
+// ===========================================================================
+
+describe('execute_code — availability gating', () => {
+  it('codeExecAvailable is false unless capabilities.codeExec === true', () => {
+    expect(codeExecAvailable({})).toBe(false);
+    expect(codeExecAvailable({ capabilities: {} })).toBe(false);
+    expect(codeExecAvailable({ capabilities: { codeExec: false } })).toBe(false);
+    expect(codeExecAvailable({ capabilities: { codeExec: true } })).toBe(true);
+  });
+
+  it('is registered but hidden by available() until the capability is advertised', async () => {
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry);
+    await registry.init({ skipBuiltins: true });
+    // Registered (visible in list) ...
+    expect(registry.list().some((t) => t.name === 'execute_code')).toBe(true);
+    // ... but NOT available without the capability ...
+    expect(registry.available({}).some((t) => t.name === 'execute_code')).toBe(false);
+    // ... and available once the host opts code-exec in.
+    expect(
+      registry
+        .available({ capabilities: { codeExec: true } })
+        .some((t) => t.name === 'execute_code'),
+    ).toBe(true);
+  });
+});
+
+// ===========================================================================
+// AC2 — resolves a PiExecutionEnv via the selector + runs via env.exec
+// ===========================================================================
+
+describe('execute_code — execution via the selector (AC2, gondolin absent)', () => {
+  it('calls the injected selector and captures env.exec stdout/stderr/exit', async () => {
+    const { env, execCalls } = fakeEnv({ stdout: 'hello\n', stderr: '', exitCode: 0 });
+    const resolveCalls: ResolveExecutionEnvOptions[] = [];
+    const resolveEnv: ExecutionEnvResolver = async (
+      opts: ResolveExecutionEnvOptions,
+      _seams?: ResolveExecutionEnvSeams,
+    ) => {
+      resolveCalls.push(opts);
+      return env;
+    };
+
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry, { resolveEnv });
+    await registry.init({ skipBuiltins: true });
+
+    const exec = registry.getExecutable('execute_code');
+    expect(exec).toBeDefined();
+    const result = (await exec?.(
+      { language: 'python', code: "print('hello')" },
+      noopGuardedSurface,
+    )) as ExecCodeResult;
+
+    // The SELECTOR was called (the tool reused resolveExecutionEnv) ...
+    expect(resolveCalls).toHaveLength(1);
+    // ... preferring the gondolin backend by default (degrades to in-process when
+    // the package / kvm / qemu is absent — which the fake selector simulates) ...
+    expect(resolveCalls[0]?.backend).toBe('gondolin');
+    // ... and the snippet ran via env.exec with a well-formed command line ...
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0]?.command).toBe(`python -c 'print('\\''hello'\\'')'`);
+    // ... and the captured output is surfaced.
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toBe('hello\n');
+    expect(result.exitCode).toBe(0);
+    expect(result.language).toBe('python');
+    expect(result.backend).toBe('gondolin');
+  });
+
+  it('forwards timeoutMs to env.exec and tears the env down (cleanup) once', async () => {
+    const fake = fakeEnv({ stdout: 'ok', exitCode: 0 });
+    const resolveEnv: ExecutionEnvResolver = async () => fake.env;
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry, { resolveEnv });
+    await registry.init({ skipBuiltins: true });
+
+    await registry.getExecutable('execute_code')?.(
+      { language: 'node', code: 'console.log(1)', timeoutMs: 5000 },
+      noopGuardedSurface,
+    );
+    expect(fake.execCalls[0]?.timeout).toBe(5000);
+    expect(fake.execCalls[0]?.command).toBe(`node -e 'console.log(1)'`);
+    expect(fake.cleanups).toBe(1);
+  });
+
+  it('surfaces a typed Result.err from env.exec as a non-ok run (never throws)', async () => {
+    const { env } = fakeEnv({ err: { code: 'E_PI_EXEC_FAILED', message: 'spawn ENOENT' } });
+    const resolveEnv: ExecutionEnvResolver = async () => env;
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry, { resolveEnv });
+    await registry.init({ skipBuiltins: true });
+
+    const result = (await registry.getExecutable('execute_code')?.(
+      { language: 'bash', code: 'echo hi' },
+      noopGuardedSurface,
+    )) as ExecCodeResult;
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('E_PI_EXEC_FAILED');
+  });
+});
+
+// ===========================================================================
+// AC2 — egress denylist honored BEFORE env.exec
+// ===========================================================================
+
+describe('execute_code — egress denylist (AC2)', () => {
+  it.each([
+    ['gh', 'gh pr create'],
+    ['git push', 'git push origin main'],
+    ['npm publish', 'npm publish'],
+    ['cleo', 'cleo complete T1'],
+    ['git remote', 'git remote add x y'],
+  ])('denies %s before resolving / running the env', async (_label, snippet) => {
+    const { env, execCalls } = fakeEnv({ stdout: '', exitCode: 0 });
+    let resolveCalled = false;
+    const resolveEnv: ExecutionEnvResolver = async () => {
+      resolveCalled = true;
+      return env;
+    };
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry, { resolveEnv });
+    await registry.init({ skipBuiltins: true });
+
+    const result = (await registry.getExecutable('execute_code')?.(
+      { language: 'bash', code: snippet },
+      noopGuardedSurface,
+    )) as ExecCodeResult;
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('E_EXEC_CODE_EGRESS_DENIED');
+    // The egress verb is rejected BEFORE the env is resolved or exec is called.
+    expect(resolveCalled).toBe(false);
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it('allows a non-egress git read verb (git status)', async () => {
+    const { env, execCalls } = fakeEnv({ stdout: 'clean', exitCode: 0 });
+    const resolveEnv: ExecutionEnvResolver = async () => env;
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry, { resolveEnv });
+    await registry.init({ skipBuiltins: true });
+
+    const result = (await registry.getExecutable('execute_code')?.(
+      { language: 'bash', code: 'git status' },
+      noopGuardedSurface,
+    )) as ExecCodeResult;
+    expect(result.ok).toBe(true);
+    expect(execCalls).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
+// buildExecCommand — per-language shaping
+// ===========================================================================
+
+describe('buildExecCommand', () => {
+  it('shapes each language to its inline-code flag with single-quoted code', () => {
+    expect(buildExecCommand('python', 'x=1')).toBe(`python -c 'x=1'`);
+    expect(buildExecCommand('node', 'x')).toBe(`node -e 'x'`);
+    expect(buildExecCommand('bash', 'echo hi')).toBe(`bash -c 'echo hi'`);
+    expect(buildExecCommand('sh', 'echo hi')).toBe(`sh -c 'echo hi'`);
+  });
+
+  it('escapes embedded single quotes safely', () => {
+    expect(buildExecCommand('bash', `echo 'a'`)).toBe(`bash -c 'echo '\\''a'\\'''`);
+  });
+
+  it('covers every supported language', () => {
+    for (const lang of EXEC_CODE_LANGUAGES) {
+      expect(buildExecCommand(lang, 'noop')).toContain('noop');
+    }
+  });
+});
+
+// ===========================================================================
+// Dispatch engine integration — frozen engine unchanged
+// ===========================================================================
+
+describe('execute_code — through the frozen ToolDispatchEngine', () => {
+  function engineFor(
+    resolveEnv: ExecutionEnvResolver,
+    opts?: { codeExec?: boolean; budget?: ToolCallBudget },
+  ) {
+    const registry = new AgentToolRegistry();
+    registerExecCodeAgentTool(registry, { resolveEnv });
+    return registry.init({ skipBuiltins: true }).then(
+      () =>
+        new ToolDispatchEngine({
+          registry,
+          tools: createToolGuard({ mode: 'enforce' }),
+          availability: opts?.codeExec === false ? {} : { capabilities: { codeExec: true } },
+          ...(opts?.budget ? { budget: opts.budget } : {}),
+        }),
+    );
+  }
+
+  it('dispatches a valid call to a captured success result', async () => {
+    const { env } = fakeEnv({ stdout: '42\n', exitCode: 0 });
+    const engine = await engineFor(async () => env);
+    const res = await engine.dispatch({
+      id: 'c1',
+      name: 'execute_code',
+      arguments: { language: 'python', code: 'print(42)' },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.name).toBe('execute_code');
+      expect(res.display).toContain('42');
+    }
+  });
+
+  it('is guard-denied when the codeExec capability is absent', async () => {
+    const { env } = fakeEnv({ stdout: '', exitCode: 0 });
+    const engine = await engineFor(async () => env, { codeExec: false });
+    const res = await engine.dispatch({
+      id: 'c2',
+      name: 'execute_code',
+      arguments: { language: 'python', code: 'print(1)' },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('guard-denied');
+  });
+
+  it('rejects invalid arguments (bad language) as invalid-args', async () => {
+    const { env } = fakeEnv({ stdout: '', exitCode: 0 });
+    const engine = await engineFor(async () => env);
+    const res = await engine.dispatch({
+      id: 'c3',
+      name: 'execute_code',
+      arguments: { language: 'ruby', code: 'puts 1' },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it('rejects a missing code argument as invalid-args', async () => {
+    const { env } = fakeEnv({ stdout: '', exitCode: 0 });
+    const engine = await engineFor(async () => env);
+    const res = await engine.dispatch({
+      id: 'c4',
+      name: 'execute_code',
+      arguments: { language: 'python' },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it("honors the dispatch engine's per-call timeout (slow env.exec → timeout)", async () => {
+    const slowEnv = fakeEnv({ stdout: 'late', exitCode: 0 });
+    // Make exec hang past the per-call timeout.
+    const env: PiExecutionEnv = {
+      ...slowEnv.env,
+      exec: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 200));
+        return { ok: true as const, value: { stdout: 'late', stderr: '', exitCode: 0 } };
+      }),
+    };
+    const engine = await engineFor(async () => env, {
+      budget: new ToolCallBudget({ perCallTimeoutMs: 20 }),
+    });
+    const res = await engine.dispatch({
+      id: 'c5',
+      name: 'execute_code',
+      arguments: { language: 'python', code: 'slow' },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('timeout');
+  });
+});

--- a/packages/core/src/tools/builtin-agent-tools.ts
+++ b/packages/core/src/tools/builtin-agent-tools.ts
@@ -27,6 +27,7 @@ import { z } from 'zod';
 import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
 import { ALWAYS_AVAILABLE } from './agent-registry.js';
 import { registerAgentToolFamilies } from './agent-tool-families.js';
+import { registerExecCodeAgentTool } from './exec-code-agent-tool.js';
 import { registerWebAgentTools } from './web-agent-tools.js';
 
 /** Available only when the named binary is known on PATH (AC5 example). */
@@ -157,4 +158,14 @@ export function registerBuiltinAgentTools(registry: AgentToolRegistry): void {
   // builds + runs with playwright NOT installed. The web tools' network egress +
   // the `browser_vision` AI call (via resolveLLMForSystem) use no raw bypass.
   registerWebAgentTools(registry);
+
+  // The `execute_code` tool (T11946 · M7 first catalog increment): the `agent`
+  // toolset's guarded code-execution capability. It routes EVERY run through the
+  // existing `resolveExecutionEnv` selector (Gondolin micro-VM when present, the
+  // in-process guarded `ExecutionEnv` otherwise — gondolin is an OPTIONAL dep, so
+  // core builds + runs with it ABSENT). The tool is ALWAYS registered but its
+  // availability predicate hides it unless the run advertises
+  // `capabilities.codeExec === true` (mirrors the playwright-gated browser tools),
+  // so a loop that never enables code execution cannot run arbitrary code.
+  registerExecCodeAgentTool(registry);
 }

--- a/packages/core/src/tools/exec-code-agent-tool.ts
+++ b/packages/core/src/tools/exec-code-agent-tool.ts
@@ -64,6 +64,7 @@ import {
   resolveExecutionEnv as realResolveExecutionEnv,
 } from '../llm/pi/resolve-execution-env.js';
 import { getLogger } from '../logger.js';
+import { resolveOrCwd } from '../paths.js';
 import { createToolGuard, type ToolGuard } from '../tools/guard.js';
 import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
 
@@ -151,7 +152,8 @@ export interface ExecCodeAgentToolOptions {
   readonly guard?: ToolGuard;
   /**
    * The absolute workspace root the in-process fallback confines fs paths under.
-   * Defaults to `process.cwd()`. The VM backend confines to its own `/workspace`.
+   * Defaults to the resolved project root (`resolveOrCwd(undefined)`, T9584 — never
+   * a bare `process.cwd()`). The VM backend confines to its own `/workspace`.
    */
   readonly workspaceRoot?: string;
   /**
@@ -280,7 +282,9 @@ export function registerExecCodeAgentTool(
       // in-process guarded env). The selector owns the optional-dep degradation —
       // this call works with gondolin ABSENT.
       const guard = options.guard ?? createToolGuard({ mode: 'enforce' });
-      const workspaceRoot = options.workspaceRoot ?? process.cwd();
+      // `resolveOrCwd` resolves to the supplied root, else the project root (T9584
+      // — never a bare `process.cwd()` in core).
+      const workspaceRoot = resolveOrCwd(options.workspaceRoot);
       const env = await resolveEnv({
         backend,
         guard,

--- a/packages/core/src/tools/exec-code-agent-tool.ts
+++ b/packages/core/src/tools/exec-code-agent-tool.ts
@@ -1,0 +1,339 @@
+/**
+ * `execute_code` agent tool — guarded code execution via a {@link PiExecutionEnv}
+ * (T11946 · M7 · epic T11456 · SG-TOOLS).
+ *
+ * The first M7 catalog increment: the ONE capability the existing ~18-tool set
+ * lacks — running a supplied code snippet. It adds NO new execution mechanism of
+ * its own; it routes EVERY run through the EXISTING per-run execution-env selector
+ * {@link import('../llm/pi/resolve-execution-env.js').resolveExecutionEnv}, which
+ * prefers the Gondolin micro-VM (`backend: 'gondolin'`) when the optional
+ * `@earendil-works/gondolin` package + `/dev/kvm` + QEMU are present, and SILENTLY
+ * DEGRADES to the always-available in-process deny-first
+ * {@link import('../llm/pi/pi-execution-env.js').GuardedExecutionEnv} otherwise.
+ * The snippet runs via `env.exec(...)` — NEVER a raw `child_process`.
+ *
+ * ## Why the selector, not a new primitive (Gate-11 + D11142)
+ *
+ * `resolveExecutionEnv` already owns the backend choice + the optional-dep
+ * degradation. Reusing it means:
+ *   - **Optional-dep safety (D11142):** this module has NO `import type` from
+ *     `@earendil-works/gondolin`; the selector loads that package lazily and ONLY
+ *     when the VM is chosen. `core` builds + runs + tests with gondolin ABSENT —
+ *     the in-process env runs. This module is import-time side-effect-free.
+ *   - **Gate-11 (Tools-vs-Skills):** the tool is DEFINED here under
+ *     `packages/core/src/tools`; it constructs NO new atomic primitive — it
+ *     consumes the existing `ExecutionEnv` seam + the existing `ToolGuard`.
+ *   - **Gate-13 (LLM chokepoint):** `execute_code` runs CODE, not an LLM call. It
+ *     constructs NO transport / client and reads no API key — there is no
+ *     chokepoint concern.
+ *
+ * ## Availability (mirrors `browser_*`)
+ *
+ * The tool is ALWAYS registered but its {@link AvailabilityCheck} returns `false`
+ * unless the run context advertises `capabilities.codeExec === true`. This mirrors
+ * the Playwright-gated `browser_*` family: registered-but-hidden until the host
+ * opts code execution in, so a loop that never enables it cannot invoke arbitrary
+ * code. (The in-process env is itself ALWAYS constructible — Gondolin is the
+ * preferred-but-optional upgrade — so the gate is a host POLICY switch, not an
+ * infra probe.)
+ *
+ * ## Egress denylist (AC2)
+ *
+ * Before a command reaches `env.exec`, the tool rejects a real-egress verb
+ * ({@link import('../llm/pi/pi-gondolin-env.js').DENIED_EXEC_PREFIXES} — `gh` /
+ * `git push` / `git remote` / `npm publish` / `cleo`) via the shared
+ * {@link import('../llm/pi/pi-gondolin-env.js').deniedEgressVerb} predicate. The
+ * Gondolin backend enforces this denylist itself; applying it HERE gives the
+ * in-process fallback the SAME egress posture (the guarded env's command denylist
+ * is policy-configured and may not include these verbs).
+ *
+ * @epic T11456
+ * @task T11946
+ * @see ../llm/pi/resolve-execution-env.js — the backend selector this tool reuses
+ * @see ../llm/pi/pi-execution-env.js — the in-process guarded `ExecutionEnv` fallback
+ * @see ./web-agent-tools.js — the `browser_*` optional-dep + capability-gated pattern mirrored here
+ */
+
+import { z } from 'zod';
+import type { PiExecutionEnv } from '../llm/pi/pi-execution-env.js';
+import { DENIED_EXEC_PREFIXES, deniedEgressVerb } from '../llm/pi/pi-gondolin-env.js';
+import {
+  type ExecutionEnvBackend,
+  type ResolveExecutionEnvOptions,
+  type ResolveExecutionEnvSeams,
+  resolveExecutionEnv as realResolveExecutionEnv,
+} from '../llm/pi/resolve-execution-env.js';
+import { getLogger } from '../logger.js';
+import { createToolGuard, type ToolGuard } from '../tools/guard.js';
+import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
+
+const log = getLogger('tool-exec-code');
+
+/** The languages `execute_code` knows how to invoke (AC2). */
+export const EXEC_CODE_LANGUAGES = ['python', 'node', 'bash', 'sh'] as const;
+
+/** One supported {@link EXEC_CODE_LANGUAGES} value. */
+export type ExecCodeLanguage = (typeof EXEC_CODE_LANGUAGES)[number];
+
+/**
+ * Available ONLY when the run context opts code execution in
+ * (`capabilities.codeExec === true`). Mirrors the `browser_*` family's
+ * `playwright`-gated predicate: the tool is ALWAYS registered (so the catalog is
+ * stable) but hidden by `available()` until the host advertises the capability, so
+ * a loop that never enables it cannot run arbitrary code.
+ */
+export const codeExecAvailable: AvailabilityCheck = (ctx) => ctx.capabilities?.codeExec === true;
+
+/**
+ * Result of an {@link registerExecCodeAgentTool | execute_code} run — the captured
+ * process output plus the resolved language and backend, for the LLM and for
+ * structured logging. `exitCode` is `null` when the process was killed by a
+ * signal/timeout (the {@link PiExecResult} contract).
+ */
+export interface ExecCodeResult {
+  /** The language the snippet was run as. */
+  readonly language: ExecCodeLanguage;
+  /** Captured standard output. */
+  readonly stdout: string;
+  /** Captured standard error. */
+  readonly stderr: string;
+  /** Process exit code, or `null` when killed by signal/timeout. */
+  readonly exitCode: number | null;
+  /** The confinement backend that ran the snippet (`gondolin` or `in-process`). */
+  readonly backend: ExecutionEnvBackend;
+  /** Whether the run completed without a denial/transport error (`exec` returned ok). */
+  readonly ok: boolean;
+  /**
+   * Present only when `ok === false`: a stable code + message for why the run did
+   * not produce a process result (e.g. a denied egress verb, or the selected
+   * env's `exec` returned `Result.err`). NEVER carries a raw secret.
+   */
+  readonly error?: { readonly code: string; readonly message: string };
+}
+
+/**
+ * The selector seam {@link registerExecCodeAgentTool} resolves a
+ * {@link PiExecutionEnv} through. Defaults to the real
+ * {@link import('../llm/pi/resolve-execution-env.js').resolveExecutionEnv}.
+ *
+ * EXPORTED so the unit test can inject a fake selector that returns a fake
+ * `PiExecutionEnv` — asserting the selector IS called and its `exec` output is
+ * captured, WITHOUT a real Gondolin VM, QEMU, or subprocess. In production the
+ * default is the real selector (Gondolin when available, in-process guarded env
+ * otherwise — gondolin ABSENT in CI).
+ */
+export type ExecutionEnvResolver = (
+  opts: ResolveExecutionEnvOptions,
+  seams?: ResolveExecutionEnvSeams,
+) => Promise<PiExecutionEnv>;
+
+/** Options for {@link registerExecCodeAgentTool} — all injectable for testing. */
+export interface ExecCodeAgentToolOptions {
+  /**
+   * The env selector. Defaults to the real
+   * {@link import('../llm/pi/resolve-execution-env.js').resolveExecutionEnv}. The
+   * test injects a fake that returns a fake `PiExecutionEnv` (no real VM/subprocess).
+   */
+  readonly resolveEnv?: ExecutionEnvResolver;
+  /**
+   * The confinement backend to PREFER. `'gondolin'` boots the micro-VM when the
+   * optional package + `/dev/kvm` + QEMU are present and DEGRADES to the in-process
+   * env otherwise (the CI / most-developer-machines path); `'in-process'` always
+   * resolves to the guarded env without probing the host. Defaults to `'gondolin'`
+   * — prefer the strongest available confinement, degrade silently.
+   */
+  readonly backend?: ExecutionEnvBackend;
+  /**
+   * The enforce-mode {@link ToolGuard} backing the in-process fallback. Defaults to
+   * a fresh `createToolGuard({ mode: 'enforce' })` per run. Injectable so a host
+   * can supply a guard with a project path allowlist + command denylist.
+   */
+  readonly guard?: ToolGuard;
+  /**
+   * The absolute workspace root the in-process fallback confines fs paths under.
+   * Defaults to `process.cwd()`. The VM backend confines to its own `/workspace`.
+   */
+  readonly workspaceRoot?: string;
+  /**
+   * The disposable seeded-copy host dir mounted RW at the VM's `/workspace`.
+   * REQUIRED only when a real Gondolin VM actually boots (`backend: 'gondolin'` AND
+   * available) — MUST be a `VACUUM INTO` snapshot dir, NEVER the live `.cleo` DBs.
+   * Ignored by the in-process fallback (the CI path).
+   */
+  readonly seededCopyDir?: string;
+}
+
+/**
+ * Shell-quote a single argument for a POSIX `sh -c` / interpreter `-c`/`-e`
+ * invocation: wrap in single quotes and escape embedded single quotes. The code
+ * is UNTRUSTED model input, so it is passed as ONE quoted argument to the
+ * interpreter's `-c`/`-e` flag rather than interpolated into the command shape.
+ *
+ * @param value - The raw argument (the model-supplied code).
+ * @returns The single-quoted, shell-safe token.
+ */
+function singleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build the command line for a `language` + `code` pair. Each interpreter runs the
+ * snippet from its inline-code flag (`python -c`, `node -e`, `bash -c`, `sh -c`)
+ * with the code passed as ONE single-quoted argument — no further shell expansion
+ * of the model's code into the command shape.
+ *
+ * @param language - The interpreter to run.
+ * @param code - The model-supplied snippet.
+ * @returns The command string handed to `env.exec`.
+ */
+export function buildExecCommand(language: ExecCodeLanguage, code: string): string {
+  const quoted = singleQuote(code);
+  switch (language) {
+    case 'python':
+      return `python -c ${quoted}`;
+    case 'node':
+      return `node -e ${quoted}`;
+    case 'bash':
+      return `bash -c ${quoted}`;
+    case 'sh':
+      return `sh -c ${quoted}`;
+  }
+}
+
+/**
+ * Register the `execute_code` tool into `registry`. Pure registration — no env is
+ * resolved, no VM is booted, no code runs here; all of that happens later inside
+ * the tool's `execute` through the injected (or default) selector. Import-time
+ * side-effect-free + optional-dep-safe (D11142).
+ *
+ * @param registry - The registry to populate.
+ * @param options - Injectable selector / backend / guard / workspace (for testing).
+ */
+export function registerExecCodeAgentTool(
+  registry: AgentToolRegistry,
+  options: ExecCodeAgentToolOptions = {},
+): void {
+  const resolveEnv: ExecutionEnvResolver = options.resolveEnv ?? realResolveExecutionEnv;
+  const backend: ExecutionEnvBackend = options.backend ?? 'gondolin';
+
+  registry.register({
+    name: 'execute_code',
+    // 'shell' — the run is a process invocation (its strongest side-effect surface).
+    class: 'shell',
+    description:
+      'Execute a code snippet in a guarded execution environment (Gondolin micro-VM ' +
+      'when available, in-process guarded sandbox otherwise) and capture its ' +
+      'stdout / stderr / exit code. Real-egress verbs (gh, git push, npm publish, ' +
+      'cleo) are denied. Available only when the run enables code execution.',
+    toolset: 'agent',
+    stateless: true,
+    available: codeExecAvailable,
+    parameters: z.object({
+      language: z
+        .enum(EXEC_CODE_LANGUAGES)
+        .describe('Interpreter to run the snippet with: python, node, bash, or sh.'),
+      code: z.string().describe('The source code / script to execute.'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Hard wall-time ceiling for the run, in milliseconds.'),
+    }),
+    execute: async (rawArgs): Promise<ExecCodeResult> => {
+      // `rawArgs` is the schema-validated argument object (the dispatch engine
+      // re-validates against `parameters` before calling). Narrow defensively.
+      const language = rawArgs.language as ExecCodeLanguage;
+      const code = String(rawArgs.code);
+      const timeoutMs = typeof rawArgs.timeoutMs === 'number' ? rawArgs.timeoutMs : undefined;
+
+      // AC2: deny a real-egress verb BEFORE the env runs it — same posture on the
+      // in-process fallback as on the Gondolin backend (whose own denylist is the
+      // shared DENIED_EXEC_PREFIXES list). The check runs against the SNIPPET
+      // itself (the leading verb the user wants to run), NOT the wrapped
+      // `bash -c '<snippet>'` command — whose argv-0 is always a benign
+      // interpreter (`bash`/`sh`/`python`/`node`). For a shell snippet (`bash`/`sh`)
+      // the code IS the command line, so `gh …`/`git push …`/`npm publish …` is
+      // caught; for `python`/`node` the same scan is a harmless extra net.
+      const denied = deniedEgressVerb(code);
+      if (denied !== null) {
+        return {
+          language,
+          stdout: '',
+          stderr: '',
+          exitCode: null,
+          backend,
+          ok: false,
+          error: {
+            code: 'E_EXEC_CODE_EGRESS_DENIED',
+            message: `egress verb "${denied}" is denied (one of: ${DENIED_EXEC_PREFIXES.join(', ')})`,
+          },
+        };
+      }
+
+      // Shape the interpreter command line (the snippet passed as ONE quoted
+      // argument to the interpreter's inline-code flag — no shell expansion of the
+      // model's code into the command shape).
+      const command = buildExecCommand(language, code);
+
+      // Resolve the per-run env through the SELECTOR (Gondolin if present, else the
+      // in-process guarded env). The selector owns the optional-dep degradation —
+      // this call works with gondolin ABSENT.
+      const guard = options.guard ?? createToolGuard({ mode: 'enforce' });
+      const workspaceRoot = options.workspaceRoot ?? process.cwd();
+      const env = await resolveEnv({
+        backend,
+        guard,
+        workspaceRoot,
+        ...(options.seededCopyDir !== undefined ? { seededCopyDir: options.seededCopyDir } : {}),
+      });
+
+      try {
+        const result = await env.exec(command, {
+          ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
+        });
+        if (!result.ok) {
+          // `exec` never throws — a denial / failure is a typed Result.err. Surface
+          // it as a non-ok run rather than a thrown executable error.
+          return {
+            language,
+            stdout: '',
+            stderr: '',
+            exitCode: null,
+            backend,
+            ok: false,
+            error: { code: result.error.code, message: result.error.message },
+          };
+        }
+        return {
+          language,
+          stdout: result.value.stdout,
+          stderr: result.value.stderr,
+          exitCode: result.value.exitCode,
+          backend,
+          ok: true,
+        };
+      } finally {
+        // Best-effort teardown — the env (VM or guarded) may own resources; cleanup
+        // never throws (the PiExecutionEnv contract).
+        try {
+          await env.cleanup();
+        } catch (err) {
+          log.debug({ err }, 'execute_code: env cleanup failed (ignored)');
+        }
+      }
+    },
+  });
+}
+
+/**
+ * Self-registration marker (AC1) — the identifier the
+ * {@link AgentToolRegistry.discover} bounded source scan greps for. Aliases
+ * {@link registerExecCodeAgentTool} so a future scan-dir discovery (or the
+ * built-in aggregator) can call it uniformly with the other agent-tool modules.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentTools(registry: AgentToolRegistry): void {
+  registerExecCodeAgentTool(registry);
+}

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -162,6 +162,21 @@ export {
   scrubSubprocessEnv,
   TRUSTED_PATH,
 } from './env-scrub.js';
+// `execute_code` agent tool (T11946 · M7) — the `agent` toolset's guarded
+// code-execution capability. Routes every run through the existing
+// `resolveExecutionEnv` selector (Gondolin micro-VM when available, in-process
+// guarded `ExecutionEnv` otherwise — gondolin is OPTIONAL, so core builds with it
+// ABSENT). Registered always; available() hides it unless `capabilities.codeExec`.
+export {
+  buildExecCommand,
+  codeExecAvailable,
+  EXEC_CODE_LANGUAGES,
+  type ExecCodeAgentToolOptions,
+  type ExecCodeLanguage,
+  type ExecCodeResult,
+  type ExecutionEnvResolver,
+  registerExecCodeAgentTool,
+} from './exec-code-agent-tool.js';
 // Atomic-tool guard chokepoint (E3 · T11407 · T11474) — the ONLY public route to
 // the fs/shell primitives. Raw primitives are intentionally not re-exported.
 export {


### PR DESCRIPTION
## T11946 — `execute_code` agent tool (M7 first catalog increment)

Adds the one capability the existing ~18-tool agent set lacks — **code execution** — routed through the EXISTING per-run execution-env selector. No new execution mechanism is introduced.

### The descriptor
A new `execute_code` `AgentToolDescriptor` in `packages/core/src/tools/exec-code-agent-tool.ts`:
- `class: 'shell'`, `toolset: 'agent'`, `stateless: true`
- Zod params: `{ language: 'python'|'node'|'bash'|'sh', code: string, timeoutMs?: positive int }`
- `available()` mirrors the `browser_*` family — **registered always, hidden** unless `ctx.capabilities.codeExec === true` (a host policy opt-in, not an infra probe; the in-process env is always constructible)
- Self-registers via the `registerAgentTools` marker (AC1) and is wired into `registerBuiltinAgentTools` + exported from the tools barrel.

### Selector reuse (the point of the task)
`execute(args, surface)` builds an interpreter command line (`python -c`/`node -e`/`bash -c`/`sh -c`, snippet passed as one single-quoted arg) and runs it through:
```
resolveExecutionEnv({ backend: 'gondolin', guard, workspaceRoot }).exec(command, { timeout })
```
`resolveExecutionEnv` (T11888) prefers the **Gondolin micro-VM** when the optional package + `/dev/kvm` + QEMU are present and **silently degrades** to the in-process deny-first `GuardedExecutionEnv` otherwise. The tool can't tell the backends apart — it just consumes the `PiExecutionEnv.exec` seam. Never a raw `child_process`.

### Egress denylist (AC2)
Before `env.exec`, a real-egress verb (`gh` / `git push` / `git remote` / `npm publish` / `cleo`) is rejected via the shared `deniedEgressVerb` predicate (now exported from `pi-gondolin-env.ts`). This gives the in-process fallback the **same egress posture** the Gondolin backend already enforces. The check runs against the snippet (the leading verb the user wants to run), since the wrapped command's argv-0 is always a benign interpreter.

### Optional-dep safety (D11142)
- **No** `@earendil-works/gondolin` dependency added — the selector loads it lazily and only when chosen.
- This module has **no `import type`** from the gondolin package; it only imports sibling Pi modules + the denylist.
- Core **builds + runs + tests with gondolin ABSENT** (`node_modules/@earendil-works` is absent; the full suite is green on the in-process path). Import-time side-effect-free.

### Gate-13
`execute_code` runs **code, not LLM calls** — it constructs no transport/client and reads no API key, so there is no chokepoint concern.

### Tests (in-process, no QEMU/subprocess)
21 tests via an **injected fake `PiExecutionEnv`** (no real Gondolin/QEMU/subprocess): registered + in the built-in catalog; selector IS called + output captured with gondolin absent; hidden when the capability is absent; each egress verb denied before `env.exec`; per-language command shaping; and the frozen `ToolDispatchEngine` honors availability + invalid-args + per-call timeout unchanged.

### Gates
- `pnpm exec biome check` — clean
- Full ordered `pnpm run build` + full `pnpm run typecheck` (`tsc -b`) — clean
- New test file: 21/21; tools + pi suites: 392/392 — green
- Gate-11 tools-vs-skills (tool DEFINED in `core/src/tools`), Gate-13 LLM chokepoint, Gate-10 contracts-purity, Gate-3/4/6 — all pass
- No canonical `.md` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)