### PR TITLE
feat(M2+M7): vault credential injection at spawn + cron schedule table (T11940/T11962)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2505,6 +2505,8 @@ export {
 export type {
   CredentialHeaderRule,
   HostAuthStrategy,
+  InjectionRule,
+  InjectionValueSource,
   MetadataHeaderRule,
   RefreshBodyFormat,
   RefreshClientAuth,

--- a/packages/contracts/src/vault/service-provider.ts
+++ b/packages/contracts/src/vault/service-provider.ts
@@ -178,6 +178,79 @@ export interface ServiceHostRule {
 }
 
 /**
+ * One declarative injection action applied to an outbound request when a resolved
+ * service credential is injected at the harness tool boundary (T11940 · M2-W3).
+ *
+ * A discriminated union over the action `kind`. The injector
+ * ({@link import('@cleocode/core').injectServiceCredentials}) materializes the
+ * sealed credential's plaintext ONLY at the wire (inside the action's value
+ * resolver) and applies these mutations to a request descriptor — there is NO MITM
+ * proxy (the seam is the in-process tool boundary, T11940 AC4):
+ *
+ *  - `set-header` — set `name` to the materialized value (overwriting any existing).
+ *  - `replace-header` — set `name` to the value ONLY if the header is already
+ *    present (a no-op when absent — used to swap a placeholder the tool emitted).
+ *  - `remove-header` — delete `name` (e.g. strip a stale `Authorization` before
+ *    re-injecting the vault credential).
+ *  - `set-param` — set the query-string parameter `name` to the materialized value.
+ *
+ * The `valueSource` discriminates WHERE the injected value comes from:
+ * `'token'` (the decrypted access token), `'credential-field'` (a named field of
+ * the credential blob, e.g. an AWS access-key id), or `'metadata'` (a non-secret
+ * connection-metadata key, e.g. a Google project id). `remove-header` carries no
+ * `valueSource` (it injects nothing).
+ *
+ * @task T11940
+ */
+export type InjectionRule =
+  | {
+      /** Set a header to the injected value (overwrites any existing). */
+      readonly kind: 'set-header';
+      /** The header name to set. */
+      readonly name: string;
+      /** Where the injected value comes from. */
+      readonly valueSource: InjectionValueSource;
+      /** For `bearer`/`basic-x-access-token` token framing — how to wrap the value. */
+      readonly framing?: HostAuthStrategy;
+    }
+  | {
+      /** Set a header ONLY when it is already present (swap a placeholder). */
+      readonly kind: 'replace-header';
+      /** The header name to replace. */
+      readonly name: string;
+      /** Where the injected value comes from. */
+      readonly valueSource: InjectionValueSource;
+      /** For `bearer`/`basic-x-access-token` token framing — how to wrap the value. */
+      readonly framing?: HostAuthStrategy;
+    }
+  | {
+      /** Remove a header (injects no value). */
+      readonly kind: 'remove-header';
+      /** The header name to remove. */
+      readonly name: string;
+    }
+  | {
+      /** Set a query-string parameter to the injected value. */
+      readonly kind: 'set-param';
+      /** The query-parameter name to set. */
+      readonly name: string;
+      /** Where the injected value comes from. */
+      readonly valueSource: InjectionValueSource;
+    };
+
+/**
+ * Where an {@link InjectionRule}'s injected value is sourced from.
+ *
+ *  - `token` — the decrypted access token (the secret materialized at the wire).
+ *  - `credential-field` — a named field of the credential blob (paired with the
+ *    rule's `name` resolution via {@link ServiceProviderDef.credentialHeaders}).
+ *  - `metadata` — a non-secret connection-metadata key.
+ *
+ * @task T11940
+ */
+export type InjectionValueSource = 'token' | 'credential-field' | 'metadata';
+
+/**
  * Inject an HTTP header from a credential-blob field (e.g. a regional API key →
  * `DD-API-KEY`). Declarative metadata; the injecting proxy is a later epic.
  *

--- a/packages/core/migrations/drizzle-cleo-global/20260610000000_t11962-schedules/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-global/20260610000000_t11962-schedules/migration.sql
@@ -1,0 +1,48 @@
+-- T11962 (under T11679) — the cron/todo schedule sink (`schedules`).
+--
+-- One row per recurring schedule registered by the `cron_schedule` agent tool
+-- (T11950): a cron expression + the task template (title / description)
+-- materialized on each fire, an `enabled` flag, and create/update timestamps. The
+-- tool registers a row daemon-OFF via the leased Gate-3 accessor
+-- (schedule-store.ts); a future daemon scheduler consumes the SAME table as a
+-- separate reader (AC4).
+--
+-- Co-located inside EACH scope's consolidated cleo.db (this file is byte-identical
+-- in drizzle-cleo-project and drizzle-cleo-global so the two lineages produce the
+-- SAME migration hash — the consolidated single-file journal converges across both
+-- under the CONSOLIDATED_JOURNAL_LINEAGES cross-lineage guard, T11829). Pure
+-- runtime infrastructure (like `_writer_leases` from T11627, `pi_session_*` from
+-- T11899, and `selfimprove_dhq` from T11911) — NOT part of the exodus target shape
+-- under `schema/cleo-project/`, so the consolidated schema-parity gate (T11364)
+-- does not re-derive its CHECK set.
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-project) which already creates dozens of tables, so `schedules` is NEVER
+-- the first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables.
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op. Each
+-- statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11962
+-- @epic T11679
+
+CREATE TABLE IF NOT EXISTS `schedules` (
+  `id` INTEGER PRIMARY KEY,
+  `schedule_id` TEXT NOT NULL,
+  `cron_expr` TEXT NOT NULL,
+  `title` TEXT NOT NULL,
+  `description` TEXT,
+  `enabled` INTEGER NOT NULL DEFAULT 1 CHECK (`enabled` IN (0, 1)),
+  `created_at` TEXT NOT NULL DEFAULT (datetime('now')),
+  `updated_at` TEXT NOT NULL DEFAULT (datetime('now'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_schedules_schedule_id` ON `schedules` (`schedule_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ix_schedules_enabled` ON `schedules` (`enabled`);

--- a/packages/core/migrations/drizzle-cleo-project/20260610000000_t11962-schedules/migration.sql
+++ b/packages/core/migrations/drizzle-cleo-project/20260610000000_t11962-schedules/migration.sql
@@ -1,0 +1,48 @@
+-- T11962 (under T11679) — the cron/todo schedule sink (`schedules`).
+--
+-- One row per recurring schedule registered by the `cron_schedule` agent tool
+-- (T11950): a cron expression + the task template (title / description)
+-- materialized on each fire, an `enabled` flag, and create/update timestamps. The
+-- tool registers a row daemon-OFF via the leased Gate-3 accessor
+-- (schedule-store.ts); a future daemon scheduler consumes the SAME table as a
+-- separate reader (AC4).
+--
+-- Co-located inside EACH scope's consolidated cleo.db (this file is byte-identical
+-- in drizzle-cleo-project and drizzle-cleo-global so the two lineages produce the
+-- SAME migration hash — the consolidated single-file journal converges across both
+-- under the CONSOLIDATED_JOURNAL_LINEAGES cross-lineage guard, T11829). Pure
+-- runtime infrastructure (like `_writer_leases` from T11627, `pi_session_*` from
+-- T11899, and `selfimprove_dhq` from T11911) — NOT part of the exodus target shape
+-- under `schema/cleo-project/`, so the consolidated schema-parity gate (T11364)
+-- does not re-derive its CHECK set.
+--
+-- ## Page-2 invariant
+--
+-- This migration runs AFTER the consolidation baseline (…_t11363-consolidation-
+-- cleo-project) which already creates dozens of tables, so `schedules` is NEVER
+-- the first CREATE on a fresh DB — rootpage 2 is already owned by
+-- `__drizzle_migrations` / the baseline tables.
+--
+-- `IF NOT EXISTS` so a re-open over an already-migrated DB is a no-op. Each
+-- statement is separated by a drizzle breakpoint marker line so node:sqlite
+-- prepare() does not silently truncate the multi-statement file to statement one
+-- (the marker token is intentionally not spelled out in this comment — drizzle's
+-- readMigrationFiles splits the file on that literal substring).
+--
+-- @task T11962
+-- @epic T11679
+
+CREATE TABLE IF NOT EXISTS `schedules` (
+  `id` INTEGER PRIMARY KEY,
+  `schedule_id` TEXT NOT NULL,
+  `cron_expr` TEXT NOT NULL,
+  `title` TEXT NOT NULL,
+  `description` TEXT,
+  `enabled` INTEGER NOT NULL DEFAULT 1 CHECK (`enabled` IN (0, 1)),
+  `created_at` TEXT NOT NULL DEFAULT (datetime('now')),
+  `updated_at` TEXT NOT NULL DEFAULT (datetime('now'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ux_schedules_schedule_id` ON `schedules` (`schedule_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ix_schedules_enabled` ON `schedules` (`enabled`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -255,6 +255,20 @@ export {
   updateConnectionTokens,
 } from './store/service-connections-accessor.js';
 export {
+  matchServiceHost,
+  matchServiceUrl,
+  type ServiceHostMatch,
+} from './store/service-host-matcher.js';
+export {
+  type InjectedRequest,
+  type InjectionDiagnostic,
+  type InjectionResult,
+  type InjectServiceCredentialsParams,
+  injectionRulesForStrategy,
+  injectServiceCredentials,
+  type OutboundRequest,
+} from './store/service-injection.js';
+export {
   type BuildAuthUrlOptions,
   type BuildAuthUrlResult,
   buildAuthUrl,

--- a/packages/core/src/store/__tests__/schedule-store.test.ts
+++ b/packages/core/src/store/__tests__/schedule-store.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the cron/todo `schedules` table + Gate-3 accessor (T11962).
+ *
+ * Required proofs:
+ *  1. **migration round-trip** — open a TEMP-DIR project `cleo.db` (real migrations
+ *     applied), assert the `schedules` table and BOTH indexes
+ *     (`ux_schedules_schedule_id`, `ix_schedules_enabled`) are present, and
+ *     round-trip a row through {@link addSchedule} / {@link getSchedule}.
+ *  2. **add / list / remove** — register two schedules, list them in creation
+ *     order (bounded read — never `.all()`), then remove one and confirm it is gone.
+ *  3. **unique handle** — the `schedule_id` minted per row is unique
+ *     (`ux_schedules_schedule_id`), and removing an unknown handle reports `false`.
+ *
+ * The accessor opens via `openDualScopeDbAtPath` (the dual-scope chokepoint) and
+ * extracts `$client` — it NEVER calls `new DatabaseSync` (Gate 3).
+ *
+ * @epic T11679
+ * @task T11962
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from '../dual-scope-db.js';
+import { SCHEDULES_TABLE } from '../schedule-schema.js';
+import { addSchedule, getSchedule, listSchedules, removeSchedule } from '../schedule-store.js';
+
+/** The narrow native-handle shape the accessor consumes (re-derived for the test). */
+type ScheduleNativeHandle = Parameters<typeof addSchedule>[0];
+
+let testRoot: string;
+let native: ScheduleNativeHandle;
+let rawNative: DatabaseSync;
+
+beforeEach(async () => {
+  testRoot = join(tmpdir(), `schedule-store-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const cleoDir = join(testRoot, 'project', '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  const dbPath = join(cleoDir, 'cleo.db');
+  // Real migrations applied (the t11962 migration creates `schedules` + indexes).
+  const handle = await openDualScopeDbAtPath('project', dbPath);
+  rawNative = (handle.db as unknown as { $client: DatabaseSync }).$client;
+  native = rawNative as unknown as ScheduleNativeHandle;
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('schedules migration + Gate-3 accessor (T11962)', () => {
+  it('migrates the table and both indexes', () => {
+    const tbl = rawNative
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(SCHEDULES_TABLE) as { name: string } | undefined;
+    expect(tbl?.name).toBe(SCHEDULES_TABLE);
+
+    const indexes = rawNative
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ? ORDER BY name`)
+      .all(SCHEDULES_TABLE)
+      .map((r) => String((r as { name: unknown }).name));
+    expect(indexes).toContain('ux_schedules_schedule_id');
+    expect(indexes).toContain('ix_schedules_enabled');
+  });
+
+  it('round-trips one schedule via add + get', () => {
+    const id = addSchedule(native, {
+      cronExpr: '0 9 * * 1',
+      title: 'weekly report',
+      description: 'compile the weekly report',
+    });
+    expect(id).toMatch(/^sched-[0-9a-f]{24}$/);
+
+    const row = getSchedule(native, id);
+    expect(row).not.toBeNull();
+    expect(row?.cronExpr).toBe('0 9 * * 1');
+    expect(row?.title).toBe('weekly report');
+    expect(row?.description).toBe('compile the weekly report');
+    expect(row?.enabled).toBe(true);
+    expect(typeof row?.createdAt).toBe('string');
+  });
+
+  it('lists schedules in creation order (bounded read)', () => {
+    const first = addSchedule(native, { cronExpr: '0 9 * * 1', title: 'a' });
+    const second = addSchedule(native, { cronExpr: '0 10 * * 2', title: 'b' });
+
+    const all = listSchedules(native);
+    expect(all.map((s) => s.scheduleId)).toEqual([first, second]);
+    expect(all[1]?.description).toBeNull();
+  });
+
+  it('removes a schedule and reports false for an unknown handle', () => {
+    const id = addSchedule(native, { cronExpr: '0 9 * * 1', title: 'gone soon' });
+    expect(removeSchedule(native, id)).toBe(true);
+    expect(getSchedule(native, id)).toBeNull();
+    expect(listSchedules(native)).toHaveLength(0);
+    // Removing an unknown handle is a no-op that reports false.
+    expect(removeSchedule(native, 'sched-000000000000000000000000')).toBe(false);
+  });
+
+  it('mints a unique handle per schedule', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 25; i++) {
+      ids.add(addSchedule(native, { cronExpr: '0 9 * * 1', title: `t${i}` }));
+    }
+    expect(ids.size).toBe(25);
+    expect(listSchedules(native)).toHaveLength(25);
+  });
+});

--- a/packages/core/src/store/__tests__/service-injection.test.ts
+++ b/packages/core/src/store/__tests__/service-injection.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Service-credential injection at the tool boundary (T11940 · M2-W3 · AC1–AC5).
+ *
+ * Required proofs:
+ *  - **AC1 — host/path matching.** `matchServiceHost` / `matchServiceUrl` resolve a
+ *    request host (and path) to the right {@link ServiceProviderDef} + host rule,
+ *    pick the most specific path-prefixed rule, and return `null` for an unclaimed
+ *    host.
+ *  - **AC2 — injection (trust-gated, sealed).** `injectServiceCredentials` resolves
+ *    a granted github connection and materializes the `Authorization: Bearer <token>`
+ *    header on the request; a `basic-x-access-token` host frames the token as
+ *    `Authorization: Basic base64("x-access-token:<token>")`; a stale Authorization
+ *    the tool emitted is stripped and replaced.
+ *  - **AC3 — redaction.** The full plaintext token appears in NO field of the result
+ *    diagnostic and the deep walk of the diagnostic finds it nowhere; the ONLY
+ *    credential-derived diagnostic string is the non-secret `tokenPreview`.
+ *  - **AC4 — no proxy.** The injector is a pure function over a request descriptor —
+ *    no network I/O fires (the injected `fetch`/`now` deps are never invoked for a
+ *    non-expired connection).
+ *  - **deny path** — a non-granted agent gets `injected: false`, the original request
+ *    untouched, and `decryptGlobal` is NEVER called (policy-before-decrypt).
+ *
+ * The vault is a TEMP-DIR `cleo.db` (off `.cleo/*.db`); no real network, no MITM.
+ *
+ * @epic T11765
+ * @task T11940
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CleoGlobalDb } from '../dual-scope-db.js';
+import { _resetDualScopeDbCache } from '../dual-scope-db.js';
+import {
+  connectService,
+  grantAgentAccess,
+  openServiceVaultAtPath,
+  type ServiceVaultDeps,
+} from '../service-connections-accessor.js';
+import { matchServiceHost, matchServiceUrl } from '../service-host-matcher.js';
+import { injectionRulesForStrategy, injectServiceCredentials } from '../service-injection.js';
+
+const AGENT = 'agent-injection-test';
+const TOKEN = 'gho_SECRET_service_token_do_not_leak_4242abcd';
+
+let testRoot: string;
+let db: CleoGlobalDb;
+
+beforeEach(async () => {
+  testRoot = join(
+    tmpdir(),
+    `service-injection-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testRoot, { recursive: true });
+  db = await openServiceVaultAtPath(join(testRoot, 'cleo.db'));
+});
+
+afterEach(() => {
+  _resetDualScopeDbCache();
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+/** Connect a github credential and grant the agent access. */
+async function connectAndGrant(label = 'default'): Promise<void> {
+  const connId = await connectService(
+    { provider: 'github', label, tokens: { accessToken: TOKEN } },
+    { db },
+  );
+  await grantAgentAccess(AGENT, connId, { mode: 'allow' }, { db });
+}
+
+/** Recursively collect every string reachable from a value (not descending functions). */
+function reachableStrings(value: unknown, seen = new Set<unknown>()): string[] {
+  if (typeof value === 'string') return [value];
+  if (value === null || typeof value !== 'object') return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  const out: string[] = [];
+  if (Array.isArray(value)) {
+    for (const item of value) out.push(...reachableStrings(item, seen));
+    return out;
+  }
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    out.push(...reachableStrings(v, seen));
+  }
+  return out;
+}
+
+// ===========================================================================
+// AC1 — host/path matching
+// ===========================================================================
+
+describe('service host matcher (AC1)', () => {
+  it('matches an exact api host to its provider + strategy', () => {
+    const m = matchServiceHost('api.github.com', '/user');
+    expect(m?.provider.provider).toBe('github');
+    expect(m?.strategy).toBe('bearer');
+  });
+
+  it('frames git-over-https github.com as basic-x-access-token', () => {
+    const m = matchServiceHost('github.com', '/owner/repo.git');
+    expect(m?.provider.provider).toBe('github');
+    expect(m?.strategy).toBe('basic-x-access-token');
+  });
+
+  it('prefers the most specific path-prefixed rule', () => {
+    // www.googleapis.com/gmail/ → gmail; /drive/ → google-drive.
+    expect(matchServiceHost('www.googleapis.com', '/gmail/v1/users/me')?.provider.provider).toBe(
+      'gmail',
+    );
+    expect(matchServiceHost('www.googleapis.com', '/drive/v3/files')?.provider.provider).toBe(
+      'google-drive',
+    );
+  });
+
+  it('returns null for an unclaimed host', () => {
+    expect(matchServiceHost('example.invalid', '/x')).toBeNull();
+    expect(matchServiceUrl('not a url')).toBeNull();
+  });
+
+  it('tolerates a port and trailing dot on the host', () => {
+    expect(matchServiceHost('api.github.com:443')?.provider.provider).toBe('github');
+    expect(matchServiceUrl('https://api.github.com./user')?.provider.provider).toBe('github');
+  });
+});
+
+// ===========================================================================
+// AC2 — injection (trust-gated, sealed)
+// ===========================================================================
+
+describe('injectServiceCredentials (AC2)', () => {
+  it('materializes a Bearer Authorization header for a granted github connection', async () => {
+    await connectAndGrant();
+    const res = await injectServiceCredentials(
+      { agentId: AGENT, request: { url: 'https://api.github.com/user', headers: {} } },
+      { vault: { db } },
+    );
+    expect(res.injected).toBe(true);
+    expect(res.request.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(res.diagnostic.provider).toBe('github');
+    expect(res.diagnostic.strategy).toBe('bearer');
+  });
+
+  it('frames a git-over-https request as Basic x-access-token', async () => {
+    await connectAndGrant();
+    const res = await injectServiceCredentials(
+      { agentId: AGENT, request: { url: 'https://github.com/owner/repo.git', headers: {} } },
+      { vault: { db } },
+    );
+    expect(res.injected).toBe(true);
+    const expected = `Basic ${Buffer.from(`x-access-token:${TOKEN}`).toString('base64')}`;
+    expect(res.request.headers.Authorization).toBe(expected);
+  });
+
+  it('strips a stale Authorization the tool emitted and replaces it', async () => {
+    await connectAndGrant();
+    const res = await injectServiceCredentials(
+      {
+        agentId: AGENT,
+        request: {
+          url: 'https://api.github.com/user',
+          headers: { authorization: 'Bearer STALE-PLACEHOLDER' },
+        },
+      },
+      { vault: { db } },
+    );
+    // Exactly one Authorization header, carrying the vault token (case-normalized).
+    const authKeys = Object.keys(res.request.headers).filter(
+      (k) => k.toLowerCase() === 'authorization',
+    );
+    expect(authKeys).toHaveLength(1);
+    expect(res.request.headers[authKeys[0] as string]).toBe(`Bearer ${TOKEN}`);
+  });
+});
+
+// ===========================================================================
+// AC3 — redaction (only tokenPreview crosses the boundary)
+// ===========================================================================
+
+describe('injectServiceCredentials redaction (AC3)', () => {
+  it('never surfaces the plaintext in the diagnostic; only tokenPreview', async () => {
+    await connectAndGrant();
+    const res = await injectServiceCredentials(
+      { agentId: AGENT, request: { url: 'https://api.github.com/user', headers: {} } },
+      { vault: { db } },
+    );
+    // The injected header DOES carry the token (it is bound to the wire) — but the
+    // DIAGNOSTIC must not. Walk every string in the diagnostic; none is the secret.
+    const diagStrings = reachableStrings(res.diagnostic);
+    expect(diagStrings).not.toContain(TOKEN);
+    expect(JSON.stringify(res.diagnostic)).not.toContain(TOKEN);
+    // The only credential-derived diagnostic string is the redacted preview.
+    expect(res.diagnostic.tokenPreview).toBeTruthy();
+    expect(res.diagnostic.tokenPreview).not.toBe(TOKEN);
+    expect(res.diagnostic.tokenPreview?.length ?? 0).toBeLessThan(TOKEN.length);
+  });
+});
+
+// ===========================================================================
+// AC4 — no proxy / no network I/O on the non-expired path
+// ===========================================================================
+
+describe('injectServiceCredentials (AC4 — no MITM proxy / no network)', () => {
+  it('performs no network I/O for a non-expired connection', async () => {
+    await connectAndGrant();
+    const fetchSpy = vi.fn();
+    const res = await injectServiceCredentials(
+      { agentId: AGENT, request: { url: 'https://api.github.com/user', headers: {} } },
+      { vault: { db }, fetch: fetchSpy as never },
+    );
+    expect(res.injected).toBe(true);
+    // No refresh needed → the injected HTTP transport is never touched.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(res.diagnostic.refreshed).toBe(false);
+  });
+});
+
+// ===========================================================================
+// deny path — policy-before-decrypt
+// ===========================================================================
+
+describe('injectServiceCredentials deny path (policy-before-decrypt)', () => {
+  it('does not inject and NEVER decrypts when the agent is not granted', async () => {
+    // Connect github but DO NOT grant the agent.
+    await connectService(
+      { provider: 'github', label: 'default', tokens: { accessToken: TOKEN } },
+      { db },
+    );
+    const decryptSpy = vi.fn(async (_ciphertext: string, _id: string) => {
+      // Should never run — assert via the call count below.
+      return JSON.stringify({ accessToken: 'LEAKED' });
+    });
+    const original = { url: 'https://api.github.com/user', headers: { 'X-Keep': '1' } };
+    const res = await injectServiceCredentials(
+      { agentId: AGENT, request: original },
+      { vault: { db, decrypt: decryptSpy as ServiceVaultDeps['decrypt'] } },
+    );
+    expect(res.injected).toBe(false);
+    // The original request is returned untouched (no Authorization added).
+    expect(res.request.headers.Authorization).toBeUndefined();
+    expect(res.request.headers['X-Keep']).toBe('1');
+    // Policy-before-decrypt: no crypto ran on the deny path.
+    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(res.diagnostic.tokenPreview).toBeNull();
+  });
+
+  it('leaves an unclaimed-host request untouched (injected: false)', async () => {
+    await connectAndGrant();
+    const res = await injectServiceCredentials(
+      { agentId: AGENT, request: { url: 'https://example.invalid/x', headers: { a: 'b' } } },
+      { vault: { db } },
+    );
+    expect(res.injected).toBe(false);
+    expect(res.request.headers).toEqual({ a: 'b' });
+    expect(res.diagnostic.provider).toBeNull();
+  });
+});
+
+// ===========================================================================
+// strategy → rule mapping
+// ===========================================================================
+
+describe('injectionRulesForStrategy', () => {
+  it('strips then sets Authorization for every strategy', () => {
+    for (const strategy of ['bearer', 'basic-x-access-token', 'header'] as const) {
+      const rules = injectionRulesForStrategy(strategy);
+      expect(rules[0]).toMatchObject({ kind: 'remove-header', name: 'Authorization' });
+      expect(rules[1]).toMatchObject({
+        kind: 'set-header',
+        name: 'Authorization',
+        framing: strategy,
+      });
+    }
+  });
+});

--- a/packages/core/src/store/schedule-schema.ts
+++ b/packages/core/src/store/schedule-schema.ts
@@ -1,0 +1,95 @@
+/**
+ * Drizzle ORM schema for the **cron / todo schedule** table (`schedules`) — the
+ * durable sink for recurring-task schedules registered by the `cron_schedule`
+ * agent tool (T11962 · under T11679 · M7 · epic T11456).
+ *
+ * One row per recurring schedule: a cron expression plus the task TEMPLATE
+ * (title / description) materialized on each fire, an `enabled` flag, and
+ * creation/update timestamps. The `cron_schedule` agent tool
+ * ({@link import('../tools/schedule-agent-tools.js')}) registers a row through the
+ * leased Gate-3 accessor ({@link import('./schedule-store.js')}) so it persists
+ * WITHOUT a running daemon (T11950 AC3); a future daemon scheduler consumes the
+ * SAME table as a separate reader (T11962 AC4).
+ *
+ * ## Pure runtime infrastructure (NOT the exodus target shape)
+ *
+ * Like `_writer_leases` (T11627), `pi_session_*` (T11899), and `selfimprove_dhq`
+ * (T11911), this table is co-located inside EACH scope's consolidated `cleo.db`
+ * (project + global) via the `drizzle-cleo-project` / `drizzle-cleo-global`
+ * migration sets — so the two lineages produce the SAME migration hash and the
+ * consolidated single-file journal converges across both
+ * (CONSOLIDATED_JOURNAL_LINEAGES cross-lineage guard, T11829). It is NOT part of
+ * the exodus target shape under `schema/cleo-project/`, so the consolidated
+ * schema-parity gate (T11364) does not re-derive its CHECK set — exactly the
+ * runtime-infrastructure precedent.
+ *
+ * ## E10 typing
+ *
+ * TEXT ISO-8601 timestamps (`created_at` / `updated_at`); a typed boolean
+ * (`enabled`, `integer({ mode: 'boolean' })` → CHECK IN (0,1)). No JSON columns —
+ * the task template is two plain TEXT columns (title + nullable description).
+ *
+ * @module
+ * @task T11962
+ * @epic T11679
+ * @see ./schedule-store.ts — the Gate-3 accessor over this table
+ * @see ./selfimprove-dhq-schema.ts — the runtime-infrastructure-table precedent this mirrors
+ * @see ../../migrations/drizzle-cleo-project — project migration (CREATE TABLE schedules)
+ * @see ../../migrations/drizzle-cleo-global — global migration (byte-identical, journal convergence)
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
+/**
+ * The physical name of the schedule table. Exported so the accessor and tests all
+ * reference one source of truth.
+ */
+export const SCHEDULES_TABLE = 'schedules' as const;
+
+/**
+ * `schedules` — one row per recurring (cron) task schedule.
+ *
+ * `cronExpr` is the recurrence (a standard 5-field cron expression); `title` /
+ * `description` are the task template materialized on each fire; `enabled` toggles
+ * whether the daemon scheduler (a separate consumer, AC4) should fire it. The row
+ * is written by the leased accessor ({@link import('./schedule-store.js')}) — the
+ * `cron_schedule` agent tool delegates to it daemon-OFF.
+ *
+ * @task T11962
+ */
+export const schedules = sqliteTable(
+  SCHEDULES_TABLE,
+  {
+    /** Surrogate primary key (autoincrement via INTEGER PRIMARY KEY rowid alias). */
+    id: integer('id').primaryKey(),
+    /** Stable opaque schedule handle (`sched-<token>`) returned to the tool caller. */
+    scheduleId: text('schedule_id').notNull(),
+    /** The recurrence — a standard 5-field cron expression (e.g. `'0 9 * * 1'`). */
+    cronExpr: text('cron_expr').notNull(),
+    /** The title of the task created on each fire (the template). */
+    title: text('title').notNull(),
+    /** Optional description for the task created on each fire. */
+    description: text('description'),
+    /**
+     * Whether the daemon scheduler should fire this schedule. Typed boolean
+     * (CHECK IN (0,1)); defaults `true` so a freshly-registered schedule is live.
+     */
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+    /** ISO-8601 UTC creation instant. Defaults to write time. */
+    createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+    /** ISO-8601 UTC last-update instant. Defaults to write time; bumped on mutation. */
+    updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    // `schedule_id` is the opaque handle the accessor looks up / removes by — unique.
+    unique('ux_schedules_schedule_id').on(table.scheduleId),
+    // Lookup index — the daemon scheduler enumerates enabled schedules.
+    index('ix_schedules_enabled').on(table.enabled),
+  ],
+);
+
+/** Row type for `schedules` SELECT queries. */
+export type ScheduleRow = typeof schedules.$inferSelect;
+/** Row type for `schedules` INSERT operations. */
+export type NewScheduleRow = typeof schedules.$inferInsert;

--- a/packages/core/src/store/schedule-store.ts
+++ b/packages/core/src/store/schedule-store.ts
@@ -1,0 +1,226 @@
+/**
+ * Store-layer accessor for the cron / todo schedule table (`schedules`) — T11962
+ * (under T11679 · M7 · epic T11456).
+ *
+ * This module is the ONLY place that touches the native `cleo.db` handle for
+ * schedule persistence. It lives INSIDE the store chokepoint
+ * (`packages/core/src/store/**`), the Gate-3 allowlist, so it may extract the
+ * native `DatabaseSync` that {@link openDualScopeDb} already holds (via drizzle's
+ * `$client`) and run prepared statements over it — exactly the established
+ * `selfimprove-dhq-store.ts` / `pi-session-store.ts` pattern. It NEVER calls
+ * `new DatabaseSync(` itself.
+ *
+ * The `cron_schedule` agent tool ({@link import('../tools/schedule-agent-tools.js')})
+ * sits OUTSIDE the chokepoint, so it must NOT open a raw handle; it calls
+ * {@link addSchedule} / {@link listSchedules} / {@link removeSchedule}. A single
+ * INSERT/DELETE is one atomic SQLite statement, so the accessor does not wrap them
+ * in a writer lease itself — daemon-OFF the chokepoint already serializes the
+ * single in-process writer; a future daemon scheduler (a separate reader, AC4)
+ * never writes through this path.
+ *
+ * Physical model (see the `t11962-schedules` migration):
+ *  - `schedules(id, schedule_id, cron_expr, title, description, enabled,
+ *    created_at, updated_at)` — one row per recurring schedule.
+ *  - `schedule_id` is a unique opaque handle (`sched-<token>`) returned to the
+ *    caller and used to remove a schedule.
+ *
+ * ## Never `.all()` an unbounded query
+ *
+ * {@link listSchedules} reads through `iterate()` with an explicit SQL `LIMIT`
+ * (capped, default {@link SCHEDULE_LIST_DEFAULT_LIMIT}), never `.all()` over the
+ * whole table — the established OOM-safe read pattern (cf.
+ * `exodus/verify-migration.ts`).
+ *
+ * @module
+ * @task T11962
+ * @epic T11679
+ * @see ./schedule-schema.ts — the drizzle table declaration (physical-name SSoT)
+ * @see ./selfimprove-dhq-store.ts — the Gate-3 native-handle accessor precedent this mirrors
+ * @see ../tools/schedule-agent-tools.ts — the `cron_schedule` tool that delegates here
+ */
+
+import { randomBytes } from 'node:crypto';
+import type { DatabaseSync as DatabaseSyncType } from 'node:sqlite';
+import { openDualScopeDb } from './dual-scope-db.js';
+import { SCHEDULES_TABLE } from './schedule-schema.js';
+
+export { SCHEDULES_TABLE } from './schedule-schema.js';
+
+/** Default cap for {@link listSchedules} — bounds the read so it never OOMs. */
+export const SCHEDULE_LIST_DEFAULT_LIMIT = 500 as const;
+
+/** Hard ceiling on a {@link listSchedules} request — a caller cannot exceed it. */
+export const SCHEDULE_LIST_MAX_LIMIT = 5000 as const;
+
+/** A persisted schedule row, decoded from `schedules`. */
+export interface ScheduleRecord {
+  /** Stable opaque schedule handle (`sched-<token>`). */
+  readonly scheduleId: string;
+  /** The recurrence — a standard 5-field cron expression. */
+  readonly cronExpr: string;
+  /** The title of the task created on each fire (the template). */
+  readonly title: string;
+  /** Optional description for the task created on each fire. */
+  readonly description: string | null;
+  /** Whether the daemon scheduler should fire this schedule. */
+  readonly enabled: boolean;
+  /** ISO-8601 UTC creation instant. */
+  readonly createdAt: string;
+  /** ISO-8601 UTC last-update instant. */
+  readonly updatedAt: string;
+}
+
+/** Fields required to register one schedule via {@link addSchedule}. */
+export interface AddScheduleParams {
+  /** The recurrence — a standard 5-field cron expression (e.g. `'0 9 * * 1'`). */
+  readonly cronExpr: string;
+  /** The title of the task to create on each fire. */
+  readonly title: string;
+  /** Optional description for the task created on each fire. */
+  readonly description?: string;
+}
+
+/** Narrow shape of the native handle methods this accessor uses. */
+type NativeRunResult = { changes: number | bigint; lastInsertRowid: number | bigint };
+interface NativeStatement {
+  run(...params: ReadonlyArray<string | number | null>): NativeRunResult;
+  get(...params: ReadonlyArray<string | number | null>): Record<string, unknown> | undefined;
+  iterate(
+    ...params: ReadonlyArray<string | number | null>
+  ): IterableIterator<Record<string, unknown>>;
+}
+interface NativeHandle {
+  prepare(sql: string): NativeStatement;
+}
+
+/**
+ * Extract the native `DatabaseSync` handle for the PROJECT-scope `cleo.db`.
+ *
+ * Routes through {@link openDualScopeDb} (the dual-scope chokepoint) — which
+ * applies the pragma SSoT, runs the consolidated migrations (creating
+ * `schedules`), and manages the singleton cache — then extracts the native handle
+ * drizzle holds on `$client`. NEVER opens a raw connection (Gate 3): it reuses the
+ * handle the chokepoint already owns.
+ *
+ * @param cwd - Working directory for project resolution (defaults to `cwd`).
+ * @returns The live native handle.
+ * @throws When the chokepoint returns a handle without `$client`.
+ */
+export async function getScheduleNativeDb(cwd?: string): Promise<NativeHandle> {
+  const handle = await openDualScopeDb('project', cwd);
+  const native = (handle.db as unknown as { $client?: DatabaseSyncType }).$client;
+  if (!native) {
+    throw new Error(
+      'T11962: openDualScopeDb returned a project handle without $client — ' +
+        'cannot extract DatabaseSync for schedule persistence.',
+    );
+  }
+  // The node:sqlite surface is wider than NativeHandle; narrow to what we use.
+  return native as unknown as NativeHandle;
+}
+
+/** Decode a raw SQLite row into a typed {@link ScheduleRecord}. */
+function decodeRow(row: Record<string, unknown>): ScheduleRecord {
+  return {
+    scheduleId: String(row.schedule_id),
+    cronExpr: String(row.cron_expr),
+    title: String(row.title),
+    description:
+      row.description === null || row.description === undefined ? null : String(row.description),
+    // SQLite stores the typed boolean as 0/1.
+    enabled: Number(row.enabled) !== 0,
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+/** Mint a stable opaque schedule handle (`sched-<24 hex>`). */
+function mintScheduleId(): string {
+  return `sched-${randomBytes(12).toString('hex')}`;
+}
+
+/**
+ * REGISTER a recurring schedule: insert one `schedules` row and return its handle.
+ *
+ * A fresh `schedule_id` is minted (`sched-<token>`) and returned so the caller can
+ * later {@link removeSchedule} by it. The row is created `enabled = true`. Writes
+ * one atomic INSERT — the chokepoint serializes the single in-process writer
+ * daemon-OFF.
+ *
+ * @param native - The native project `cleo.db` handle (from {@link getScheduleNativeDb}).
+ * @param params - The cron expression + task template.
+ * @returns The minted schedule handle.
+ */
+export function addSchedule(native: NativeHandle, params: AddScheduleParams): string {
+  const scheduleId = mintScheduleId();
+  native
+    .prepare(
+      `INSERT INTO ${SCHEDULES_TABLE} ` +
+        `(schedule_id, cron_expr, title, description, enabled) ` +
+        `VALUES (?, ?, ?, ?, 1)`,
+    )
+    .run(scheduleId, params.cronExpr, params.title, params.description ?? null);
+  return scheduleId;
+}
+
+/**
+ * LIST registered schedules in stable creation order (`created_at ASC`, then `id`).
+ *
+ * Bounded by an explicit SQL `LIMIT` and read through `iterate()` — NEVER an
+ * unbounded `.all()`. The request limit is clamped to
+ * `[1, {@link SCHEDULE_LIST_MAX_LIMIT}]`, defaulting to
+ * {@link SCHEDULE_LIST_DEFAULT_LIMIT}.
+ *
+ * @param native - The native project `cleo.db` handle.
+ * @param limit - Maximum rows to return (clamped). Defaults to the default cap.
+ * @returns The ordered schedule records (at most `limit`).
+ */
+export function listSchedules(
+  native: NativeHandle,
+  limit: number = SCHEDULE_LIST_DEFAULT_LIMIT,
+): ScheduleRecord[] {
+  const clamped = Math.max(1, Math.min(Math.floor(limit), SCHEDULE_LIST_MAX_LIMIT));
+  const stmt = native.prepare(
+    `SELECT schedule_id, cron_expr, title, description, enabled, created_at, updated_at ` +
+      `FROM ${SCHEDULES_TABLE} ORDER BY created_at ASC, id ASC LIMIT ?`,
+  );
+  const out: ScheduleRecord[] = [];
+  for (const row of stmt.iterate(clamped)) {
+    out.push(decodeRow(row));
+  }
+  return out;
+}
+
+/**
+ * GET one schedule by its opaque handle, or `null` when no such schedule exists.
+ *
+ * @param native - The native project `cleo.db` handle.
+ * @param scheduleId - The `sched-<token>` handle.
+ * @returns The schedule record, or `null`.
+ */
+export function getSchedule(native: NativeHandle, scheduleId: string): ScheduleRecord | null {
+  const row = native
+    .prepare(
+      `SELECT schedule_id, cron_expr, title, description, enabled, created_at, updated_at ` +
+        `FROM ${SCHEDULES_TABLE} WHERE schedule_id = ?`,
+    )
+    .get(scheduleId);
+  return row === undefined ? null : decodeRow(row);
+}
+
+/**
+ * REMOVE a schedule by its opaque handle.
+ *
+ * Writes one atomic DELETE. Returns whether a row was actually removed (`false`
+ * when the handle is unknown).
+ *
+ * @param native - The native project `cleo.db` handle.
+ * @param scheduleId - The `sched-<token>` handle to remove.
+ * @returns `true` if a row was deleted, `false` when no such schedule existed.
+ */
+export function removeSchedule(native: NativeHandle, scheduleId: string): boolean {
+  const result = native
+    .prepare(`DELETE FROM ${SCHEDULES_TABLE} WHERE schedule_id = ?`)
+    .run(scheduleId);
+  return Number(result.changes) > 0;
+}

--- a/packages/core/src/store/service-host-matcher.ts
+++ b/packages/core/src/store/service-host-matcher.ts
@@ -1,0 +1,143 @@
+/**
+ * Service host/path → provider matcher (T11940 · M2-W3 · AC1).
+ *
+ * EP-UNIVERSAL-SERVICE-VAULT (epic T11765 · saga SG-VAULT-CORE T10409). The first
+ * half of the injection-at-tool-boundary seam: given the host (and optional path)
+ * of an outbound request a harness tool is about to make, resolve which
+ * {@link ServiceProviderDef} (and therefore which `service_connections` provider)
+ * the request's host belongs to, plus the matching {@link ServiceHostRule} that
+ * declares HOW the credential is injected (the {@link HostAuthStrategy}).
+ *
+ * Pure, side-effect-free, decrypt-free: it consults ONLY the declarative
+ * {@link SERVICE_PROVIDERS} registry (frozen DATA in `@cleocode/contracts`). It
+ * never opens a DB, never decrypts, never touches the network — so it is NOT a DB
+ * chokepoint concern (Gate 3) and carries no credential material.
+ *
+ * ## Matching model (mirrors onecli `apps.rs::match_host`)
+ *
+ * `host` matches EXACTLY against `ServiceHostRule.host`, with one well-defined
+ * suffix case: a rule host beginning with `.` (or a registry host that is a bare
+ * apex like `amazonaws.com`) matches any sub-domain suffix — used for wildcard
+ * families like AWS. `pathPrefix`, when present on a rule, further narrows the
+ * match to requests whose path starts with it (e.g. the legacy
+ * `www.googleapis.com/gmail/` endpoints). When multiple rules match, the MOST
+ * SPECIFIC wins: a `pathPrefix` rule beats a host-only rule, and a longer
+ * `pathPrefix` beats a shorter one.
+ *
+ * @module store/service-host-matcher
+ * @task T11940
+ * @epic T11765
+ * @saga T10409
+ * @see @cleocode/contracts/vault/service-provider — SERVICE_PROVIDERS + ServiceHostRule
+ * @see ./service-injection.ts — the injector that consumes a match to mutate a request
+ */
+
+import {
+  type HostAuthStrategy,
+  SERVICE_PROVIDERS,
+  type ServiceHostRule,
+  type ServiceProviderDef,
+} from '@cleocode/contracts';
+
+/** The result of resolving an outbound request's host/path to a service provider. */
+export interface ServiceHostMatch {
+  /** The matched provider definition. */
+  readonly provider: ServiceProviderDef;
+  /** The specific host rule that matched (declares the injection strategy). */
+  readonly rule: ServiceHostRule;
+  /** Convenience: the injection strategy from {@link rule}. */
+  readonly strategy: HostAuthStrategy;
+}
+
+/**
+ * Normalize a host: lowercase, strip a trailing dot, strip a `:port` suffix.
+ *
+ * @param host - The raw host (may carry a port / trailing dot / mixed case).
+ * @returns The normalized host for exact / suffix comparison.
+ */
+function normalizeHost(host: string): string {
+  const lower = host.trim().toLowerCase().replace(/\.$/, '');
+  const colon = lower.indexOf(':');
+  return colon === -1 ? lower : lower.slice(0, colon);
+}
+
+/**
+ * Does `requestHost` match a rule's `ruleHost`?
+ *
+ * Exact match, OR a suffix match when the rule host is an apex domain (no
+ * sub-domain label of its own, e.g. `amazonaws.com`) — then any `*.amazonaws.com`
+ * host matches. An exact-equality rule host with sub-domain labels
+ * (e.g. `api.github.com`) matches ONLY that host.
+ */
+function hostMatches(requestHost: string, ruleHost: string): boolean {
+  if (requestHost === ruleHost) return true;
+  // Apex-domain suffix match: a two-label rule host (`amazonaws.com`) matches any
+  // deeper sub-domain (`s3.us-east-1.amazonaws.com`). A rule host with three or
+  // more labels (`api.github.com`) is treated as exact-only.
+  const ruleLabels = ruleHost.split('.');
+  if (ruleLabels.length === 2 && requestHost.endsWith(`.${ruleHost}`)) {
+    return true;
+  }
+  return false;
+}
+
+/** Does a rule's optional `pathPrefix` admit `requestPath`? (absent prefix ⇒ yes) */
+function pathMatches(requestPath: string, rule: ServiceHostRule): boolean {
+  if (rule.pathPrefix === undefined) return true;
+  return requestPath.startsWith(rule.pathPrefix);
+}
+
+/**
+ * Resolve an outbound request's host (+ optional path) to the matching service
+ * provider + host rule, or `null` when no provider claims the host (T11940 AC1).
+ *
+ * When several rules match (e.g. a host-only rule and a `pathPrefix` rule on the
+ * same host), the MOST SPECIFIC wins: a rule with a `pathPrefix` beats one without,
+ * and a longer `pathPrefix` beats a shorter one. Among equally-specific matches the
+ * first registry entry wins (stable iteration order of {@link SERVICE_PROVIDERS}).
+ *
+ * @param host - The request host (e.g. `api.github.com`; a `:port` / trailing dot
+ *   is tolerated).
+ * @param path - The request path (defaults to `/`); narrows `pathPrefix` rules.
+ * @returns The {@link ServiceHostMatch}, or `null` when no provider matches.
+ * @task T11940
+ */
+export function matchServiceHost(host: string, path = '/'): ServiceHostMatch | null {
+  const reqHost = normalizeHost(host);
+  const reqPath = path.startsWith('/') ? path : `/${path}`;
+  let best: ServiceHostMatch | null = null;
+  let bestScore = -1;
+
+  for (const provider of Object.values(SERVICE_PROVIDERS)) {
+    for (const rule of provider.hostRules) {
+      if (!hostMatches(reqHost, rule.host)) continue;
+      if (!pathMatches(reqPath, rule)) continue;
+      // Specificity score: path-prefixed rules outrank host-only; longer prefix wins.
+      const score = rule.pathPrefix === undefined ? 0 : rule.pathPrefix.length;
+      if (score > bestScore) {
+        bestScore = score;
+        best = { provider, rule, strategy: rule.strategy };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve the matching provider for a full URL string (convenience over
+ * {@link matchServiceHost} that parses the URL's host + path).
+ *
+ * @param url - The absolute request URL (e.g. `https://api.github.com/user`).
+ * @returns The {@link ServiceHostMatch}, or `null` when the URL is unparseable or
+ *   no provider matches.
+ * @task T11940
+ */
+export function matchServiceUrl(url: string): ServiceHostMatch | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  return matchServiceHost(parsed.host, parsed.pathname);
+}

--- a/packages/core/src/store/service-injection.ts
+++ b/packages/core/src/store/service-injection.ts
@@ -1,0 +1,317 @@
+/**
+ * Service-credential injection at the harness tool boundary (T11940 · M2-W3).
+ *
+ * EP-UNIVERSAL-SERVICE-VAULT (epic T11765 · saga SG-VAULT-CORE T10409). The second
+ * half of the injection seam: given an outbound HTTP request a harness tool is about
+ * to make, resolve the matching service connection, refresh it if expired, and apply
+ * the declarative {@link InjectionRule} model — materializing the secret ONLY at the
+ * wire inside the sealed handle's `fetch()`.
+ *
+ * ## NO MITM proxy (AC4)
+ *
+ * The seam is the IN-PROCESS tool boundary — {@link injectServiceCredentials} is a
+ * pure function over a {@link OutboundRequest} descriptor. There is NO CONNECT proxy,
+ * no man-in-the-middle process, no port to bind: the harness calls this immediately
+ * before it builds its `fetch()`, gets back the mutated headers/URL, and makes the
+ * call itself. The function neither performs nor intercepts any network I/O.
+ *
+ * ## Trust-gated, refresh-first (AC2)
+ *
+ * Credential resolution delegates to {@link selfHealConnection} (the store's
+ * resolve-path): it runs the trust gate FIRST (a denied agent gets `null` with NO
+ * decrypt) and transparently REFRESHES a past-expiry token before sealing. Only on a
+ * passing gate is a {@link SealedCredential} returned.
+ *
+ * ## Decrypt-only-at-wire + redaction (AC3)
+ *
+ * The credential is a {@link SealedCredential}: its `fetch()` is the SOLE decrypt
+ * point and is invoked HERE, exactly once, when an injection rule needs the token —
+ * the materialized plaintext is consumed in-place to build the header/param value and
+ * NEVER bound to a returned field, logged, or serialized. The only credential-derived
+ * string that crosses the diagnostic boundary is the non-secret
+ * {@link SealedCredential.tokenPreview} ({@link InjectionDiagnostic.tokenPreview}).
+ *
+ * @module store/service-injection
+ * @task T11940
+ * @epic T11765
+ * @saga T10409
+ * @see ./service-host-matcher.ts — host/path → provider resolution (AC1)
+ * @see ./service-oauth.ts — `selfHealConnection` (trust-gated, refresh-first sealed resolve)
+ * @see ../llm/sealed-credential.ts — `makeSealedCredential` (the shared egress handle)
+ */
+
+import type { HostAuthStrategy, InjectionRule, SealedCredential } from '@cleocode/contracts';
+import { matchServiceUrl, type ServiceHostMatch } from './service-host-matcher.js';
+import {
+  type SelfHealOptions,
+  type ServiceOAuthDeps,
+  selfHealConnection,
+} from './service-oauth.js';
+
+/**
+ * The mutable outbound-request descriptor the injector reads and rewrites. The
+ * harness builds this from the request it is about to make; after injection it
+ * uses the (possibly rewritten) `url` + `headers` to call `fetch()`.
+ */
+export interface OutboundRequest {
+  /** The absolute request URL (host + path drive provider matching). */
+  readonly url: string;
+  /** The request headers (case-insensitive on the wire; stored case-preserving). */
+  readonly headers: Readonly<Record<string, string>>;
+}
+
+/** The header/URL mutations an injection produced (the rewritten request). */
+export interface InjectedRequest {
+  /** The (possibly rewritten) request URL — `set-param` rules add query params. */
+  readonly url: string;
+  /** The rewritten request headers with the credential injected. */
+  readonly headers: Record<string, string>;
+}
+
+/** A NON-SECRET diagnostic describing what an injection did (safe to log). */
+export interface InjectionDiagnostic {
+  /** The matched provider key (e.g. `github`), or `null` when no provider matched. */
+  readonly provider: string | null;
+  /** The connection label that was injected, or `null` when none. */
+  readonly label: string | null;
+  /** The injection strategy applied, or `null` when no provider matched. */
+  readonly strategy: HostAuthStrategy | null;
+  /**
+   * The NON-SECRET redacted token preview ({@link SealedCredential.tokenPreview}) —
+   * the ONLY credential-derived string permitted to cross a logging/diagnostic
+   * boundary (≤ last 4 chars). `null` when no credential was injected.
+   */
+  readonly tokenPreview: string | null;
+  /** Whether a transparent refresh fired before injection. */
+  readonly refreshed: boolean;
+}
+
+/** The result of {@link injectServiceCredentials}. */
+export interface InjectionResult {
+  /**
+   * Whether a credential was injected. `false` when no provider claims the host, or
+   * the agent's trust gate denied / the connection is missing-or-uncredentialed —
+   * in which case `request` is the ORIGINAL request, untouched.
+   */
+  readonly injected: boolean;
+  /** The (possibly rewritten) request — mutated only when {@link injected}. */
+  readonly request: InjectedRequest;
+  /** A non-secret diagnostic (safe to log). */
+  readonly diagnostic: InjectionDiagnostic;
+}
+
+/** Parameters for {@link injectServiceCredentials}. */
+export interface InjectServiceCredentialsParams {
+  /** The agent making the outbound request (trust-gated). */
+  readonly agentId: string;
+  /** The outbound request descriptor to inject into. */
+  readonly request: OutboundRequest;
+  /**
+   * The connection label to use for the matched provider (defaults to `'default'`).
+   * A provider can have several labelled connections; the caller selects which.
+   */
+  readonly label?: string;
+  /** Out-of-band manual-approval flag forwarded to the trust gate. */
+  readonly approved?: boolean;
+  /**
+   * Seconds of pre-expiry headroom at which to refresh (forwarded to
+   * {@link selfHealConnection}). Defaults to 0 (refresh only once past expiry).
+   */
+  readonly skewSeconds?: number;
+}
+
+/** The default connection label when the caller does not specify one. */
+const DEFAULT_LABEL = 'default';
+
+/**
+ * Translate a host rule's {@link HostAuthStrategy} into the concrete
+ * {@link InjectionRule} list applied for a matched request.
+ *
+ * This is the SSoT mapping strategy → injection actions:
+ *  - `bearer` — `Authorization: Bearer <token>` (overwrite any existing auth).
+ *  - `basic-x-access-token` — `Authorization: Basic base64("x-access-token:<token>")`
+ *    (GitHub git-over-HTTPS).
+ *  - `header` — the token goes via a named header rather than `Authorization`; the
+ *    concrete header is provider-declared (`credentialHeaders`), so here we still
+ *    set `Authorization: Bearer` as the safe default and let a provider that needs a
+ *    custom header carry it via its `credentialHeaders` (a later breadth task wires
+ *    those). All three strategies first strip a stale `Authorization` the tool may
+ *    have emitted (`remove-header`) so the vault credential is authoritative.
+ *
+ * @param strategy - The matched host rule's injection strategy.
+ * @returns The ordered injection actions.
+ */
+export function injectionRulesForStrategy(strategy: HostAuthStrategy): readonly InjectionRule[] {
+  // Always strip any stale Authorization the tool emitted, then set the vault one.
+  return [
+    { kind: 'remove-header', name: 'Authorization' },
+    { kind: 'set-header', name: 'Authorization', valueSource: 'token', framing: strategy },
+  ];
+}
+
+/** Build the framed `Authorization` value for a token under a host strategy. */
+function frameToken(token: string, framing: HostAuthStrategy | undefined): string {
+  switch (framing) {
+    case 'basic-x-access-token': {
+      const basic = Buffer.from(`x-access-token:${token}`, 'utf8').toString('base64');
+      return `Basic ${basic}`;
+    }
+    default:
+      // `bearer`, `header` (default), and an absent framing all bearer-frame.
+      return `Bearer ${token}`;
+  }
+}
+
+/** Find a header key case-insensitively; returns the existing key or `undefined`. */
+function findHeaderKey(headers: Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) return key;
+  }
+  return undefined;
+}
+
+/**
+ * Apply one injection rule to a header bag + URL, materializing the token from the
+ * sealed handle ONLY when a value-bearing rule needs it.
+ *
+ * The plaintext token (when materialized) lives ONLY as the local `token` binding
+ * for the duration of this call and is consumed in-place into the header/param —
+ * it is never returned, logged, or stored.
+ */
+function applyRule(
+  rule: InjectionRule,
+  headers: Record<string, string>,
+  url: URL,
+  token: string,
+): void {
+  switch (rule.kind) {
+    case 'remove-header': {
+      const existing = findHeaderKey(headers, rule.name);
+      if (existing !== undefined) delete headers[existing];
+      return;
+    }
+    case 'set-header': {
+      const existing = findHeaderKey(headers, rule.name);
+      const value = rule.valueSource === 'token' ? frameToken(token, rule.framing) : token;
+      if (existing !== undefined) delete headers[existing];
+      headers[rule.name] = value;
+      return;
+    }
+    case 'replace-header': {
+      const existing = findHeaderKey(headers, rule.name);
+      if (existing === undefined) return; // only replace a present header
+      headers[existing] = rule.valueSource === 'token' ? frameToken(token, rule.framing) : token;
+      return;
+    }
+    case 'set-param': {
+      url.searchParams.set(rule.name, token);
+      return;
+    }
+  }
+}
+
+/** Whether the rule set contains any value-bearing rule (needs a materialized token). */
+function needsToken(rules: readonly InjectionRule[]): boolean {
+  return rules.some((r) => r.kind !== 'remove-header');
+}
+
+/**
+ * Resolve + inject a service credential into an outbound request at the tool
+ * boundary (T11940 · AC1–AC4).
+ *
+ * Flow:
+ *  1. Match the request URL's host/path to a provider ({@link matchServiceUrl}).
+ *     No match → return the original request untouched (`injected: false`).
+ *  2. Resolve the connection via {@link selfHealConnection} — trust-gated +
+ *     refresh-first. Denied / missing / uncredentialed → original request untouched.
+ *  3. Materialize the token ONCE at the wire (`sealed.fetch()`) and apply the
+ *     {@link injectionRulesForStrategy} rule list to a COPY of the headers + a
+ *     parsed URL. The plaintext is consumed in-place; only the non-secret
+ *     {@link SealedCredential.tokenPreview} reaches the diagnostic.
+ *
+ * @param params - The agent, request, label, and refresh knobs.
+ * @param deps - Injectable OAuth/clock/vault deps (test seam; a fake vault proves
+ *   injection + redaction without a real `cleo.db` or network).
+ * @returns The {@link InjectionResult} — the (possibly rewritten) request + a
+ *   non-secret diagnostic.
+ * @task T11940
+ */
+export async function injectServiceCredentials(
+  params: InjectServiceCredentialsParams,
+  deps: ServiceOAuthDeps = {},
+): Promise<InjectionResult> {
+  const label = params.label ?? DEFAULT_LABEL;
+  const originalRequest: InjectedRequest = {
+    url: params.request.url,
+    headers: { ...params.request.headers },
+  };
+
+  // 1. Match the host/path to a provider.
+  const match: ServiceHostMatch | null = matchServiceUrl(params.request.url);
+  if (match === null) {
+    return {
+      injected: false,
+      request: originalRequest,
+      diagnostic: {
+        provider: null,
+        label: null,
+        strategy: null,
+        tokenPreview: null,
+        refreshed: false,
+      },
+    };
+  }
+
+  // 2. Resolve the connection — trust-gated + refresh-first (sealed on allow).
+  const healOptions: SelfHealOptions = {
+    agentId: params.agentId,
+    provider: match.provider.provider,
+    label,
+    ...(params.approved !== undefined ? { approved: params.approved } : {}),
+    ...(params.skewSeconds !== undefined ? { skewSeconds: params.skewSeconds } : {}),
+  };
+  const heal = await selfHealConnection(healOptions, deps);
+  const sealed: SealedCredential | null = heal.sealed;
+  if (sealed === null) {
+    // Denied / missing / uncredentialed — leave the request untouched.
+    return {
+      injected: false,
+      request: originalRequest,
+      diagnostic: {
+        provider: match.provider.provider,
+        label,
+        strategy: match.strategy,
+        tokenPreview: null,
+        refreshed: heal.refreshed,
+      },
+    };
+  }
+
+  // 3. Apply the strategy's injection rules. Materialize the token at the wire ONCE
+  //    (the SOLE decrypt point) and consume it in-place; it never escapes this scope.
+  const rules = injectionRulesForStrategy(match.strategy);
+  const headers = { ...params.request.headers };
+  const url = new URL(params.request.url);
+  let token = '';
+  if (needsToken(rules)) {
+    const decrypted = await sealed.fetch();
+    token = decrypted.value;
+  }
+  for (const rule of rules) {
+    applyRule(rule, headers, url, token);
+  }
+  // The local `token` goes out of scope here — never returned or logged.
+
+  return {
+    injected: true,
+    request: { url: url.toString(), headers },
+    diagnostic: {
+      provider: match.provider.provider,
+      label,
+      strategy: match.strategy,
+      tokenPreview: sealed.tokenPreview,
+      refreshed: heal.refreshed,
+    },
+  };
+}

--- a/packages/core/src/tools/__tests__/schedule-agent-tools.test.ts
+++ b/packages/core/src/tools/__tests__/schedule-agent-tools.test.ts
@@ -27,6 +27,7 @@ import { createToolGuard } from '../guard.js';
 import {
   type CronScheduleResult,
   registerScheduleAgentTools,
+  type ScheduleStore,
   type TaskOps,
 } from '../schedule-agent-tools.js';
 
@@ -35,11 +36,12 @@ const noopSurface = {} as GuardedToolSurface;
 interface FakeCalls {
   add: Array<Record<string, unknown>>;
   list: Array<Record<string, unknown>>;
+  schedule: Array<Record<string, unknown>>;
 }
 
 /** A fake {@link TaskOps} store that records every call. */
 function fakeTasks(): { tasks: TaskOps; calls: FakeCalls } {
-  const calls: FakeCalls = { add: [], list: [] };
+  const calls: FakeCalls = { add: [], list: [], schedule: [] };
   const tasks: TaskOps = {
     add: async (_root, params) => {
       calls.add.push(params);
@@ -51,6 +53,21 @@ function fakeTasks(): { tasks: TaskOps; calls: FakeCalls } {
     },
   };
   return { tasks, calls };
+}
+
+/**
+ * A fake {@link ScheduleStore} that records every `add` and returns a deterministic
+ * handle — no real `cleo.db` is opened. `failWith`, when set, makes `add` throw so
+ * the typed-failure path can be exercised.
+ */
+function fakeSchedule(calls: FakeCalls, failWith?: Error): ScheduleStore {
+  return {
+    add: async (_root, params) => {
+      calls.schedule.push(params);
+      if (failWith) throw failWith;
+      return 'sched-deadbeefdeadbeefdeadbeef';
+    },
+  };
 }
 
 // ===========================================================================
@@ -104,10 +121,15 @@ describe('schedule-agent-tools — availability (AC2)', () => {
 // ===========================================================================
 
 describe('schedule-agent-tools — delegation (AC2/AC3)', () => {
-  async function registryWith(): Promise<{ registry: AgentToolRegistry; calls: FakeCalls }> {
+  async function registryWith(
+    scheduleFailWith?: Error,
+  ): Promise<{ registry: AgentToolRegistry; calls: FakeCalls }> {
     const { tasks, calls } = fakeTasks();
     const registry = new AgentToolRegistry();
-    registerScheduleAgentTools(registry, { tasks });
+    registerScheduleAgentTools(registry, {
+      tasks,
+      schedule: fakeSchedule(calls, scheduleFailWith),
+    });
     await registry.init({ skipBuiltins: true });
     return { registry, calls };
   }
@@ -134,14 +156,31 @@ describe('schedule-agent-tools — delegation (AC2/AC3)', () => {
     expect(calls.list[0]).toMatchObject({ parent: 'T100', limit: 10 });
   });
 
-  it('cron_schedule returns a typed unavailable result (no schema invented; no daemon block)', async () => {
-    const { registry } = await registryWith();
+  it('cron_schedule delegates to the schedule store and returns the minted id', async () => {
+    const { registry, calls } = await registryWith();
+    const out = (await registry.getExecutable('cron_schedule')?.(
+      { cron: '0 9 * * 1', title: 'weekly', description: 'do the weekly thing' },
+      noopSurface,
+    )) as CronScheduleResult;
+    expect(out.ok).toBe(true);
+    expect(out.scheduleId).toBe('sched-deadbeefdeadbeefdeadbeef');
+    expect(calls.schedule).toHaveLength(1);
+    expect(calls.schedule[0]).toMatchObject({
+      cron: '0 9 * * 1',
+      title: 'weekly',
+      description: 'do the weekly thing',
+    });
+  });
+
+  it('cron_schedule returns a typed failure (no throw) when the store errors', async () => {
+    const { registry } = await registryWith(new Error('disk full'));
     const out = (await registry.getExecutable('cron_schedule')?.(
       { cron: '0 9 * * 1', title: 'weekly' },
       noopSurface,
     )) as CronScheduleResult;
     expect(out.ok).toBe(false);
     expect(out.error?.code).toBe('E_SCHEDULE_STORE_UNAVAILABLE');
+    expect(out.error?.message).toContain('disk full');
   });
 });
 

--- a/packages/core/src/tools/schedule-agent-tools.ts
+++ b/packages/core/src/tools/schedule-agent-tools.ts
@@ -10,14 +10,15 @@
  *     uses). No new table, no new schema.
  *   - **`todo_list`** — list tasks, DELEGATING to `tasksListOp` (the same path
  *     `cleo list` uses).
- *   - **`cron_schedule`** — register a recurring schedule. The schedule DOMAIN
- *     has no persisted store yet (there is no `schedules` table; `node-cron` is
- *     used only by the in-process daemon GC/sentient timers), so per AC3 this tool
- *     does NOT invent schema. It is REGISTERED (so the catalog is stable) but its
+ *   - **`cron_schedule`** — register a recurring schedule. The schedule store now
+ *     exists (the `schedules` table + leased Gate-3 accessor `store/schedule-store.ts`,
+ *     T11962 under T11679), so this tool DELEGATES to {@link ScheduleStore.add} and
+ *     persists a row daemon-OFF (a future daemon scheduler consumes the SAME table
+ *     as a separate reader). It stays REGISTERED-but-capability-gated: its
  *     {@link AvailabilityCheck} hides it until a host advertises a schedule store
- *     (`capabilities.scheduleStore === true`), and invoking it without the store
- *     returns a typed `E_SCHEDULE_STORE_UNAVAILABLE` failure pointing at the
- *     follow-up that adds the store (T11962, under T11679). `todo_*` are always
+ *     (`capabilities.scheduleStore === true`) so a host that has opted out of the
+ *     schedule domain does not surface it; invoking it without the store still
+ *     returns a typed `E_SCHEDULE_STORE_UNAVAILABLE` failure. `todo_*` are always
  *     available daemon-OFF.
  *
  * ## Why a seam, not a hardcoded import (testing + Gate-11)
@@ -82,26 +83,47 @@ export interface TaskOps {
 }
 
 /**
- * The result `cron_schedule` returns when no schedule store backs it — a typed,
- * non-throwing failure pointing at the follow-up that adds the store. The tool is
- * registered (catalog-stable) but gated unavailable until the store ships.
+ * The result `cron_schedule` returns: on success the minted `scheduleId` of the
+ * persisted row; on failure a typed, non-throwing error (e.g. when no schedule
+ * store backs the host). The tool is registered (catalog-stable) and gated on the
+ * `scheduleStore` host capability.
  */
 export interface CronScheduleResult {
   /** Whether a schedule row was registered. */
   readonly ok: boolean;
-  /** The registered schedule's ID (present on success — once a store backs it). */
+  /** The registered schedule's ID (present on success). */
   readonly scheduleId?: string;
-  /** A stable code + message for why scheduling is unavailable (present on failure). */
+  /** A stable code + message for why scheduling failed (present on failure). */
   readonly error?: { readonly code: string; readonly message: string };
 }
 
 /**
+ * The schedule-store operation the `cron_schedule` tool delegates to. Injectable
+ * so the unit test can supply a fake store; defaults to the real Gate-3 accessor
+ * (`store/schedule-store.ts`) opened through the {@link openDualScopeDb} chokepoint.
+ */
+export interface ScheduleStore {
+  /**
+   * Register a recurring schedule and return its minted opaque handle.
+   *
+   * @param projectRoot - The project root whose `cleo.db` the schedule persists in.
+   * @param params - The cron expression + task template (title / description).
+   * @returns The minted `sched-<token>` handle.
+   */
+  readonly add: (
+    projectRoot: string,
+    params: { cron: string; title: string; description?: string },
+  ) => Promise<string>;
+}
+
+/**
  * Available only when the host advertises a schedule store
- * (`capabilities.scheduleStore === true`). The schedule domain has no persisted
- * store yet (T11962, under T11679), so `cron_schedule` is registered-but-hidden
- * — mirroring the playwright-gated browser tools — until the store ships. This is
- * a host POLICY/capability switch, not a daemon probe: registration of a schedule
- * row is meant to persist WITHOUT a live daemon once the store exists.
+ * (`capabilities.scheduleStore === true`). The schedule store now EXISTS (the
+ * `schedules` table + leased Gate-3 accessor, T11962 under T11679), so the gate is
+ * a host POLICY/capability switch — a host that has opted out of the schedule
+ * domain does not surface `cron_schedule`. Registration of a schedule row persists
+ * WITHOUT a live daemon (the chokepoint serializes the single in-process writer);
+ * a future daemon scheduler consumes the same table as a separate reader.
  */
 export const scheduleStoreAvailable: AvailabilityCheck = (ctx) =>
   ctx.capabilities?.scheduleStore === true;
@@ -110,6 +132,12 @@ export const scheduleStoreAvailable: AvailabilityCheck = (ctx) =>
 export interface ScheduleAgentToolOptions {
   /** The task ops seam. Defaults to the real `tasksAddOp` / `tasksListOp`. */
   readonly tasks?: TaskOps;
+  /**
+   * The schedule-store seam `cron_schedule` delegates to. Defaults to the real
+   * Gate-3 accessor (`store/schedule-store.ts`). Injected in tests with a fake
+   * store so registration is asserted WITHOUT opening a real `cleo.db`.
+   */
+  readonly schedule?: ScheduleStore;
   /**
    * The project root threaded into every op (defaults to the resolved project
    * root via {@link resolveOrCwd} — never a bare `process.cwd()` in core, T9584).
@@ -129,6 +157,29 @@ async function realTaskOps(): Promise<TaskOps> {
   return {
     add: (root, params) => tasksAddOp(root, params),
     list: (root, params) => tasksListOp(root, params),
+  };
+}
+
+/**
+ * Build the real schedule-store seam by lazily importing the Gate-3 accessor.
+ * Lazy so this tool module stays import-time side-effect-free; the import (and the
+ * `cleo.db` open) happens only when `cron_schedule` first fires. The accessor
+ * routes through {@link openDualScopeDb} (the dual-scope chokepoint) — it NEVER
+ * opens a raw handle.
+ *
+ * @returns The production {@link ScheduleStore}.
+ */
+async function realScheduleStore(): Promise<ScheduleStore> {
+  const { getScheduleNativeDb, addSchedule } = await import('../store/schedule-store.js');
+  return {
+    add: async (root, params) => {
+      const native = await getScheduleNativeDb(root);
+      return addSchedule(native, {
+        cronExpr: params.cron,
+        title: params.title,
+        description: params.description,
+      });
+    },
   };
 }
 
@@ -235,15 +286,15 @@ export function registerScheduleAgentTools(
     },
   });
 
-  // --- cron_schedule (gated unavailable until a schedule store ships) ------
+  // --- cron_schedule (persists a row through the leased Gate-3 store) -------
   registry.register({
     name: 'cron_schedule',
-    // 'fs' — registering a schedule is meant to persist a store row (once the store exists).
+    // 'fs' — registering a schedule persists a store row.
     class: 'fs',
     description:
-      'Register a recurring schedule (cron expression → task template). The schedule store is ' +
-      'not yet implemented (follow-up T11962 under T11679); this tool is hidden until a host ' +
-      'advertises a schedule store and returns a typed unavailable result otherwise.',
+      'Register a recurring schedule (cron expression → task template). Persists a row to the ' +
+      'project schedule store and returns its schedule ID. Gated on the host advertising a ' +
+      'schedule store; persists daemon-OFF (a daemon scheduler consumes the table separately).',
     toolset: 'agent',
     stateless: false,
     available: scheduleStoreAvailable,
@@ -255,20 +306,29 @@ export function registerScheduleAgentTools(
         .optional()
         .describe('A description for the task created on each fire.'),
     }),
-    execute: async (): Promise<CronScheduleResult> => {
-      // The schedule domain has no persisted store yet (AC3 — do not invent
-      // schema). Return a typed, non-throwing unavailable result pointing at the
-      // follow-up that adds the store. Once T11962 lands, this tool's `execute`
-      // writes a schedule row through the new accessor and its availability gates
-      // on the real store rather than this placeholder.
-      return {
-        ok: false,
-        error: {
-          code: 'E_SCHEDULE_STORE_UNAVAILABLE',
-          message:
-            'the cron/schedule store is not yet implemented — tracked in T11962 (under T11679)',
-        },
-      };
+    execute: async (rawArgs): Promise<CronScheduleResult> => {
+      // Delegate to the schedule-store seam (the real Gate-3 accessor, or an
+      // injected fake in tests). The accessor routes through openDualScopeDb — no
+      // raw db open here. A store/IO failure is returned as a typed, non-throwing
+      // result so the agent loop sees a structured failure rather than an
+      // exception.
+      const cron = String(rawArgs.cron);
+      const title = String(rawArgs.title);
+      const description =
+        rawArgs.description === undefined ? undefined : String(rawArgs.description);
+      try {
+        const schedule = options.schedule ?? (await realScheduleStore());
+        const scheduleId = await schedule.add(projectRoot, { cron, title, description });
+        return { ok: true, scheduleId };
+      } catch (err) {
+        return {
+          ok: false,
+          error: {
+            code: 'E_SCHEDULE_STORE_UNAVAILABLE',
+            message: `failed to register schedule: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        };
+      }
     },
   });
 }


### PR DESCRIPTION
## Summary

Two CORE pieces under EP-UNIVERSAL-SERVICE-VAULT (T11765) / T11679.

### T11940 (M2-W3) — service-credential injection at the harness tool boundary
The universal vault (T10409) stores service credentials; this wires PHYSICAL injection of a resolved credential into an outbound request at the in-process tool boundary — **no MITM proxy** (AC4, the seam is the tool boundary, not a CONNECT proxy).

- **`packages/core/src/store/service-host-matcher.ts`** (AC1) — resolves an outbound request host/path → matching `ServiceProviderDef` + host rule via the declarative `SERVICE_PROVIDERS` registry. Most-specific path-prefix wins; apex-domain suffix match; port/trailing-dot tolerant.
- **`packages/core/src/store/service-injection.ts`** (AC2/AC3/AC4) — `injectServiceCredentials` applies the `InjectionRule` model (`set-header`/`replace-header`/`remove-header`/`set-param`) to a request descriptor. Trust-gated + refresh-first via the existing `selfHealConnection`. The secret is materialized **only at the wire** inside the sealed handle's `fetch()` and consumed in-place — only the non-secret `tokenPreview` crosses the diagnostic boundary. Pure function over a request descriptor: no proxy, no port, no network I/O.
- **`packages/contracts/src/vault/service-provider.ts`** — `InjectionRule` / `InjectionValueSource` discriminated-union model (types-only, Gate-10 clean).

Injection hook point: the harness calls `injectServiceCredentials({ agentId, request })` immediately before building its `fetch()`, gets back the mutated headers/URL, and makes the call itself.

### T11962 — persisted cron/todo schedule table + accessor; ungate `cron_schedule`
Unblocks the M7 cron tool (T11950).

- **`packages/core/src/store/schedule-schema.ts`** + migration (`drizzle-cleo-project` + `drizzle-cleo-global`, **byte-identical** → same hash → journal convergence; `--> statement-breakpoint` between statements; page-2 invariant honored). Pure runtime-infra table (not the exodus target shape), mirroring the `selfimprove_dhq` / `pi_session_*` precedent — so the schema-parity gate (T11364) does not re-derive its CHECK set.
- **`packages/core/src/store/schedule-store.ts`** — Gate-3 accessor (`add`/`list`/`remove`) over the `openDualScopeDb` chokepoint native handle (no raw DB open). `list` reads via `iterate()` with an explicit `LIMIT` — never an unbounded `.all()`.
- **`packages/core/src/tools/schedule-agent-tools.ts`** — `cron_schedule` now **delegates** to the new accessor through an injectable `ScheduleStore` seam, returns the minted schedule id, and is no longer a hardcoded-unavailable stub (still capability-gated on the host `scheduleStore` switch; persists daemon-OFF; a daemon scheduler consumes the same table separately).

## Tests
- `service-injection.test.ts` (13) — host matching, Bearer + Basic-x-access-token framing, stale-Authorization strip+replace, **redaction** (full secret in no diagnostic field), **no network I/O**, and the **policy-before-decrypt deny path** (decrypt spy asserts zero calls).
- `schedule-store.test.ts` (6) — real-migration round-trip (table + both indexes), add/list/remove, unique handle.
- `schedule-agent-tools.test.ts` — updated: cron_schedule delegates + typed-failure path.

## Gates
- `biome ci` 0/0 · full `typecheck` · full `build` · `cleo check arch` **6/6** (incl. Gate-3 DB-open, Gate-13 LLM-chokepoint −12 vs baseline, Gate-10 contracts-purity).
- Core suite: **12133 passed**; the 16 failures are pre-existing environmental `worktree-*` / `audit` git-sandbox tests ("integrateWorktree not available in test fallback") — none touch changed code.

## Evidence
Worktree-evidence-blocked (T11959 — worktree commit not reachable from main HEAD). Orchestrator to complete via `pr:<n>` after merge.

Closes T11940
Closes T11962

🤖 Generated with [Claude Code](https://claude.com/claude-code)