### PR TITLE
feat(M7): agent-tool catalog — memory/mcp/run_skill/cron-todo/media (T11947-T11951)

### DIFF
--- a/.changeset/t11947-t11951-m7-agent-tool-catalog.md
+++ b/.changeset/t11947-t11951-m7-agent-tool-catalog.md
@@ -1,0 +1,28 @@
+---
+id: t11947-t11951-m7-agent-tool-catalog
+tasks: [T11947, T11948, T11949, T11950, T11951]
+kind: feat
+summary: M7 agent-tool catalog — 5 new built-in harness tools (memory / mcp / run_skill / cron-todo / vision-media)
+---
+
+Adds five new agent-tool families to the harness `AgentToolRegistry`, each in its own
+file under `packages/core/src/tools/` and registered via `registerBuiltinAgentTools`.
+Every family CONSUMES an existing subsystem (no new store, no new loader, no raw
+provider client):
+
+- **T11947 — memory** (`memory_search` / `memory_observe` / `memory_fetch` /
+  `memory_timeline`): delegate to the existing BRAIN ops (`memory/engine-compat.ts`).
+  Always available daemon-OFF.
+- **T11948 — native MCP client (fan-in)**: connect-time `initialize` → `tools/list`
+  → register each remote tool as a live-only proxy `AgentToolDescriptor`; stdio/sse/http
+  via an `McpTransport` seam, no external MCP SDK. Replaces the external mcp-tool dep
+  for the host-loop path.
+- **T11949 — `run_skill`**: bridges the existing SKILL.md loader (`skills/discovery.ts`
+  `findSkill` + `dispatchExplicit`) to the loop; surfaces only invocable skills.
+- **T11950 — cron/todo** (`todo_add` / `todo_list` / `cron_schedule`): `todo_*` delegate
+  to the task store ops; `cron_schedule` is registered but gated unavailable until a
+  schedule store ships (follow-up T11962 under T11679) — no schema invented.
+- **T11951 — vision/media** (`vision_analyze` / `image_generate` / `text_to_speech`):
+  the first occupants of the `media` toolset; every model call routes through the E9
+  chokepoint (`resolveLLMForSystem` / `ModelRunner`) exactly like `browser_vision`
+  (Gate-13). Hidden unless egress is allowed AND a multimodal model is advertised.

--- a/packages/core/src/tools/__tests__/agent-registry.test.ts
+++ b/packages/core/src/tools/__tests__/agent-registry.test.ts
@@ -159,8 +159,12 @@ describe('AgentToolRegistry — toolset grouping (AC4)', () => {
     expect(webNames).toEqual(
       expect.arrayContaining(['web_search', 'web_extract', 'browser_navigate']),
     );
-    // No notebook primitives implemented yet — empty but present.
-    expect(grouped.media).toEqual([]);
+    // The media toolset (T11951): vision_analyze/image_generate/text_to_speech are
+    // its first occupants. Superset check so adding tools doesn't break this.
+    const mediaNames = grouped.media.map((t) => t.name);
+    expect(mediaNames).toEqual(
+      expect.arrayContaining(['vision_analyze', 'image_generate', 'text_to_speech']),
+    );
   });
 
   it('byToolset(toolset) filters to a single group', async () => {

--- a/packages/core/src/tools/__tests__/mcp-agent-tool.test.ts
+++ b/packages/core/src/tools/__tests__/mcp-agent-tool.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the native MCP client (fan-IN) agent tool (T11948 · M7 · epic T11456).
+ *
+ * Uses an IN-MEMORY fake MCP server (an {@link McpTransport} that answers
+ * `initialize` / `tools/list` / `tools/call` from a fixed tool set) — no real
+ * stdio / SSE / HTTP transport, no external MCP server. Covers:
+ *   - connect → `tools/list` → register each remote tool as a proxy
+ *     AgentToolDescriptor (toolset 'agent') BEFORE the registry is frozen;
+ *   - a proxy tool's execute proxies over the transport (`tools/call`) and formats
+ *     the result;
+ *   - a transport error becomes a TYPED dispatch failure (never throws);
+ *   - availability: a fan-in tool is available only while the connection is live.
+ *
+ * @task T11948
+ * @epic T11456
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { describe, expect, it } from 'vitest';
+import { AgentToolRegistry } from '../agent-registry.js';
+import {
+  connectMcpServer,
+  type McpTransport,
+  mcpToolName,
+  registerMcpConnectionTools,
+} from '../mcp-agent-tool.js';
+
+const noopSurface = {} as GuardedToolSurface;
+
+/**
+ * An in-memory fake MCP server transport. Answers the MCP handshake + a fixed tool
+ * set; records `tools/call` invocations. `failCalls` makes `tools/call` reject so
+ * the typed-failure path is exercised.
+ */
+function fakeTransport(opts: { failCalls?: boolean } = {}): {
+  transport: McpTransport;
+  callArgs: Array<{ name: string; arguments: unknown }>;
+  closed: () => boolean;
+} {
+  const callArgs: Array<{ name: string; arguments: unknown }> = [];
+  let closed = false;
+  const transport: McpTransport = {
+    request: async (method, params) => {
+      if (closed) throw new Error('transport closed');
+      if (method === 'initialize') return { protocolVersion: '2025-06-18' };
+      if (method === 'tools/list') {
+        return {
+          tools: [
+            {
+              name: 'echo',
+              description: 'Echo back text.',
+              inputSchema: {
+                type: 'object',
+                properties: { text: { type: 'string', description: 'Text to echo.' } },
+                required: ['text'],
+              },
+            },
+          ],
+        };
+      }
+      if (method === 'tools/call') {
+        if (opts.failCalls) throw new Error('remote boom');
+        callArgs.push(params as { name: string; arguments: unknown });
+        const args = (params as { arguments: { text: string } }).arguments;
+        return { content: [{ type: 'text', text: `echo: ${args.text}` }] };
+      }
+      throw new Error(`unexpected method ${method}`);
+    },
+    close: async () => {
+      closed = true;
+    },
+  };
+  return { transport, callArgs, closed: () => closed };
+}
+
+describe('mcp-agent-tool — connect-time fan-in', () => {
+  it('connects, lists tools, and registers each remote tool as a proxy BEFORE freeze', async () => {
+    const { transport } = fakeTransport();
+    const conn = await connectMcpServer('demo', transport);
+    expect(conn.tools.map((t) => t.name)).toEqual(['echo']);
+
+    const registry = new AgentToolRegistry();
+    const names = registerMcpConnectionTools(registry, conn);
+    await registry.init({ skipBuiltins: true });
+
+    const expectedName = mcpToolName('demo', 'echo');
+    expect(names).toEqual([expectedName]);
+    const tool = registry.get(expectedName);
+    expect(tool?.toolset).toBe('agent');
+    expect(tool?.class).toBe('net');
+  });
+
+  it("a proxy tool's execute proxies over the transport and formats the result", async () => {
+    const { transport, callArgs } = fakeTransport();
+    const conn = await connectMcpServer('demo', transport);
+    const registry = new AgentToolRegistry();
+    registerMcpConnectionTools(registry, conn);
+    await registry.init({ skipBuiltins: true });
+
+    const out = (await registry.getExecutable(mcpToolName('demo', 'echo'))?.(
+      { text: 'hi' },
+      noopSurface,
+    )) as { ok: boolean; content: string };
+    expect(callArgs).toEqual([{ name: 'echo', arguments: { text: 'hi' } }]);
+    expect(out.ok).toBe(true);
+    expect(out.content).toBe('echo: hi');
+  });
+
+  it('a transport error becomes a typed failure (never throws)', async () => {
+    const { transport } = fakeTransport({ failCalls: true });
+    const conn = await connectMcpServer('demo', transport);
+    const registry = new AgentToolRegistry();
+    registerMcpConnectionTools(registry, conn);
+    await registry.init({ skipBuiltins: true });
+
+    const out = (await registry.getExecutable(mcpToolName('demo', 'echo'))?.(
+      { text: 'hi' },
+      noopSurface,
+    )) as { ok: boolean; error: { code: string } };
+    expect(out.ok).toBe(false);
+    expect(out.error.code).toBe('E_MCP_CALL_FAILED');
+  });
+});
+
+describe('mcp-agent-tool — availability tracks the live connection', () => {
+  it('a fan-in tool is available only while the connection is live', async () => {
+    const { transport } = fakeTransport();
+    const conn = await connectMcpServer('demo', transport);
+    const registry = new AgentToolRegistry();
+    registerMcpConnectionTools(registry, conn);
+    await registry.init({ skipBuiltins: true });
+
+    const name = mcpToolName('demo', 'echo');
+    expect(registry.available({}).some((t) => t.name === name)).toBe(true);
+
+    // Drop the connection — the proxy tool reports unavailable.
+    await conn.disconnect();
+    expect(conn.isLive()).toBe(false);
+    expect(registry.available({}).some((t) => t.name === name)).toBe(false);
+
+    // ... and a call into the dead connection is a typed failure, not a throw.
+    const out = (await registry.getExecutable(name)?.({ text: 'hi' }, noopSurface)) as {
+      ok: boolean;
+      error: { code: string };
+    };
+    expect(out.ok).toBe(false);
+    expect(out.error.code).toBe('E_MCP_CONNECTION_DEAD');
+  });
+});

--- a/packages/core/src/tools/__tests__/media-agent-tools.test.ts
+++ b/packages/core/src/tools/__tests__/media-agent-tools.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the vision / media agent-tool family (T11951 · M7 · epic T11456).
+ *
+ * Every model call MUST route through the E9 `resolveLLMForSystem` chokepoint +
+ * sealed-credential handle and the single `ModelRunner` — never a raw provider
+ * call (Gate-13). These tests mock BOTH the resolver and the runner (no real
+ * credential, no real network) and assert:
+ *   - AC1 register vision_analyze / image_generate / text_to_speech in the 'media'
+ *     toolset via the self-registering marker + the built-in catalog;
+ *   - AC2 the call routes through resolveLLMForSystem → ModelRunner, sending a
+ *     multimodal turn; the sealed credential is fetch()-materialized only at the wire;
+ *   - AC3 hidden when egress is denied or no multimodal capability; visible otherwise;
+ *   - AC4 Zod schema validation (missing prompt → invalid-args);
+ *   - AC5 graceful degradation (aiUnavailable, runner never built) when no credential.
+ *
+ * @task T11951
+ * @epic T11456
+ */
+
+import type { TransportMessage } from '@cleocode/contracts/llm/normalized-response.js';
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MediaModelResult } from '../media-agent-tools.js';
+
+let sentMessages: TransportMessage[] | undefined;
+let sealedFetched = false;
+
+const resolveLLMForSystem = vi.fn();
+const modelRunnerBuild = vi.fn();
+
+vi.mock('../../llm/system-resolver.js', () => ({
+  resolveLLMForSystem: (...args: unknown[]) => resolveLLMForSystem(...args),
+}));
+
+vi.mock('../../llm/model-runner.js', () => ({
+  ModelRunner: {
+    build: (...args: unknown[]) => modelRunnerBuild(...args),
+  },
+}));
+
+// Imported AFTER the mocks so the executable's dynamic imports bind to them.
+const { AgentToolRegistry } = await import('../agent-registry.js');
+const { registerBuiltinAgentTools } = await import('../builtin-agent-tools.js');
+const { ToolDispatchEngine } = await import('../dispatch.js');
+const { createToolGuard } = await import('../guard.js');
+const { multimodalAvailable, registerMediaAgentTools } = await import('../media-agent-tools.js');
+
+const noopSurface = {} as GuardedToolSurface;
+const MULTIMODAL_CTX = { networkEgressAllowed: true, capabilities: { multimodal: true } };
+
+afterEach(() => {
+  sentMessages = undefined;
+  sealedFetched = false;
+  vi.clearAllMocks();
+});
+
+/** Mock a resolved credential + a session that records the turn it received. */
+function mockResolvedWithSession(content: string): void {
+  resolveLLMForSystem.mockResolvedValue({
+    provider: 'anthropic',
+    model: 'mock-multimodal-model',
+    client: null,
+    credential: { provider: 'anthropic', source: 'env', authType: 'api_key' },
+    sealedCredential: {
+      provider: 'anthropic',
+      account: 'mock',
+      tokenPreview: '…mock',
+      fetch: async () => {
+        sealedFetched = true;
+        return { value: 'sk-mock' };
+      },
+    },
+    source: 'role-config',
+    apiMode: 'anthropic_messages',
+    baseUrl: null,
+    authType: 'api_key',
+  });
+  modelRunnerBuild.mockResolvedValue({
+    languageModel: null,
+    session: {
+      async send(messages: TransportMessage[]) {
+        sentMessages = messages;
+        return { content, toolCalls: null };
+      },
+    },
+  });
+}
+
+/** Build a media registry with an injected image reader (no real file). */
+async function mediaRegistry(): Promise<InstanceType<typeof AgentToolRegistry>> {
+  const r = new AgentToolRegistry();
+  registerMediaAgentTools(r, {
+    readImage: async () => ({ base64: 'AAAA', mediaType: 'image/png' }),
+  });
+  await r.init({ skipBuiltins: true });
+  return r;
+}
+
+// ===========================================================================
+// AC1 — registration in the 'media' toolset
+// ===========================================================================
+
+describe('media-agent-tools — registration (AC1)', () => {
+  it('exports a self-registering marker that registers the three media tools', async () => {
+    const mod = await import('../media-agent-tools.js');
+    expect(typeof mod.registerAgentTools).toBe('function');
+    const registry = new AgentToolRegistry();
+    mod.registerAgentTools(registry);
+    for (const name of ['vision_analyze', 'image_generate', 'text_to_speech']) {
+      expect(registry.get(name)?.toolset).toBe('media');
+    }
+  });
+
+  it('the built-in catalog populates the previously-empty media toolset', async () => {
+    const registry = new AgentToolRegistry();
+    registerBuiltinAgentTools(registry);
+    await registry.init({ skipBuiltins: true });
+    const mediaNames = registry.byToolset('media').map((t) => t.name);
+    expect(mediaNames).toEqual(
+      expect.arrayContaining(['vision_analyze', 'image_generate', 'text_to_speech']),
+    );
+  });
+});
+
+// ===========================================================================
+// AC3 — availability gates on egress + multimodal capability
+// ===========================================================================
+
+describe('media-agent-tools — availability (AC3)', () => {
+  it('multimodalAvailable requires egress AND a multimodal capability', () => {
+    expect(multimodalAvailable({})).toBe(false);
+    expect(
+      multimodalAvailable({ networkEgressAllowed: false, capabilities: { multimodal: true } }),
+    ).toBe(false);
+    expect(multimodalAvailable({ capabilities: { multimodal: true } })).toBe(true);
+    expect(
+      multimodalAvailable({ networkEgressAllowed: true, capabilities: { multimodal: true } }),
+    ).toBe(true);
+  });
+
+  it('is hidden credential-OFF / egress-OFF and visible with the capability', async () => {
+    const r = await mediaRegistry();
+    expect(
+      r.available({ networkEgressAllowed: false }).some((t) => t.name === 'vision_analyze'),
+    ).toBe(false);
+    expect(r.available(MULTIMODAL_CTX).some((t) => t.name === 'vision_analyze')).toBe(true);
+  });
+});
+
+// ===========================================================================
+// AC2 — routes through the E9 chokepoint
+// ===========================================================================
+
+describe('media-agent-tools — E9 chokepoint routing (AC2)', () => {
+  it('vision_analyze sends image + prompt as a multimodal turn via ModelRunner', async () => {
+    mockResolvedWithSession('A red square.');
+    const r = await mediaRegistry();
+    const out = (await r.getExecutable('vision_analyze')?.(
+      { imagePath: '/tmp/x.png', prompt: 'What is this?' },
+      noopSurface,
+    )) as MediaModelResult;
+
+    expect(resolveLLMForSystem).toHaveBeenCalledWith('task-executor', expect.any(Object));
+    expect(sealedFetched).toBe(true);
+    expect(sentMessages).toHaveLength(1);
+    const content = sentMessages?.[0]?.content as ReadonlyArray<{
+      type: string;
+      source?: { mediaType: string };
+    }>;
+    expect(content.find((b) => b.type === 'text')).toBeDefined();
+    expect(content.find((b) => b.type === 'image')?.source?.mediaType).toBe('image/png');
+    expect(out.ok).toBe(true);
+    expect(out.content).toBe('A red square.');
+    expect(out.model).toBe('mock-multimodal-model');
+  });
+
+  it('image_generate routes through the chokepoint and flags unsupported synthesis', async () => {
+    mockResolvedWithSession('I cannot create images.');
+    const r = await mediaRegistry();
+    const out = (await r.getExecutable('image_generate')?.(
+      { prompt: 'a cat' },
+      noopSurface,
+    )) as MediaModelResult;
+    expect(resolveLLMForSystem).toHaveBeenCalled();
+    expect(out.ok).toBe(true);
+    expect(out.unsupported).toBe(true);
+  });
+
+  it('text_to_speech routes through the chokepoint and flags unsupported audio', async () => {
+    mockResolvedWithSession('I cannot produce audio.');
+    const r = await mediaRegistry();
+    const out = (await r.getExecutable('text_to_speech')?.(
+      { text: 'hello' },
+      noopSurface,
+    )) as MediaModelResult;
+    expect(resolveLLMForSystem).toHaveBeenCalled();
+    expect(out.ok).toBe(true);
+    expect(out.unsupported).toBe(true);
+  });
+});
+
+// ===========================================================================
+// AC5 — graceful degradation when no credential resolves
+// ===========================================================================
+
+describe('media-agent-tools — graceful degradation (AC5)', () => {
+  it('vision_analyze returns aiUnavailable and never builds the runner when no credential', async () => {
+    resolveLLMForSystem.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'unknown',
+      client: null,
+      credential: null,
+      sealedCredential: null,
+      source: 'implicit-fallback',
+      apiMode: 'anthropic_messages',
+      baseUrl: null,
+      authType: null,
+    });
+    const r = await mediaRegistry();
+    const out = (await r.getExecutable('vision_analyze')?.(
+      { imagePath: '/tmp/x.png', prompt: 'What is this?' },
+      noopSurface,
+    )) as MediaModelResult;
+    expect(modelRunnerBuild).not.toHaveBeenCalled();
+    expect(out.ok).toBe(false);
+    expect(out.aiUnavailable).toBe(true);
+  });
+
+  it('vision_analyze surfaces a typed image-read failure (no throw)', async () => {
+    const r = new AgentToolRegistry();
+    registerMediaAgentTools(r, {
+      readImage: async () => {
+        throw new Error('ENOENT');
+      },
+    });
+    await r.init({ skipBuiltins: true });
+    const out = (await r.getExecutable('vision_analyze')?.(
+      { imagePath: '/nope.png', prompt: 'x' },
+      noopSurface,
+    )) as MediaModelResult;
+    expect(out.ok).toBe(false);
+    expect(out.error?.code).toBe('E_IMAGE_READ_FAILED');
+  });
+});
+
+// ===========================================================================
+// AC4 — Zod schema validation through the frozen dispatch engine
+// ===========================================================================
+
+describe('media-agent-tools — schema validation (AC4)', () => {
+  async function engine() {
+    const r = await mediaRegistry();
+    return new ToolDispatchEngine({
+      registry: r,
+      tools: createToolGuard({ mode: 'enforce' }),
+      availability: MULTIMODAL_CTX,
+    });
+  }
+
+  it('rejects image_generate without a prompt as invalid-args', async () => {
+    const res = await (await engine()).dispatch({
+      id: 'c1',
+      name: 'image_generate',
+      arguments: {},
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it('is guard-denied when the media capability is absent', async () => {
+    const r = await mediaRegistry();
+    const eng = new ToolDispatchEngine({
+      registry: r,
+      tools: createToolGuard({ mode: 'enforce' }),
+      availability: { networkEgressAllowed: false },
+    });
+    const res = await eng.dispatch({
+      id: 'c2',
+      name: 'text_to_speech',
+      arguments: { text: 'hi' },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('guard-denied');
+  });
+});

--- a/packages/core/src/tools/__tests__/memory-agent-tools.test.ts
+++ b/packages/core/src/tools/__tests__/memory-agent-tools.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the memory (BRAIN) agent-tool family (T11947 · M7 · epic T11456).
+ *
+ * FULLY MOCKED — no real `brain.db`. The four BRAIN memory ops are supplied
+ * through an INJECTED fake {@link MemoryOps} surface, so every assertion runs
+ * in-process. Covers:
+ *   - AC1 registration via the self-registering marker + part of the built-in
+ *     catalog (toolset 'agent');
+ *   - AC2 each tool DELEGATES to the injected memory op with the right params;
+ *   - AC3 Zod schema validation (missing query / empty ids → invalid-args);
+ *   - AC4 availability always-true daemon-OFF;
+ *   - AC5 delegation asserted with an injected fake Brain surface.
+ *
+ * @task T11947
+ * @epic T11456
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { describe, expect, it } from 'vitest';
+import type { EngineResult } from '../../engine-result.js';
+import { AgentToolRegistry } from '../agent-registry.js';
+import { registerBuiltinAgentTools } from '../builtin-agent-tools.js';
+import { ToolDispatchEngine } from '../dispatch.js';
+import { createToolGuard } from '../guard.js';
+import { type MemoryOps, registerMemoryAgentTools } from '../memory-agent-tools.js';
+
+/** Unused guarded surface — the memory tools resolve their own seam. */
+const noopSurface = {} as GuardedToolSurface;
+
+// ===========================================================================
+// Test doubles
+// ===========================================================================
+
+interface FakeCalls {
+  find: Array<{ query: string; limit?: number }>;
+  observe: Array<{ text: string; title?: string }>;
+  fetch: Array<{ ids: string[] }>;
+  timeline: Array<{ anchor: string; depthBefore?: number; depthAfter?: number }>;
+}
+
+/** A fake {@link MemoryOps} that records every call and returns canned success. */
+function fakeMemory(): { memory: MemoryOps; calls: FakeCalls } {
+  const calls: FakeCalls = { find: [], observe: [], fetch: [], timeline: [] };
+  const ok = (data: unknown): EngineResult => ({ success: true, data });
+  const memory: MemoryOps = {
+    find: async (params) => {
+      calls.find.push(params);
+      return ok({ hits: [{ id: 'O-1', title: 'hit' }] });
+    },
+    observe: async (params) => {
+      calls.observe.push(params);
+      return ok({ id: 'O-new' });
+    },
+    fetch: async (params) => {
+      calls.fetch.push(params);
+      return ok({ entries: [{ id: params.ids[0] }] });
+    },
+    timeline: async (params) => {
+      calls.timeline.push(params);
+      return ok({ before: [], after: [] });
+    },
+  };
+  return { memory, calls };
+}
+
+// ===========================================================================
+// AC1 — registration
+// ===========================================================================
+
+describe('memory-agent-tools — registration (AC1)', () => {
+  it('exports a self-registering marker that registers the four memory tools', async () => {
+    const mod = await import('../memory-agent-tools.js');
+    expect(typeof mod.registerAgentTools).toBe('function');
+    const registry = new AgentToolRegistry();
+    mod.registerAgentTools(registry);
+    for (const name of ['memory_search', 'memory_observe', 'memory_fetch', 'memory_timeline']) {
+      expect(registry.get(name)).toBeDefined();
+    }
+  });
+
+  it('is part of the built-in catalog in the agent toolset', async () => {
+    const registry = new AgentToolRegistry();
+    registerBuiltinAgentTools(registry);
+    await registry.init({ skipBuiltins: true });
+    const agentNames = registry.byToolset('agent').map((t) => t.name);
+    expect(agentNames).toEqual(
+      expect.arrayContaining([
+        'memory_search',
+        'memory_observe',
+        'memory_fetch',
+        'memory_timeline',
+      ]),
+    );
+  });
+});
+
+// ===========================================================================
+// AC4 — availability always-true daemon-OFF
+// ===========================================================================
+
+describe('memory-agent-tools — availability (AC4)', () => {
+  it('every memory tool is available with NO egress / capabilities (daemon-OFF)', async () => {
+    const registry = new AgentToolRegistry();
+    registerMemoryAgentTools(registry, { memory: fakeMemory().memory });
+    await registry.init({ skipBuiltins: true });
+    const available = registry.available({ networkEgressAllowed: false }).map((t) => t.name);
+    expect(available).toEqual(
+      expect.arrayContaining([
+        'memory_search',
+        'memory_observe',
+        'memory_fetch',
+        'memory_timeline',
+      ]),
+    );
+  });
+});
+
+// ===========================================================================
+// AC2 / AC5 — delegation to the injected Brain surface
+// ===========================================================================
+
+describe('memory-agent-tools — delegation (AC2/AC5)', () => {
+  async function registryWith(): Promise<{ registry: AgentToolRegistry; calls: FakeCalls }> {
+    const { memory, calls } = fakeMemory();
+    const registry = new AgentToolRegistry();
+    registerMemoryAgentTools(registry, { memory });
+    await registry.init({ skipBuiltins: true });
+    return { registry, calls };
+  }
+
+  it('memory_search delegates query + limit to memory.find', async () => {
+    const { registry, calls } = await registryWith();
+    const out = await registry.getExecutable('memory_search')?.(
+      { query: 'auth', limit: 5 },
+      noopSurface,
+    );
+    expect(calls.find).toEqual([{ query: 'auth', limit: 5 }]);
+    expect(out).toEqual({ hits: [{ id: 'O-1', title: 'hit' }] });
+  });
+
+  it('memory_observe delegates text + title to memory.observe', async () => {
+    const { registry, calls } = await registryWith();
+    await registry.getExecutable('memory_observe')?.(
+      { text: 'a learning', title: 'Title' },
+      noopSurface,
+    );
+    expect(calls.observe).toEqual([{ text: 'a learning', title: 'Title' }]);
+  });
+
+  it('memory_fetch delegates ids to memory.fetch', async () => {
+    const { registry, calls } = await registryWith();
+    await registry.getExecutable('memory_fetch')?.({ ids: ['O-1', 'D-2'] }, noopSurface);
+    expect(calls.fetch).toEqual([{ ids: ['O-1', 'D-2'] }]);
+  });
+
+  it('memory_timeline delegates anchor + depths to memory.timeline', async () => {
+    const { registry, calls } = await registryWith();
+    await registry.getExecutable('memory_timeline')?.(
+      { anchor: 'O-1', depthBefore: 2, depthAfter: 3 },
+      noopSurface,
+    );
+    expect(calls.timeline).toEqual([{ anchor: 'O-1', depthBefore: 2, depthAfter: 3 }]);
+  });
+
+  it('surfaces a typed EngineFailure as a non-ok result (never throws)', async () => {
+    const registry = new AgentToolRegistry();
+    const memory: MemoryOps = {
+      find: async () => ({
+        success: false,
+        error: { code: 'E_BRAIN_SEARCH', message: 'boom' },
+      }),
+      observe: async () => ({ success: true, data: {} }),
+      fetch: async () => ({ success: true, data: {} }),
+      timeline: async () => ({ success: true, data: {} }),
+    };
+    registerMemoryAgentTools(registry, { memory });
+    await registry.init({ skipBuiltins: true });
+    const out = (await registry.getExecutable('memory_search')?.({ query: 'x' }, noopSurface)) as {
+      ok: boolean;
+      error: { code: string };
+    };
+    expect(out.ok).toBe(false);
+    expect(out.error.code).toBe('E_BRAIN_SEARCH');
+  });
+});
+
+// ===========================================================================
+// AC3 — Zod schema validation through the frozen dispatch engine
+// ===========================================================================
+
+describe('memory-agent-tools — schema validation (AC3)', () => {
+  async function engine(): Promise<ToolDispatchEngine> {
+    const registry = new AgentToolRegistry();
+    registerMemoryAgentTools(registry, { memory: fakeMemory().memory });
+    await registry.init({ skipBuiltins: true });
+    return new ToolDispatchEngine({ registry, tools: createToolGuard({ mode: 'enforce' }) });
+  }
+
+  it('rejects memory_search without a query as invalid-args', async () => {
+    const res = await (await engine()).dispatch({
+      id: 'c1',
+      name: 'memory_search',
+      arguments: {},
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it('rejects memory_fetch with an empty ids array as invalid-args', async () => {
+    const res = await (await engine()).dispatch({
+      id: 'c2',
+      name: 'memory_fetch',
+      arguments: { ids: [] },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it('dispatches a valid memory_search call', async () => {
+    const res = await (await engine()).dispatch({
+      id: 'c3',
+      name: 'memory_search',
+      arguments: { query: 'auth' },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/core/src/tools/__tests__/schedule-agent-tools.test.ts
+++ b/packages/core/src/tools/__tests__/schedule-agent-tools.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the cron / todo agent-tool family (T11950 · M7 · epic T11456).
+ *
+ * FULLY MOCKED — no real `tasks.db`. The task ops are supplied through an INJECTED
+ * fake {@link TaskOps} store. Covers:
+ *   - AC1 register todo_add / todo_list / cron_schedule (toolset 'agent') via the
+ *     self-registering marker + part of the built-in catalog;
+ *   - AC2 todo_* delegate to the injected store; cron_schedule does NOT block on a
+ *     daemon — it returns a typed unavailable result until a schedule store ships;
+ *   - todo_* availability always-true daemon-OFF; cron_schedule hidden until the
+ *     host advertises a schedule store;
+ *   - AC3 no new table invented (cron_schedule returns E_SCHEDULE_STORE_UNAVAILABLE);
+ *   - AC4 Zod schema validation (missing title → invalid-args).
+ *
+ * @task T11950
+ * @epic T11456
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { describe, expect, it } from 'vitest';
+import type { AddTaskResult } from '../../tasks/add.js';
+import type { ListTasksResult } from '../../tasks/list.js';
+import { AgentToolRegistry } from '../agent-registry.js';
+import { registerBuiltinAgentTools } from '../builtin-agent-tools.js';
+import { ToolDispatchEngine } from '../dispatch.js';
+import { createToolGuard } from '../guard.js';
+import {
+  type CronScheduleResult,
+  registerScheduleAgentTools,
+  type TaskOps,
+} from '../schedule-agent-tools.js';
+
+const noopSurface = {} as GuardedToolSurface;
+
+interface FakeCalls {
+  add: Array<Record<string, unknown>>;
+  list: Array<Record<string, unknown>>;
+}
+
+/** A fake {@link TaskOps} store that records every call. */
+function fakeTasks(): { tasks: TaskOps; calls: FakeCalls } {
+  const calls: FakeCalls = { add: [], list: [] };
+  const tasks: TaskOps = {
+    add: async (_root, params) => {
+      calls.add.push(params);
+      return { task: { id: 'T1', title: params.title } } as unknown as AddTaskResult;
+    },
+    list: async (_root, params) => {
+      calls.list.push(params);
+      return { tasks: [], total: 0, filtered: 0 } as unknown as ListTasksResult;
+    },
+  };
+  return { tasks, calls };
+}
+
+// ===========================================================================
+// AC1 — registration
+// ===========================================================================
+
+describe('schedule-agent-tools — registration (AC1)', () => {
+  it('exports a self-registering marker that registers the three tools', async () => {
+    const mod = await import('../schedule-agent-tools.js');
+    expect(typeof mod.registerAgentTools).toBe('function');
+    const registry = new AgentToolRegistry();
+    mod.registerAgentTools(registry);
+    for (const name of ['todo_add', 'todo_list', 'cron_schedule']) {
+      expect(registry.get(name)).toBeDefined();
+    }
+  });
+
+  it('is part of the built-in catalog in the agent toolset', async () => {
+    const registry = new AgentToolRegistry();
+    registerBuiltinAgentTools(registry);
+    await registry.init({ skipBuiltins: true });
+    const agentNames = registry.byToolset('agent').map((t) => t.name);
+    expect(agentNames).toEqual(expect.arrayContaining(['todo_add', 'todo_list', 'cron_schedule']));
+  });
+});
+
+// ===========================================================================
+// AC2 — availability (todo_* always-on; cron_schedule gated)
+// ===========================================================================
+
+describe('schedule-agent-tools — availability (AC2)', () => {
+  it('todo_* are available daemon-OFF; cron_schedule is hidden without a schedule store', async () => {
+    const registry = new AgentToolRegistry();
+    registerScheduleAgentTools(registry, { tasks: fakeTasks().tasks });
+    await registry.init({ skipBuiltins: true });
+
+    const off = registry.available({ networkEgressAllowed: false }).map((t) => t.name);
+    expect(off).toEqual(expect.arrayContaining(['todo_add', 'todo_list']));
+    expect(off).not.toContain('cron_schedule');
+
+    // ... and visible once the host advertises a schedule store.
+    const withStore = registry
+      .available({ capabilities: { scheduleStore: true } })
+      .map((t) => t.name);
+    expect(withStore).toContain('cron_schedule');
+  });
+});
+
+// ===========================================================================
+// AC2/AC3 — delegation + cron_schedule does not block on a daemon
+// ===========================================================================
+
+describe('schedule-agent-tools — delegation (AC2/AC3)', () => {
+  async function registryWith(): Promise<{ registry: AgentToolRegistry; calls: FakeCalls }> {
+    const { tasks, calls } = fakeTasks();
+    const registry = new AgentToolRegistry();
+    registerScheduleAgentTools(registry, { tasks });
+    await registry.init({ skipBuiltins: true });
+    return { registry, calls };
+  }
+
+  it('todo_add delegates to the task store add op', async () => {
+    const { registry, calls } = await registryWith();
+    await registry.getExecutable('todo_add')?.(
+      { title: 'do a thing', priority: 'high', acceptance: ['ac1'] },
+      noopSurface,
+    );
+    expect(calls.add).toHaveLength(1);
+    expect(calls.add[0]).toMatchObject({
+      title: 'do a thing',
+      priority: 'high',
+      type: 'task',
+      acceptance: ['ac1'],
+    });
+  });
+
+  it('todo_list delegates to the task store list op', async () => {
+    const { registry, calls } = await registryWith();
+    await registry.getExecutable('todo_list')?.({ parent: 'T100', limit: 10 }, noopSurface);
+    expect(calls.list).toHaveLength(1);
+    expect(calls.list[0]).toMatchObject({ parent: 'T100', limit: 10 });
+  });
+
+  it('cron_schedule returns a typed unavailable result (no schema invented; no daemon block)', async () => {
+    const { registry } = await registryWith();
+    const out = (await registry.getExecutable('cron_schedule')?.(
+      { cron: '0 9 * * 1', title: 'weekly' },
+      noopSurface,
+    )) as CronScheduleResult;
+    expect(out.ok).toBe(false);
+    expect(out.error?.code).toBe('E_SCHEDULE_STORE_UNAVAILABLE');
+  });
+});
+
+// ===========================================================================
+// AC4 — Zod schema validation through the frozen dispatch engine
+// ===========================================================================
+
+describe('schedule-agent-tools — schema validation (AC4)', () => {
+  async function engine(): Promise<ToolDispatchEngine> {
+    const registry = new AgentToolRegistry();
+    registerScheduleAgentTools(registry, { tasks: fakeTasks().tasks });
+    await registry.init({ skipBuiltins: true });
+    return new ToolDispatchEngine({
+      registry,
+      tools: createToolGuard({ mode: 'enforce' }),
+      availability: { capabilities: { scheduleStore: true } },
+    });
+  }
+
+  it('rejects todo_add without a title as invalid-args', async () => {
+    const res = await (await engine()).dispatch({ id: 'c1', name: 'todo_add', arguments: {} });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it('dispatches a valid todo_add call', async () => {
+    const res = await (await engine()).dispatch({
+      id: 'c2',
+      name: 'todo_add',
+      arguments: { title: 'x' },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/core/src/tools/__tests__/skill-agent-tool.test.ts
+++ b/packages/core/src/tools/__tests__/skill-agent-tool.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the `run_skill` agent tool (T11949 · M7 · epic T11456).
+ *
+ * FULLY MOCKED — no real SKILL.md on disk. The skills-subsystem seam
+ * ({@link SkillResolver}) is INJECTED, so every assertion runs in-process.
+ * Covers:
+ *   - AC1 registration via the self-registering marker + part of the built-in
+ *     catalog (toolset 'agent');
+ *   - run_skill resolves an invocable skill via `findSkill` + returns its
+ *     instructions and dispatch protocol;
+ *   - rejects a non-invocable skill (typed E_SKILL_NOT_INVOCABLE) and an unknown
+ *     skill (E_SKILL_NOT_FOUND) without throwing;
+ *   - availability always-true daemon-OFF;
+ *   - Zod schema validation (missing name → invalid-args).
+ *
+ * @task T11949
+ * @epic T11456
+ */
+
+import type { GuardedToolSurface } from '@cleocode/contracts/tools/skill-executor';
+import { describe, expect, it } from 'vitest';
+import type { Skill } from '../../skills/types.js';
+import { AgentToolRegistry } from '../agent-registry.js';
+import { registerBuiltinAgentTools } from '../builtin-agent-tools.js';
+import { ToolDispatchEngine } from '../dispatch.js';
+import { createToolGuard } from '../guard.js';
+import {
+  type RunSkillResult,
+  registerSkillAgentTool,
+  type SkillResolver,
+} from '../skill-agent-tool.js';
+
+const noopSurface = {} as GuardedToolSurface;
+
+/** Build a minimal {@link Skill} fixture. */
+function skill(name: string, invocable: boolean): Skill {
+  return {
+    name,
+    dirName: name,
+    path: `/skills/${name}`,
+    skillMdPath: `/skills/${name}/SKILL.md`,
+    frontmatter: { name, description: `${name} desc`, invocable, protocol: 'research' },
+    content: `# ${name}\nbody`,
+  };
+}
+
+/** A fake {@link SkillResolver} over a fixed in-memory skill set. */
+function fakeResolver(skills: readonly Skill[]): SkillResolver {
+  const byName = new Map(skills.map((s) => [s.dirName, s]));
+  return {
+    findSkill: (name) => byName.get(name) ?? null,
+    dispatchExplicit: (name) => {
+      const s = byName.get(name);
+      if (s === undefined) return null;
+      return {
+        skill: s.dirName,
+        strategy: 'label',
+        confidence: 1,
+        ...(s.frontmatter.protocol !== undefined ? { protocol: s.frontmatter.protocol } : {}),
+      };
+    },
+  };
+}
+
+// ===========================================================================
+// AC1 — registration
+// ===========================================================================
+
+describe('run_skill — registration (AC1)', () => {
+  it('exports a self-registering marker that registers run_skill', async () => {
+    const mod = await import('../skill-agent-tool.js');
+    expect(typeof mod.registerAgentTools).toBe('function');
+    const registry = new AgentToolRegistry();
+    mod.registerAgentTools(registry);
+    expect(registry.get('run_skill')).toBeDefined();
+  });
+
+  it('is part of the built-in catalog in the agent toolset', async () => {
+    const registry = new AgentToolRegistry();
+    registerBuiltinAgentTools(registry);
+    await registry.init({ skipBuiltins: true });
+    const tool = registry.get('run_skill');
+    expect(tool?.toolset).toBe('agent');
+    expect(registry.byToolset('agent').some((t) => t.name === 'run_skill')).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Availability + resolution
+// ===========================================================================
+
+describe('run_skill — availability + resolution', () => {
+  async function execFor(skills: readonly Skill[]) {
+    const registry = new AgentToolRegistry();
+    registerSkillAgentTool(registry, { resolver: fakeResolver(skills) });
+    await registry.init({ skipBuiltins: true });
+    const exec = registry.getExecutable('run_skill');
+    if (exec === undefined) throw new Error('run_skill missing');
+    return { registry, exec };
+  }
+
+  it('is available with NO egress / capabilities (daemon-OFF)', async () => {
+    const { registry } = await execFor([]);
+    expect(
+      registry.available({ networkEgressAllowed: false }).some((t) => t.name === 'run_skill'),
+    ).toBe(true);
+  });
+
+  it('resolves an invocable skill and returns its instructions + protocol', async () => {
+    const { exec } = await execFor([skill('ct-research-agent', true)]);
+    const out = (await exec({ name: 'ct-research-agent' }, noopSurface)) as RunSkillResult;
+    expect(out.ok).toBe(true);
+    expect(out.skill).toBe('ct-research-agent');
+    expect(out.protocol).toBe('research');
+    expect(out.instructions).toContain('ct-research-agent');
+  });
+
+  it('rejects a non-invocable skill (typed, no throw)', async () => {
+    const { exec } = await execFor([skill('ct-task-executor', false)]);
+    const out = (await exec({ name: 'ct-task-executor' }, noopSurface)) as RunSkillResult;
+    expect(out.ok).toBe(false);
+    expect(out.error?.code).toBe('E_SKILL_NOT_INVOCABLE');
+  });
+
+  it('rejects an unknown skill (typed, no throw)', async () => {
+    const { exec } = await execFor([]);
+    const out = (await exec({ name: 'nope' }, noopSurface)) as RunSkillResult;
+    expect(out.ok).toBe(false);
+    expect(out.error?.code).toBe('E_SKILL_NOT_FOUND');
+  });
+});
+
+// ===========================================================================
+// Schema validation through the frozen dispatch engine
+// ===========================================================================
+
+describe('run_skill — schema validation', () => {
+  async function engine(): Promise<ToolDispatchEngine> {
+    const registry = new AgentToolRegistry();
+    registerSkillAgentTool(registry, { resolver: fakeResolver([skill('s', true)]) });
+    await registry.init({ skipBuiltins: true });
+    return new ToolDispatchEngine({ registry, tools: createToolGuard({ mode: 'enforce' }) });
+  }
+
+  it('rejects run_skill without a name as invalid-args', async () => {
+    const res = await (await engine()).dispatch({ id: 'c1', name: 'run_skill', arguments: {} });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.kind).toBe('invalid-args');
+  });
+
+  it('dispatches a valid run_skill call', async () => {
+    const res = await (await engine()).dispatch({
+      id: 'c2',
+      name: 'run_skill',
+      arguments: { name: 's' },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/core/src/tools/builtin-agent-tools.ts
+++ b/packages/core/src/tools/builtin-agent-tools.ts
@@ -28,6 +28,11 @@ import type { AgentToolRegistry, AvailabilityCheck } from './agent-registry.js';
 import { ALWAYS_AVAILABLE } from './agent-registry.js';
 import { registerAgentToolFamilies } from './agent-tool-families.js';
 import { registerExecCodeAgentTool } from './exec-code-agent-tool.js';
+import { registerMcpAgentTools } from './mcp-agent-tool.js';
+import { registerMediaAgentTools } from './media-agent-tools.js';
+import { registerMemoryAgentTools } from './memory-agent-tools.js';
+import { registerScheduleAgentTools } from './schedule-agent-tools.js';
+import { registerSkillAgentTool } from './skill-agent-tool.js';
 import { registerWebAgentTools } from './web-agent-tools.js';
 
 /** Available only when the named binary is known on PATH (AC5 example). */
@@ -168,4 +173,35 @@ export function registerBuiltinAgentTools(registry: AgentToolRegistry): void {
   // `capabilities.codeExec === true` (mirrors the playwright-gated browser tools),
   // so a loop that never enables code execution cannot run arbitrary code.
   registerExecCodeAgentTool(registry);
+
+  // The memory (BRAIN) family (T11947 · M7): `memory_search` / `memory_observe` /
+  // `memory_fetch` / `memory_timeline`. Each DELEGATES to the existing BRAIN
+  // memory ops (`memory/engine-compat.ts`) — no new store, no new SQL. Always
+  // available daemon-OFF (a local SQLite op through the store chokepoint).
+  registerMemoryAgentTools(registry);
+
+  // The `run_skill` tool (T11949 · M7): bridges the EXISTING SKILL.md loader
+  // (`skills/discovery.ts#findSkill`) + dispatch path to the loop. Surfaces only
+  // invocable skills; rejects non-invocable ones. No new loader/parser. Always
+  // available daemon-OFF (a local fs scan).
+  registerSkillAgentTool(registry);
+
+  // The cron/todo family (T11950 · M7): `todo_add` / `todo_list` DELEGATE to the
+  // existing task store ops (`tasks/ops.ts`); `cron_schedule` is registered but
+  // gated unavailable until a schedule store ships (follow-up T11962 under
+  // T11679) — no schema invented here.
+  registerScheduleAgentTools(registry);
+
+  // The vision/media family (T11951 · M7): `vision_analyze` / `image_generate` /
+  // `text_to_speech` — the FIRST occupants of the `media` toolset. EVERY model
+  // call routes through the E9 chokepoint (resolveLLMForSystem / ModelRunner) like
+  // `browser_vision` — no raw provider client (Gate-13). Hidden unless egress is
+  // allowed AND the host advertises a multimodal model.
+  registerMediaAgentTools(registry);
+
+  // The native MCP client fan-IN (T11948 · M7): with NO MCP connections supplied
+  // this is a no-op (core runs MCP-OFF). A host connects external MCP servers via
+  // `connectMcpServer` BEFORE the registry is frozen, then fans each server's
+  // remote tools in as live-only proxy tools.
+  registerMcpAgentTools(registry);
 }

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -189,13 +189,55 @@ export {
   type ToolGuard,
   type ToolGuardPolicy,
 } from './guard.js';
+export {
+  buildMcpProxyTool,
+  connectMcpServer,
+  MCP_TRANSPORT_KINDS,
+  type McpAgentToolOptions,
+  type McpConnection,
+  type McpRemoteTool,
+  type McpToolCallResult,
+  type McpTransport,
+  type McpTransportKind,
+  mcpToolName,
+  registerMcpAgentTools,
+  registerMcpConnectionTools,
+} from './mcp-agent-tool.js';
+// M7 agent-tool catalog (T11947–T11951) — memory / mcp / run_skill / cron-todo /
+// vision-media families. Each DEFINED here under `packages/core/src/tools`
+// (Gate-11) and CONSUMES an existing subsystem (BRAIN / skills / task store / E9
+// chokepoint) — no new store, no new loader, no raw provider client (Gate-13).
+export {
+  type MediaAgentToolOptions,
+  type MediaModelResult,
+  multimodalAvailable,
+  registerMediaAgentTools,
+} from './media-agent-tools.js';
+export {
+  type MemoryAgentToolOptions,
+  type MemoryOps,
+  registerMemoryAgentTools,
+} from './memory-agent-tools.js';
 // PTY shell runner (T1741) — the terminal toolset's execution backend; lazily +
 // optionally loads `node-pty`, transparently degrading to non-PTY `spawn`.
 export { runPty } from './pty.js';
+export {
+  type CronScheduleResult,
+  registerScheduleAgentTools,
+  type ScheduleAgentToolOptions,
+  scheduleStoreAvailable,
+  type TaskOps,
+} from './schedule-agent-tools.js';
 export { type ZodSchemaTool, zodSchemaToOpenAITool } from './schema-gen.js';
 // Injectable shell executor (E3 · T11406) — threaded into the guard's
 // executeShell/runGit; substitutes the subprocess layer in tests/sandboxes.
 export { defaultShellExecutor, type ShellExecutor } from './shell.js';
+export {
+  type RunSkillResult,
+  registerSkillAgentTool,
+  type SkillAgentToolOptions,
+  type SkillResolver,
+} from './skill-agent-tool.js';
 export { registerWebAgentTools, type WebAgentToolOptions } from './web-agent-tools.js';
 export {
   defaultHttpFetch,

--- a/packages/core/src/tools/mcp-agent-tool.ts
+++ b/packages/core/src/tools/mcp-agent-tool.ts
@@ -1,0 +1,360 @@
+/**
+ * Native MCP client (fan-IN) agent tool — connect-time `listTools` → register each
+ * remote tool into the {@link ./agent-registry.js | AgentToolRegistry}
+ * (T11948 · M7 · epic T11456 · SG-TOOLS · satisfies T11593 EP-MCP-HOST-FANIN + T1746).
+ *
+ * Where the runtime gateway is the MCP *server* (fan-OUT: it EXPOSES cleo ops as
+ * MCP tools), this is the MCP *client* (fan-IN: it CONNECTS to an external MCP
+ * server and PULLS its tools into cleo's own agent loop). On connect the client
+ * performs the MCP handshake (`initialize` → `tools/list`) and registers EACH
+ * remote tool as a proxy {@link AgentToolDescriptor} BEFORE the registry is frozen
+ * (init-time fan-in). Each proxy tool's `execute` issues a `tools/call` over the
+ * SAME transport and formats the result for the loop; a transport failure becomes a
+ * typed result (the executable NEVER throws — the frozen ToolDispatchEngine is
+ * unchanged).
+ *
+ * This REPLACES the external mcp-tool dependency for the host-loop path. It is a
+ * deliberately-minimal native client — NO external MCP SDK dependency: the wire is
+ * the standard MCP JSON-RPC ({@link McpTransport}), with stdio / SSE / HTTP
+ * transports as concrete {@link McpTransport} implementations. Placed in `core` per
+ * the package boundary (consumed by the harness, never redefined there — Gate-11).
+ *
+ * ## Availability (AC — live-connection only)
+ *
+ * A fan-in tool is available ONLY while its MCP server connection is live. The
+ * client exposes an {@link McpConnection.isLive} cell that each proxy tool's
+ * {@link AvailabilityCheck} reads; once the connection closes (or its transport
+ * errors fatally), the proxy tools report unavailable rather than dispatching into
+ * a dead transport.
+ *
+ * ## Gate-13
+ *
+ * No model/transport/provider LLM client is constructed here — the MCP transport
+ * speaks the tool protocol, not an LLM wire. There is no chokepoint concern.
+ *
+ * @epic T11456
+ * @task T11948
+ * @see ../../runtime/src/gateway/mcp/types.ts — the MCP server (fan-out) wire types this mirrors
+ * @see ./exec-code-agent-tool.js — the injectable-seam + self-registering-marker pattern mirrored here
+ */
+
+import { z } from 'zod';
+import { getLogger } from '../logger.js';
+import type {
+  AgentToolDescriptor,
+  AgentToolRegistry,
+  AvailabilityCheck,
+} from './agent-registry.js';
+
+const log = getLogger('tool-mcp-client');
+
+/** JSON Schema property descriptor for a single remote-tool input field. */
+export interface McpInputProperty {
+  /** JSON Schema primitive type (`'string'`, `'number'`, …). */
+  readonly type: string;
+  /** Human-readable description. */
+  readonly description?: string;
+  /** Allowed values (JSON Schema `enum`). */
+  readonly enum?: readonly string[];
+}
+
+/**
+ * MCP remote-tool definition (minimal subset — no external MCP SDK dependency).
+ * The shape returned by an MCP server's `tools/list`.
+ */
+export interface McpRemoteTool {
+  /** Stable remote tool name. */
+  readonly name: string;
+  /** Human-readable description. */
+  readonly description?: string;
+  /** JSON Schema for the tool's input parameters. */
+  readonly inputSchema?: {
+    readonly type?: string;
+    readonly properties?: Readonly<Record<string, McpInputProperty>>;
+    readonly required?: readonly string[];
+  };
+}
+
+/** A single content block returned by an MCP `tools/call`. */
+export interface McpContent {
+  readonly type: string;
+  readonly text?: string;
+}
+
+/** Result returned by an MCP `tools/call`. */
+export interface McpToolCallResult {
+  readonly content?: readonly McpContent[];
+  readonly isError?: boolean;
+}
+
+/**
+ * The wire seam every MCP transport implements: issue a JSON-RPC `method` with
+ * `params` and resolve the typed `result`. The stdio / SSE / HTTP transports are
+ * concrete implementations; the unit test injects an in-memory fake. The transport
+ * owns framing + correlation — this module only speaks MCP methods over it.
+ */
+export interface McpTransport {
+  /**
+   * Send an MCP JSON-RPC request and resolve its `result`.
+   *
+   * @param method - The MCP method (`'initialize'`, `'tools/list'`, `'tools/call'`).
+   * @param params - The method params.
+   * @returns The JSON-RPC `result` payload.
+   * @throws When the transport is dead or the server returns a JSON-RPC error.
+   */
+  request(method: string, params?: Readonly<Record<string, unknown>>): Promise<unknown>;
+  /** Close the transport (idempotent). After close, {@link request} rejects. */
+  close(): Promise<void>;
+}
+
+/** Transport kinds a native MCP client connection can speak over. */
+export const MCP_TRANSPORT_KINDS = ['stdio', 'sse', 'http'] as const;
+
+/** One supported {@link MCP_TRANSPORT_KINDS} value. */
+export type McpTransportKind = (typeof MCP_TRANSPORT_KINDS)[number];
+
+/**
+ * A live MCP client connection: a transport + the liveness cell the proxy tools'
+ * availability predicate reads. Produced by {@link connectMcpServer}.
+ */
+export interface McpConnection {
+  /** A stable server name used to namespace the fan-in tool names. */
+  readonly serverName: string;
+  /** The underlying transport. */
+  readonly transport: McpTransport;
+  /** The remote tools discovered at connect (`tools/list`). */
+  readonly tools: readonly McpRemoteTool[];
+  /** `true` while the connection is live; flips `false` on {@link disconnect}. */
+  isLive(): boolean;
+  /** Close the transport and flip the liveness cell to `false`. */
+  disconnect(): Promise<void>;
+}
+
+/**
+ * Perform the MCP handshake over `transport` and discover its tools: send
+ * `initialize`, then `tools/list`. Returns a live {@link McpConnection} whose
+ * liveness cell is `true` until {@link McpConnection.disconnect}. The transport is
+ * supplied by the caller (so stdio / SSE / HTTP — or an in-memory fake — all flow
+ * through the same path).
+ *
+ * @param serverName - Stable name to namespace this server's fan-in tools.
+ * @param transport - The MCP transport to handshake over.
+ * @returns The connected {@link McpConnection}.
+ * @throws When `initialize` or `tools/list` fails (the connection is not live).
+ */
+export async function connectMcpServer(
+  serverName: string,
+  transport: McpTransport,
+): Promise<McpConnection> {
+  await transport.request('initialize', {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'cleo', version: '0' },
+  });
+  const listed = await transport.request('tools/list', {});
+  const tools = extractRemoteTools(listed);
+
+  let live = true;
+  return {
+    serverName,
+    transport,
+    tools,
+    isLive: () => live,
+    disconnect: async () => {
+      live = false;
+      try {
+        await transport.close();
+      } catch (err) {
+        log.debug({ err, serverName }, 'mcp: transport close failed (ignored)');
+      }
+    },
+  };
+}
+
+/** Narrow a `tools/list` result into an {@link McpRemoteTool}[] defensively. */
+function extractRemoteTools(listed: unknown): McpRemoteTool[] {
+  if (
+    typeof listed === 'object' &&
+    listed !== null &&
+    'tools' in listed &&
+    Array.isArray((listed as { tools: unknown }).tools)
+  ) {
+    return (listed as { tools: McpRemoteTool[] }).tools.filter(
+      (t): t is McpRemoteTool => typeof t?.name === 'string',
+    );
+  }
+  return [];
+}
+
+/**
+ * The namespaced agent-tool name for a remote MCP tool: `mcp_<server>_<tool>`. So
+ * two servers exposing a same-named tool never collide in the registry.
+ *
+ * @param serverName - The MCP server's stable name.
+ * @param toolName - The remote tool's name.
+ * @returns The namespaced, registry-unique tool name.
+ */
+export function mcpToolName(serverName: string, toolName: string): string {
+  const safe = (s: string): string => s.replace(/[^a-zA-Z0-9_]/g, '_');
+  return `mcp_${safe(serverName)}_${safe(toolName)}`;
+}
+
+/**
+ * Build a Zod parameter schema from a remote tool's JSON Schema. The fan-in proxy
+ * accepts an open object (the remote server is the source of truth for its own
+ * validation); we surface declared properties as a permissive record so the model
+ * sees the shape while the remote performs authoritative validation.
+ *
+ * @param tool - The remote tool definition.
+ * @returns A Zod schema for the proxy's parameters.
+ */
+function remoteToolSchema(tool: McpRemoteTool): z.ZodType {
+  const props = tool.inputSchema?.properties ?? {};
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const required = new Set(tool.inputSchema?.required ?? []);
+  for (const [key, prop] of Object.entries(props)) {
+    let field: z.ZodTypeAny;
+    switch (prop.type) {
+      case 'number':
+      case 'integer':
+        field = z.number();
+        break;
+      case 'boolean':
+        field = z.boolean();
+        break;
+      case 'array':
+        field = z.array(z.unknown());
+        break;
+      case 'object':
+        field = z.record(z.string(), z.unknown());
+        break;
+      default:
+        field = z.string();
+    }
+    if (prop.description) field = field.describe(prop.description);
+    shape[key] = required.has(key) ? field : field.optional();
+  }
+  return z.object(shape).passthrough();
+}
+
+/**
+ * Build the proxy {@link AgentToolDescriptor} for ONE remote tool over a live
+ * connection. Its `execute` issues `tools/call` over the connection's transport
+ * and formats the result; a transport / server error becomes a typed result (never
+ * throws). Its availability returns `true` only while the connection is live.
+ *
+ * @param conn - The live MCP connection.
+ * @param tool - The remote tool to proxy.
+ * @returns The proxy descriptor to register.
+ */
+export function buildMcpProxyTool(conn: McpConnection, tool: McpRemoteTool): AgentToolDescriptor {
+  const liveOnly: AvailabilityCheck = () => conn.isLive();
+  return {
+    name: mcpToolName(conn.serverName, tool.name),
+    // 'net' — the proxy reaches an external MCP server over its transport.
+    class: 'net',
+    description:
+      tool.description ??
+      `Proxy for remote MCP tool "${tool.name}" on server "${conn.serverName}".`,
+    toolset: 'agent',
+    stateless: false,
+    available: liveOnly,
+    parameters: remoteToolSchema(tool),
+    execute: async (rawArgs): Promise<unknown> => {
+      if (!conn.isLive()) {
+        return {
+          ok: false,
+          error: {
+            code: 'E_MCP_CONNECTION_DEAD',
+            message: `MCP server "${conn.serverName}" connection is no longer live`,
+          },
+        };
+      }
+      try {
+        const result = (await conn.transport.request('tools/call', {
+          name: tool.name,
+          arguments: rawArgs,
+        })) as McpToolCallResult;
+        const text = (result.content ?? [])
+          .map((c) => c.text ?? '')
+          .filter((t) => t.length > 0)
+          .join('\n');
+        return { ok: result.isError !== true, isError: result.isError === true, content: text };
+      } catch (err) {
+        // A transport / server error is a typed dispatch failure, never a throw.
+        return {
+          ok: false,
+          error: {
+            code: 'E_MCP_CALL_FAILED',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Register every fan-in proxy tool for a live MCP connection into `registry`. Pure
+ * registration over an ALREADY-connected {@link McpConnection} — the connect /
+ * `tools/list` happened in {@link connectMcpServer} (which the host calls at
+ * init-time, before the registry is frozen). Each remote tool becomes one proxy
+ * descriptor (AC1); each is hidden once the connection drops (AC — live-only).
+ *
+ * @param registry - The registry to populate (must not yet be frozen).
+ * @param conn - The live MCP connection whose tools to fan in.
+ * @returns The registered proxy tool names.
+ */
+export function registerMcpConnectionTools(
+  registry: AgentToolRegistry,
+  conn: McpConnection,
+): string[] {
+  const names: string[] = [];
+  for (const tool of conn.tools) {
+    const descriptor = buildMcpProxyTool(conn, tool);
+    registry.register(descriptor);
+    names.push(descriptor.name);
+  }
+  return names;
+}
+
+/** Options for {@link registerMcpAgentTools} — the connections to fan in. */
+export interface McpAgentToolOptions {
+  /**
+   * Already-connected MCP connections whose remote tools to fan in. The host
+   * connects each server (via {@link connectMcpServer}) at init-time, BEFORE the
+   * registry is frozen, then passes the live connections here. Defaults to none —
+   * with no MCP servers configured this is a no-op (core runs MCP-OFF).
+   */
+  readonly connections?: readonly McpConnection[];
+}
+
+/**
+ * Register the fan-in proxy tools for every supplied MCP connection. Pure
+ * registration — no network handshake here (the connections are already live);
+ * the connect happens earlier in {@link connectMcpServer}. With no connections
+ * this is a no-op (the common no-MCP-configured case).
+ *
+ * @param registry - The registry to populate.
+ * @param options - The live connections to fan in.
+ */
+export function registerMcpAgentTools(
+  registry: AgentToolRegistry,
+  options: McpAgentToolOptions = {},
+): void {
+  for (const conn of options.connections ?? []) {
+    registerMcpConnectionTools(registry, conn);
+  }
+}
+
+/**
+ * Self-registration marker (AC1) — the identifier the
+ * {@link AgentToolRegistry.discover} bounded source scan greps for. With no live
+ * connections supplied this registers nothing (a host wires connections via
+ * {@link registerMcpAgentTools} directly with its connected servers).
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentTools(registry: AgentToolRegistry): void {
+  registerMcpAgentTools(registry);
+}

--- a/packages/core/src/tools/media-agent-tools.ts
+++ b/packages/core/src/tools/media-agent-tools.ts
@@ -1,0 +1,319 @@
+/**
+ * Vision / media agent-tool family — `vision_analyze` / `image_generate` /
+ * `text_to_speech` (T11951 · M7 · epic T11456 · SG-TOOLS).
+ *
+ * The FIRST occupants of the previously-empty `media` toolset. Every model /
+ * multimodal call routes THROUGH the single E9 chokepoint
+ * ({@link import('../llm/system-resolver.js')}'s `resolveLLMForSystem` →
+ * {@link import('../llm/model-runner.js')}'s `ModelRunner`), EXACTLY like
+ * `browser_vision` ({@link ./web-agent-tools.js}). There is NO raw provider client,
+ * NO new transport, NO API-key read at this call-site — the plaintext credential is
+ * materialized from the sealed handle ONLY at the wire inside `ModelRunner.build`
+ * (Gate-13 stays green).
+ *
+ *   - **`vision_analyze`** — read a local image + a prompt, send them as a single
+ *     multimodal user turn through the chokepoint, return the model's analysis.
+ *   - **`image_generate`** — send an image prompt through the chokepoint; returns
+ *     the model's response (text/asset-ref it emits). When the resolved model
+ *     cannot generate an image the chokepoint degrades — the tool surfaces an
+ *     `unsupported` flag rather than constructing a bespoke image client.
+ *   - **`text_to_speech`** — send text through the chokepoint for narration intent;
+ *     same degradation contract when the modality is unsupported.
+ *
+ * ## Availability (AC3 — mirrors `browser_vision`)
+ *
+ * Hidden unless outbound egress is permitted AND the host advertises a multimodal
+ * model (`networkEgressAllowed !== false && capabilities.multimodal === true`).
+ * Registered-but-hidden so core runs credential-OFF / egress-OFF and the catalog
+ * stays stable. (The capability flag is the host's "a multimodal model is
+ * resolvable" promise — availability is a SYNC predicate, so the actual resolution
+ * happens at `execute` time with graceful degradation when no credential resolves.)
+ *
+ * @epic T11456
+ * @task T11951
+ * @see ./web-agent-tools.js — `browser_vision`, the E9-routed multimodal pattern mirrored here
+ * @see ../llm/system-resolver.js — `resolveLLMForSystem` (the E9 chokepoint)
+ * @see ../llm/model-runner.js — `ModelRunner` (the single SSoT wire builder)
+ */
+
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import type { TransportMessage } from '@cleocode/contracts/llm/normalized-response.js';
+import { z } from 'zod';
+import { getLogger } from '../logger.js';
+import type {
+  AgentToolRegistry,
+  AvailabilityCheck,
+  ToolAvailabilityContext,
+} from './agent-registry.js';
+
+const log = getLogger('tool-media-agent');
+
+/**
+ * Available only when outbound egress is permitted AND the host advertises a
+ * multimodal model. Mirrors `browser_vision`'s availability: registered-but-hidden
+ * (so the `media` catalog is stable) until a context advertises both
+ * `networkEgressAllowed !== false` and `capabilities.multimodal === true`.
+ */
+export const multimodalAvailable: AvailabilityCheck = (ctx: ToolAvailabilityContext) =>
+  ctx.networkEgressAllowed !== false && ctx.capabilities?.multimodal === true;
+
+/**
+ * Read a local image file as base64 + sniff its MIME type from the extension.
+ * Injectable so the unit test supplies image bytes without a real file on disk.
+ */
+export type ImageReader = (path: string) => Promise<{ base64: string; mediaType: string }>;
+
+/** Default {@link ImageReader} — a local `fs` read + extension-based MIME sniff. */
+const defaultImageReader: ImageReader = async (path) => {
+  const bytes = await readFile(path);
+  return { base64: bytes.toString('base64'), mediaType: mediaTypeForPath(path) };
+};
+
+/** Map a file extension to its image MIME type (defaults to `image/png`). */
+function mediaTypeForPath(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.webp':
+      return 'image/webp';
+    case '.gif':
+      return 'image/gif';
+    default:
+      return 'image/png';
+  }
+}
+
+/** The outcome of a chokepoint-routed media call. */
+export interface MediaModelResult {
+  /** Whether a model produced a response. */
+  readonly ok: boolean;
+  /** The model's textual response (analysis / description / refusal). */
+  readonly content?: string;
+  /** The model that answered (present once a credential resolves). */
+  readonly model?: string;
+  /**
+   * `true` when no credential resolved through the E9 chokepoint — the call
+   * degraded gracefully rather than throwing (mirrors `browser_vision`).
+   */
+  readonly aiUnavailable?: boolean;
+  /**
+   * `true` when the resolved model cannot serve the requested modality
+   * (e.g. true image synthesis / TTS audio). The tool does NOT construct a
+   * bespoke client for an unsupported modality (Gate-13) — it reports this.
+   */
+  readonly unsupported?: boolean;
+  /** A stable code + message when the call failed for another reason. */
+  readonly error?: { readonly code: string; readonly message: string };
+}
+
+/** Options for {@link registerMediaAgentTools} — all injectable for testing. */
+export interface MediaAgentToolOptions {
+  /** The local-image reader. Defaults to a real `fs` read + MIME sniff. */
+  readonly readImage?: ImageReader;
+  /** Project root threaded into the E9 resolver (defaults to the resolver's own fallback). */
+  readonly projectRoot?: string;
+}
+
+/**
+ * Resolve an LLM through the SINGLE E9 chokepoint and send `messages` as one turn
+ * via the SSoT {@link ModelRunner}. The sealed credential is materialized ONLY at
+ * the wire (inside `ModelRunner.build`); there is NO raw provider/transport
+ * construction here (Gate-13). Returns `aiUnavailable: true` when no credential
+ * resolves — graceful degradation, not an error (mirrors `runBrowserVision`).
+ *
+ * @param messages - The provider-neutral turn (text and/or image blocks).
+ * @param projectRoot - Project root for the resolver.
+ * @returns The {@link MediaModelResult}.
+ */
+async function runChokepointModel(
+  messages: TransportMessage[],
+  projectRoot: string | undefined,
+): Promise<MediaModelResult> {
+  // E9 resolution chokepoint — the ONLY route to an LLM credential. Never throws.
+  const { resolveLLMForSystem } = await import('../llm/system-resolver.js');
+  const resolved = await resolveLLMForSystem('task-executor', {
+    ...(projectRoot !== undefined ? { projectRoot } : {}),
+  });
+  if (!resolved.sealedCredential) {
+    return { ok: false, aiUnavailable: true };
+  }
+
+  try {
+    // Build the wire surfaces via the single SSoT ModelRunner (Gate-13: no raw
+    // transport / provider construction here). The token is materialized from the
+    // sealed handle inside ModelRunner only.
+    const { ModelRunner } = await import('../llm/model-runner.js');
+    const apiKey = (await resolved.sealedCredential.fetch()).value;
+    const built = await ModelRunner.build({
+      provider: resolved.provider,
+      model: resolved.model,
+      credential: resolved.credential
+        ? {
+            provider: resolved.credential.provider,
+            apiKey,
+            source: resolved.credential.source,
+            authType: resolved.credential.authType,
+          }
+        : null,
+      source: resolved.source,
+      ...(resolved.credentialLabel !== undefined
+        ? { credentialLabel: resolved.credentialLabel }
+        : {}),
+      apiMode: resolved.apiMode,
+      baseUrl: resolved.baseUrl,
+      authType: resolved.authType,
+      ...(resolved.capabilities !== undefined ? { capabilities: resolved.capabilities } : {}),
+    });
+    const response = await built.session.send(messages);
+    return { ok: true, content: response.content ?? undefined, model: resolved.model };
+  } catch (err) {
+    log.warn({ err }, 'media tool: chokepoint model call failed — returning unavailable');
+    return { ok: false, model: resolved.model, aiUnavailable: true };
+  }
+}
+
+/**
+ * Register the vision / media agent-tool family into `registry`. Pure
+ * registration — no model is resolved, no credential is read, no file is opened
+ * here; all of that happens later inside each tool's `execute` through the E9
+ * chokepoint (and the injected image reader). Import-time side-effect-free.
+ *
+ * @param registry - The registry to populate.
+ * @param options - Injectable image reader / project root (for testing).
+ */
+export function registerMediaAgentTools(
+  registry: AgentToolRegistry,
+  options: MediaAgentToolOptions = {},
+): void {
+  const readImage = options.readImage ?? defaultImageReader;
+  const projectRoot = options.projectRoot;
+
+  // --- vision_analyze (image + prompt → analysis, via the E9 chokepoint) ----
+  registry.register({
+    name: 'vision_analyze',
+    // 'shell' — the call captures an external model response (its strongest surface).
+    class: 'shell',
+    description:
+      'Analyse a local image with a vision model: reads the image and sends it plus a ' +
+      'prompt as a multimodal turn through the resolveLLMForSystem chokepoint. Returns ' +
+      'the model analysis, or aiUnavailable when no credential resolves.',
+    toolset: 'media',
+    stateless: true,
+    available: multimodalAvailable,
+    parameters: z.object({
+      imagePath: z.string().describe('Absolute path to the image file to analyse.'),
+      prompt: z.string().describe('Question / instruction for the vision model about the image.'),
+    }),
+    execute: async (rawArgs): Promise<MediaModelResult> => {
+      const imagePath = String(rawArgs.imagePath);
+      const prompt = String(rawArgs.prompt);
+      let image: { base64: string; mediaType: string };
+      try {
+        image = await readImage(imagePath);
+      } catch (err) {
+        return {
+          ok: false,
+          error: {
+            code: 'E_IMAGE_READ_FAILED',
+            message: `could not read image at "${imagePath}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          },
+        };
+      }
+      const messages: TransportMessage[] = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: prompt },
+            {
+              type: 'image',
+              source: { type: 'base64', data: image.base64, mediaType: image.mediaType },
+            },
+          ],
+        },
+      ];
+      return runChokepointModel(messages, projectRoot);
+    },
+  });
+
+  // --- image_generate (prompt → image, via the E9 chokepoint) --------------
+  registry.register({
+    name: 'image_generate',
+    class: 'shell',
+    description:
+      'Generate an image from a text prompt by routing the request through the ' +
+      'resolveLLMForSystem chokepoint. When the resolved model cannot synthesize an image, ' +
+      'reports unsupported rather than constructing a bespoke image client.',
+    toolset: 'media',
+    stateless: true,
+    available: multimodalAvailable,
+    parameters: z.object({
+      prompt: z.string().describe('A text description of the image to generate.'),
+    }),
+    execute: async (rawArgs): Promise<MediaModelResult> => {
+      const prompt = String(rawArgs.prompt);
+      const messages: TransportMessage[] = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: `Generate an image for the following description. If you cannot produce an image, say so explicitly.\n\n${prompt}`,
+            },
+          ],
+        },
+      ];
+      const result = await runChokepointModel(messages, projectRoot);
+      // The chat chokepoint does not emit raw image bytes; surface the model's
+      // response and flag that true synthesis is not served by this path.
+      return { ...result, unsupported: result.ok ? true : result.unsupported };
+    },
+  });
+
+  // --- text_to_speech (text → narration intent, via the E9 chokepoint) -----
+  registry.register({
+    name: 'text_to_speech',
+    class: 'shell',
+    description:
+      'Convert text to speech by routing the request through the resolveLLMForSystem ' +
+      'chokepoint. When the resolved model cannot synthesize audio, reports unsupported ' +
+      'rather than constructing a bespoke TTS client.',
+    toolset: 'media',
+    stateless: true,
+    available: multimodalAvailable,
+    parameters: z.object({
+      text: z.string().describe('The text to narrate as speech.'),
+    }),
+    execute: async (rawArgs): Promise<MediaModelResult> => {
+      const text = String(rawArgs.text);
+      const messages: TransportMessage[] = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: `Produce speech audio for the following text. If you cannot produce audio, say so explicitly.\n\n${text}`,
+            },
+          ],
+        },
+      ];
+      const result = await runChokepointModel(messages, projectRoot);
+      return { ...result, unsupported: result.ok ? true : result.unsupported };
+    },
+  });
+}
+
+/**
+ * Self-registration marker (AC1) — the identifier the
+ * {@link AgentToolRegistry.discover} bounded source scan greps for. Aliases
+ * {@link registerMediaAgentTools} so a future scan-dir discovery (or the built-in
+ * aggregator) can call it uniformly with the other agent-tool modules.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentTools(registry: AgentToolRegistry): void {
+  registerMediaAgentTools(registry);
+}

--- a/packages/core/src/tools/memory-agent-tools.ts
+++ b/packages/core/src/tools/memory-agent-tools.ts
@@ -1,0 +1,247 @@
+/**
+ * Memory (BRAIN) agent-tool family — `memory_search` / `memory_observe` /
+ * `memory_fetch` / `memory_timeline` (T11947 · M7 · epic T11456 · SG-TOOLS).
+ *
+ * Surfaces the EXISTING BRAIN cognitive-memory operations to the agent loop as
+ * `agent`-toolset tools, mirroring the `cleo memory find|observe|fetch|timeline`
+ * CLI verbs. It adds NO new store, NO new SQL, and NO new schema: each tool
+ * DELEGATES to the established memory ops in
+ * {@link import('../memory/engine-compat.js')}
+ * ({@link memoryFind} / {@link memoryObserve} / {@link memoryFetch} /
+ * {@link memoryTimeline}), which themselves route through the BRAIN retrieval
+ * accessors + the store chokepoint. The agent loop never re-implements brain
+ * retrieval — it reuses the SAME path the CLI and the orchestrator use.
+ *
+ * ## Why a seam, not a hardcoded import (AC5 + Gate-11)
+ *
+ * The four memory ops are injected through the {@link MemoryOps} seam, defaulting
+ * to the real `engine-compat` functions. This lets the unit test inject a FAKE
+ * Brain surface and assert delegation + schema validation WITHOUT opening a real
+ * `brain.db`. Production binds the real ops. The tools are DEFINED here under
+ * `packages/core/src/tools` and CONSUME the memory subsystem — they construct no
+ * new atomic primitive (Gate-11).
+ *
+ * ## Availability (AC4)
+ *
+ * BRAIN read/write is a LOCAL SQLite operation through the store chokepoint — no
+ * credential, no network, no daemon. Every memory tool is therefore
+ * {@link ALWAYS_AVAILABLE}: it works daemon-OFF and credential-OFF.
+ *
+ * ## Gate-13
+ *
+ * No model/transport/provider client is constructed here — BRAIN search is a
+ * local FTS/SQLite query, not an LLM call. There is no chokepoint concern.
+ *
+ * @epic T11456
+ * @task T11947
+ * @see ../memory/engine-compat.js — the memory ops this family delegates to
+ * @see ./exec-code-agent-tool.js — the injectable-seam + self-registering-marker pattern mirrored here
+ */
+
+import { z } from 'zod';
+import type { EngineResult } from '../engine-result.js';
+import {
+  memoryFetch as realMemoryFetch,
+  memoryFind as realMemoryFind,
+  memoryObserve as realMemoryObserve,
+  memoryTimeline as realMemoryTimeline,
+} from '../memory/engine-compat.js';
+import { resolveOrCwd } from '../paths.js';
+import { type AgentToolRegistry, ALWAYS_AVAILABLE } from './agent-registry.js';
+
+/**
+ * The BRAIN memory operations the family delegates to. Each member has the SAME
+ * signature as the corresponding `engine-compat` function — `(params, root?) →
+ * Promise<EngineResult>`. Injectable so the unit test can supply a fake Brain
+ * surface; defaults to the real ops in production.
+ */
+export interface MemoryOps {
+  /** Token-efficient compact search (→ `cleo memory find`). */
+  readonly find: (
+    params: { query: string; limit?: number },
+    projectRoot?: string,
+  ) => Promise<EngineResult>;
+  /** Append an observation (→ `cleo memory observe`). */
+  readonly observe: (
+    params: { text: string; title?: string },
+    projectRoot?: string,
+  ) => Promise<EngineResult>;
+  /** Batch fetch entries by ID (→ `cleo memory fetch`). */
+  readonly fetch: (params: { ids: string[] }, projectRoot?: string) => Promise<EngineResult>;
+  /** Chronological context around an anchor (→ `cleo memory timeline`). */
+  readonly timeline: (
+    params: { anchor: string; depthBefore?: number; depthAfter?: number },
+    projectRoot?: string,
+  ) => Promise<EngineResult>;
+}
+
+/** The real BRAIN memory ops — the production default for {@link MemoryOps}. */
+const REAL_MEMORY_OPS: MemoryOps = {
+  find: realMemoryFind,
+  observe: realMemoryObserve,
+  fetch: realMemoryFetch,
+  timeline: realMemoryTimeline,
+};
+
+/** Options for {@link registerMemoryAgentTools} — all injectable for testing. */
+export interface MemoryAgentToolOptions {
+  /** The memory ops seam. Defaults to the real `engine-compat` functions. */
+  readonly memory?: MemoryOps;
+  /**
+   * The project root threaded into every op (defaults to the resolved project
+   * root via {@link resolveOrCwd} — never a bare `process.cwd()` in core, T9584).
+   */
+  readonly projectRoot?: string;
+}
+
+/**
+ * Coerce an {@link EngineResult} into the opaque value the loop serialises back
+ * to the model. On success the `data` payload is returned as-is; on failure a
+ * stable `{ ok: false, error }` shape is returned (the op never throws for an
+ * expected failure — it returns a typed `EngineFailure`).
+ *
+ * @param result - The op's EngineResult.
+ * @returns The success data, or a typed failure object.
+ */
+function unwrapEngineResult(result: EngineResult): unknown {
+  if (result.success) return result.data;
+  return { ok: false, error: result.error };
+}
+
+/**
+ * Register the memory (BRAIN) agent-tool family into `registry`. Pure
+ * registration — no `brain.db` is opened, no query runs here; all of that happens
+ * later inside each tool's `execute` through the injected (or default) ops.
+ * Import-time side-effect-free.
+ *
+ * @param registry - The registry to populate.
+ * @param options - Injectable memory ops / project root (for testing).
+ */
+export function registerMemoryAgentTools(
+  registry: AgentToolRegistry,
+  options: MemoryAgentToolOptions = {},
+): void {
+  const memory: MemoryOps = options.memory ?? REAL_MEMORY_OPS;
+  const projectRoot = resolveOrCwd(options.projectRoot);
+
+  // --- memory_search (→ memoryFind) ----------------------------------------
+  registry.register({
+    name: 'memory_search',
+    // 'search' — a local read-query of the BRAIN store (no side effect beyond reading).
+    class: 'search',
+    description:
+      'Search BRAIN cognitive memory (decisions / patterns / learnings / observations) ' +
+      'for entries matching a query, returning compact hits (IDs + titles). Use memory_fetch ' +
+      'to retrieve full details for a hit.',
+    toolset: 'agent',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      query: z.string().describe('Free-text search query.'),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Maximum number of compact hits to return.'),
+    }),
+    execute: async (rawArgs): Promise<unknown> => {
+      const query = String(rawArgs.query);
+      const limit = typeof rawArgs.limit === 'number' ? rawArgs.limit : undefined;
+      const result = await memory.find({ query, limit }, projectRoot);
+      return unwrapEngineResult(result);
+    },
+  });
+
+  // --- memory_observe (→ memoryObserve) ------------------------------------
+  registry.register({
+    name: 'memory_observe',
+    // 'fs' — persists a row to the local BRAIN store (its strongest side-effect surface).
+    class: 'fs',
+    description:
+      'Append a new observation to BRAIN memory (an O-prefixed entry). Use after a ' +
+      'non-trivial step to record a learning or decision for future sessions.',
+    toolset: 'agent',
+    stateless: false,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      text: z.string().describe('The observation body to store.'),
+      title: z.string().optional().describe('A short title for the observation.'),
+    }),
+    execute: async (rawArgs): Promise<unknown> => {
+      const text = String(rawArgs.text);
+      const title = rawArgs.title === undefined ? undefined : String(rawArgs.title);
+      const result = await memory.observe({ text, title }, projectRoot);
+      return unwrapEngineResult(result);
+    },
+  });
+
+  // --- memory_fetch (→ memoryFetch) ----------------------------------------
+  registry.register({
+    name: 'memory_fetch',
+    class: 'search',
+    description:
+      'Fetch full details for one or more BRAIN entries by ID (e.g. O-abc123, D-def456). ' +
+      'Use after memory_search to expand a compact hit.',
+    toolset: 'agent',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      ids: z
+        .array(z.string())
+        .min(1)
+        .describe('One or more BRAIN entry IDs to fetch (e.g. ["O-abc123"]).'),
+    }),
+    execute: async (rawArgs): Promise<unknown> => {
+      const ids = Array.isArray(rawArgs.ids) ? rawArgs.ids.map(String) : [];
+      const result = await memory.fetch({ ids }, projectRoot);
+      return unwrapEngineResult(result);
+    },
+  });
+
+  // --- memory_timeline (→ memoryTimeline) ----------------------------------
+  registry.register({
+    name: 'memory_timeline',
+    class: 'search',
+    description:
+      'Retrieve chronological context around a BRAIN entry — the entries recorded before ' +
+      'and after a given anchor ID — to understand the sequence of observations and decisions.',
+    toolset: 'agent',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      anchor: z.string().describe('The BRAIN entry ID to anchor the timeline window on.'),
+      depthBefore: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('How many entries before the anchor to include.'),
+      depthAfter: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('How many entries after the anchor to include.'),
+    }),
+    execute: async (rawArgs): Promise<unknown> => {
+      const anchor = String(rawArgs.anchor);
+      const depthBefore = typeof rawArgs.depthBefore === 'number' ? rawArgs.depthBefore : undefined;
+      const depthAfter = typeof rawArgs.depthAfter === 'number' ? rawArgs.depthAfter : undefined;
+      const result = await memory.timeline({ anchor, depthBefore, depthAfter }, projectRoot);
+      return unwrapEngineResult(result);
+    },
+  });
+}
+
+/**
+ * Self-registration marker (AC1) — the identifier the
+ * {@link AgentToolRegistry.discover} bounded source scan greps for. Aliases
+ * {@link registerMemoryAgentTools} so a future scan-dir discovery (or the
+ * built-in aggregator) can call it uniformly with the other agent-tool modules.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentTools(registry: AgentToolRegistry): void {
+  registerMemoryAgentTools(registry);
+}

--- a/packages/core/src/tools/schedule-agent-tools.ts
+++ b/packages/core/src/tools/schedule-agent-tools.ts
@@ -1,0 +1,286 @@
+/**
+ * Cron / todo agent-tool family — `todo_add` / `todo_list` / `cron_schedule`
+ * (T11950 · M7 · epic T11456 · SG-TOOLS).
+ *
+ * Surfaces the EXISTING task store to the agent loop as `agent`-toolset tools that
+ * work daemon-OFF:
+ *
+ *   - **`todo_add`** — create a task, DELEGATING to the existing
+ *     {@link import('../tasks/ops.js')}'s `tasksAddOp` (the same path `cleo add`
+ *     uses). No new table, no new schema.
+ *   - **`todo_list`** — list tasks, DELEGATING to `tasksListOp` (the same path
+ *     `cleo list` uses).
+ *   - **`cron_schedule`** — register a recurring schedule. The schedule DOMAIN
+ *     has no persisted store yet (there is no `schedules` table; `node-cron` is
+ *     used only by the in-process daemon GC/sentient timers), so per AC3 this tool
+ *     does NOT invent schema. It is REGISTERED (so the catalog is stable) but its
+ *     {@link AvailabilityCheck} hides it until a host advertises a schedule store
+ *     (`capabilities.scheduleStore === true`), and invoking it without the store
+ *     returns a typed `E_SCHEDULE_STORE_UNAVAILABLE` failure pointing at the
+ *     follow-up that adds the store (T11962, under T11679). `todo_*` are always
+ *     available daemon-OFF.
+ *
+ * ## Why a seam, not a hardcoded import (testing + Gate-11)
+ *
+ * The task ops are injected through the {@link TaskOps} seam, defaulting to the
+ * real `ops` functions. The unit test injects a FAKE store and asserts delegation
+ * + schema validation WITHOUT opening a real `tasks.db`. The tools are DEFINED
+ * here under `packages/core/src/tools` and CONSUME the task subsystem — they
+ * construct no new atomic primitive (Gate-11).
+ *
+ * ## Gate-13
+ *
+ * No model/transport/provider client is constructed here — task CRUD is a local
+ * SQLite operation. There is no chokepoint concern.
+ *
+ * @epic T11456
+ * @task T11950
+ * @see ../tasks/ops.js — `tasksAddOp` / `tasksListOp` (the ops this family delegates to)
+ * @see ./exec-code-agent-tool.js — the injectable-seam + capability-gated availability pattern mirrored here
+ */
+
+import type { TaskPriority, TaskStatus, TaskType } from '@cleocode/contracts';
+import { z } from 'zod';
+import { resolveOrCwd } from '../paths.js';
+import type { AddTaskResult } from '../tasks/add.js';
+import type { ListTasksResult } from '../tasks/list.js';
+import {
+  type AgentToolRegistry,
+  ALWAYS_AVAILABLE,
+  type AvailabilityCheck,
+} from './agent-registry.js';
+
+/**
+ * The task store operations the `todo_*` tools delegate to. Each member has the
+ * SAME signature as the corresponding `ops` function. Injectable so the unit test
+ * can supply a fake store; defaults to the real ops in production.
+ */
+export interface TaskOps {
+  /** Create a task (→ `tasksAddOp`). */
+  readonly add: (
+    projectRoot: string,
+    params: {
+      title: string;
+      description?: string;
+      parent?: string;
+      priority?: TaskPriority;
+      type?: TaskType;
+      acceptance?: string[];
+    },
+  ) => Promise<AddTaskResult>;
+  /** List tasks (→ `tasksListOp`). */
+  readonly list: (
+    projectRoot: string,
+    params: {
+      parent?: string;
+      status?: TaskStatus;
+      priority?: TaskPriority;
+      type?: TaskType;
+      limit?: number;
+    },
+  ) => Promise<ListTasksResult>;
+}
+
+/**
+ * The result `cron_schedule` returns when no schedule store backs it — a typed,
+ * non-throwing failure pointing at the follow-up that adds the store. The tool is
+ * registered (catalog-stable) but gated unavailable until the store ships.
+ */
+export interface CronScheduleResult {
+  /** Whether a schedule row was registered. */
+  readonly ok: boolean;
+  /** The registered schedule's ID (present on success — once a store backs it). */
+  readonly scheduleId?: string;
+  /** A stable code + message for why scheduling is unavailable (present on failure). */
+  readonly error?: { readonly code: string; readonly message: string };
+}
+
+/**
+ * Available only when the host advertises a schedule store
+ * (`capabilities.scheduleStore === true`). The schedule domain has no persisted
+ * store yet (T11962, under T11679), so `cron_schedule` is registered-but-hidden
+ * — mirroring the playwright-gated browser tools — until the store ships. This is
+ * a host POLICY/capability switch, not a daemon probe: registration of a schedule
+ * row is meant to persist WITHOUT a live daemon once the store exists.
+ */
+export const scheduleStoreAvailable: AvailabilityCheck = (ctx) =>
+  ctx.capabilities?.scheduleStore === true;
+
+/** Options for {@link registerScheduleAgentTools} — all injectable for testing. */
+export interface ScheduleAgentToolOptions {
+  /** The task ops seam. Defaults to the real `tasksAddOp` / `tasksListOp`. */
+  readonly tasks?: TaskOps;
+  /**
+   * The project root threaded into every op (defaults to the resolved project
+   * root via {@link resolveOrCwd} — never a bare `process.cwd()` in core, T9584).
+   */
+  readonly projectRoot?: string;
+}
+
+/**
+ * Build the real task-ops seam by lazily importing the existing `ops` module.
+ * Lazy so this tool module stays import-time side-effect-free; the import happens
+ * only when the real ops are first needed.
+ *
+ * @returns The production {@link TaskOps}.
+ */
+async function realTaskOps(): Promise<TaskOps> {
+  const { tasksAddOp, tasksListOp } = await import('../tasks/ops.js');
+  return {
+    add: (root, params) => tasksAddOp(root, params),
+    list: (root, params) => tasksListOp(root, params),
+  };
+}
+
+/**
+ * Register the cron / todo agent-tool family into `registry`. Pure registration —
+ * no `tasks.db` is opened, no row is written here; all of that happens later
+ * inside each tool's `execute` through the injected (or lazily-resolved real)
+ * ops. Import-time side-effect-free.
+ *
+ * @param registry - The registry to populate.
+ * @param options - Injectable task ops / project root (for testing).
+ */
+export function registerScheduleAgentTools(
+  registry: AgentToolRegistry,
+  options: ScheduleAgentToolOptions = {},
+): void {
+  const projectRoot = resolveOrCwd(options.projectRoot);
+
+  // --- todo_add (→ tasksAddOp) ---------------------------------------------
+  registry.register({
+    name: 'todo_add',
+    // 'fs' — persists a row to the local tasks store (its strongest side-effect surface).
+    class: 'fs',
+    description:
+      'Add a task (todo) to the project task store. Delegates to the same path as `cleo add`. ' +
+      'Returns the created task. Always available daemon-OFF.',
+    toolset: 'agent',
+    stateless: false,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      title: z.string().describe('The task title.'),
+      description: z.string().optional().describe('A longer task description.'),
+      parent: z.string().optional().describe('Parent task/epic ID to nest this task under.'),
+      priority: z
+        .enum(['critical', 'high', 'medium', 'low'])
+        .optional()
+        .describe('Task priority (default medium).'),
+      acceptance: z
+        .array(z.string())
+        .optional()
+        .describe('Acceptance criteria — one entry per criterion.'),
+    }),
+    execute: async (rawArgs): Promise<unknown> => {
+      const tasks = options.tasks ?? (await realTaskOps());
+      const title = String(rawArgs.title);
+      const description =
+        rawArgs.description === undefined ? undefined : String(rawArgs.description);
+      const parent = rawArgs.parent === undefined ? undefined : String(rawArgs.parent);
+      const priority =
+        rawArgs.priority === 'critical' ||
+        rawArgs.priority === 'high' ||
+        rawArgs.priority === 'medium' ||
+        rawArgs.priority === 'low'
+          ? rawArgs.priority
+          : undefined;
+      const acceptance = Array.isArray(rawArgs.acceptance)
+        ? rawArgs.acceptance.map(String)
+        : undefined;
+      return tasks.add(projectRoot, {
+        title,
+        description,
+        parent,
+        priority,
+        type: 'task',
+        acceptance,
+      });
+    },
+  });
+
+  // --- todo_list (→ tasksListOp) -------------------------------------------
+  registry.register({
+    name: 'todo_list',
+    // 'search' — a local read-query of the tasks store.
+    class: 'search',
+    description:
+      'List tasks (todos) from the project task store, optionally filtered by parent / status / ' +
+      'priority. Delegates to the same path as `cleo list`. Always available daemon-OFF.',
+    toolset: 'agent',
+    stateless: true,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      parent: z.string().optional().describe('Only list direct children of this task/epic ID.'),
+      status: z.string().optional().describe('Filter by status (e.g. pending, in_progress, done).'),
+      priority: z
+        .enum(['critical', 'high', 'medium', 'low'])
+        .optional()
+        .describe('Filter by priority.'),
+      limit: z.number().int().positive().optional().describe('Maximum number of tasks to return.'),
+    }),
+    execute: async (rawArgs): Promise<unknown> => {
+      const tasks = options.tasks ?? (await realTaskOps());
+      const parent = rawArgs.parent === undefined ? undefined : String(rawArgs.parent);
+      const status =
+        rawArgs.status === undefined ? undefined : (String(rawArgs.status) as TaskStatus);
+      const priority =
+        rawArgs.priority === 'critical' ||
+        rawArgs.priority === 'high' ||
+        rawArgs.priority === 'medium' ||
+        rawArgs.priority === 'low'
+          ? rawArgs.priority
+          : undefined;
+      const limit = typeof rawArgs.limit === 'number' ? rawArgs.limit : undefined;
+      return tasks.list(projectRoot, { parent, status, priority, limit });
+    },
+  });
+
+  // --- cron_schedule (gated unavailable until a schedule store ships) ------
+  registry.register({
+    name: 'cron_schedule',
+    // 'fs' — registering a schedule is meant to persist a store row (once the store exists).
+    class: 'fs',
+    description:
+      'Register a recurring schedule (cron expression → task template). The schedule store is ' +
+      'not yet implemented (follow-up T11962 under T11679); this tool is hidden until a host ' +
+      'advertises a schedule store and returns a typed unavailable result otherwise.',
+    toolset: 'agent',
+    stateless: false,
+    available: scheduleStoreAvailable,
+    parameters: z.object({
+      cron: z.string().describe('A cron expression for the recurrence (e.g. "0 9 * * 1").'),
+      title: z.string().describe('The title of the task to create on each fire.'),
+      description: z
+        .string()
+        .optional()
+        .describe('A description for the task created on each fire.'),
+    }),
+    execute: async (): Promise<CronScheduleResult> => {
+      // The schedule domain has no persisted store yet (AC3 — do not invent
+      // schema). Return a typed, non-throwing unavailable result pointing at the
+      // follow-up that adds the store. Once T11962 lands, this tool's `execute`
+      // writes a schedule row through the new accessor and its availability gates
+      // on the real store rather than this placeholder.
+      return {
+        ok: false,
+        error: {
+          code: 'E_SCHEDULE_STORE_UNAVAILABLE',
+          message:
+            'the cron/schedule store is not yet implemented — tracked in T11962 (under T11679)',
+        },
+      };
+    },
+  });
+}
+
+/**
+ * Self-registration marker (AC1) — the identifier the
+ * {@link AgentToolRegistry.discover} bounded source scan greps for. Aliases
+ * {@link registerScheduleAgentTools} so a future scan-dir discovery (or the
+ * built-in aggregator) can call it uniformly with the other agent-tool modules.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentTools(registry: AgentToolRegistry): void {
+  registerScheduleAgentTools(registry);
+}

--- a/packages/core/src/tools/skill-agent-tool.ts
+++ b/packages/core/src/tools/skill-agent-tool.ts
@@ -1,0 +1,189 @@
+/**
+ * `run_skill` agent tool — bridge the EXISTING SKILL.md loader to the agent loop
+ * (T11949 · M7 · epic T11456 · SG-TOOLS; replaces the cancelled T11869).
+ *
+ * T11869 ("adopt Pi's SKILL.md loader") is CANCELLED: CLEO ALREADY owns a native
+ * skill loader + dispatch path ({@link import('../skills/discovery.js')}'s
+ * `parseFrontmatter` / `discoverSkill` / `findSkill`, plus
+ * {@link import('../skills/dispatch.js')}'s `dispatchExplicit`). This tool does
+ * NOT rebuild any of that. It surfaces the SUBSET of skills the model may invoke —
+ * those whose frontmatter marks `invocable: true` — to the loop as a single
+ * `run_skill` tool. `run_skill`:
+ *
+ *   - resolves a skill BY NAME via the EXISTING {@link findSkill} (the same
+ *     filesystem scan + name-mapping the CLI uses);
+ *   - REJECTS a skill whose frontmatter is not `invocable: true` (a typed, non-
+ *     throwing failure result) — only explicitly-invocable skills are runnable;
+ *   - dispatches the resolved skill through the EXISTING
+ *     {@link dispatchExplicit} path and returns the skill's instructions
+ *     (`SKILL.md` body) + dispatch metadata for the loop to act on.
+ *
+ * No new loader, no new parser, no new dispatch mechanism — pure consumption of
+ * the skills subsystem (Gate-11: DEFINED here under `packages/core/src/tools`,
+ * CONSUMES the skills path). The tier-0 skill-drift gate + skill-coverage map are
+ * untouched — this is a consumer of the loader, not a change to it.
+ *
+ * ## Availability (always-true, daemon-OFF)
+ *
+ * Skill discovery is a LOCAL filesystem scan — no credential, no network, no
+ * daemon. `run_skill` is therefore {@link ALWAYS_AVAILABLE}.
+ *
+ * ## Gate-13
+ *
+ * No model/transport/provider client is constructed here — resolving + reading a
+ * SKILL.md is local I/O. There is no chokepoint concern.
+ *
+ * @epic T11456
+ * @task T11949
+ * @see ../skills/discovery.js — `findSkill` (the existing loader this tool reuses)
+ * @see ../skills/dispatch.js — `dispatchExplicit` (the existing dispatch path)
+ */
+
+import { z } from 'zod';
+import { resolveOrCwd } from '../paths.js';
+import type { Skill } from '../skills/types.js';
+import { type AgentToolRegistry, ALWAYS_AVAILABLE } from './agent-registry.js';
+
+/**
+ * The skills-subsystem seam {@link registerSkillAgentTool} resolves + dispatches a
+ * skill through. Each member has the SAME signature as the corresponding existing
+ * function. Injectable so the unit test can supply a fake skill surface (no real
+ * SKILL.md on disk); defaults to the real `discovery` / `dispatch` functions.
+ */
+export interface SkillResolver {
+  /** Resolve a skill by name (→ `findSkill`). Returns `null` when unknown. */
+  readonly findSkill: (name: string, cwd?: string) => Skill | null;
+  /**
+   * Dispatch an explicit skill (→ `dispatchExplicit`). Returns the dispatch
+   * metadata, or `null` when the skill does not resolve.
+   */
+  readonly dispatchExplicit: (
+    skillName: string,
+    cwd?: string,
+  ) => { skill: string; strategy: string; confidence: number; protocol?: string } | null;
+}
+
+/** The shape `run_skill` returns to the loop — resolution outcome + payload. */
+export interface RunSkillResult {
+  /** Whether an invocable skill resolved and dispatched. */
+  readonly ok: boolean;
+  /** The resolved skill's canonical directory name (present on success). */
+  readonly skill?: string;
+  /** The dispatched protocol, when the skill declares one. */
+  readonly protocol?: string;
+  /** The `SKILL.md` body the loop acts on (present on success). */
+  readonly instructions?: string;
+  /** A stable code + message for why resolution failed (present on failure). */
+  readonly error?: { readonly code: string; readonly message: string };
+}
+
+/** Options for {@link registerSkillAgentTool} — all injectable for testing. */
+export interface SkillAgentToolOptions {
+  /** The skills-subsystem seam. Defaults to the real discovery + dispatch functions. */
+  readonly resolver?: SkillResolver;
+  /**
+   * The cwd skill discovery scans from (defaults to the resolved project root via
+   * {@link resolveOrCwd} — never a bare `process.cwd()` in core, T9584).
+   */
+  readonly cwd?: string;
+}
+
+/**
+ * Build the real skills-subsystem seam by lazily importing the existing
+ * `discovery` + `dispatch` modules. Lazy so this tool module is import-time
+ * side-effect-free (the skills modules run filesystem-touching telemetry on
+ * load); the import happens only when the real resolver is first needed.
+ *
+ * @returns The production {@link SkillResolver}.
+ */
+async function realResolver(): Promise<SkillResolver> {
+  const { findSkill } = await import('../skills/discovery.js');
+  const { dispatchExplicit } = await import('../skills/dispatch.js');
+  return {
+    findSkill,
+    dispatchExplicit: (skillName, cwd) => {
+      const result = dispatchExplicit(skillName, cwd);
+      if (result === null) return null;
+      return {
+        skill: result.skill,
+        strategy: result.strategy,
+        confidence: result.confidence,
+        ...(result.protocol !== undefined ? { protocol: result.protocol } : {}),
+      };
+    },
+  };
+}
+
+/**
+ * Register the `run_skill` tool into `registry`. Pure registration — no skill is
+ * resolved, no SKILL.md is read here; all of that happens later inside the tool's
+ * `execute` through the injected (or lazily-resolved real) seam. Import-time
+ * side-effect-free.
+ *
+ * @param registry - The registry to populate.
+ * @param options - Injectable resolver / cwd (for testing).
+ */
+export function registerSkillAgentTool(
+  registry: AgentToolRegistry,
+  options: SkillAgentToolOptions = {},
+): void {
+  const cwd = resolveOrCwd(options.cwd);
+
+  registry.register({
+    name: 'run_skill',
+    // 'shell' — invoking a skill is a procedure run (its strongest side-effect surface).
+    class: 'shell',
+    description:
+      'Resolve and run an invocable CLEO skill by name. Returns the skill instructions ' +
+      '(SKILL.md body) and dispatch metadata for the loop to act on. Only skills whose ' +
+      'frontmatter marks them invocable can be run.',
+    toolset: 'agent',
+    stateless: false,
+    available: ALWAYS_AVAILABLE,
+    parameters: z.object({
+      name: z.string().describe('The skill name to resolve and run (e.g. "ct-research-agent").'),
+    }),
+    execute: async (rawArgs): Promise<RunSkillResult> => {
+      const name = String(rawArgs.name);
+      const resolver = options.resolver ?? (await realResolver());
+
+      const skill = resolver.findSkill(name, cwd);
+      if (skill === null) {
+        return {
+          ok: false,
+          error: { code: 'E_SKILL_NOT_FOUND', message: `no skill named "${name}"` },
+        };
+      }
+      if (skill.frontmatter.invocable !== true) {
+        return {
+          ok: false,
+          error: {
+            code: 'E_SKILL_NOT_INVOCABLE',
+            message: `skill "${skill.dirName}" is not invocable (frontmatter.invocable !== true)`,
+          },
+        };
+      }
+
+      // Dispatch through the EXISTING explicit-dispatch path (no new mechanism).
+      const dispatch = resolver.dispatchExplicit(name, cwd);
+      return {
+        ok: true,
+        skill: skill.dirName,
+        ...(dispatch?.protocol !== undefined ? { protocol: dispatch.protocol } : {}),
+        ...(skill.content !== undefined ? { instructions: skill.content } : {}),
+      };
+    },
+  });
+}
+
+/**
+ * Self-registration marker (AC1) — the identifier the
+ * {@link AgentToolRegistry.discover} bounded source scan greps for. Aliases
+ * {@link registerSkillAgentTool} so a future scan-dir discovery (or the built-in
+ * aggregator) can call it uniformly with the other agent-tool modules.
+ *
+ * @param registry - The registry to populate.
+ */
+export function registerAgentTools(registry: AgentToolRegistry): void {
+  registerSkillAgentTool(registry);
+}


### PR DESCRIPTION
## M7 agent-tool catalog — 5 new built-in harness tools

Delivers the M7 agent-tool catalog: 5 new built-in agent-tool families for the harness loop, each in its own file under `packages/core/src/tools/` and registered via `registerBuiltinAgentTools`. Every family **CONSUMES an existing subsystem** — no new store, no new loader, no raw provider client. Zod param schemas, TSDoc on every export, ESM `.js` imports, kebab-case files. Tools live only in `packages/core/src/tools/` (Gate-11); the media model calls route through the E9 chokepoint (Gate-13).

### Per-tool

| Task | Tool(s) | File | Delegates to | Availability |
|------|---------|------|--------------|--------------|
| **T11947** | `memory_search` / `memory_observe` / `memory_fetch` / `memory_timeline` | `memory-agent-tools.ts` | existing BRAIN ops (`memory/engine-compat.ts`) — no new SQL/store | always-on daemon-OFF |
| **T11948** | native MCP client fan-in (proxy tool per remote tool) | `mcp-agent-tool.ts` | `McpTransport` seam (stdio/sse/http), connect-time `initialize`→`tools/list`→register; no external MCP SDK | live-connection only |
| **T11949** | `run_skill` | `skill-agent-tool.ts` | existing `skills/discovery.ts#findSkill` + `dispatchExplicit`; only invocable skills; rejects non-invocable | always-on daemon-OFF |
| **T11950** | `todo_add` / `todo_list` / `cron_schedule` | `schedule-agent-tools.ts` | task store ops (`tasks/ops.ts`); `cron_schedule` gated unavailable (no schedule store yet) | todo_* always-on; cron_schedule gated |
| **T11951** | `vision_analyze` / `image_generate` / `text_to_speech` | `media-agent-tools.ts` | E9 chokepoint (`resolveLLMForSystem`/`ModelRunner`) like `browser_vision` — no raw client | egress + multimodal capability |

`cron_schedule` (T11950) is registered but gated as not-yet-available because there is **no persisted schedule store** — per AC3 a follow-up was filed (**T11962** under T11679) to add the schema/accessor rather than inventing it here.

### Tests
5 new fully-mocked spec files (injected seams — no real brain.db / MCP server / SKILL.md / tasks.db / provider) + updated `agent-registry.test.ts` `media` bucket assertion (media toolset is now populated).

### Gates run (cgroup-capped)
- `pnpm exec biome ci .` — **0 errors**, 3744 files
- `pnpm run build` — pass
- `pnpm run typecheck` (full `tsc -b`) — pass
- `pnpm --filter @cleocode/core run test` — **290/290 tools tests pass**; the 14 unrelated worktree/git-sandbox failures are **confirmed pre-existing on clean origin/main** (nested git-worktree ops blocked in the sandbox)
- Gate-11 (tools-vs-skills): OK · Gate-13 (LLM chokepoint): **no new violations** (41 vs baseline 53) · Gate-3 (DB open) strict OK · Gate-4 (contracts fan-out) OK · Gate-6 (CLI boundary) no new violations in changed files

Closes T11947 T11948 T11949 T11950 T11951

🤖 Generated with [Claude Code](https://claude.com/claude-code)