### PR TITLE
feat(M6): Studio workgraph view + reskin shell + vault dashboard (T11558/T11561/T11943)

### DIFF
--- a/packages/core/src/store/__tests__/service-vault.test.ts
+++ b/packages/core/src/store/__tests__/service-vault.test.ts
@@ -32,6 +32,7 @@ import {
   connectService,
   getConnection,
   grantAgentAccess,
+  listAllGrants,
   listConnections,
   openServiceVaultAtPath,
   resolveSealedConnection,
@@ -161,6 +162,50 @@ describe('service-vault store CRUD round-trip (real crypto)', () => {
     // Materialize at the wire — real encrypt→decrypt round-trip yields the token.
     const decrypted = await sealed?.fetch();
     expect(decrypted?.value).toBe(tokens.accessToken);
+  }, 30_000);
+});
+
+describe('service-vault listAllGrants — redacted dashboard read (T11943)', () => {
+  const tokens: ServiceTokenBlob = { accessToken: 'tok_dashboard_secret_ZZZ' };
+
+  it('lists every grant joined to its connection identity, with NO token material', async () => {
+    const deps: ServiceVaultDeps = { db };
+    const ghId = await connectService(
+      { provider: 'github', label: 'work', tokens, scopes: ['repo'] },
+      deps,
+    );
+    const googleId = await connectService({ provider: 'google', label: 'mail', tokens }, deps);
+    await grantAgentAccess('agent-a', ghId, { mode: 'allow' }, deps);
+    await grantAgentAccess('agent-b', ghId, { mode: 'block' }, deps);
+    await grantAgentAccess('agent-a', googleId, { mode: 'allow', manualApproval: true }, deps);
+
+    const grants = await listAllGrants(undefined, deps);
+    expect(grants).toHaveLength(3);
+
+    // Provider/label are joined from the connection; the token never appears.
+    const serialized = JSON.stringify(grants);
+    expect(serialized).not.toContain(tokens.accessToken);
+
+    const ghAllow = grants.find((g) => g.agentId === 'agent-a' && g.provider === 'github');
+    expect(ghAllow).toMatchObject({ label: 'work', mode: 'allow', manualApproval: false });
+
+    const ghBlock = grants.find((g) => g.agentId === 'agent-b' && g.provider === 'github');
+    expect(ghBlock?.mode).toBe('block');
+
+    const googleManual = grants.find((g) => g.agentId === 'agent-a' && g.provider === 'google');
+    expect(googleManual).toMatchObject({ label: 'mail', mode: 'allow', manualApproval: true });
+  }, 30_000);
+
+  it('filters to one agent when an agentId is supplied', async () => {
+    const deps: ServiceVaultDeps = { db };
+    const connId = await connectService({ provider: 'github', label: 'solo', tokens }, deps);
+    await grantAgentAccess('only-me', connId, { mode: 'allow' }, deps);
+    await grantAgentAccess('someone-else', connId, { mode: 'allow' }, deps);
+
+    const mine = await listAllGrants('only-me', deps);
+    expect(mine).toHaveLength(1);
+    expect(mine[0]?.agentId).toBe('only-me');
+    expect(mine[0]?.provider).toBe('github');
   }, 30_000);
 });
 

--- a/packages/core/src/store/service-connections-accessor.ts
+++ b/packages/core/src/store/service-connections-accessor.ts
@@ -412,6 +412,79 @@ export async function listConnections(
 }
 
 /**
+ * A NON-SECRET, dashboard-facing view of one `agent_service_grants` row joined
+ * to its connection identity. Carries the granted agent, the per-session access
+ * policy (`mode` / `manualApproval`), and the connection's `provider`/`label`
+ * so a read-only surface (the Studio vault dashboard, T11943) can render "which
+ * agent may use which connection" WITHOUT touching the encrypted token blob.
+ *
+ * @task T11943
+ */
+export interface AgentGrantView {
+  /** The granted agent's id. */
+  readonly agentId: string;
+  /** The connection this grant authorizes (FK to `service_connections.id`). */
+  readonly serviceConnectionId: number;
+  /** The connection's provider key, when the connection still exists. */
+  readonly provider: string | null;
+  /** The connection's label, when the connection still exists. */
+  readonly label: string | null;
+  /** The session policy mode (`allow` | `block`). */
+  readonly mode: SessionPolicy['mode'];
+  /** Whether the policy requires an out-of-band manual approval per session. */
+  readonly manualApproval: boolean;
+  /** ISO-8601 grant-creation instant. */
+  readonly createdAt: string;
+  /** ISO-8601 last-update instant. */
+  readonly updatedAt: string;
+}
+
+/**
+ * LIST every agent grant as a NON-SECRET {@link AgentGrantView}, joined to its
+ * connection's `provider`/`label` for display. NEVER decrypts and never carries
+ * a token — the dashboard read path (T11943).
+ *
+ * The join is performed in-memory (one `agent_service_grants` scan + one
+ * `service_connections` scan, both already redacted) so the accessor stays a
+ * pure read with no second round-trip per grant. A grant whose connection was
+ * deleted out-of-band resolves `provider`/`label` to `null` (defensive — the
+ * cascade should prevent this, but the view must not throw).
+ *
+ * @param agentId - When set, restrict to one agent's grants; otherwise all.
+ * @task T11943
+ */
+export async function listAllGrants(
+  agentId?: string,
+  deps?: ServiceVaultDeps,
+): Promise<AgentGrantView[]> {
+  const db = await resolveDb(deps);
+  const grantRows =
+    agentId === undefined
+      ? await db.select().from(agentServiceGrants)
+      : await db.select().from(agentServiceGrants).where(eq(agentServiceGrants.agentId, agentId));
+
+  // Build a connection-id → identity map once (redacted views, no token).
+  const connRows = await db.select().from(serviceConnections);
+  const identityById = new Map<number, { provider: string; label: string }>();
+  for (const c of connRows) identityById.set(c.id, { provider: c.provider, label: c.label });
+
+  return grantRows.map((g) => {
+    const identity = identityById.get(g.serviceConnectionId) ?? null;
+    const policy = parseSessionPolicy(g.sessionPolicy);
+    return {
+      agentId: g.agentId,
+      serviceConnectionId: g.serviceConnectionId,
+      provider: identity?.provider ?? null,
+      label: identity?.label ?? null,
+      mode: policy.mode,
+      manualApproval: policy.manualApproval ?? false,
+      createdAt: g.createdAt,
+      updatedAt: g.updatedAt,
+    };
+  });
+}
+
+/**
  * REVOKE a connection: flip `status` to `revoked` and CLEAR the credential blob.
  *
  * Clearing `credentials_enc` makes the secret unrecoverable (the ciphertext is

--- a/packages/studio/src/lib/components/WorkGraphView.svelte
+++ b/packages/studio/src/lib/components/WorkGraphView.svelte
@@ -1,0 +1,282 @@
+<!--
+  WorkGraphView — the saga-scoped WORKGRAPH visualisation (T11791 →
+  T11558 · E3-WORKGRAPH-VIEW).
+
+  Renders ONE saga's epics / tasks / subtasks as a single relationship
+  graph: **containment** (`parent` edges, solid) plus the **depends_on**
+  (`depends`, dotted) and `blocks` (dashed) edges between them. It is a
+  thin consumer of the SHARED graph kit — it builds NO new graph engine:
+
+    - projection   → {@link tasksToGraph} (`$lib/graph/adapters/tasks-adapter`),
+      scoped to the saga via `epicScope: sagaId` (the adapter's ancestor
+      walk includes every descendant epic/task/subtask of the saga).
+    - rendering    → {@link SvgRenderer} (`$lib/graph/renderers`), the same
+      d3-force + SVG renderer GraphTab uses for ≤ 300-node relationship
+      views. High-density live surfaces use CosmosRenderer; a workgraph is
+      a low-density structural view so SVG is the right renderer.
+    - drilldown    → click a node → the shared {@link DetailDrawer} (sibling
+      to the Kanban dispatcher's drawer) with the task's parent chain +
+      upstream / downstream dependency links.
+
+  Zero hex literals reach this component — every colour comes from
+  `tokens.css` via `$lib/graph/edge-kinds.ts` (edges) or the SvgRenderer's
+  `getComputedStyle` status-token cache (nodes), so a `[data-theme]` switch
+  (T11796) re-themes the whole graph for free.
+
+  The component is presentational + pure-data: its `tasks` / `deps` come
+  from the gateway-backed server load (`loadExplorerBundle`), never a
+  direct DB read.
+
+  @task T11791
+  @task T11558
+  @epic T11558
+  @saga T11555
+-->
+<script lang="ts">
+  import type { Task } from '@cleocode/contracts';
+  import type { EdgeKind, GraphNode as KitGraphNode } from '$lib/graph/types.js';
+  import { tasksToGraph } from '$lib/graph/adapters/tasks-adapter.js';
+  import SvgRenderer from '$lib/graph/renderers/SvgRenderer.svelte';
+  import {
+    DetailDrawer,
+    type DependencyLink,
+    type ParentChainEntry,
+  } from '$lib/components/tasks';
+  import type { TaskDependencyEdge } from '$lib/server/tasks/explorer-loader.js';
+
+  interface Props {
+    /** Full task set (from the gateway-backed explorer bundle). */
+    tasks: Task[];
+    /** All dependency edges from the bundle. */
+    deps: TaskDependencyEdge[];
+    /**
+     * The saga (or any ancestor) id to scope the graph to. Every descendant
+     * epic / task / subtask is included via the adapter's ancestor walk.
+     * When omitted the full bundle projects (parity with GraphTab).
+     */
+    sagaId?: string | null;
+    /** Include cancelled epics in the projection. Default false. */
+    includeCancelled?: boolean;
+    /** Optional initially-selected node id (drives the drawer on mount). */
+    selectedId?: string | null;
+  }
+
+  let {
+    tasks,
+    deps,
+    sagaId = null,
+    includeCancelled = false,
+    selectedId = $bindable(null),
+  }: Props = $props();
+
+  // ---------------------------------------------------------------------------
+  // Projection — the saga-scoped graph kit bundle.
+  // ---------------------------------------------------------------------------
+
+  const graph = $derived(
+    tasksToGraph(tasks, deps, {
+      epicScope: sagaId,
+      includeCancelled,
+      includeArchived: false,
+    }),
+  );
+
+  /** Visible edge kinds — containment + both dependency families. */
+  const VISIBLE_EDGE_KINDS = new Set<EdgeKind>(['parent', 'blocks', 'depends']);
+
+  // ---------------------------------------------------------------------------
+  // DetailDrawer wiring — resolved from the local selection.
+  // ---------------------------------------------------------------------------
+
+  const tasksById: Map<string, Task> = $derived(new Map(tasks.map((t) => [t.id, t])));
+
+  const selectedTask: Task | null = $derived(
+    selectedId ? (tasksById.get(selectedId) ?? null) : null,
+  );
+
+  /** Upstream dependency links: tasks the selected node depends on. */
+  const upstreamLinks: DependencyLink[] = $derived.by(() => {
+    if (!selectedTask) return [];
+    const out: DependencyLink[] = [];
+    for (const d of deps) {
+      if (d.taskId !== selectedTask.id) continue;
+      const blocker = tasksById.get(d.dependsOn);
+      if (!blocker) continue;
+      out.push({
+        id: blocker.id,
+        title: blocker.title,
+        status: blocker.status,
+        priority: blocker.priority,
+      });
+    }
+    return out;
+  });
+
+  /** Downstream dependency links: tasks that depend on the selected node. */
+  const downstreamLinks: DependencyLink[] = $derived.by(() => {
+    if (!selectedTask) return [];
+    const out: DependencyLink[] = [];
+    for (const d of deps) {
+      if (d.dependsOn !== selectedTask.id) continue;
+      const dependent = tasksById.get(d.taskId);
+      if (!dependent) continue;
+      out.push({
+        id: dependent.id,
+        title: dependent.title,
+        status: dependent.status,
+        priority: dependent.priority,
+      });
+    }
+    return out;
+  });
+
+  /** Containment chain: walk `parentId` up to (and including) the saga root. */
+  const parentChain: ParentChainEntry[] = $derived.by(() => {
+    if (!selectedTask) return [];
+    const chain: ParentChainEntry[] = [];
+    let current = selectedTask.parentId ? tasksById.get(selectedTask.parentId) : undefined;
+    const seen = new Set<string>();
+    while (current && !seen.has(current.id)) {
+      seen.add(current.id);
+      chain.unshift({ id: current.id, title: current.title, type: current.type });
+      current = current.parentId ? tasksById.get(current.parentId) : undefined;
+    }
+    return chain;
+  });
+
+  function onNodeClicked(n: KitGraphNode): void {
+    selectedId = n.id;
+  }
+
+  function onDrawerClose(): void {
+    selectedId = null;
+  }
+
+  function onDrawerSelectDep(id: string): void {
+    selectedId = id;
+  }
+</script>
+
+<div class="workgraph-view">
+  <div class="workgraph-meta">
+    <span class="count">
+      <strong>{graph.nodes.length}</strong> nodes ·
+      <strong>{graph.edges.length}</strong> edges
+      {#if sagaId}· scoped to <code>{sagaId}</code>{/if}
+    </span>
+    <span class="legend-hint">containment · depends · blocks</span>
+  </div>
+
+  <div class="workgraph-body">
+    <div class="graph-wrap">
+      {#if graph.nodes.length === 0}
+        <div class="empty-state">
+          <p>
+            No tasks in this workgraph
+            {#if sagaId}for <code>{sagaId}</code>{/if}.
+          </p>
+        </div>
+      {:else}
+        <SvgRenderer
+          nodes={graph.nodes}
+          edges={graph.edges}
+          clusters={graph.clusters}
+          visibleEdgeKinds={VISIBLE_EDGE_KINDS}
+          selectedNodeId={selectedId}
+          onNodeClick={onNodeClicked}
+          showLabels="id-only"
+          nodeRenderer="pill"
+          showToolbar
+          showLegend
+          ariaLabel="Saga workgraph — containment and dependency edges"
+        />
+      {/if}
+    </div>
+
+    {#if selectedTask}
+      <DetailDrawer
+        task={selectedTask}
+        upstream={upstreamLinks}
+        downstream={downstreamLinks}
+        {parentChain}
+        onClose={onDrawerClose}
+        onSelectDep={onDrawerSelectDep}
+      />
+    {/if}
+  </div>
+</div>
+
+<style>
+  .workgraph-view {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    height: 100%;
+    min-height: 0;
+  }
+
+  .workgraph-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .count {
+    font-size: var(--text-xs);
+    color: var(--text-dim);
+  }
+
+  .count strong {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .count code {
+    font-family: var(--font-mono);
+    color: var(--accent);
+    font-size: var(--text-2xs);
+  }
+
+  .legend-hint {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    color: var(--text-faint);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .workgraph-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    gap: 0;
+  }
+
+  .graph-wrap {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+
+  .empty-state {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
+    font-size: var(--text-sm);
+  }
+
+  .empty-state code {
+    font-family: var(--font-mono);
+    color: var(--text-dim);
+  }
+</style>

--- a/packages/studio/src/lib/components/shell/ThemeSwitcher.svelte
+++ b/packages/studio/src/lib/components/shell/ThemeSwitcher.svelte
@@ -1,0 +1,145 @@
+<!--
+  ThemeSwitcher — the client-only operator-console theme picker (T11798 ·
+  E6-RESKIN-SHELL).
+
+  A thin, presentational control bound to the {@link ThemeStore} rune. It
+  renders the theme catalogue as a segmented selector plus a light/dark
+  toggle and reflects the active theme onto `<html>` via the store (which
+  re-resolves every `var(--…)` token for free). SSR-safe: the store guards
+  all `document` / `localStorage` access, and this component reads
+  `theme.active` reactively.
+
+  The host route is responsible for `theme.hydrate()` inside a client
+  `$effect` so the persisted choice restores on load — this component only
+  switches.
+
+  @task T11798
+  @epic T11561 — E6-RESKIN-SHELL
+  @saga T11555
+-->
+<script lang="ts">
+  import {
+    STUDIO_THEME_LABELS,
+    type StudioTheme,
+    type ThemeStore,
+  } from '$lib/stores/theme.svelte.js';
+
+  interface Props {
+    /** The shared theme rune store (constructed + hydrated by the host route). */
+    theme: ThemeStore;
+  }
+
+  let { theme }: Props = $props();
+
+  function selectTheme(t: StudioTheme): void {
+    theme.set(t);
+  }
+</script>
+
+<div class="theme-switcher" role="group" aria-label="Operator console theme">
+  <div class="seg" role="radiogroup" aria-label="Theme palette">
+    {#each theme.themes as t (t)}
+      <button
+        type="button"
+        class="seg-btn"
+        class:active={theme.active === t}
+        role="radio"
+        aria-checked={theme.active === t}
+        title={`${STUDIO_THEME_LABELS[t]} theme`}
+        onclick={() => selectTheme(t)}
+      >
+        <span class="swatch" data-theme={t} aria-hidden="true"></span>
+        {STUDIO_THEME_LABELS[t]}
+      </button>
+    {/each}
+  </div>
+
+  <button
+    type="button"
+    class="mode-btn"
+    aria-pressed={theme.light}
+    title="Toggle light operator console"
+    onclick={() => theme.toggleLight()}
+  >
+    {theme.light ? 'Light' : 'Dark'}
+  </button>
+</div>
+
+<style>
+  .theme-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .seg {
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+  }
+
+  .seg-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    border: none;
+    background: transparent;
+    color: var(--text-dim);
+    font-size: var(--text-2xs);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: color var(--ease), background var(--ease);
+  }
+
+  .seg-btn:hover {
+    color: var(--text);
+  }
+
+  .seg-btn.active {
+    color: var(--bg);
+    background: var(--accent);
+  }
+
+  .seg-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+
+  .swatch {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: var(--radius-pill);
+    /* The swatch carries its OWN data-theme so each pip previews that
+       theme's accent regardless of the active console theme. */
+    background: var(--accent);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+  }
+
+  .mode-btn {
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--border);
+    background: var(--bg-elev-2);
+    color: var(--text-dim);
+    font-size: var(--text-2xs);
+    font-weight: 600;
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: color var(--ease), border-color var(--ease);
+  }
+
+  .mode-btn:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+
+  .mode-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+</style>

--- a/packages/studio/src/lib/components/tasks/GraphTab.svelte
+++ b/packages/studio/src/lib/components/tasks/GraphTab.svelte
@@ -280,9 +280,17 @@
     filters: GraphFiltersHandle;
     /** Distinct labels across the bundle (drives the labels chip group). */
     labels?: string[];
+    /**
+     * The active project id (from the root layout data) — when present, the
+     * tab offers an "open in operator console" deep link to the saga-scoped
+     * workgraph shell (T11558). Passed as a prop (NOT read from `$app/stores`)
+     * so this module stays import-safe in the vitest node environment that
+     * exercises its pure exports.
+     */
+    activeProjectId?: string | null;
   }
 
-  let { tasks, deps, filters, labels = [] }: Props = $props();
+  let { tasks, deps, filters, labels = [], activeProjectId = null }: Props = $props();
 
   // ---------------------------------------------------------------------------
   // Derive the visible task set (post-filter) once; the adapter then
@@ -376,6 +384,24 @@
     clickNode(filters, n.id);
   }
 
+  // ---------------------------------------------------------------------------
+  // Operator-console deep link (T11558 · E3-WORKGRAPH-VIEW).
+  //
+  // The full-bundle relationship graph here is the cross-saga view; the
+  // saga-SCOPED workgraph + live board live in the operator-console shell
+  // (`/studio/[projectId]/[sagaId]`). When an epic/saga scope is active, link
+  // straight to that scope's shell; otherwise link to the project's saga
+  // picker. `activeProjectId` is a prop fed from the root layout data.
+  // ---------------------------------------------------------------------------
+
+  const workgraphHref = $derived.by<string | null>(() => {
+    if (!activeProjectId) return null;
+    const scope = filters.state.epic;
+    return scope
+      ? `/studio/${activeProjectId}/${scope}`
+      : `/studio/${activeProjectId}`;
+  });
+
   function onDrawerClose(): void {
     filters.setSelected(null);
   }
@@ -403,6 +429,11 @@
         Showing <strong>{graph.nodes.length}</strong> of <strong>{tasks.length}</strong>
         tasks
       </span>
+      {#if workgraphHref}
+        <a class="workgraph-link" href={workgraphHref}>
+          Open in operator console →
+        </a>
+      {/if}
     </div>
   </div>
 
@@ -488,6 +519,24 @@
   .visible-count strong {
     color: var(--text);
     font-variant-numeric: tabular-nums;
+  }
+
+  .workgraph-link {
+    margin-left: auto;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .workgraph-link:hover {
+    text-decoration: underline;
+  }
+
+  .workgraph-link:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+    border-radius: var(--radius-sm);
   }
 
   .graph-body {

--- a/packages/studio/src/lib/stores/theme.svelte.ts
+++ b/packages/studio/src/lib/stores/theme.svelte.ts
@@ -1,0 +1,155 @@
+/**
+ * `theme.svelte.ts` — the client-only Svelte-5 RUNE store backing the
+ * multi-theme operator-console switcher (T11796 · E6-RESKIN-SHELL).
+ *
+ * The store owns the active `[data-theme]` selection + the light/dark
+ * preference and reflects BOTH onto the `<html>` element so every
+ * `var(--…)` reference in `tokens.css` re-resolves for free. It persists
+ * the choice to `localStorage` so a reload restores it, and it is a no-op
+ * under SSR (guards every `document` / `localStorage` access) — a route
+ * mounts it inside a `$effect` (client-only) exactly like the saga-board
+ * store.
+ *
+ * ## Why a class with `$state`
+ *
+ * `$state` is a compiler rune that only works inside a `.svelte` /
+ * `.svelte.ts` module. A class instance with `$state` fields is the
+ * canonical Svelte-5 shared-reactive-object pattern (same shape as
+ * {@link import('./saga-board.svelte.js').SagaBoardStore}) — a component
+ * reads `theme.active` reactively and calls `theme.set(...)` to switch.
+ *
+ * @packageDocumentation
+ * @module $lib/stores/theme
+ *
+ * @task T11796 — multi-theme token blocks + client-only theme rune
+ * @epic T11561 — E6-RESKIN-SHELL
+ * @saga T11555
+ */
+
+/** The catalogue of operator-console themes (mirrors `tokens.css` blocks). */
+export const STUDIO_THEMES = ['hermes', 'nous', 'bronze', 'slate', 'mono'] as const;
+
+/** One operator-console theme id. */
+export type StudioTheme = (typeof STUDIO_THEMES)[number];
+
+/** Human-readable labels for the theme switcher UI. */
+export const STUDIO_THEME_LABELS: Record<StudioTheme, string> = {
+  hermes: 'Hermes',
+  nous: 'Nous',
+  bronze: 'Bronze',
+  slate: 'Slate',
+  mono: 'Mono',
+};
+
+/** The default theme when nothing is persisted. */
+export const DEFAULT_STUDIO_THEME: StudioTheme = 'hermes';
+
+/** `localStorage` keys the store reads / writes. */
+const THEME_KEY = 'cleo-studio-theme';
+const MODE_KEY = 'cleo-studio-theme-mode';
+
+/** Narrow an arbitrary string to a known theme, else the default. */
+function coerceTheme(value: string | null): StudioTheme {
+  return (STUDIO_THEMES as readonly string[]).includes(value ?? '')
+    ? (value as StudioTheme)
+    : DEFAULT_STUDIO_THEME;
+}
+
+/**
+ * The reactive theme store. Construct via {@link createThemeStore}.
+ *
+ * Holds the active theme + light-mode flag as `$state`; `apply()` reflects
+ * them onto `<html>` (`data-theme` + a `.light` class). All DOM access is
+ * SSR-guarded so the store is safe to instantiate at module scope and
+ * `apply()` from a client `$effect`.
+ */
+export class ThemeStore {
+  /** The active operator-console theme. */
+  #active = $state<StudioTheme>(DEFAULT_STUDIO_THEME);
+  /** Whether the light operator-console variant is active. */
+  #light = $state(false);
+
+  /**
+   * @param initial - Optional SSR-provided initial theme (e.g. from a cookie).
+   */
+  constructor(initial?: StudioTheme) {
+    if (initial) this.#active = initial;
+  }
+
+  /** The active theme id. */
+  get active(): StudioTheme {
+    return this.#active;
+  }
+
+  /** Whether the light variant is active. */
+  get light(): boolean {
+    return this.#light;
+  }
+
+  /** The ordered theme catalogue (static). */
+  get themes(): readonly StudioTheme[] {
+    return STUDIO_THEMES;
+  }
+
+  /**
+   * Hydrate from `localStorage` (client-only) then reflect onto `<html>`.
+   * Idempotent + SSR-safe (no-op on the server). A route calls this once
+   * from a client `$effect`.
+   */
+  hydrate(): void {
+    if (typeof localStorage !== 'undefined') {
+      this.#active = coerceTheme(localStorage.getItem(THEME_KEY));
+      this.#light = localStorage.getItem(MODE_KEY) === 'light';
+    }
+    this.apply();
+  }
+
+  /**
+   * Switch to a new theme, persist it, and re-apply.
+   *
+   * @param theme - The theme to activate.
+   */
+  set(theme: StudioTheme): void {
+    this.#active = theme;
+    if (typeof localStorage !== 'undefined') localStorage.setItem(THEME_KEY, theme);
+    this.apply();
+  }
+
+  /**
+   * Toggle the light operator-console variant, persist it, and re-apply.
+   */
+  toggleLight(): void {
+    this.#light = !this.#light;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(MODE_KEY, this.#light ? 'light' : 'dark');
+    }
+    this.apply();
+  }
+
+  /**
+   * Reflect the current `$state` onto the document root. SSR-safe (the
+   * `document` guard makes this a no-op on the server).
+   */
+  apply(): void {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.setAttribute('data-theme', this.#active);
+    root.classList.toggle('light', this.#light);
+  }
+}
+
+/**
+ * Create a {@link ThemeStore}. The ergonomic entry point a route uses.
+ *
+ * @param initial - Optional SSR initial theme.
+ * @returns A fresh reactive theme store.
+ *
+ * @example
+ * ```ts
+ * const theme = createThemeStore();
+ * $effect(() => { theme.hydrate(); });
+ * ```
+ */
+export function createThemeStore(initial?: StudioTheme): ThemeStore {
+  return new ThemeStore(initial);
+}

--- a/packages/studio/src/lib/styles/tokens.css
+++ b/packages/studio/src/lib/styles/tokens.css
@@ -176,6 +176,136 @@
   --shadow-focus: 0 0 0 3px var(--accent-halo);
 }
 
+/* ===================================================================
+ * Multi-theme token blocks (T11561 · E6-RESKIN-SHELL)
+ *
+ * Each `[data-theme="<name>"]` block layers ONLY the *palette* tokens
+ * (surface / border / text / accent + the semantic family) over the
+ * `:root` defaults above. Structural tokens (spacing, radii, motion,
+ * typography, shadows) are inherited unchanged from `:root` — a theme
+ * never re-defines the grid, only the colours. This keeps every block
+ * small and guarantees the design-system shape is identical across
+ * themes (OCP — open for a new theme, closed for layout drift).
+ *
+ * `data-theme` is set on `<html>` by the client-only theme rune
+ * (`$lib/stores/theme.svelte.ts`). The default (no attribute, or
+ * `data-theme="hermes"`) resolves to the operator-console `:root`
+ * violet. Status / priority / edge tokens reference the semantic
+ * family via `var(--…)` so re-mapping the family below re-themes the
+ * whole graph + board surface for free.
+ *
+ * Theme catalogue:
+ *   - hermes  — default operator-console violet (=`:root`; explicit block
+ *               so the switcher can name it).
+ *   - nous    — cool cyan/teal "deep-thought" console.
+ *   - bronze  — warm amber/bronze low-glare console.
+ *   - slate   — neutral desaturated graphite (high-contrast, calm).
+ *   - mono    — achromatic monochrome (accessibility / print-friendly).
+ *
+ * Each theme also ships a `.light` opt-in variant (`[data-theme="x"].light`)
+ * for operators who prefer a light operator console.
+ * ----------------------------------------------------------------- */
+
+/* --- Hermes (default operator-console violet) ------------------- */
+[data-theme="hermes"] {
+  /* Identical to :root — named so the switcher can round-trip it. */
+  --bg:           #0b0d12;
+  --bg-elev-1:    #151822;
+  --bg-elev-2:    #1b1f2c;
+  --border:        #2a2e3d;
+  --border-strong: #3a4055;
+  --text:       #e7eaf3;
+  --text-dim:   #9aa3b2;
+  --text-faint: #6b7280;
+  --accent:      #a78bfa;
+  --accent-soft: rgba(167, 139, 250, 0.2);
+  --accent-halo: rgba(167, 139, 250, 0.12);
+}
+
+/* --- Nous (cyan/teal deep-thought console) --------------------- */
+[data-theme="nous"] {
+  --bg:           #07110f;
+  --bg-elev-1:    #0e1c1a;
+  --bg-elev-2:    #142826;
+  --border:        #1f3a37;
+  --border-strong: #2c534e;
+  --text:       #e3f4f1;
+  --text-dim:   #93b4af;
+  --text-faint: #5d7d78;
+  --accent:      #2dd4bf;
+  --accent-soft: rgba(45, 212, 191, 0.2);
+  --accent-halo: rgba(45, 212, 191, 0.12);
+  --info:         #22d3ee;
+  --info-soft:    rgba(34, 211, 238, 0.2);
+}
+
+/* --- Bronze (warm amber/bronze low-glare console) -------------- */
+[data-theme="bronze"] {
+  --bg:           #120d07;
+  --bg-elev-1:    #1d150c;
+  --bg-elev-2:    #281d11;
+  --border:        #3a2c1a;
+  --border-strong: #523f26;
+  --text:       #f4ecde;
+  --text-dim:   #c0aa86;
+  --text-faint: #8a7459;
+  --accent:      #f59e0b;
+  --accent-soft: rgba(245, 158, 11, 0.2);
+  --accent-halo: rgba(245, 158, 11, 0.12);
+  --success:      #84cc16;
+  --success-soft: rgba(132, 204, 22, 0.2);
+}
+
+/* --- Slate (neutral graphite, calm high-contrast) -------------- */
+[data-theme="slate"] {
+  --bg:           #0e1014;
+  --bg-elev-1:    #181b21;
+  --bg-elev-2:    #21252d;
+  --border:        #2f343e;
+  --border-strong: #424857;
+  --text:       #eef1f6;
+  --text-dim:   #a4adbd;
+  --text-faint: #717a8a;
+  --accent:      #60a5fa;
+  --accent-soft: rgba(96, 165, 250, 0.2);
+  --accent-halo: rgba(96, 165, 250, 0.12);
+}
+
+/* --- Mono (achromatic monochrome, print/accessibility) --------- */
+[data-theme="mono"] {
+  --bg:           #0a0a0a;
+  --bg-elev-1:    #161616;
+  --bg-elev-2:    #1f1f1f;
+  --border:        #2e2e2e;
+  --border-strong: #444444;
+  --text:       #f2f2f2;
+  --text-dim:   #a0a0a0;
+  --text-faint: #6a6a6a;
+  --accent:      #e5e5e5;
+  --accent-soft: rgba(229, 229, 229, 0.16);
+  --accent-halo: rgba(229, 229, 229, 0.1);
+  --success:      #d4d4d4;
+  --warning:      #bdbdbd;
+  --danger:       #fafafa;
+  --info:         #cfcfcf;
+  --neutral:      #8a8a8a;
+}
+
+/* --- Light operator-console variants (opt-in) ------------------ */
+[data-theme].light {
+  --bg:           #f7f8fb;
+  --bg-elev-1:    #ffffff;
+  --bg-elev-2:    #eef1f6;
+  --border:        #d8dde7;
+  --border-strong: #b7bfcd;
+  --text:       #15181f;
+  --text-dim:   #4a5365;
+  --text-faint: #79839a;
+  --shadow-sm:    0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow-md:    0 4px 12px rgba(15, 23, 42, 0.1);
+  --shadow-lg:    0 12px 32px rgba(15, 23, 42, 0.14);
+}
+
 /* Honour user motion preference — override every motion token so that
  * transitions, spring curves, and looping pulses resolve to a no-op. */
 @media (prefers-reduced-motion: reduce) {

--- a/packages/studio/src/routes/+layout.svelte
+++ b/packages/studio/src/routes/+layout.svelte
@@ -21,14 +21,22 @@
   }
   let { data, children }: Props = $props();
 
-  const navItems = [
+  // The operator-console (saga workgraph + live board) is project-scoped, so
+  // its nav target is the active project's saga picker when one is selected.
+  const consoleHref = $derived(
+    data.activeProjectId ? `/studio/${data.activeProjectId}` : '/projects',
+  );
+
+  const navItems = $derived([
     { href: '/brain', label: 'Brain', description: '5-substrate living canvas', exact: true },
     { href: '/brain/overview', label: 'Memory', description: 'BRAIN dashboard (decisions, observations, quality)', exact: false },
     { href: '/code', label: 'Code', description: 'Code intelligence', exact: false },
     { href: '/tasks', label: 'Tasks', description: 'Task management', exact: false },
     { href: '/tasks/kanban', label: 'Board', description: 'Agent-lifecycle dispatcher board (read-only)', exact: false },
+    { href: consoleHref, label: 'Console', description: 'Saga operator console — workgraph + live dispatcher board', exact: false },
+    { href: '/settings/vault', label: 'Vault', description: 'Service vault — connected services + agent grants (read-only)', exact: false },
     { href: '/projects', label: 'Admin', description: 'Project registry — scan, index, and manage projects', exact: false },
-  ];
+  ]);
 </script>
 
 <a class="skip-link" href="#main">Skip to content</a>

--- a/packages/studio/src/routes/settings/vault/+page.server.ts
+++ b/packages/studio/src/routes/settings/vault/+page.server.ts
@@ -1,0 +1,114 @@
+/**
+ * `/settings/vault` — server load for the read-only service-vault dashboard
+ * (T11943 · M2-W6 · E-UNIVERSAL-SERVICE-VAULT).
+ *
+ * Surfaces the global service vault — `service_connections` + per-agent
+ * `agent_service_grants` — through the CORE read facades
+ * ({@link listConnections} / {@link listAllGrants}). Both return REDACTED,
+ * non-secret views: provider / label / status / scopes / expiry /
+ * hasCredentials and, for grants, the agent + policy mode. NO ciphertext, NO
+ * plaintext, NO `tokenPreview`-able material ever reaches this load — the
+ * decrypted token never leaves core (AC1).
+ *
+ * Studio holds NO second store and opens NO DB directly (AC3): this load calls
+ * the same core accessors the `cleo service list|status` CLI verbs use, so the
+ * dashboard and the CLI agree on one source of truth. Connect / revoke are NOT
+ * exposed here (read-first M2) — they route through the CLI (`cleo service
+ * connect|revoke`), linked from the page.
+ *
+ * @task T11943
+ * @epic T11765 — E-UNIVERSAL-SERVICE-VAULT
+ * @saga T10409
+ */
+
+import {
+  type AgentGrantView,
+  listAllGrants,
+  listConnections,
+  type ServiceConnectionView,
+} from '@cleocode/core/store/service-connections-accessor.js';
+import type { PageServerLoad } from './$types';
+
+/** A redacted connection row for the dashboard (NEVER carries a token). */
+export interface VaultConnectionRow {
+  /** Service provider key (e.g. `github`). */
+  provider: string;
+  /** Connection label, unique within the provider. */
+  label: string;
+  /** Health status (`active` | `expired` | `revoked`). */
+  status: string;
+  /** Granted scopes (non-secret). */
+  scopes: string[];
+  /** ISO-8601 access-token expiry, or null. */
+  expiresAt: string | null;
+  /** Whether a credential blob has been written (the OAuth flow ran). */
+  hasCredentials: boolean;
+  /** ISO-8601 connected-at instant. */
+  connectedAt: string;
+}
+
+/** A redacted per-agent grant row for the dashboard. */
+export interface VaultGrantRow {
+  /** The granted agent's id. */
+  agentId: string;
+  /** Connection provider, or null when the connection was deleted. */
+  provider: string | null;
+  /** Connection label, or null when the connection was deleted. */
+  label: string | null;
+  /** Session policy mode (`allow` | `block`). */
+  mode: string;
+  /** Whether the grant requires an out-of-band manual approval per session. */
+  manualApproval: boolean;
+}
+
+/** The payload the vault dashboard renders. */
+export interface VaultDashboardData {
+  /** Redacted connection rows, grouped+sorted client-side. */
+  connections: VaultConnectionRow[];
+  /** Redacted per-agent grant rows. */
+  grants: VaultGrantRow[];
+  /** Set when the vault could not be read (e.g. no global cleo.db yet). */
+  error?: string;
+}
+
+/** Project a core {@link ServiceConnectionView} onto the redacted dashboard row. */
+function toConnectionRow(v: ServiceConnectionView): VaultConnectionRow {
+  return {
+    provider: v.provider,
+    label: v.label,
+    status: v.status,
+    scopes: [...v.scopes],
+    expiresAt: v.expiresAt,
+    hasCredentials: v.hasCredentials,
+    connectedAt: v.connectedAt,
+  };
+}
+
+/** Project a core {@link AgentGrantView} onto the redacted dashboard row. */
+function toGrantRow(v: AgentGrantView): VaultGrantRow {
+  return {
+    agentId: v.agentId,
+    provider: v.provider,
+    label: v.label,
+    mode: v.mode,
+    manualApproval: v.manualApproval,
+  };
+}
+
+export const load: PageServerLoad = async (): Promise<VaultDashboardData> => {
+  try {
+    // Both reads go through the CORE redacted facades — one source of truth
+    // shared with `cleo service list|status`. Neither decrypts.
+    const [connections, grants] = await Promise.all([listConnections(), listAllGrants()]);
+    return {
+      connections: connections.map(toConnectionRow),
+      grants: grants.map(toGrantRow),
+    };
+  } catch (e) {
+    return {
+      connections: [],
+      grants: [],
+      error: e instanceof Error ? e.message : 'Failed to read the service vault.',
+    };
+  }
+};

--- a/packages/studio/src/routes/settings/vault/+page.svelte
+++ b/packages/studio/src/routes/settings/vault/+page.svelte
@@ -1,0 +1,312 @@
+<!--
+  /settings/vault — the READ-ONLY service-vault dashboard (T11943 · M2-W6).
+
+  Lists the global service vault: connected services
+  (`service_connections` — provider / label / status / scopes / expiry) and
+  the per-agent grants (`agent_service_grants` — agent / connection / policy
+  mode). Every value comes from the CORE redacted read facades via the server
+  load — NO secret, NO ciphertext, NO `tokenPreview` ever reaches the browser.
+
+  Connect / revoke / grant are NOT performed here (read-first M2). The page
+  links the operator to the CLI verbs (`cleo service connect|revoke`) — the
+  ratified write path. The dashboard observes; it does not mutate.
+
+  SECURITY: this page renders ONLY non-secret identity + status fields. Adding
+  any field that could carry a token is forbidden by the redacted server
+  contract (`VaultConnectionRow` / `VaultGrantRow` carry no secret).
+
+  @task T11943
+  @epic T11765 — E-UNIVERSAL-SERVICE-VAULT
+  @saga T10409
+-->
+<script lang="ts">
+  import { Badge, Card } from '$lib/ui';
+  import type { PageData } from './$types';
+  import type { VaultGrantRow } from './+page.server.js';
+
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+
+  /** Group connections by provider for display (stable provider-asc order). */
+  const groupedConnections = $derived.by(() => {
+    const groups = new Map<string, typeof data.connections>();
+    for (const conn of data.connections) {
+      const list = groups.get(conn.provider);
+      if (list) list.push(conn);
+      else groups.set(conn.provider, [conn]);
+    }
+    return Array.from(groups.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([provider, list]) => ({
+        provider,
+        connections: list.slice().sort((a, b) => a.label.localeCompare(b.label)),
+      }));
+  });
+
+  /** Grants keyed by `provider:label` so they render under their connection. */
+  const grantsByConnection = $derived.by(() => {
+    const map = new Map<string, VaultGrantRow[]>();
+    for (const g of data.grants) {
+      if (g.provider === null || g.label === null) continue;
+      const key = `${g.provider}:${g.label}`;
+      const list = map.get(key);
+      if (list) list.push(g);
+      else map.set(key, [g]);
+    }
+    return map;
+  });
+
+  /** Grants whose connection was deleted out-of-band (orphans). */
+  const orphanGrants = $derived(data.grants.filter((g) => g.provider === null || g.label === null));
+
+  function statusTone(status: string): 'success' | 'warning' | 'danger' | 'neutral' {
+    if (status === 'active') return 'success';
+    if (status === 'expired') return 'warning';
+    if (status === 'revoked') return 'danger';
+    return 'neutral';
+  }
+
+  function formatExpiry(expiresAt: string | null): string {
+    if (expiresAt === null) return 'never';
+    const ms = Date.parse(expiresAt) - Date.now();
+    if (!Number.isFinite(ms)) return expiresAt;
+    if (ms < 0) return 'expired';
+    const hours = Math.round(ms / 3_600_000);
+    if (hours < 48) return `${hours}h`;
+    return `${Math.round(hours / 24)}d`;
+  }
+</script>
+
+<svelte:head>
+  <title>Service Vault — CLEO Studio</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<section class="vault-page">
+  <header class="page-header">
+    <div>
+      <span class="eyebrow">SERVICE VAULT</span>
+      <h1>Connected services</h1>
+      <p class="muted">
+        Read-only view of the global service vault — connections + per-agent grants. Secrets never
+        leave core; this dashboard shows identity, scopes, and status only. Manage connections via
+        <code>cleo service connect</code> / <code>cleo service revoke</code>.
+      </p>
+    </div>
+  </header>
+
+  {#if data.error}
+    <Card padding="cozy">
+      <div class="error" role="alert">Failed to load the vault: {data.error}</div>
+    </Card>
+  {:else if data.connections.length === 0}
+    <Card padding="cozy">
+      <p class="muted">
+        No service connections yet. Connect one with
+        <code>cleo service connect &lt;provider&gt;</code> from the CLI.
+      </p>
+    </Card>
+  {:else}
+    <div class="groups">
+      {#each groupedConnections as group (group.provider)}
+        <Card padding="cozy">
+          {#snippet header()}
+            <h2 class="group-title">
+              {group.provider}
+              <span class="muted">
+                · {group.connections.length}
+                {group.connections.length === 1 ? 'connection' : 'connections'}
+              </span>
+            </h2>
+          {/snippet}
+
+          <table class="conns">
+            <thead>
+              <tr>
+                <th scope="col">Label</th>
+                <th scope="col">Status</th>
+                <th scope="col">Scopes</th>
+                <th scope="col">Expiry</th>
+                <th scope="col">Credential</th>
+                <th scope="col">Agent grants</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each group.connections as conn (conn.label)}
+                {@const grants = grantsByConnection.get(`${conn.provider}:${conn.label}`) ?? []}
+                <tr>
+                  <td><code>{conn.label}</code></td>
+                  <td><Badge tone={statusTone(conn.status)} size="sm">{conn.status}</Badge></td>
+                  <td class="scopes">
+                    {#if conn.scopes.length === 0}
+                      <span class="muted">—</span>
+                    {:else}
+                      {#each conn.scopes as scope (scope)}
+                        <Badge tone="neutral" size="sm">{scope}</Badge>
+                      {/each}
+                    {/if}
+                  </td>
+                  <td>{formatExpiry(conn.expiresAt)}</td>
+                  <td>
+                    {#if conn.hasCredentials}
+                      <Badge tone="info" size="sm">stored</Badge>
+                    {:else}
+                      <span class="muted">none</span>
+                    {/if}
+                  </td>
+                  <td class="grants">
+                    {#if grants.length === 0}
+                      <span class="muted">no grants</span>
+                    {:else}
+                      {#each grants as grant (grant.agentId)}
+                        <span class="grant" title={`policy: ${grant.mode}`}>
+                          <code>{grant.agentId}</code>
+                          <Badge tone={grant.mode === 'block' ? 'danger' : 'success'} size="sm">
+                            {grant.mode}
+                          </Badge>
+                          {#if grant.manualApproval}
+                            <Badge tone="warning" size="sm">manual</Badge>
+                          {/if}
+                        </span>
+                      {/each}
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </Card>
+      {/each}
+    </div>
+
+    {#if orphanGrants.length > 0}
+      <Card padding="cozy">
+        {#snippet header()}
+          <h2 class="group-title">
+            Orphan grants
+            <span class="muted">· {orphanGrants.length} (connection deleted)</span>
+          </h2>
+        {/snippet}
+        <ul class="orphans">
+          {#each orphanGrants as grant, i (i)}
+            <li>
+              <code>{grant.agentId}</code> → connection #{grant.provider === null
+                ? '(deleted)'
+                : `${grant.provider}:${grant.label}`}
+              <Badge tone={grant.mode === 'block' ? 'danger' : 'neutral'} size="sm">
+                {grant.mode}
+              </Badge>
+            </li>
+          {/each}
+        </ul>
+      </Card>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .vault-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    max-width: 72rem;
+    margin: 0 auto;
+  }
+
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    letter-spacing: 0.12em;
+    color: var(--text-faint);
+    text-transform: uppercase;
+  }
+
+  .page-header h1 {
+    font-size: var(--text-2xl);
+    margin: var(--space-1) 0;
+  }
+
+  .muted {
+    color: var(--text-dim);
+    font-size: var(--text-sm);
+    margin: 0;
+  }
+
+  .muted code,
+  .error {
+    font-family: var(--font-mono);
+  }
+
+  .error {
+    color: var(--danger);
+  }
+
+  .groups {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .group-title {
+    font-size: var(--text-md);
+    margin: 0;
+    font-weight: 600;
+  }
+
+  table.conns {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  table.conns th,
+  table.conns td {
+    text-align: left;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border);
+    font-size: var(--text-sm);
+    vertical-align: top;
+  }
+
+  table.conns th {
+    font-weight: 600;
+    color: var(--text-dim);
+    font-size: var(--text-xs);
+  }
+
+  td code,
+  .grant code {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--accent);
+  }
+
+  .scopes,
+  .grants {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
+
+  .grant {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  .orphans {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    color: var(--text-dim);
+  }
+
+  .orphans code {
+    font-family: var(--font-mono);
+    color: var(--accent);
+  }
+</style>

--- a/packages/studio/src/routes/studio/[projectId]/+page.server.ts
+++ b/packages/studio/src/routes/studio/[projectId]/+page.server.ts
@@ -1,0 +1,110 @@
+/**
+ * `/studio/[projectId]` — the saga picker for the operator-console shell
+ * (T11558 · E3-WORKGRAPH-VIEW · navigation project ▸ saga ▸ workgraph).
+ *
+ * Lists the project's sagas (and standalone epics) so an operator can drill
+ * from a project into a saga's `/studio/[projectId]/[sagaId]` workgraph shell.
+ * Projects the SHARED, gateway-backed {@link loadExplorerBundle} — the same
+ * one-round-trip source the explorer + shell use — so no second query and no
+ * direct DB read.
+ *
+ * @task T11558
+ * @epic T11558 — E3-WORKGRAPH-VIEW
+ * @saga T11555
+ */
+
+import { resolveProjectContext } from '$lib/server/project-context.js';
+import { loadExplorerBundle } from '$lib/server/tasks/explorer-loader.js';
+import type { PageServerLoad } from './$types';
+
+/** One pickable root in the saga picker. */
+export interface SagaPickRow {
+  /** Task id. */
+  id: string;
+  /** Title. */
+  title: string;
+  /** Root type — `saga` or standalone `epic`. */
+  type: string;
+  /** Lifecycle status. */
+  status: string;
+  /** Count of descendant tasks (subtree size, for the chip). */
+  descendantCount: number;
+}
+
+/** The payload the picker renders. */
+export interface SagaPickerData {
+  /** Resolved project id (echo). */
+  projectId: string;
+  /** Project display name. */
+  projectName: string;
+  /** Sagas + standalone epics, sorted by descendant count desc. */
+  roots: SagaPickRow[];
+  /** Set when the project / tasks.db could not be read. */
+  error?: string;
+}
+
+export const load: PageServerLoad = async ({ params, locals }): Promise<SagaPickerData> => {
+  const { projectId } = params;
+
+  const ctx =
+    locals.projectCtx.projectId === projectId
+      ? locals.projectCtx
+      : (resolveProjectContext(projectId) ?? null);
+
+  if (!ctx?.tasksDbExists) {
+    return {
+      projectId,
+      projectName: ctx?.name ?? projectId,
+      roots: [],
+      error: `Project "${projectId}" is not registered or has no tasks database.`,
+    };
+  }
+
+  try {
+    const explorer = await loadExplorerBundle({ projectCtx: ctx });
+
+    // Build a parent → children adjacency once, then count each root's subtree.
+    const childrenOf = new Map<string, string[]>();
+    for (const t of explorer.tasks) {
+      if (!t.parentId) continue;
+      const list = childrenOf.get(t.parentId);
+      if (list) list.push(t.id);
+      else childrenOf.set(t.parentId, [t.id]);
+    }
+
+    const subtreeCount = (rootId: string): number => {
+      let count = 0;
+      const stack = [...(childrenOf.get(rootId) ?? [])];
+      const seen = new Set<string>();
+      while (stack.length > 0) {
+        const id = stack.pop();
+        if (id === undefined || seen.has(id)) continue;
+        seen.add(id);
+        count += 1;
+        const kids = childrenOf.get(id);
+        if (kids) stack.push(...kids);
+      }
+      return count;
+    };
+
+    const roots: SagaPickRow[] = explorer.tasks
+      .filter((t) => t.type === 'saga' || (t.type === 'epic' && !t.parentId))
+      .map((t) => ({
+        id: t.id,
+        title: t.title,
+        type: t.type ?? 'task',
+        status: t.status,
+        descendantCount: subtreeCount(t.id),
+      }))
+      .sort((a, b) => b.descendantCount - a.descendantCount || a.id.localeCompare(b.id));
+
+    return { projectId, projectName: ctx.name, roots };
+  } catch (e) {
+    return {
+      projectId,
+      projectName: ctx.name,
+      roots: [],
+      error: e instanceof Error ? e.message : 'Failed to load the saga list.',
+    };
+  }
+};

--- a/packages/studio/src/routes/studio/[projectId]/+page.svelte
+++ b/packages/studio/src/routes/studio/[projectId]/+page.svelte
@@ -1,0 +1,171 @@
+<!--
+  /studio/[projectId] — the SAGA PICKER for the operator-console shell
+  (T11558 · E3-WORKGRAPH-VIEW).
+
+  Lists the project's sagas + standalone epics so an operator drills
+  project ▸ saga ▸ workgraph. Each row links to the saga's
+  `/studio/[projectId]/[sagaId]` shell. Pure presentation over the
+  gateway-backed server bundle.
+
+  @task T11558
+  @epic T11558
+  @saga T11555
+-->
+<script lang="ts">
+  import { Badge, Card } from '$lib/ui';
+  import type { PageData } from './$types';
+
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+
+  /** Status → badge tone. */
+  function statusTone(status: string): 'success' | 'warning' | 'danger' | 'info' | 'neutral' {
+    if (status === 'done') return 'success';
+    if (status === 'active') return 'info';
+    if (status === 'blocked') return 'danger';
+    if (status === 'pending') return 'warning';
+    return 'neutral';
+  }
+</script>
+
+<svelte:head>
+  <title>{data.projectName} sagas — CLEO Studio</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<section class="picker">
+  <header class="picker-head">
+    <div>
+      <span class="eyebrow">OPERATOR CONSOLE</span>
+      <h1>{data.projectName} — Sagas</h1>
+      <p class="muted">Pick a saga to open its workgraph + live dispatcher board.</p>
+    </div>
+  </header>
+
+  {#if data.error}
+    <Card padding="cozy">
+      <div class="error" role="alert">{data.error}</div>
+    </Card>
+  {:else if data.roots.length === 0}
+    <Card padding="cozy">
+      <p class="muted">
+        No sagas or standalone epics in this project yet. Create one with
+        <code>cleo saga create</code>.
+      </p>
+    </Card>
+  {:else}
+    <ul class="roots">
+      {#each data.roots as root (root.id)}
+        <li>
+          <a class="root" href={`/studio/${data.projectId}/${root.id}`}>
+            <span class="root-id"><code>{root.id}</code></span>
+            <span class="root-title">{root.title}</span>
+            <span class="root-meta">
+              <Badge tone="info" size="sm">{root.type}</Badge>
+              <Badge tone={statusTone(root.status)} size="sm">{root.status}</Badge>
+              <span class="count">{root.descendantCount} tasks</span>
+            </span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .picker {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    max-width: 60rem;
+    margin: 0 auto;
+  }
+
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    letter-spacing: 0.12em;
+    color: var(--text-faint);
+    text-transform: uppercase;
+  }
+
+  .picker-head h1 {
+    font-size: var(--text-2xl);
+    margin: var(--space-1) 0;
+  }
+
+  .muted {
+    color: var(--text-dim);
+    font-size: var(--text-sm);
+    margin: 0;
+  }
+
+  .muted code,
+  .error {
+    font-family: var(--font-mono);
+  }
+
+  .error {
+    color: var(--danger);
+  }
+
+  .roots {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .root {
+    display: grid;
+    grid-template-columns: minmax(6rem, auto) 1fr auto;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg-elev-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color var(--ease), background var(--ease);
+  }
+
+  .root:hover {
+    border-color: var(--accent);
+    background: var(--bg-elev-2);
+  }
+
+  .root:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+
+  .root-id code {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--accent);
+  }
+
+  .root-title {
+    font-size: var(--text-sm);
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .root-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .count {
+    font-size: var(--text-2xs);
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/packages/studio/src/routes/studio/[projectId]/[sagaId]/+page.server.ts
+++ b/packages/studio/src/routes/studio/[projectId]/[sagaId]/+page.server.ts
@@ -1,0 +1,85 @@
+/**
+ * `/studio/[projectId]/[sagaId]` — server load for the saga operator-console
+ * shell (T11797 · E6-RESKIN-SHELL).
+ *
+ * Resolves the project from the `[projectId]` route param (NOT just the active
+ * cookie, so a deep-link to any project's saga works), then loads the SHARED,
+ * gateway-backed {@link loadExplorerBundle} ONCE. The shell projects that one
+ * bundle into BOTH the workgraph pane ({@link WorkGraphView}, scoped to the
+ * saga via the adapter's ancestor walk) and the kanban pane — exactly the
+ * one-round-trip contract the `/tasks` explorer uses.
+ *
+ * The saga identity (`sagaTask`) is resolved from the bundle so the shell can
+ * render the saga title + a "not found" state without a second query.
+ *
+ * @task T11797
+ * @epic T11561 — E6-RESKIN-SHELL
+ * @saga T11555
+ */
+
+import type { Task } from '@cleocode/contracts';
+import { resolveProjectContext } from '$lib/server/project-context.js';
+import { type ExplorerBundle, loadExplorerBundle } from '$lib/server/tasks/explorer-loader.js';
+import type { PageServerLoad } from './$types';
+
+/** The payload the shell page renders. */
+export interface SagaShellData {
+  /** The resolved project id (echoed for the breadcrumb). */
+  projectId: string;
+  /** Human-readable project name, or the id when unresolved. */
+  projectName: string;
+  /** The saga (or scope-root) id this shell is bound to. */
+  sagaId: string;
+  /** The resolved saga task identity, or null when not found in the bundle. */
+  saga: Pick<Task, 'id' | 'title' | 'type' | 'status'> | null;
+  /** The shared explorer bundle (tasks + deps) — both panes project this. */
+  explorer: ExplorerBundle | null;
+  /** Set when the project / tasks.db could not be read. */
+  error?: string;
+}
+
+export const load: PageServerLoad = async ({ params, locals }): Promise<SagaShellData> => {
+  const { projectId, sagaId } = params;
+
+  // Resolve the project from the route param first; fall back to the active
+  // context (cookie) when the param matches it — this lets a deep link target
+  // ANY registered project, not just the currently-selected one.
+  const ctx =
+    locals.projectCtx.projectId === projectId
+      ? locals.projectCtx
+      : (resolveProjectContext(projectId) ?? null);
+
+  if (!ctx?.tasksDbExists) {
+    return {
+      projectId,
+      projectName: ctx?.name ?? projectId,
+      sagaId,
+      saga: null,
+      explorer: null,
+      error: `Project "${projectId}" is not registered or has no tasks database.`,
+    };
+  }
+
+  try {
+    const explorer = await loadExplorerBundle({ projectCtx: ctx });
+    const sagaTask = explorer.tasks.find((t) => t.id === sagaId) ?? null;
+    return {
+      projectId,
+      projectName: ctx.name,
+      sagaId,
+      saga: sagaTask
+        ? { id: sagaTask.id, title: sagaTask.title, type: sagaTask.type, status: sagaTask.status }
+        : null,
+      explorer,
+    };
+  } catch (e) {
+    return {
+      projectId,
+      projectName: ctx.name,
+      sagaId,
+      saga: null,
+      explorer: null,
+      error: e instanceof Error ? e.message : 'Failed to load the saga workgraph bundle.',
+    };
+  }
+};

--- a/packages/studio/src/routes/studio/[projectId]/[sagaId]/+page.svelte
+++ b/packages/studio/src/routes/studio/[projectId]/[sagaId]/+page.svelte
@@ -1,0 +1,330 @@
+<!--
+  /studio/[projectId]/[sagaId] — the SAGA OPERATOR-CONSOLE SHELL
+  (T11797 / T11798 · E6-RESKIN-SHELL).
+
+  A mission-control shell for ONE saga with a sibling **workgraph | kanban**
+  toggle over the SHARED data layer:
+
+    - workgraph → {@link WorkGraphView}, the saga-scoped graph (containment +
+      depends edges) over `$lib/graph` — SSR-rendered from the server bundle.
+    - kanban    → {@link SagaKanbanPane}, the live dispatcher board scoped to
+      the saga, mounted CLIENT-ONLY (`{#if browser}`) so the `EventSource`
+      SSE pane never runs during SSR (the opencode `/s/[id]` pattern).
+
+  Both panes project the SAME server bundle (`data.explorer`) — one round
+  trip, two views. The toggle round-trips through the URL (`?view=`) so a
+  deep link is shareable.
+
+  Operator-console aesthetic: a compact mono command bar (project ▸ saga
+  breadcrumb · live indicator · theme switcher) over a full-bleed canvas.
+  This is a RESKIN — it reuses every existing token + component, forks no
+  design system, and stays Svelte-5 runes throughout.
+
+  `noindex` (opencode `/s/[id]` pattern): a per-saga operator view is not a
+  public document — keep it out of search indexes.
+
+  @task T11797
+  @task T11798
+  @epic T11561 — E6-RESKIN-SHELL
+  @saga T11555
+-->
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { Badge } from '$lib/ui';
+  import WorkGraphView from '$lib/components/WorkGraphView.svelte';
+  import ThemeSwitcher from '$lib/components/shell/ThemeSwitcher.svelte';
+  import { createThemeStore } from '$lib/stores/theme.svelte.js';
+  import SagaKanbanPane from './SagaKanbanPane.svelte';
+  import type { PageData } from './$types';
+
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+
+  // ---- Theme rune (client-only hydrate) ----
+  const theme = createThemeStore();
+  $effect(() => {
+    theme.hydrate();
+  });
+
+  // ---- View toggle (workgraph | kanban), URL-round-tripped ----
+  type ShellView = 'workgraph' | 'kanban';
+
+  const view = $derived<ShellView>(
+    $page.url.searchParams.get('view') === 'kanban' ? 'kanban' : 'workgraph',
+  );
+
+  function setView(next: ShellView): void {
+    const url = new URL($page.url);
+    url.searchParams.set('view', next);
+    void goto(url.pathname + url.search, { replaceState: true, noScroll: true, keepFocus: true });
+  }
+
+  // ---- Saga-subtree id set (for the kanban pane scope) ----
+  /**
+   * The id set of the saga + every descendant, derived from the bundle's
+   * parent pointers. Used to scope the live board to this saga without a
+   * second store or query. Iterates to a fixed point: a child joins the set
+   * once its parent is already in it.
+   */
+  const subtreeIds = $derived.by<ReadonlySet<string>>(() => {
+    const out = new Set<string>([data.sagaId]);
+    const tasks = data.explorer?.tasks ?? [];
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const t of tasks) {
+        if (out.has(t.id)) continue;
+        if (t.parentId && out.has(t.parentId)) {
+          out.add(t.id);
+          grew = true;
+        }
+      }
+    }
+    return out;
+  });
+
+  const sagaTitle = $derived(data.saga?.title ?? data.sagaId);
+  const nodeCount = $derived(data.explorer?.tasks.length ?? 0);
+</script>
+
+<svelte:head>
+  <title>{data.sagaId} · {data.projectName} — CLEO Studio</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<section class="saga-shell" data-view={view}>
+  <!-- Operator command bar -->
+  <header class="command-bar">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a class="crumb" href="/projects">{data.projectName}</a>
+      <span class="sep" aria-hidden="true">▸</span>
+      <span class="crumb current" title={sagaTitle}>
+        <code>{data.sagaId}</code>
+        {#if data.saga}<span class="crumb-title">{data.saga.title}</span>{/if}
+      </span>
+      {#if data.saga}
+        <Badge tone="info" size="sm">{data.saga.type}</Badge>
+      {/if}
+    </nav>
+
+    <div class="toggle" role="tablist" aria-label="Saga view">
+      <button
+        type="button"
+        class="toggle-btn"
+        class:active={view === 'workgraph'}
+        role="tab"
+        aria-selected={view === 'workgraph'}
+        onclick={() => setView('workgraph')}
+      >
+        Workgraph
+      </button>
+      <button
+        type="button"
+        class="toggle-btn"
+        class:active={view === 'kanban'}
+        role="tab"
+        aria-selected={view === 'kanban'}
+        onclick={() => setView('kanban')}
+      >
+        Kanban
+      </button>
+    </div>
+
+    <div class="bar-right">
+      <ThemeSwitcher {theme} />
+    </div>
+  </header>
+
+  <!-- Canvas -->
+  <div class="canvas">
+    {#if data.error}
+      <div class="shell-error" role="alert">
+        <p>{data.error}</p>
+      </div>
+    {:else if !data.explorer}
+      <div class="shell-error" role="alert">
+        <p>No workgraph bundle available for this saga.</p>
+      </div>
+    {:else if view === 'workgraph'}
+      <WorkGraphView
+        tasks={data.explorer.tasks}
+        deps={data.explorer.deps}
+        sagaId={data.sagaId}
+      />
+    {:else}
+      <!-- Kanban pane is the LIVE SSE board — client-only mount. -->
+      {#if browser}
+        <SagaKanbanPane sagaId={data.sagaId} {subtreeIds} />
+      {:else}
+        <div class="ssr-placeholder">
+          <p>Loading the live board…</p>
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  <footer class="shell-foot">
+    <span class="hint">
+      {nodeCount} tasks in bundle · containment + depends · operator console
+    </span>
+  </footer>
+</section>
+
+<style>
+  .saga-shell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    /* Fill the layout main; subtract the global header + main padding. */
+    height: calc(100vh - 7rem);
+    min-height: 0;
+  }
+
+  .command-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-elev-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+  }
+
+  .crumbs {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .crumb {
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    font-weight: 500;
+  }
+
+  .crumb:hover {
+    color: var(--text);
+  }
+
+  .crumb.current {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text);
+    min-width: 0;
+  }
+
+  .crumb code {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--accent);
+  }
+
+  .crumb-title {
+    font-size: var(--text-sm);
+    color: var(--text-dim);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 28ch;
+  }
+
+  .sep {
+    color: var(--text-faint);
+    font-size: var(--text-xs);
+  }
+
+  .toggle {
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    margin-left: auto;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+  }
+
+  .toggle-btn {
+    padding: var(--space-1) var(--space-4);
+    border: none;
+    background: transparent;
+    color: var(--text-dim);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: color var(--ease), background var(--ease);
+  }
+
+  .toggle-btn:hover {
+    color: var(--text);
+  }
+
+  .toggle-btn.active {
+    color: var(--bg);
+    background: var(--accent);
+  }
+
+  .toggle-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+
+  .bar-right {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .canvas {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+  }
+
+  .shell-error {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--danger);
+    background: var(--danger-soft);
+    border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
+    border-radius: var(--radius-md);
+    padding: var(--space-6);
+    text-align: center;
+  }
+
+  .ssr-placeholder {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
+    font-size: var(--text-sm);
+  }
+
+  .shell-foot {
+    display: flex;
+    justify-content: center;
+    padding-top: var(--space-1);
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .hint {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    color: var(--text-faint);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+</style>

--- a/packages/studio/src/routes/studio/[projectId]/[sagaId]/SagaKanbanPane.svelte
+++ b/packages/studio/src/routes/studio/[projectId]/[sagaId]/SagaKanbanPane.svelte
@@ -1,0 +1,273 @@
+<!--
+  SagaKanbanPane — the saga-scoped, LIVE kanban pane for the operator-console
+  shell (T11797 · E6-RESKIN-SHELL).
+
+  A thin wrapper over the existing `saga-board` RUNE STORE (#1059 · T11789):
+  it hydrates ONCE through the gateway data layer and stays live via the
+  store's SINGLE `EventSource` (`tasks.subscribe`). The shell scopes the board
+  to one saga by filtering the store's cards to the saga's subtree (computed
+  from the `subtreeIds` set the server load derived once from the shared
+  explorer bundle) — so the pane reuses the exact same store + write-path the
+  full dispatcher board uses, with NO second store and NO direct DB read.
+
+  This component is mounted CLIENT-ONLY by the shell (`{#if browser}`) so the
+  `EventSource` SSE pane never runs during SSR — the opencode `/s/[id]`
+  pattern (a live session view that only hydrates on the client).
+
+  @task T11797
+  @epic T11561 — E6-RESKIN-SHELL
+  @saga T11555
+-->
+<script lang="ts">
+  import { Board, type BoardCard, type BoardLane } from '$lib/components/board';
+  import { DetailDrawer } from '$lib/components/tasks';
+  import {
+    createSagaBoard,
+    type SagaBoardCard,
+  } from '$lib/stores/saga-board.svelte.js';
+  import type { AgentLifecycleLane } from '$lib/components/tasks';
+  import { planLaneTransition } from '$lib/components/tasks';
+  import type { Task } from '@cleocode/contracts';
+  import { untrack } from 'svelte';
+
+  interface Props {
+    /** The saga id this pane is scoped to (shown in the empty state). */
+    sagaId: string;
+    /**
+     * The id set of the saga's subtree (saga + every descendant epic / task /
+     * subtask), derived server-side from the shared explorer bundle. Cards
+     * outside this set are filtered out so the pane shows ONLY this saga.
+     */
+    subtreeIds: ReadonlySet<string>;
+  }
+
+  let { sagaId, subtreeIds }: Props = $props();
+
+  // The shared, gateway-backed live board store (root-scoped subscription).
+  // The pane mounts fresh per saga, so the root is fixed for the store's life;
+  // `untrack` captures the initial `sagaId` without a reactive-read warning.
+  const board = createSagaBoard({ root: untrack(() => sagaId) });
+  let hydrated = $state(false);
+
+  $effect(() => {
+    void board.hydrate().then(() => {
+      hydrated = true;
+    });
+    board.connect();
+    return () => board.disconnect();
+  });
+
+  /** Lane definitions in board order (static taxonomy from the store). */
+  const lanes = $derived<BoardLane[]>(board.lanes);
+
+  /** Saga-scoped cards: the store's columns, filtered to this saga's subtree. */
+  const flatCards = $derived<Array<BoardCard & { __lane: string }>>(
+    board.columns.flatMap((col) =>
+      col.cards
+        .filter((card) => subtreeIds.has(card.id))
+        .map((card: SagaBoardCard) => ({ ...card, __lane: card.lane })),
+    ),
+  );
+
+  /** Identity resolver — reads the resolved lane id off each card. */
+  function laneResolver(card: BoardCard): string {
+    return (card as BoardCard & { __lane?: string }).__lane ?? 'backlog';
+  }
+
+  // ---- Selection → drawer ----
+  let selectedId = $state<string | null>(null);
+  const selectedCard = $derived<(BoardCard & { __lane: string }) | null>(
+    selectedId ? (flatCards.find((c) => c.id === selectedId) ?? null) : null,
+  );
+
+  const drawerTask = $derived<Task | null>(
+    selectedCard
+      ? {
+          id: selectedCard.id,
+          title: selectedCard.title,
+          description: selectedCard.title,
+          status: selectedCard.status,
+          priority: selectedCard.priority,
+          size: (selectedCard.size ?? undefined) as Task['size'],
+          createdAt: new Date().toISOString(),
+        }
+      : null,
+  );
+
+  function handleSelect(cardId: string): void {
+    selectedId = cardId;
+  }
+
+  function closeDrawer(): void {
+    selectedId = null;
+  }
+
+  // ---- Toast ----
+  let toast = $state<{ kind: 'ok' | 'err'; message: string } | null>(null);
+  let toastTimer: ReturnType<typeof setTimeout> | null = null;
+  function showToast(kind: 'ok' | 'err', message: string): void {
+    toast = { kind, message };
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      toast = null;
+    }, 4200);
+  }
+
+  /** Drag a card to a new lane — same client gate + store write-path as the board. */
+  async function handleMove(cardId: string, fromLaneRaw: string, toLaneRaw: string): Promise<void> {
+    const fromLane = fromLaneRaw as AgentLifecycleLane;
+    const toLane = toLaneRaw as AgentLifecycleLane;
+    const planned = planLaneTransition(cardId, fromLane, toLane);
+    if (!planned.ok) {
+      showToast('err', planned.message);
+      return;
+    }
+    const result = await board.move(cardId, fromLane, toLane);
+    if (!result.ok) {
+      showToast('err', result.message);
+      return;
+    }
+    showToast('ok', planned.plan.summary);
+  }
+
+  const liveConnected = $derived(hydrated && board.connected);
+  const scopedTotal = $derived(flatCards.length);
+</script>
+
+<div class="saga-kanban-pane">
+  <div class="pane-meta">
+    <span class="count"><strong>{scopedTotal}</strong> cards in saga</span>
+    <span class="live" class:connected={liveConnected}>
+      <span class="live-dot" aria-hidden="true"></span>
+      {liveConnected ? 'live' : 'connecting…'}
+    </span>
+  </div>
+
+  {#if hydrated && scopedTotal === 0}
+    <div class="empty-state">
+      <p>No active cards in <code>{sagaId}</code>.</p>
+    </div>
+  {:else}
+    <div class="board-host">
+      <Board {lanes} cards={flatCards} {laneResolver} onSelect={handleSelect} onMove={handleMove} />
+    </div>
+  {/if}
+</div>
+
+{#if toast}
+  <div class="toast" class:err={toast.kind === 'err'} role="status" aria-live="polite">
+    {toast.message}
+  </div>
+{/if}
+
+{#if drawerTask}
+  <DetailDrawer task={drawerTask} onClose={closeDrawer} />
+{/if}
+
+<style>
+  .saga-kanban-pane {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    height: 100%;
+    min-height: 0;
+  }
+
+  .pane-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .count {
+    font-size: var(--text-xs);
+    color: var(--text-dim);
+  }
+
+  .count strong {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .live {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    color: var(--text-faint);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .live-dot {
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: var(--radius-pill);
+    background: var(--neutral);
+  }
+
+  .live.connected {
+    color: var(--success);
+  }
+
+  .live.connected .live-dot {
+    background: var(--success);
+    animation: var(--ease-pulse) pulse;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+  }
+
+  .board-host {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .board-host :global(.board-scroll) {
+    height: 100%;
+  }
+
+  .empty-state {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
+    font-size: var(--text-sm);
+  }
+
+  .empty-state code {
+    font-family: var(--font-mono);
+    color: var(--text-dim);
+  }
+
+  .toast {
+    position: fixed;
+    left: 50%;
+    bottom: var(--space-4);
+    transform: translateX(-50%);
+    z-index: 50;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    background: var(--bg-elev-2);
+    border: 1px solid var(--accent);
+    color: var(--text);
+    font-size: var(--text-sm);
+    box-shadow: var(--shadow-lg);
+    max-width: min(560px, calc(100vw - 2 * var(--space-4)));
+  }
+
+  .toast.err {
+    border-color: var(--danger);
+    color: var(--danger);
+  }
+</style>

--- a/packages/studio/src/routes/tasks/+page.svelte
+++ b/packages/studio/src/routes/tasks/+page.svelte
@@ -578,7 +578,13 @@
               {filters}
             />
           {:else if filters.state.view === 'graph'}
-            <GraphTab tasks={explorerTasks} deps={explorerDeps} {filters} labels={explorerLabels} />
+            <GraphTab
+              tasks={explorerTasks}
+              deps={explorerDeps}
+              {filters}
+              labels={explorerLabels}
+              activeProjectId={$page.data.activeProjectId ?? null}
+            />
           {:else}
             <KanbanTab tasks={explorerTasks} deps={explorerDeps} {filters} />
           {/if}


### PR DESCRIPTION
## Summary

Completes the Cleo Studio M6 surface — workgraph view, multi-theme operator-console shell, and a read-only service-vault dashboard. All three reuse existing primitives (the `src/lib/graph` kit, the #1059 `saga-board` rune store, the tokens.css SSoT, the core service facades) — no forked design system, no new graph engine, no second store.

Closes T11558 T11561 T11943.

### T11558 — E3-WORKGRAPH-VIEW
- `packages/studio/src/lib/components/WorkGraphView.svelte`: renders a saga's epics/tasks/subtasks with **containment** (`parent`) + **depends_on** + **blocks** edges, reusing `SvgRenderer` + `tasksToGraph` (scoped via `epicScope: sagaId`). Click node → shared `DetailDrawer` (parent chain + up/downstream dep links).
- `/studio/[projectId]` saga picker (project ▸ saga ▸ workgraph navigation, AC3) and a GraphTab "Open in operator console →" deep link wire it to the T954 graph tab (AC4/AC6).
- Data: the gateway-backed `loadExplorerBundle` (tasks + deps), the same one-round-trip source GraphTab/KanbanTab use; `tasks.workgraph.audit` confirmed present as a gateway op.

### T11561 — E6-RESKIN-SHELL
- Five `[data-theme]` palette blocks (Hermes/Nous/Bronze/Slate/Mono + opt-in `.light` variants) layered over `tokens.css` — only palette tokens re-mapped, structure inherited (AC1).
- `theme.svelte.ts` client-only theme rune (localStorage-persisted, reflects `data-theme` + `.light` on `<html>`) + `ThemeSwitcher.svelte`.
- `/studio/[projectId]/[sagaId]` operator-console shell with a **workgraph | kanban** sibling toggle over ONE server bundle (AC2). The kanban pane reuses the #1059 `saga-board` rune store (ONE `tasks.subscribe` SSE), mounted **client-only** (`{#if browser}`) + `noindex` (AC3, opencode `/s/[id]` pattern). Operator-console aesthetic, Svelte-5 runes throughout (AC4).

### T11943 — M2-W6 vault dashboard (read-first)
- `/settings/vault` read-only route lists service connections (provider/label/status/scopes/expiry) + per-agent grants via the CORE redacted facades `listConnections` + a new `listAllGrants` accessor. **No ciphertext, no plaintext, no tokenPreview ever reaches the browser** (AC1/AC2). Studio holds no second store, opens no DB (AC3). Connect/revoke link to the CLI.
- `listAllGrants` covered by 2 new `service-vault.test.ts` cases (redacted join + agent filter, token-absence assertion).

## Gates
- `biome check` — **0/0** clean across all changed files.
- `@cleocode/core` build — **0 TS errors** (incl. new accessor + test).
- Studio component/route tests — green; the GraphTab/index unit-test regression from a `$app/stores` import was fixed by switching GraphTab to an `activeProjectId` **prop** (keeps the module import-safe in vitest node env). New service-vault tests 10/10.
- CORE-First lint (T9622) — **PASS** (Studio routes consume core facades; no raw `.prepare(`/`DatabaseSync(`).
- `cleo check arch` — **6/6 gates PASS**.

## Known environmental friction (NOT introduced here)
- Studio Vite SSR **prerender** build hits the known T1693 cascade: `@cleocode/cant` / `@cleocode/runtime` are not hoisted/linked in the isolated worktree, so the post-transform SSR module resolution fails. The Vite transform of all 4856 modules (including every new file) succeeds — this builds in CI dependency order.
- `svelte-check` reports `Property 'projectCtx' does not exist on type 'Locals'` across **all** routes (86 of 90 in files untouched here) — a pre-existing ambient `App.Locals` resolution gap in the worktree, not a regression.
- `brain/stream` test file (untouched) fails on the unbuilt `@cleocode/runtime/gateway/http` — same environmental cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)