### PR TITLE
feat(M7): PSYCHE schema tier — bitemporal + network columns + extraction-gate + derivation-queue (daemon-OFF, T10405 subset)

### DIFF
--- a/packages/core/migrations/drizzle-brain/20260610000001_t10405-bitemporal-network-columns/migration.sql
+++ b/packages/core/migrations/drizzle-brain/20260610000001_t10405-bitemporal-network-columns/migration.sql
@@ -1,0 +1,71 @@
+-- T10405 (SG-PSYCHE-FOUNDATION · Tier 5): bitemporal `expired_at` + four-network `network`.
+--
+-- Completes the Graphiti 4-timestamp bitemporal model on the four BRAIN tables.
+-- Prior schema shipped created_at + valid_at + invalid_at; this migration adds the
+-- 4th timestamp `expired_at` (TRANSACTION-time end — when a row was retracted from
+-- the active store, distinct from `invalid_at` = VALID-time end). It also adds the
+-- four-network classification column `network` (world / bank / opinion / observation
+-- per masterplan §16.D Mem0-V3 envelope). Both columns are declared in
+-- memory-schema.ts; this file is their forward Drizzle DDL (T9179 precedent —
+-- columns reach a fresh DB via Drizzle, never via the retired ensureColumns()).
+--
+-- Per-table `network` DEFAULT matches the row's cognitive role:
+--   brain_decisions    → 'bank'        (durable account-of-record)
+--   brain_patterns     → 'world'       (objective recurring behaviour)
+--   brain_learnings    → 'opinion'     (evaluative belief, updates on evidence)
+--   brain_observations → 'observation' (raw episodic event)
+--
+-- The enum is enforced in-app (no SQLite CHECK constraint — Lesson 3 convention).
+-- All statements are ALTER TABLE ADD COLUMN / CREATE INDEX IF NOT EXISTS → atomic
+-- + idempotent on SQLite 3.35+. The migration-manager reconciler marks this
+-- migration applied-without-running when the columns already exist (consolidated
+-- cleo.db path), or executes it directly on a standalone / fresh brain DB.
+--
+-- SAFE FOR: SQLite 3.35+ (ALTER TABLE ADD COLUMN is atomic)
+
+ALTER TABLE brain_decisions ADD COLUMN expired_at TEXT;
+--> statement-breakpoint
+ALTER TABLE brain_decisions ADD COLUMN network TEXT DEFAULT 'bank';
+--> statement-breakpoint
+ALTER TABLE brain_patterns ADD COLUMN expired_at TEXT;
+--> statement-breakpoint
+ALTER TABLE brain_patterns ADD COLUMN network TEXT DEFAULT 'world';
+--> statement-breakpoint
+ALTER TABLE brain_learnings ADD COLUMN expired_at TEXT;
+--> statement-breakpoint
+ALTER TABLE brain_learnings ADD COLUMN network TEXT DEFAULT 'opinion';
+--> statement-breakpoint
+ALTER TABLE brain_observations ADD COLUMN expired_at TEXT;
+--> statement-breakpoint
+ALTER TABLE brain_observations ADD COLUMN network TEXT DEFAULT 'observation';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_decisions_expired_at
+  ON brain_decisions (expired_at);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_decisions_network
+  ON brain_decisions (network);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_patterns_expired_at
+  ON brain_patterns (expired_at);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_patterns_network
+  ON brain_patterns (network);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_learnings_expired_at
+  ON brain_learnings (expired_at);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_learnings_network
+  ON brain_learnings (network);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_observations_expired_at
+  ON brain_observations (expired_at);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_brain_observations_network
+  ON brain_observations (network);
+--> statement-breakpoint
+-- T10405 (Tier 6): exponential-backoff gate on the derivation queue.
+-- A re-queued item carries `next_attempt_at = now + base * 2^retryCount` so the
+-- worker's claim query skips it until the backoff window elapses (no hot-loop on
+-- a transiently-failing item). NULL = claimable now (default for new items).
+ALTER TABLE deriver_queue ADD COLUMN next_attempt_at TEXT;
+

--- a/packages/core/src/deriver/__tests__/deriver-queue.test.ts
+++ b/packages/core/src/deriver/__tests__/deriver-queue.test.ts
@@ -15,8 +15,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { enqueueDerivation, enqueueObservationBatch } from '../enqueue.js';
 import {
+  BACKOFF_BASE_SECONDS,
+  BACKOFF_MAX_SECONDS,
   claimNextItem,
   completeItem,
+  computeBackoffSeconds,
   failItem,
   MAX_RETRY_COUNT,
   recoverStaleItems,
@@ -44,10 +47,11 @@ function setupDb(): DatabaseSync {
       error_msg     TEXT,
       retry_count   INTEGER NOT NULL DEFAULT 0,
       created_at    TEXT NOT NULL DEFAULT (datetime('now')),
-      completed_at  TEXT
+      completed_at  TEXT,
+      next_attempt_at TEXT
     );
     CREATE INDEX idx_deriver_queue_status_priority
-      ON deriver_queue(status, priority DESC, created_at ASC);
+      ON deriver_queue(status, priority DESC, created_at ASC, next_attempt_at);
     CREATE INDEX idx_deriver_queue_item
       ON deriver_queue(item_type, item_id);
     CREATE INDEX idx_deriver_queue_claimed_at
@@ -219,6 +223,107 @@ describe('failItem', () => {
       .prepare<{ status: string }, [string]>('SELECT status FROM deriver_queue WHERE id=?')
       .get(existingRow.id)!;
     expect(row.status).toBe('failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exponential-backoff tests (T10405 · SG-PSYCHE-FOUNDATION Tier 6)
+// ---------------------------------------------------------------------------
+
+describe('computeBackoffSeconds', () => {
+  it('grows geometrically from the base delay', () => {
+    expect(computeBackoffSeconds(1)).toBe(BACKOFF_BASE_SECONDS);
+    expect(computeBackoffSeconds(2)).toBe(BACKOFF_BASE_SECONDS * 2);
+    expect(computeBackoffSeconds(3)).toBe(BACKOFF_BASE_SECONDS * 4);
+  });
+
+  it('clamps a zero/negative attempt to the base delay', () => {
+    expect(computeBackoffSeconds(0)).toBe(BACKOFF_BASE_SECONDS);
+    expect(computeBackoffSeconds(-3)).toBe(BACKOFF_BASE_SECONDS);
+  });
+
+  it('caps at BACKOFF_MAX_SECONDS for large attempts', () => {
+    expect(computeBackoffSeconds(100)).toBe(BACKOFF_MAX_SECONDS);
+  });
+});
+
+describe('failItem backoff gating', () => {
+  it('sets a future next_attempt_at on re-queue and blocks immediate re-claim', () => {
+    enqueueDerivation('observation', 'obs-bo', { db });
+    const item = claimNextItem({ db, workerId: 'w1' })!;
+    failItem(item.id, 'transient', { db });
+
+    const row = db
+      .prepare<{ status: string; next_attempt_at: string | null }, [string]>(
+        'SELECT status, next_attempt_at FROM deriver_queue WHERE id=?',
+      )
+      .get(item.id)!;
+    expect(row.status).toBe('pending');
+    // Backoff is in the future → not yet claimable.
+    expect(row.next_attempt_at).not.toBeNull();
+    expect(new Date(row.next_attempt_at as string).getTime()).toBeGreaterThan(Date.now());
+
+    // The claim query must skip the backed-off item.
+    expect(claimNextItem({ db, workerId: 'w2' })).toBeNull();
+  });
+
+  it('re-claims once the backoff window has elapsed', () => {
+    enqueueDerivation('observation', 'obs-bo2', { db });
+    const item = claimNextItem({ db, workerId: 'w1' })!;
+    failItem(item.id, 'transient', { db });
+
+    // Backdate next_attempt_at into the past to simulate elapsed backoff.
+    db.prepare('UPDATE deriver_queue SET next_attempt_at=? WHERE id=?').run(
+      new Date(Date.now() - 1000).toISOString(),
+      item.id,
+    );
+
+    const reclaimed = claimNextItem({ db, workerId: 'w2' });
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed?.id).toBe(item.id);
+    expect(reclaimed?.retryCount).toBe(1);
+  });
+
+  it('clears next_attempt_at when the item is permanently failed', () => {
+    enqueueDerivation('observation', 'obs-bo3', { db });
+    db.prepare('UPDATE deriver_queue SET retry_count=?, status=? WHERE item_id=?').run(
+      MAX_RETRY_COUNT - 1,
+      'in_progress',
+      'obs-bo3',
+    );
+    const existingRow = db
+      .prepare<{ id: string }, []>('SELECT id FROM deriver_queue LIMIT 1')
+      .get()!;
+    failItem(existingRow.id, 'final', { db });
+
+    const row = db
+      .prepare<{ status: string; next_attempt_at: string | null }, [string]>(
+        'SELECT status, next_attempt_at FROM deriver_queue WHERE id=?',
+      )
+      .get(existingRow.id)!;
+    expect(row.status).toBe('failed');
+    expect(row.next_attempt_at).toBeNull();
+  });
+});
+
+describe('recoverStaleItems backoff gating', () => {
+  it('sets a backoff gate on re-queued stale items', () => {
+    enqueueDerivation('observation', 'obs-stale-bo', { db });
+    claimNextItem({ db, workerId: 'w1' });
+    const staleTime = new Date(Date.now() - (STALE_CLAIM_MINUTES + 5) * 60_000).toISOString();
+    db.prepare("UPDATE deriver_queue SET claimed_at=? WHERE item_id='obs-stale-bo'").run(staleTime);
+
+    const result = recoverStaleItems({ db });
+    expect(result.requeued).toBe(1);
+
+    const row = db
+      .prepare<{ status: string; next_attempt_at: string | null }, []>(
+        'SELECT status, next_attempt_at FROM deriver_queue LIMIT 1',
+      )
+      .get()!;
+    expect(row.status).toBe('pending');
+    expect(row.next_attempt_at).not.toBeNull();
+    expect(new Date(row.next_attempt_at as string).getTime()).toBeGreaterThan(Date.now());
   });
 });
 

--- a/packages/core/src/deriver/queue-manager.ts
+++ b/packages/core/src/deriver/queue-manager.ts
@@ -31,6 +31,20 @@ export const STALE_CLAIM_MINUTES = 30;
 /** Max retry count before item is moved to 'failed' permanently. */
 export const MAX_RETRY_COUNT = 5;
 
+/**
+ * Base exponential-backoff delay in seconds for a re-queued item (T10405).
+ *
+ * A failed/recovered item's next claim is gated until
+ * `now + BACKOFF_BASE_SECONDS * 2^(retryCount - 1)`, capped at
+ * {@link BACKOFF_MAX_SECONDS}. With base 30s the schedule is
+ * 30s → 60s → 120s → 240s (then capped), so a transiently-failing item
+ * backs off geometrically instead of hot-looping the worker.
+ */
+export const BACKOFF_BASE_SECONDS = 30;
+
+/** Maximum exponential-backoff delay in seconds (cap for {@link computeBackoffSeconds}). */
+export const BACKOFF_MAX_SECONDS = 30 * 60;
+
 /** SQLite busy error string (returned when BEGIN IMMEDIATE cannot acquire lock). */
 const SQLITE_BUSY_STR = 'database is locked';
 
@@ -103,6 +117,30 @@ function minutesAgo(n: number): string {
   return new Date(Date.now() - n * 60_000).toISOString();
 }
 
+/**
+ * Compute the exponential-backoff delay (seconds) for a re-queued item (T10405).
+ *
+ * Returns `BACKOFF_BASE_SECONDS * 2^(attempt - 1)` capped at
+ * {@link BACKOFF_MAX_SECONDS}. `attempt` is the *new* retry count (1-based:
+ * the first failure backs off by the base delay). An `attempt` of 0 or less is
+ * clamped to 1 so the first retry always waits at least the base delay.
+ *
+ * @param attempt - The new (post-increment) retry count for the item.
+ * @returns Backoff delay in seconds, in `[BACKOFF_BASE_SECONDS, BACKOFF_MAX_SECONDS]`.
+ *
+ * @task T10405
+ */
+export function computeBackoffSeconds(attempt: number): number {
+  const safeAttempt = attempt < 1 ? 1 : attempt;
+  const delay = BACKOFF_BASE_SECONDS * 2 ** (safeAttempt - 1);
+  return Math.min(delay, BACKOFF_MAX_SECONDS);
+}
+
+/** Return ISO 8601 timestamp for N seconds in the future. */
+function secondsFromNow(n: number): string {
+  return new Date(Date.now() + n * 1000).toISOString();
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -137,22 +175,26 @@ export function claimNextItem(options: ClaimOptions = {}): ClaimedItem | null {
   }
 
   try {
+    // T10405: gate on the exponential-backoff window — a re-queued item with a
+    // future `next_attempt_at` is skipped until its backoff elapses. Fresh items
+    // (next_attempt_at IS NULL) are always eligible.
+    const now = new Date().toISOString();
     const row = nativeDb
       .prepare(
         `SELECT id, item_type, item_id, priority, retry_count
          FROM deriver_queue
          WHERE status = 'pending'
+           AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
          ORDER BY priority DESC, created_at ASC
          LIMIT 1`,
       )
-      .get() as RawClaimRow | undefined;
+      .get(now) as RawClaimRow | undefined;
 
     if (!row) {
       nativeDb.exec('ROLLBACK');
       return null;
     }
 
-    const now = new Date().toISOString();
     nativeDb
       .prepare(
         `UPDATE deriver_queue
@@ -206,8 +248,10 @@ export function completeItem(itemId: string, options: CompleteOptions = {}): voi
  * Mark a claimed item as failed (with optional error message).
  *
  * If `retryCount` is below {@link MAX_RETRY_COUNT}, the item is re-queued
- * to `pending` with `retryCount + 1` (for retry next batch).
- * Otherwise the item is permanently moved to `failed`.
+ * to `pending` with `retryCount + 1` and an exponential-backoff
+ * `next_attempt_at` (T10405) so it is not re-claimed until the backoff window
+ * elapses. Otherwise the item is permanently moved to `failed` (DLQ semantics)
+ * and its backoff gate is cleared.
  *
  * @param itemId   - The deriver_queue.id to fail.
  * @param errorMsg - Human-readable error for the error_msg column.
@@ -227,16 +271,19 @@ export function failItem(itemId: string, errorMsg: string, options: CompleteOpti
   if (!row) return;
 
   const nextRetry = (row.retry_count ?? 0) + 1;
-  const nextStatus = nextRetry >= MAX_RETRY_COUNT ? 'failed' : 'pending';
+  const permanentFail = nextRetry >= MAX_RETRY_COUNT;
+  const nextStatus = permanentFail ? 'failed' : 'pending';
+  // Re-queued items back off geometrically; permanently-failed items clear the gate.
+  const nextAttemptAt = permanentFail ? null : secondsFromNow(computeBackoffSeconds(nextRetry));
 
   nativeDb
     .prepare(
       `UPDATE deriver_queue
        SET status = ?, retry_count = ?, error_msg = ?,
-           claimed_at = NULL, claimed_by = NULL
+           claimed_at = NULL, claimed_by = NULL, next_attempt_at = ?
        WHERE id = ? AND status = 'in_progress'`,
     )
-    .run(nextStatus, nextRetry, errorMsg, itemId);
+    .run(nextStatus, nextRetry, errorMsg, nextAttemptAt, itemId);
 }
 
 /**
@@ -282,14 +329,16 @@ export function recoverStaleItems(options: CompleteOptions = {}): StaleRecoveryR
         .run(nextRetry, row.id);
       result.failed++;
     } else {
+      // T10405: re-queued stale items also back off geometrically.
+      const nextAttemptAt = secondsFromNow(computeBackoffSeconds(nextRetry));
       nativeDb
         .prepare(
           `UPDATE deriver_queue
            SET status = 'pending', retry_count = ?, error_msg = 'recovered from stale claim',
-               claimed_at = NULL, claimed_by = NULL
+               claimed_at = NULL, claimed_by = NULL, next_attempt_at = ?
            WHERE id = ?`,
         )
-        .run(nextRetry, row.id);
+        .run(nextRetry, nextAttemptAt, row.id);
       result.requeued++;
     }
   }

--- a/packages/core/src/store/__tests__/memory-schema.test.ts
+++ b/packages/core/src/store/__tests__/memory-schema.test.ts
@@ -192,4 +192,116 @@ describe('brain.db schema', () => {
     expect(() => resetBrainDbState()).not.toThrow();
     expect(() => resetBrainDbState()).not.toThrow();
   });
+
+  // T10405 (SG-PSYCHE-FOUNDATION · Tier 5): bitemporal + four-network columns.
+
+  /** Return the set of column names for a table via PRAGMA table_info. */
+  async function columnNames(table: string): Promise<Set<string>> {
+    const {
+      getBrainDb,
+      getBrainNativeDb,
+      closeBrainDb: close,
+    } = await import('../memory-sqlite.js');
+    close();
+    await getBrainDb();
+    const nativeDb = getBrainNativeDb();
+    expect(nativeDb).toBeTruthy();
+    const cols = nativeDb!.prepare(`PRAGMA table_info("${table}")`).all() as Array<{
+      name: string;
+    }>;
+    return new Set(cols.map((c) => c.name));
+  }
+
+  const BITEMPORAL_NETWORK_TABLES = [
+    'brain_decisions',
+    'brain_patterns',
+    'brain_learnings',
+    'brain_observations',
+  ] as const;
+
+  for (const table of BITEMPORAL_NETWORK_TABLES) {
+    it(`adds expired_at + network columns to ${table}`, async () => {
+      const cols = await columnNames(table);
+      // The full 4-timestamp bitemporal set: a creation timestamp + valid_at +
+      // invalid_at shipped earlier; expired_at is the T10405 4th timestamp.
+      // brain_patterns names its creation timestamp `extracted_at`; the other
+      // three use `created_at`.
+      const creationCol = table === 'brain_patterns' ? 'extracted_at' : 'created_at';
+      expect(cols.has(creationCol)).toBe(true);
+      expect(cols.has('valid_at')).toBe(true);
+      expect(cols.has('invalid_at')).toBe(true);
+      expect(cols.has('expired_at')).toBe(true);
+      // Four-network classification column.
+      expect(cols.has('network')).toBe(true);
+    });
+  }
+
+  it('adds next_attempt_at backoff column to deriver_queue', async () => {
+    const cols = await columnNames('deriver_queue');
+    expect(cols.has('next_attempt_at')).toBe(true);
+  });
+
+  it('creates the T10405 bitemporal + network indexes', async () => {
+    const {
+      getBrainDb,
+      getBrainNativeDb,
+      closeBrainDb: close,
+    } = await import('../memory-sqlite.js');
+    close();
+    await getBrainDb();
+    const nativeDb = getBrainNativeDb();
+    expect(nativeDb).toBeTruthy();
+
+    const indexNames = new Set(
+      (
+        nativeDb!
+          .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'")
+          .all() as Array<{ name: string }>
+      ).map((i) => i.name),
+    );
+
+    for (const table of BITEMPORAL_NETWORK_TABLES) {
+      expect(indexNames.has(`idx_${table}_expired_at`)).toBe(true);
+      expect(indexNames.has(`idx_${table}_network`)).toBe(true);
+    }
+  });
+
+  it('defaults network per cognitive role and accepts an explicit four-network value', async () => {
+    const {
+      getBrainDb,
+      getBrainNativeDb,
+      closeBrainDb: close,
+    } = await import('../memory-sqlite.js');
+    close();
+    await getBrainDb();
+    const nativeDb = getBrainNativeDb();
+    expect(nativeDb).toBeTruthy();
+
+    // Insert a decision row WITHOUT network → DEFAULT 'bank'; verify expired_at NULL.
+    nativeDb!
+      .prepare(
+        `INSERT INTO brain_decisions (id, type, decision, rationale, confidence)
+         VALUES (?, 'architecture', 'd', 'r', 'high')`,
+      )
+      .run('dec-t10405-default');
+    const defaulted = nativeDb!
+      .prepare('SELECT network, expired_at FROM brain_decisions WHERE id = ?')
+      .get('dec-t10405-default') as { network: string | null; expired_at: string | null };
+    expect(defaulted.network).toBe('bank');
+    expect(defaulted.expired_at).toBeNull();
+
+    // Insert an observation with an EXPLICIT four-network value + expired_at.
+    const expiry = new Date().toISOString();
+    nativeDb!
+      .prepare(
+        `INSERT INTO brain_observations (id, type, title, network, expired_at)
+         VALUES (?, 'discovery', 't', 'world', ?)`,
+      )
+      .run('obs-t10405-explicit', expiry);
+    const explicit = nativeDb!
+      .prepare('SELECT network, expired_at FROM brain_observations WHERE id = ?')
+      .get('obs-t10405-explicit') as { network: string | null; expired_at: string | null };
+    expect(explicit.network).toBe('world');
+    expect(explicit.expired_at).toBe(expiry);
+  });
 });

--- a/packages/core/src/store/schema/memory-schema.ts
+++ b/packages/core/src/store/schema/memory-schema.ts
@@ -101,6 +101,44 @@ export const BRAIN_DECISION_TYPES = [
  */
 export const BRAIN_DECISION_CATEGORIES = ['architectural', 'agent_dispatch', 'other'] as const;
 
+/**
+ * Four-network memory classification (T10405 · SG-PSYCHE-FOUNDATION Tier 5).
+ *
+ * Every BRAIN row is tagged with one of four cognitive networks. The taxonomy
+ * mirrors the masterplan §16.D Mem0-V3 envelope classification and lets the
+ * retrieval layer reason about *what kind* of fact a row holds — not just its
+ * cognitive type (semantic/episodic/procedural) or memory tier.
+ *
+ * - `world`       — Objective, externally-verifiable facts about the project /
+ *                   environment ("the release pipeline is PR-gated", "Node 24
+ *                   ships node:sqlite"). Highest trust; rarely contradicted.
+ * - `bank`        — Durable account-of-record entries: decisions, commitments,
+ *                   ledgered outcomes ("we adopted ADR-065", "release v2026.6.12
+ *                   shipped"). Append-mostly; superseded via links, not deletes.
+ * - `opinion`     — Subjective / evaluative beliefs that carry `confidence` and
+ *                   update on new evidence ("agent X is unreliable on task Y").
+ *                   The mutable network — opinion rows are expected to flip.
+ * - `observation` — Raw episodic event records ("ran the build", "saw 12 test
+ *                   failures"). The default network; the substrate the other
+ *                   three are distilled from.
+ *
+ * NULL semantics: legacy rows carry no network. Writers default new rows to
+ * `'observation'`; the consolidator/deriver re-classifies into world/bank/opinion
+ * as facts are distilled. Stored as a plain TEXT column (no SQLite CHECK — the
+ * enum is enforced in-app per the project's Lesson-3 convention).
+ *
+ * @task T10405
+ * @epic T10405
+ * @saga T10405
+ */
+export const BRAIN_NETWORK_TYPES = ['world', 'bank', 'opinion', 'observation'] as const;
+
+/**
+ * Union of the four-network classification values (T10405).
+ * @see BRAIN_NETWORK_TYPES
+ */
+export type BrainNetwork = (typeof BRAIN_NETWORK_TYPES)[number];
+
 /** Confidence levels for decisions. */
 export const BRAIN_CONFIDENCE_LEVELS = ['low', 'medium', 'high'] as const;
 
@@ -253,6 +291,24 @@ export const brainDecisions = sqliteTable(
      * (ADR-009); this column is a convenience gate for bulk eviction queries.
      */
     invalidAt: text('invalid_at'),
+
+    /**
+     * Bitemporal (T10405 · Graphiti 4-timestamp): TRANSACTION-time end —
+     * when this row was retracted from the active store (ISO 8601 text).
+     *
+     * Distinct from `invalidAt` (VALID-time end = when the fact stopped being
+     * true in the world). A row can be valid-in-the-world (`invalid_at IS NULL`)
+     * yet expired-in-the-store (`expired_at` set) when superseded by a newer
+     * write of the same fact — and vice versa. NULL = currently active.
+     * Point-in-time `as-of` queries gate on `expired_at` for store state.
+     */
+    expiredAt: text('expired_at'),
+
+    /**
+     * Four-network classification (T10405 · {@link BRAIN_NETWORK_TYPES}).
+     * Decisions are durable account-of-record entries → default `'bank'`.
+     */
+    network: text('network', { enum: BRAIN_NETWORK_TYPES }).default('bank'),
 
     /**
      * Source reliability level — separate from content quality_score (T549 §3.1.5).
@@ -441,6 +497,9 @@ export const brainDecisions = sqliteTable(
     index('idx_brain_decisions_mem_type').on(table.memoryType),
     index('idx_brain_decisions_verified').on(table.verified),
     index('idx_brain_decisions_valid_at').on(table.validAt),
+    // T10405: bitemporal expired_at + four-network indexes
+    index('idx_brain_decisions_expired_at').on(table.expiredAt),
+    index('idx_brain_decisions_network').on(table.network),
     index('idx_brain_decisions_source_conf').on(table.sourceConfidence),
     // T726 indexes
     index('idx_brain_decisions_tier_promoted_at').on(table.tierPromotedAt),
@@ -510,6 +569,20 @@ export const brainPatterns = sqliteTable(
      * NULL = currently valid. Set by consolidator when frequency+successRate drops below threshold.
      */
     invalidAt: text('invalid_at'),
+
+    /**
+     * Bitemporal (T10405 · Graphiti 4-timestamp): TRANSACTION-time end —
+     * when this pattern row was retracted from the active store (ISO 8601 text).
+     * Distinct from `invalidAt` (VALID-time end). NULL = currently active.
+     * @see brainDecisions.expiredAt for the full bitemporal contract.
+     */
+    expiredAt: text('expired_at'),
+
+    /**
+     * Four-network classification (T10405 · {@link BRAIN_NETWORK_TYPES}).
+     * Patterns are objective recurring behaviours of the project → default `'world'`.
+     */
+    network: text('network', { enum: BRAIN_NETWORK_TYPES }).default('world'),
 
     /**
      * Source reliability level — separate from content quality_score (T549 §3.1.5).
@@ -597,6 +670,9 @@ export const brainPatterns = sqliteTable(
     index('idx_brain_patterns_mem_type').on(table.memoryType),
     index('idx_brain_patterns_verified').on(table.verified),
     index('idx_brain_patterns_valid_at').on(table.validAt),
+    // T10405: bitemporal expired_at + four-network indexes
+    index('idx_brain_patterns_expired_at').on(table.expiredAt),
+    index('idx_brain_patterns_network').on(table.network),
     index('idx_brain_patterns_source_conf').on(table.sourceConfidence),
     // T726 indexes
     index('idx_brain_patterns_tier_promoted_at').on(table.tierPromotedAt),
@@ -656,6 +732,20 @@ export const brainLearnings = sqliteTable(
      * NULL = currently valid. Set by consolidator on contradiction detection or TTL decay.
      */
     invalidAt: text('invalid_at'),
+
+    /**
+     * Bitemporal (T10405 · Graphiti 4-timestamp): TRANSACTION-time end —
+     * when this learning row was retracted from the active store (ISO 8601 text).
+     * Distinct from `invalidAt` (VALID-time end). NULL = currently active.
+     * @see brainDecisions.expiredAt for the full bitemporal contract.
+     */
+    expiredAt: text('expired_at'),
+
+    /**
+     * Four-network classification (T10405 · {@link BRAIN_NETWORK_TYPES}).
+     * Learnings are evaluative beliefs that update on new evidence → default `'opinion'`.
+     */
+    network: text('network', { enum: BRAIN_NETWORK_TYPES }).default('opinion'),
 
     /**
      * Source reliability level — separate from content quality_score (T549 §3.1.5).
@@ -726,6 +816,9 @@ export const brainLearnings = sqliteTable(
     index('idx_brain_learnings_verified').on(table.verified),
     index('idx_brain_learnings_valid_at').on(table.validAt),
     index('idx_brain_learnings_invalid').on(table.invalidAt),
+    // T10405: bitemporal expired_at + four-network indexes
+    index('idx_brain_learnings_expired_at').on(table.expiredAt),
+    index('idx_brain_learnings_network').on(table.network),
     index('idx_brain_learnings_source_conf').on(table.sourceConfidence),
     // T726 indexes
     index('idx_brain_learnings_tier_promoted_at').on(table.tierPromotedAt),
@@ -796,6 +889,21 @@ export const brainObservations = sqliteTable(
      * Temporal query pattern: WHERE valid_at <= :t AND (invalid_at IS NULL OR invalid_at > :t)
      */
     invalidAt: text('invalid_at'),
+
+    /**
+     * Bitemporal (T10405 · Graphiti 4-timestamp): TRANSACTION-time end —
+     * when this observation row was retracted from the active store (ISO 8601 text).
+     * Distinct from `invalidAt` (VALID-time end). NULL = currently active.
+     * Point-in-time `as-of` queries gate on `expired_at` for store state.
+     * @see brainDecisions.expiredAt for the full bitemporal contract.
+     */
+    expiredAt: text('expired_at'),
+
+    /**
+     * Four-network classification (T10405 · {@link BRAIN_NETWORK_TYPES}).
+     * Observations are raw episodic event records → default `'observation'`.
+     */
+    network: text('network', { enum: BRAIN_NETWORK_TYPES }).default('observation'),
 
     /**
      * Source reliability level — separate from content quality_score (T549 §3.1.5).
@@ -969,6 +1077,9 @@ export const brainObservations = sqliteTable(
     index('idx_brain_observations_verified').on(table.verified),
     index('idx_brain_observations_valid_at').on(table.validAt),
     index('idx_brain_observations_invalid').on(table.invalidAt),
+    // T10405: bitemporal expired_at + four-network indexes
+    index('idx_brain_observations_expired_at').on(table.expiredAt),
+    index('idx_brain_observations_network').on(table.network),
     index('idx_brain_observations_source_conf').on(table.sourceConfidence),
     // T726 indexes
     index('idx_brain_observations_tier_promoted_at').on(table.tierPromotedAt),
@@ -2301,10 +2412,29 @@ export const deriverQueue = sqliteTable(
 
     /** ISO 8601 timestamp when the item was successfully completed. Null until done. */
     completedAt: text('completed_at'),
+
+    /**
+     * Exponential-backoff gate (T10405 · SG-PSYCHE-FOUNDATION Tier 6).
+     *
+     * ISO 8601 timestamp before which a re-queued (`pending`) item MUST NOT be
+     * re-claimed. Set by `failItem` / `recoverStaleItems` to
+     * `now + base * 2^retryCount` (capped). A NULL value means "claimable now"
+     * (the default for freshly-enqueued items).
+     *
+     * The claim query gates on `(next_attempt_at IS NULL OR next_attempt_at <= now)`
+     * so a transiently-failing item backs off instead of hot-looping the worker.
+     */
+    nextAttemptAt: text('next_attempt_at'),
   },
   (table) => [
-    // Primary claim query: pending items ordered by priority desc, created_at asc
-    index('idx_deriver_queue_status_priority').on(table.status, table.priority, table.createdAt),
+    // Primary claim query: pending items ordered by priority desc, created_at asc.
+    // T10405: extended with next_attempt_at so the backoff gate is index-covered.
+    index('idx_deriver_queue_status_priority').on(
+      table.status,
+      table.priority,
+      table.createdAt,
+      table.nextAttemptAt,
+    ),
     // Dedup check: one pending/in_progress item per (itemType, itemId)
     index('idx_deriver_queue_item').on(table.itemType, table.itemId),
     // Stale-claim recovery: find in_progress items with old claimed_at


### PR DESCRIPTION
## Scope — M7 \"psyche\" deliverable, daemon-OFF schema tier (T10405 subset)

T10405 (SG-PSYCHE-FOUNDATION) is a large saga spanning daemon-ON runtime (~31 ACs). This PR delivers ONLY the **daemon-OFF schema tier** that runs without the daemon, plus tests. The daemon-ON runtime loop, scheduler, and consolidation pipeline are **filed as follow-ups, not implemented here**.

## What's in scope (this PR)

### Bitemporal + four-network schema (`memory-schema.ts`)
- **VERIFIED existing**: `created_at` / `valid_at` / `invalid_at` on all four BRAIN tables (`brain_decisions`, `brain_patterns`, `brain_learnings`, `brain_observations`).
- **ADDED `expired_at`** — the missing 4th Graphiti timestamp (TRANSACTION-time end of a row in the store, distinct from `invalid_at` = VALID-time end of a fact in the world). Point-in-time `as-of` queries gate on it.
- **ADDED `network`** — the four-network classification enum (`world` | `bank` | `opinion` | `observation`, `BRAIN_NETWORK_TYPES`) per masterplan §16.D. Per-table role defaults: decisions=`bank`, patterns=`world`, learnings=`opinion`, observations=`observation`.
- 8 covering indexes (`expired_at` + `network` per table).

### Migration (`drizzle-brain/20260610000001_t10405-bitemporal-network-columns`)
- Idempotent `ALTER … ADD COLUMN` + `CREATE INDEX IF NOT EXISTS`, with `--> statement-breakpoint` between **every** statement (node:sqlite multi-statement truncation invariant).
- Follows the T9179 forward-migration precedent (the retired `ensureColumns()` path → forward Drizzle DDL). The migration-manager reconciler marks it applied-without-running when columns already exist (consolidated `cleo.db`), or executes it directly on a fresh/standalone brain DB.
- **Does NOT bypass `openDualScopeDb`** — Gate-3 strict DB-open passes (0 violations).

### Derivation-queue backoff (`deriver/queue-manager.ts`)
- The `deriver_queue` table + `packages/core/src/deriver/` module (SKIP-LOCKED claim + retry/DLQ) **already existed** (T1145). This PR HARDENS the missing **\"+ backoff\"** half required by the scope: a `next_attempt_at` exponential-backoff gate (base 30s, doubling, capped 30min). `failItem`/`recoverStaleItems` stamp a future `next_attempt_at` on re-queue; `claimNextItem` skips backed-off items instead of hot-looping a transiently-failing item.

### Verified, no change needed
- `extraction-gate.ts` — confirmed it is the Mem0 chokepoint (hash + cosine-similarity + confidence checks, T549).
- `dialectic-evaluator.ts` — confirmed its LLM call routes through `resolveLlmBackend('warm')` (the chokepoint resolver), so it is **Gate-13 compliant** (no raw transport/client/API-key reads).

## Tests
- Backoff unit tests: `computeBackoffSeconds` schedule, claim gating, re-claim after window, DLQ clears the gate.
- Schema tests: `expired_at` + `network` column presence per table, T10405 indexes, per-role defaults, explicit four-network insert round-trip, `deriver_queue.next_attempt_at`.
- **42/42 targeted + 44/44 parity/migration green.** Full core suite: **12106 passed**; the 15 failures are pre-existing **environmental** worktree/spawn git-sandbox failures (`integrateWorktree not available in test fallback`) untouched by this diff.

## Gates
- `pnpm exec biome ci` — clean (0/0)
- `pnpm run build` — success (full dependency chain)
- `pnpm --filter @cleocode/core run typecheck` — clean (0 errors)
- `cleo check arch` — 6/6 pass (Gate-3 DB-open = 0 violations)
- `lint-llm-chokepoint` (Gate-13) — no new violations (41 vs baseline 53)

## Follow-ups filed for the daemon-ON runtime (out of scope)
- **Epic T11969** — EP-PSYCHE-RUNTIME-DAEMON-ON
  - **T11970** — derivation-worker run-loop (`cleo memory derive-worker --watch`) driving the queue with the new backoff gate
  - **T11971** — Mem0-V3 envelope writers populate `network` classification at extraction time (+ opinion confidence/evidence updates)
  - **T11972** — bitemporal time-travel readers honor `expired_at` (`cleo brain query --at` / `cleo memory as-of`)
  - **T11973** — dreamer specialists + reconciler + writer-CRITIC non-invention audit in `sleep-consolidation`

## Evidence note
Worktree-evidence verification is blocked by T11959 (`cleo verify` runs against the main-checkout HEAD; the worktree commit `cab6db77c` is not reachable from it). Orchestrator completes T10405 via `pr:<n>` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)