### PR TITLE
fix(T11961): ws-pty teardown keeps an error sink — late ECONNRESET no longer daemon-fatal (macOS CI shard killer)

### DIFF
--- a/packages/runtime/src/gateway/http/__tests__/ws-pty.test.ts
+++ b/packages/runtime/src/gateway/http/__tests__/ws-pty.test.ts
@@ -26,6 +26,7 @@
  * @saga T10400
  */
 
+import { EventEmitter } from 'node:events';
 import { connect, type Socket } from 'node:net';
 import type { DispatchRequest, DispatchResponse } from '@cleocode/contracts/gateway';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -33,6 +34,7 @@ import type { GatewayHandler } from '../../index.js';
 import { startHttpServer } from '../listen.js';
 import {
   __setWsPtyTestHooks,
+  attachWsPtyEndpoint,
   authorizeUpgrade,
   computeAcceptKey,
   decodeWsFrame,
@@ -40,6 +42,7 @@ import {
   type GateDecision,
   isWsPtyPath,
   scrubPtyEnv,
+  type UpgradableServer,
   WS_PTY_PATH,
 } from '../ws-pty.js';
 
@@ -436,5 +439,55 @@ describe('T11922 in-process WS-PTY round-trip (AC1/AC2/AC3)', () => {
     // the registry is clean.
     await new Promise((r) => setTimeout(r, 50));
     await server.close();
+  });
+
+  it('T11961: teardown leaves an error sink on the socket (late ECONNRESET is swallowed)', async () => {
+    // Regression for the teardown race (the macOS CI shard killer): teardown
+    // removes the live 'error' listener and THEN writes the close frame + FIN.
+    // A peer that destroyed abruptly (RST) surfaces that write failure
+    // ASYNCHRONOUSLY — on a listener-less socket Node escalates it to an
+    // uncaught exception, killing the daemon. The invariant under test: after
+    // teardown the socket still has an 'error' listener, and emitting a late
+    // socket error does not throw. A scripted fake socket makes the sequence
+    // deterministic (the real-socket race only fires under macOS CI timing).
+    installEchoPtyStub();
+
+    class FakeSocket extends EventEmitter {
+      writableEnded = false;
+      destroyed = false;
+      write(_chunk: unknown): boolean {
+        return true;
+      }
+      end(): void {
+        this.writableEnded = true;
+      }
+      destroy(): void {
+        this.destroyed = true;
+      }
+    }
+    const fakeServer = new EventEmitter();
+    const handle = attachWsPtyEndpoint(fakeServer as unknown as UpgradableServer);
+    closers.push(async () => handle.close());
+
+    const socket = new FakeSocket();
+    const req = {
+      url: WS_PTY_PATH,
+      headers: { 'sec-websocket-key': 'dGhlIHNhbXBsZSBub25jZQ==' },
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    fakeServer.emit('upgrade', req, socket, Buffer.alloc(0));
+    // Let the async bridge (PTY stub load + spawn) settle.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(handle.sessionCount).toBe(1);
+
+    // Client close frame → server teardown (removes the live listeners, then
+    // writes the close frame + FIN — the window where the race lived).
+    socket.emit('data', encodeClientFrame(0x8, Buffer.alloc(0)));
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The fix's invariant: an error sink remains, and a late async socket
+    // error (the in-flight write failing against a peer RST) is swallowed.
+    expect(socket.listenerCount('error')).toBeGreaterThan(0);
+    expect(() => socket.emit('error', new Error('read ECONNRESET'))).not.toThrow();
   });
 });

--- a/packages/runtime/src/gateway/http/ws-pty.ts
+++ b/packages/runtime/src/gateway/http/ws-pty.ts
@@ -484,6 +484,22 @@ function rejectUpgrade(socket: Duplex, status: number, reason: string): void {
 }
 
 /**
+ * Terminal `'error'` sink installed by a session's teardown.
+ *
+ * Teardown removes the live `onError` listener (it routes back into teardown)
+ * but the socket still has a close frame + FIN in flight; an abrupt peer RST
+ * surfaces that write failure asynchronously. Without a listener Node turns
+ * the `ECONNRESET`/`EPIPE` into an uncaught exception — fatal for the daemon.
+ * The session is already dead at this point, so the error is intentionally
+ * dropped.
+ *
+ * @task T11961
+ */
+function swallowLateSocketError(): void {
+  // intentionally empty — late socket errors on a torn-down session are noise
+}
+
+/**
  * Complete the RFC 6455 handshake on a gated upgrade socket, then spawn + bridge
  * a PTY bidirectionally. Returns a {@link WsPtySession} whose `teardown()` is the
  * single idempotent close path (AC3). When `node-pty` is absent, the socket is
@@ -554,6 +570,13 @@ async function bridgePty(
     socket.removeListener('data', onData);
     socket.removeListener('error', onError);
     socket.removeListener('close', onSocketClose);
+    // The socket outlives teardown: the close frame + FIN below are still in
+    // flight, and a peer that destroyed abruptly (RST) surfaces the write
+    // failure ASYNCHRONOUSLY as a socket 'error' AFTER the listeners above are
+    // removed. The try/catch only covers synchronous throws — without a sink
+    // the late ECONNRESET/EPIPE becomes an uncaught exception that kills the
+    // daemon (T11961; also the macOS CI shard killer in ws-pty.test.ts).
+    socket.on('error', swallowLateSocketError);
     if (!socket.writableEnded) {
       try {
         socket.write(encodeCloseFrame(code, reason.slice(0, 120)));


### PR DESCRIPTION
## Summary

Root-causes and fixes the intermittent macOS `Unit Tests shard 1` failure that has been killing CI runs with **all tests passing** (failed both #1050 and #1051 this way: 8.9k/8.9k tests green, job fails on an unhandled `read ECONNRESET` originating in `ws-pty.test.ts`).

**It is not test flake — it is a production daemon-crash bug.** `teardown()` in `ws-pty.ts` removes the live socket `'error'` listener and *then* writes the WS close frame + FIN. When the peer destroyed abruptly (RST), that in-flight write fails **asynchronously**; the surrounding `try/catch` only covers synchronous throws, so the late `ECONNRESET`/`EPIPE` lands on a listener-less socket and Node escalates it to an uncaught exception. In production that kills the gateway daemon any time a terminal client disconnects abruptly mid-teardown.

## Fix

After detaching the live listeners, attach `swallowLateSocketError` as a terminal sink — the session is already dead; the late error is noise.

## Regression test (verified true reproducer)

A scripted fake socket drives upgrade → close-frame teardown deterministically (the real-socket race only fires under macOS CI timing) and asserts the invariant directly: `listenerCount('error') > 0` after teardown, and a late `'error'` emit does not throw. **Verified to FAIL against the unfixed source** (`expected 0 to be greater than 0`) and pass with the fix. Full `ws-pty.test.ts` suite: 19/19.

Unblocks the login lane (#1051 → #1050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)