### PR TITLE
fix(T11974): ship selfimprove scenario fixtures in @cleocode/core dist (unblock dogfood loop)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -810,6 +810,18 @@ export declare function is_canonical(skillPath: string, options?: IsCanonicalOpt
   });
   console.log('  -> packages/core/dist/*.d.ts');
 
+  // Copy the self-improvement scenario fixtures into dist (T11974). These are
+  // non-TS assets the `cleo selfimprove run` loop reads at runtime from
+  // `dist/selfimprove/scenarios/<name>/{scenario,golden}.json`; neither the
+  // esbuild entry-point scan nor `tsc` emits them, so without this copy a
+  // published install trips the loop's circuit-breaker (DHQ-078).
+  await cp(
+    resolve(__dirname, 'packages/core/src/selfimprove/scenarios'),
+    resolve(__dirname, 'packages/core/dist/selfimprove/scenarios'),
+    { recursive: true },
+  );
+  console.log('  -> packages/core/dist/selfimprove/scenarios/** (fixtures)');
+
   // ---------------------------------------------------------------------------
   // Wave 6: runtime + adapters (both dep core — independent of each other)
   // ---------------------------------------------------------------------------

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -398,7 +398,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-selfimprove-fixtures.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "cd ../.. && vitest run --config packages/core/vitest.integration.config.ts",

--- a/packages/core/scripts/copy-selfimprove-fixtures.mjs
+++ b/packages/core/scripts/copy-selfimprove-fixtures.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Copy the self-improvement scenario fixtures into `packages/core/dist` (T11974).
+ *
+ * The self-improvement loop (`cleo selfimprove run --scenario <name>`) loads its
+ * scenario + golden fixtures from disk at runtime via
+ * {@link ../src/selfimprove/scenario.ts | loadScenario}, which resolves the
+ * fixture directory relative to its own compiled location
+ * (`dist/selfimprove/scenarios/<name>/{scenario,golden}.json`).
+ *
+ * These are non-TS assets, so neither `tsc` nor the esbuild entry-point scan in
+ * the root `build.mjs` emits them — without this copy step a released/built
+ * install ships no fixtures and the loop trips its circuit-breaker with
+ * `E_SELFIMPROVE_SCENARIO_INVALID: Cannot read scenario fixture …` (DHQ-078).
+ *
+ * Mirrors the established convention of shipping non-TS runtime assets (the
+ * `templates`, `schemas`, `migrations` top-level dirs in the package `files`
+ * list) — here the fixtures must live *inside* `dist` because the resolver
+ * derives their path from `import.meta.url` of the compiled module.
+ *
+ * Idempotent: re-running overwrites the destination tree.
+ *
+ * @module copy-selfimprove-fixtures
+ * @task T11974
+ */
+
+import { cp, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(here, '..');
+
+/** Source fixture root (TypeScript-source tree). */
+const SRC = resolve(packageRoot, 'src/selfimprove/scenarios');
+/** Destination fixture root inside the compiled bundle. */
+const DEST = resolve(packageRoot, 'dist/selfimprove/scenarios');
+
+/**
+ * Copy the scenario fixture tree from `src` into `dist`.
+ *
+ * @returns Resolves once the copy completes.
+ */
+async function copySelfImproveFixtures() {
+  if (!existsSync(SRC)) {
+    throw new Error(`[copy-selfimprove-fixtures] source fixtures missing at ${SRC}`);
+  }
+  await mkdir(dirname(DEST), { recursive: true });
+  await cp(SRC, DEST, { recursive: true });
+  console.log(`[copy-selfimprove-fixtures] ${SRC} -> ${DEST}`);
+}
+
+await copySelfImproveFixtures();

--- a/packages/core/src/selfimprove/__tests__/scenario-fixture-packaging.test.ts
+++ b/packages/core/src/selfimprove/__tests__/scenario-fixture-packaging.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Packaging smoke test: the self-improvement scenario fixtures must ship inside
+ * the compiled `dist` tree so a released/built install can run
+ * `cleo selfimprove run --scenario <name>` (T11974 · DHQ-078).
+ *
+ * The runtime resolver ({@link ../scenario.ts | loadScenario}) derives the
+ * fixture directory from `import.meta.url` of the *compiled* module, i.e.
+ * `dist/selfimprove/scenarios/<name>/{scenario,golden}.json`. These are non-TS
+ * assets that neither `tsc` nor the esbuild entry-point scan emits — they are
+ * copied into `dist` by `scripts/copy-selfimprove-fixtures.mjs` (per-package
+ * build) and the equivalent step in the root `build.mjs` (publish bundle).
+ *
+ * This test asserts the fixtures resolve from the package's `dist` location for
+ * the `dhq-replay-find` scenario, so a regression that drops the copy step is
+ * caught before publish. It reads the package root from `import.meta.url`
+ * rather than relying on `src`, so it fails if `dist` was built without the
+ * fixtures present.
+ *
+ * @epic T11889
+ * @task T11974
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Resolve the `@cleocode/core` package root from this test file's location.
+ *
+ * This file lives at `src/selfimprove/__tests__/`, so the package root is three
+ * directories up.
+ */
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** The canned scenario the self-improvement loop replays by default. */
+const SCENARIO = 'dhq-replay-find';
+
+describe('selfimprove scenario fixture packaging (T11974)', () => {
+  it('copies the scenario.json + golden.json into dist after build', () => {
+    const distDir = resolve(packageRoot, 'dist/selfimprove/scenarios', SCENARIO);
+    const distScenario = resolve(distDir, 'scenario.json');
+    const distGolden = resolve(distDir, 'golden.json');
+
+    // If dist does not exist yet (e.g. tests run before any build), skip the
+    // hard dist assertion but still prove the source fixtures exist so the copy
+    // step has something to copy.
+    const builtDistExists = existsSync(resolve(packageRoot, 'dist/selfimprove/scenario.js'));
+    if (builtDistExists) {
+      expect(existsSync(distScenario)).toBe(true);
+      expect(existsSync(distGolden)).toBe(true);
+    }
+  });
+
+  it('has the source fixtures the copy step ships', () => {
+    const srcDir = resolve(packageRoot, 'src/selfimprove/scenarios', SCENARIO);
+    expect(existsSync(resolve(srcDir, 'scenario.json'))).toBe(true);
+    expect(existsSync(resolve(srcDir, 'golden.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (DHQ-078 · T11974)

`cleo selfimprove run --scenario dhq-replay-find` (the harness self-improvement
loop) tripped its circuit-breaker with:

```
E_SELFIMPROVE_SCENARIO_INVALID: Cannot read scenario fixture at
  .../@cleocode/core/dist/selfimprove/scenarios/dhq-replay-find/scenario.json
```

The scenario + golden fixtures live in source
(`packages/core/src/selfimprove/scenarios/<name>/{scenario,golden}.json`) but
are **non-TS assets**: neither `tsc` nor the esbuild entry-point scan in the root
`build.mjs` emits them into `dist`. A released/built install therefore shipped no
fixtures, and the loop could never run. The runtime resolver
(`loadScenario` in `scenario.ts`) derives the fixture path from `import.meta.url`
of the *compiled* module — i.e. `dist/selfimprove/scenarios/...` — so the files
must physically exist there.

## The asset-copy fix

- New `packages/core/scripts/copy-selfimprove-fixtures.mjs` — recursively copies
  `src/selfimprove/scenarios/**` → `dist/selfimprove/scenarios/**`. Idempotent.
- Wired into the **per-package** `build` script: `"build": "tsc && node scripts/copy-selfimprove-fixtures.mjs"`.
- Mirrored in the **publish** path (`build.mjs`, esbuild bundle) right after
  core's `tsc --emitDeclarationOnly` in Wave 5, using the already-imported `cp`.
- This mirrors how other non-TS runtime assets ship (the `templates`/`schemas`/`migrations`
  dirs in `files`); fixtures must live *inside* `dist` because the resolver
  derives their path from the compiled module location.
- New smoke test `scenario-fixture-packaging.test.ts` asserts the fixtures
  resolve from the built `dist` for `dhq-replay-find`.

## DRY-RUN validation (DEFAULT — no `--execute`)

After a capped `pnpm run build`, running the **built** CLI:

`node packages/cleo/dist/cli/index.js selfimprove run --scenario dhq-replay-find`

now reaches a **real replay + diff** (no longer halts on the missing fixture):

```json
{"success":true,"data":{
  "outcome":"regression-dry-run",
  "scenario":"dhq-replay-find",
  "executed":false,
  "regressions":[
    {"opIndex":0,"opCoord":"tasks.find","path":"data/count","expected":1},
    {"opIndex":1,"opCoord":"tasks.show","path":"success","actual":false,"expected":true}
    /* … real envelope diffs vs golden … */
  ],
  "draftPr":null,
  "breaker":{"open":false,"reason":null,"detail":null}
}}
```

Key signals: `breaker.open=false` (NOT `halted: Cannot read scenario fixture`),
`executed:false` + `draftPr:null` (dry-run did not write or open a PR). The loop
replays the canned `tasks.find` / `tasks.show` ops in-process and diffs against
the golden — exactly the AC4 success condition. (The reported regressions reflect
the canned golden vs the live store and are expected for a dogfood replay; the
point is the loop now *runs* instead of circuit-breaking.)

## What `--execute` additionally requires

To produce a **real DHQ row + draft PR** the orchestrator must, in addition to
this fix:

1. Pass `--execute` (default is OFF ⇒ dry-run only).
2. `CLEO_PI_RUNNER_ENABLED=1` — the Pi in-process runner must be enabled.
3. Valid LLM credentials in the vault (the loop's replay/diff/proposal path needs
   a resolvable provider; absent creds it degrades gracefully).
4. The DB **mutation lease** (DbWriterLease) — the leased `selfimprove_dhq`
   UPSERT and draft-PR egress require the autonomous-build mutation lease.

## Gates

- `pnpm exec biome ci .` — clean (3774 files, 0 errors).
- capped `pnpm run build` — success; `dist/selfimprove/scenarios/dhq-replay-find/{scenario,golden}.json` present.
- capped `pnpm run typecheck` (`tsc -b`, full) — clean.
- `pnpm --filter @cleocode/core vitest run src/selfimprove` — 8 files / 58 tests pass (incl. new smoke test).
- `cleo check arch` — 6/6 gates pass.

Pre-existing worktree audit/`database is not open` (T5188/T11959) noise is unrelated.

## Evidence

`cleo verify --gate implemented` was blocked by the worktree-evidence limitation
(T11959 — commit not reachable from the main-checkout HEAD). Complete via `pr:<n>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)