### PR TITLE
chore(release): v2026.6.14 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2026.6.14] (2026-06-10)
+
+> **Gateway-write + agent-tool + Studio interactivity release** — the gateway grows the task write-path (streaming subscribe + reorder/bulk-move/assignee), the agent harness gains a real M7 tool catalog (memory/MCP/skills/cron/media) and service-credential injection, Studio becomes an interactive Kanban dispatcher with workgraph + vault views and a multi-theme reskin, and the self-improvement loop becomes runnable from a released install. New harness/tool behaviour remains **default-OFF / opt-in**; the released CLI is behaviourally compatible with v2026.6.13. 11 PRs (#1049, #1053–#1063), all CI-green through the merge-bar gate.
+
+### Added
+
+- **Gateway task write-path — streaming subscribe + mutation ops.** `tasks.subscribe` (SSE streaming source) plus `tasks.reorder-rank`, `tasks.bulk-move`, and `tasks.assignee` ops with handlers, and a corresponding SDK regen — the gateway can now drive live task boards over HTTP/SSE. _(T11556 / T11785 / T11786; #1053)_
+- **M7 agent-tool catalog.** The agent harness gains the first real tool suite — `memory`, `mcp-client`, `run_skill`, `cron`/`todo`, and `media` tools — plus a `cron_schedule` table + accessor and an ungated `cron_schedule` tool. _(T11947–T11951, T11962; #1054/#1061)_
+- **Channels: Local-TUI `ChannelAdapter`.** The first channel adapter implementation, wiring the Local-TUI surface into the channels layer. _(T11952; #1055)_
+- **PSYCHE schema tier (daemon-OFF subset).** Bitemporal `expired_at` + `network` columns and deriver backoff land as a schema tier — the storage substrate for the PSYCHE loop, shipped inert (daemon-OFF). _(T10405; #1060)_
+- **Studio interactive Kanban dispatcher.** Studio becomes interactive: a gateway write-path (CORE-First, routed through the gateway SDK), a saga-board rune store, drag-transition dispatch, a Conductor, and SSE live updates — the dispatcher board. _(T11557 / T11559; #1059)_
+- **Studio workgraph view + reskin + vault dashboard.** A saga-scoped `WorkGraphView` with a `DetailDrawer`, a multi-theme reskin shell (5 themes via theme-token rune + `/studio/[projectId]/[sagaId]` shell), and a read-only vault dashboard over core service facades. _(T11558 / T11561 / T11943; #1062)_
+- **Vault: service-credential injection at the tool HTTP boundary.** Service credentials are injected at the tool HTTP boundary as sealed handles — agent tools reach external services without ever seeing raw keys. _(T11940; #1061)_
+
+### Changed
+
+- **Self-improvement loop runnable from a released install.** The `selfimprove` scenario fixtures now ship in the `@cleocode/core` dist, so the dogfood loop runs from a released install rather than only from a source checkout. _(T11974; #1063)_
+
+### DevEx
+
+- **Merge-bar aggregate gate + `cleo check pr`.** A single merge-bar aggregate CI gate plus a `cleo check pr` verb consolidates the PR-readiness signal. _(T11955 / T11956; #1049)_
+- **DHQ burn — CI/test resilience.** Apt-resilient ripgrep install, a `gen:tier-snapshot` drift gate (auto-regen), a vitest-workspace-resolver fix, and a depends-gate `--waive-depends` escape hatch (DHQ-077/074/070/071). _(T11966 / T11957 / T11953 / T11954; #1057)_
+
 ## [2026.6.13] (2026-06-09)
 
 > **Pi-harness foundation release** — the in-process agentic runner spine, the authority layer that makes autonomous multi-agent execution safe, and the first walking-skeleton of the self-improvement loop. All new runtime behaviour ships **default-OFF** behind explicit flags; the released CLI is behaviourally identical to v2026.6.12 until those flags are set. 28 PRs (#995–#1019), 120 commits, all CI-green through the PR gate.


### PR DESCRIPTION
## v2026.6.14 — Gateway-write + agent-tool + Studio interactivity release

Adds the `## [2026.6.14]` section to root `CHANGELOG.md`. **CHANGELOG PR only** — does not tag or publish. The release is tag-driven: merge this → `git tag v2026.6.14` → `release.yml` syncs `package.json` from the tag + publishes → `cleo release reconcile v2026.6.14`.

Covers 11 PRs (#1049, #1053–#1063):

### Added
- Gateway task write-path — `tasks.subscribe` (SSE) + `tasks.reorder-rank`/`bulk-move`/`assignee` + SDK regen (#1053, T11556)
- M7 agent-tool catalog — memory/mcp-client/run_skill/cron-todo/media + `cron_schedule` table + ungated cron tool (#1054/#1061, T11947–T11951/T11962)
- Channels: Local-TUI `ChannelAdapter` (#1055, T11952)
- PSYCHE schema tier — bitemporal `expired_at` + `network` columns + deriver backoff, daemon-OFF (#1060, T10405)
- Studio interactive Kanban dispatcher — gateway write-path + saga-board rune store + drag-transition + Conductor + SSE (#1059, T11557/T11559)
- Studio workgraph view + reskin (5 themes) + vault dashboard (#1062, T11558/T11561/T11943)
- Vault service-credential injection at the tool HTTP boundary, sealed-handle (#1061, T11940)

### Changed
- Self-improve loop — scenario fixtures now shipped in core dist, runnable from a released install (#1063, T11974)

### DevEx
- Merge-bar aggregate gate + `cleo check pr` (#1049, T11955/T11956)
- DHQ burn — apt-resilient ripgrep + `gen:tier-snapshot` drift gate + vitest-workspace-resolver + depends-gate `--waive-depends` (#1057, T11966/T11957/T11953/T11954)

`cleo release validate-changelog v2026.6.14` passes (`headerFound: ## [2026.6.14]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)