### PR TITLE
feat(T11975): self-improve fix-generation stage — closes the autonomous DHQ→fix→draft-PR pipeline (gated, draft-only)

### DIFF
--- a/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
+++ b/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for the self-improvement fix-generation stage (T11889 · T11975).
+ *
+ * Two surfaces are covered:
+ *
+ *  1. **`fix-gen.ts` unit** — the pure helpers (`fixPatchPath`,
+ *     `looksLikeUnifiedDiff`, `buildFixGenPrompt`, `stripCodeFences`) plus
+ *     `generateFixPatch` with a DETERMINISTIC FAKE generator: a canned patch is
+ *     written to the expected path; an empty / non-diff / throwing / `'none'`
+ *     generator degrades to `{ kind: 'skipped' }` and writes NO file. NO real LLM
+ *     is reached.
+ *
+ *  2. **`run-loop.ts` integration (the capstone)** — a regression replay + a
+ *     deterministic fake fix generator proves the WHOLE pipeline closes: regression
+ *     ⇒ leased DHQ ⇒ fix-gen writes `selfimprove-<scenario>.patch` ⇒ the egress's
+ *     `existsSync` guard fires ⇒ `openDraftPr` would open a DRAFT PR (gh shell-out
+ *     MOCKED — the injected `run` captures the `gh pr create --draft` invocation;
+ *     NO real git/gh fires). The complementary case proves the gate: with the
+ *     Pi-runner gate OFF, NO patch is written and the egress stays a dry-run.
+ *
+ * The LLM dependency is the injectable {@link FixGenerator} seam — every test
+ * supplies a fake. The E9 chokepoint is never touched.
+ *
+ * @epic T11889
+ * @task T11975
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import type { DispatchResponse } from '@cleocode/contracts/gateway';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from '../../store/dual-scope-db.js';
+import { SELFIMPROVE_DHQ_TABLE } from '../../store/selfimprove-dhq-schema.js';
+import { _resetWriterLeaseStateForTest } from '../../store/writer-lease.js';
+import { createToolGuard } from '../../tools/guard.js';
+import { createDhqAdapter, type DhqAdapter } from '../dhq-adapter.js';
+import type { DiffEntry } from '../envelope-diff.js';
+import {
+  buildFixGenPrompt,
+  type FixGenerator,
+  type FixGenOutput,
+  type FixGenRequest,
+  fixPatchPath,
+  generateFixPatch,
+  looksLikeUnifiedDiff,
+  stripCodeFences,
+} from '../fix-gen.js';
+import type { ReplayDispatch } from '../replay.js';
+import { runSelfImprove } from '../run-loop.js';
+
+vi.mock('../../logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+/** The canned fixture scenario shipped under `scenarios/dhq-replay-find`. */
+const SCENARIO = 'dhq-replay-find';
+
+/** A minimal but valid unified diff a fake generator can return. */
+const CANNED_PATCH = [
+  'diff --git a/packages/core/src/foo.ts b/packages/core/src/foo.ts',
+  'index 0000000..1111111 100644',
+  '--- a/packages/core/src/foo.ts',
+  '+++ b/packages/core/src/foo.ts',
+  '@@ -1,1 +1,1 @@',
+  '-export const x = 1;',
+  '+export const x = 2;',
+].join('\n');
+
+/** A regression diff entry the request carries as evidence. */
+const REGRESSION: DiffEntry = {
+  opIndex: 0,
+  opCoord: 'tasks.find',
+  path: 'data/count',
+  actual: 2,
+  expected: 1,
+};
+
+/** Build a fix-gen request for the canned scenario rooted at `root`. */
+function makeRequest(root: string): FixGenRequest {
+  return {
+    dhqId: 'DHQ-deadbeef',
+    scenario: SCENARIO,
+    questionHash: 'deadbeefcafef00d',
+    regressions: [REGRESSION],
+    repoContext: { projectRoot: root, summary: 'find returns wrong count' },
+  };
+}
+
+/** A deterministic fake generator that returns a fixed {@link FixGenOutput}. */
+function fakeGenerator(output: FixGenOutput): FixGenerator {
+  return { propose: vi.fn(async () => output) };
+}
+
+describe('fix-gen — pure helpers', () => {
+  it('fixPatchPath sanitizes the scenario and resolves against cwd', () => {
+    // `/`, `.`, `.`, `/` → 4 dashes; no traversal escapes the cwd.
+    const p = fixPatchPath('weird/../name', '/tmp/proj');
+    expect(p).toBe('/tmp/proj/selfimprove-weird----name.patch');
+  });
+
+  it('looksLikeUnifiedDiff accepts a real diff and rejects prose / empty', () => {
+    expect(looksLikeUnifiedDiff(CANNED_PATCH)).toBe(true);
+    expect(looksLikeUnifiedDiff('Sorry, I cannot help with that.')).toBe(false);
+    expect(looksLikeUnifiedDiff('')).toBe(false);
+    expect(looksLikeUnifiedDiff('   \n  ')).toBe(false);
+  });
+
+  it('stripCodeFences unwraps a fenced diff but leaves a bare diff untouched', () => {
+    expect(stripCodeFences('```diff\n' + CANNED_PATCH + '\n```')).toBe(CANNED_PATCH);
+    expect(stripCodeFences(CANNED_PATCH)).toBe(CANNED_PATCH);
+  });
+
+  it('buildFixGenPrompt embeds the regression coordinates + demands a unified diff', () => {
+    const { system, user } = buildFixGenPrompt(makeRequest('/tmp/p'));
+    expect(system).toContain('unified diff');
+    expect(system).toContain('NO_PATCH');
+    expect(user).toContain('tasks.find');
+    expect(user).toContain('data/count');
+    expect(user).toContain('DHQ-deadbeef');
+  });
+});
+
+describe('fix-gen — generateFixPatch with a deterministic fake', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `fixgen-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('writes the canned patch to the egress-expected path', async () => {
+    const generator = fakeGenerator({ kind: 'patch', diff: CANNED_PATCH, model: 'fake-model' });
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+
+    expect(res.kind).toBe('written');
+    if (res.kind !== 'written') throw new Error('unreachable');
+    expect(res.patchPath).toBe(join(root, `selfimprove-${SCENARIO}.patch`));
+    expect(res.model).toBe('fake-model');
+    expect(existsSync(res.patchPath)).toBe(true);
+    const written = readFileSync(res.patchPath, 'utf8');
+    expect(written.startsWith('diff --git')).toBe(true);
+    expect(written.endsWith('\n')).toBe(true); // normalized trailing newline
+  });
+
+  it('degrades to skipped (no file) when the generator returns none', async () => {
+    const generator = fakeGenerator({ kind: 'none', reason: 'model-declined' });
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+    expect(res.kind).toBe('skipped');
+    if (res.kind === 'skipped') expect(res.reason).toContain('model-declined');
+    expect(existsSync(join(root, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+  });
+
+  it('degrades to skipped (no file) when the output is not a unified diff', async () => {
+    const generator = fakeGenerator({ kind: 'patch', diff: 'just some prose', model: 'm' });
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+    expect(res.kind).toBe('skipped');
+    if (res.kind === 'skipped') expect(res.reason).toBe('fixgen-not-a-diff');
+    expect(existsSync(join(root, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+  });
+
+  it('degrades to skipped (no file) when the generator throws — never rethrows', async () => {
+    const generator: FixGenerator = {
+      propose: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+    expect(res.kind).toBe('skipped');
+    if (res.kind === 'skipped') expect(res.reason).toContain('fixgen-threw');
+    expect(existsSync(join(root, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+  });
+});
+
+/**
+ * Build a dispatch port that DIVERGES from the golden so the loop finds a
+ * regression (mirrors the run-loop test's regressionDispatch).
+ */
+function regressionDispatch(): ReplayDispatch {
+  return vi.fn(
+    async (op): Promise<DispatchResponse> => ({
+      meta: {
+        gateway: 'query',
+        domain: 'tasks',
+        operation: op.operation,
+        timestamp: new Date().toISOString(),
+        duration_ms: 3,
+        source: 'rpc',
+        requestId: `req-${op.operation}`,
+      },
+      success: true,
+      data: { operation: op.operation, drifted: 'unexpected' },
+    }),
+  );
+}
+
+describe('run-loop CAPSTONE — regression → fix-gen → DRAFT PR (deterministic fake, mocked gh)', () => {
+  let testRoot: string;
+  let projectRoot: string;
+  let native: DatabaseSync;
+  let realAdapter: DhqAdapter;
+  const guard = createToolGuard({ mode: 'enforce' });
+
+  beforeEach(async () => {
+    testRoot = join(tmpdir(), `fixgen-loop-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    projectRoot = join(testRoot, 'project');
+    const cleoDir = join(projectRoot, '.cleo');
+    mkdirSync(cleoDir, { recursive: true });
+    const handle = await openDualScopeDbAtPath('project', join(cleoDir, 'cleo.db'));
+    native = (handle.db as unknown as { $client: DatabaseSync }).$client;
+    realAdapter = createDhqAdapter({ cwd: projectRoot, now: () => 1000 });
+  });
+
+  afterEach(() => {
+    _resetDualScopeDbCache();
+    _resetWriterLeaseStateForTest();
+    try {
+      rmSync(testRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  /** Read the one open DHQ row's regression_json (the recorded evidence). */
+  function openRegressionJson(): string | null {
+    const row = native
+      .prepare(`SELECT regression_json AS j FROM ${SELFIMPROVE_DHQ_TABLE} WHERE status = 'open'`)
+      .get() as { j: string } | undefined;
+    return row?.j ?? null;
+  }
+
+  it('GATE ON: fake fix-gen writes a patch ⇒ egress opens a DRAFT PR (gh fully mocked)', async () => {
+    const generator = fakeGenerator({ kind: 'patch', diff: CANNED_PATCH, model: 'fake-model' });
+
+    // FULLY MOCKED git/gh runner — every shell-out is captured, NEVER executed.
+    // Injected straight into the run-loop's egress via the `draftPrRun` seam so
+    // the whole capstone is one deterministic call with NO real git/gh.
+    const ghCalls: string[][] = [];
+    const draftPrRun = vi.fn((file: string, args: readonly string[]): string => {
+      ghCalls.push([file, ...args]);
+      if (file === 'gh' && args[0] === 'pr' && args[1] === 'create') {
+        return 'https://github.com/cleocode/cleocode/pull/4242\n';
+      }
+      return '';
+    });
+
+    const res = await runSelfImprove({
+      scenario: SCENARIO,
+      dispatch: regressionDispatch(),
+      backend: 'in-process',
+      guard,
+      adapter: realAdapter,
+      cwd: projectRoot,
+      execute: true,
+      piRunnerEnabled: true, // arm fix-gen WITHOUT mutating process.env
+      fixGenerator: generator,
+      draftPrRun, // mock the egress shell-out
+    });
+
+    // 1. The pipeline closed: regression acted on + fix-gen wrote the patch.
+    expect(res.outcome).toBe('regression-acted');
+    expect(res.fixGen?.kind).toBe('written');
+    expect(generator.propose).toHaveBeenCalledTimes(1);
+    const patchPath = join(projectRoot, `selfimprove-${SCENARIO}.patch`);
+    expect(existsSync(patchPath)).toBe(true);
+    if (res.fixGen?.kind === 'written') {
+      expect(res.fixGen.patchPath).toBe(patchPath);
+    }
+
+    // 2. The egress found the patch (no E_NOT_FOUND skip) + opened a DRAFT PR.
+    expect(res.draftPr?.kind).toBe('ok');
+    if (res.draftPr?.kind === 'ok') {
+      expect(res.draftPr.prUrl).toBe('https://github.com/cleocode/cleocode/pull/4242');
+    }
+    const ghCreate = ghCalls.find(([f, a]) => f === 'gh' && a === 'pr');
+    expect(ghCreate).toBeDefined();
+    expect(ghCreate?.join(' ')).toContain('--draft');
+    expect(ghCreate?.join(' ')).toContain('--base');
+    // NEVER a push to main.
+    expect(ghCalls.some(([, ...a]) => /push.*\bmain\b/.test(a.join(' ')))).toBe(false);
+
+    // 3. The PR url + fix-gen outcome were recorded back onto the leased DHQ row.
+    const evidence = openRegressionJson();
+    expect(evidence).not.toBeNull();
+    expect(evidence).toContain('"fixGen"');
+    expect(evidence).toContain('"written"');
+  });
+
+  it('GATE OFF: piRunnerEnabled=false ⇒ NO patch written, egress is a no-patch skip', async () => {
+    const generator = fakeGenerator({ kind: 'patch', diff: CANNED_PATCH, model: 'fake-model' });
+
+    const res = await runSelfImprove({
+      scenario: SCENARIO,
+      dispatch: regressionDispatch(),
+      backend: 'in-process',
+      guard,
+      adapter: realAdapter,
+      cwd: projectRoot,
+      execute: true,
+      piRunnerEnabled: false, // gate OFF
+      fixGenerator: generator,
+    });
+
+    // DHQ still emitted (execute), but fix-gen never ran and no patch exists.
+    expect(res.fixGen).toBeNull();
+    expect(generator.propose).not.toHaveBeenCalled();
+    expect(existsSync(join(projectRoot, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+
+    // With no patch on disk the egress degrades to the existing no-patch skip.
+    expect(res.draftPr?.kind).toBe('error');
+    if (res.draftPr?.kind === 'error') {
+      expect(res.draftPr.code).toBe('E_NOT_FOUND');
+    }
+  });
+});

--- a/packages/core/src/selfimprove/fix-gen.ts
+++ b/packages/core/src/selfimprove/fix-gen.ts
@@ -1,0 +1,399 @@
+/**
+ * Fix-generation stage for the self-improvement loop (T11889 · T11975).
+ *
+ * This is the missing autonomous link the v1 loop explicitly stubbed out
+ * ("NO autonomous fix-gen in v1", see {@link "./run-loop.js"}): given a detected
+ * regression (an open `selfimprove_dhq` + its envelope-diff) plus minimal repo
+ * context, it asks the LLM to PROPOSE a unified-diff patch and writes that patch
+ * to the path the draft-PR egress ({@link "./draft-pr.js".openDraftPr}) already
+ * `existsSync`-checks: `<cwd>/selfimprove-<scenario>.patch`. Once the patch is on
+ * disk the existing egress guard opens ONE DRAFT PR — closing the
+ * DHQ → fix → draft-PR pipeline end-to-end.
+ *
+ * ## Hard safety posture (unchanged from v1 — P5 spec §B.7)
+ *
+ *   - **LLM ONLY via the E9 chokepoint.** The real generator
+ *     ({@link createLlmFixGenerator}) resolves its model strictly through
+ *     {@link "../llm/system-resolver.js".resolveLLMForSystem} → {@link ModelRunner}
+ *     (Gate-13). It constructs NO raw provider client, reads NO `*_API_KEY` env,
+ *     and hardcodes no model id — the resolver/registry is the SSoT. The
+ *     plaintext token is materialized only at the wire boundary (E10).
+ *   - **Draft-PR-ONLY, never auto-merge.** This module produces a PATCH FILE only;
+ *     the egress that consumes it always opens a `--draft` PR against a feature
+ *     branch (never `main`). This module performs NO git/gh action.
+ *   - **Graceful degrade, never a rogue mutation.** Every failure (no credential,
+ *     LLM error, empty / non-unified-diff output) returns a typed
+ *     {@link FixGenResult} of kind `'skipped'` and writes NO patch file — so the
+ *     existing egress guard (`existsSync` on the patch path) simply skips the PR.
+ *     This function NEVER throws.
+ *   - **Injectable seam.** The LLM dependency is the {@link FixGenerator} port;
+ *     unit tests inject a deterministic fake that returns a canned patch, so NO
+ *     real LLM is reached in tests.
+ *
+ * CORE-first: this engine lives in `core` and owns the `FixGenerator` port TYPE.
+ * Import-time side-effect-free.
+ *
+ * @module @cleocode/core/selfimprove/fix-gen
+ * @epic T11889
+ * @task T11975
+ */
+
+import { writeFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+import { cwd as processCwd } from 'node:process';
+import type { Logger } from 'pino';
+import type { DiffEntry } from './envelope-diff.js';
+
+/**
+ * The E9 system-of-use label the fix-generator resolves its model under. Maps to
+ * the `judgement` role (see `SYSTEM_ROLE_MAP`) — the closest standing role for
+ * "reason about a regression and propose a code change".
+ */
+const FIXGEN_SYSTEM = 'task-executor' as const;
+
+/** A leading marker every unified-diff hunk header / file header carries. */
+const UNIFIED_DIFF_MARKERS = ['diff --git ', '--- ', '+++ ', '@@ '] as const;
+
+/**
+ * The structured request handed to a {@link FixGenerator}. Carries only what the
+ * generator needs to draft a patch: the DHQ identity, the scenario, the
+ * regression diff, and a minimal slice of repo context.
+ */
+export interface FixGenRequest {
+  /** The stable `'DHQ-###'` handle of the open regression. */
+  readonly dhqId: string;
+  /** The scenario whose replay diverged from the golden. */
+  readonly scenario: string;
+  /** The idempotency hash tying this request to ONE open DHQ row. */
+  readonly questionHash: string;
+  /** The structured regression entries (the evidence) from the envelope diff. */
+  readonly regressions: readonly DiffEntry[];
+  /**
+   * Minimal repo context the generator may use to ground the patch (e.g. the
+   * project root, a short description). Kept small on purpose — the loop does NOT
+   * stuff the whole repo into the prompt.
+   */
+  readonly repoContext: FixGenRepoContext;
+}
+
+/** Minimal repo context grounding a fix-generation request. */
+export interface FixGenRepoContext {
+  /** Absolute project root the patch is generated against. */
+  readonly projectRoot: string;
+  /** Optional one-line summary of what the scenario exercises. */
+  readonly summary?: string;
+}
+
+/** A generated patch, or an explicit "no usable patch" signal. */
+export type FixGenOutput =
+  | {
+      /** The generator produced a candidate unified-diff patch. */
+      readonly kind: 'patch';
+      /** The raw unified-diff text (validated by {@link generateFixPatch}). */
+      readonly diff: string;
+      /** The model id that produced it (for audit). */
+      readonly model: string;
+    }
+  | {
+      /** The generator produced no usable patch (degrade — never an error throw). */
+      readonly kind: 'none';
+      /** Machine-stable reason for the absence. */
+      readonly reason: string;
+    };
+
+/**
+ * The injectable fix-generation port (the LLM seam).
+ *
+ * The real implementation ({@link createLlmFixGenerator}) drives the E9 chokepoint;
+ * tests inject a deterministic fake returning a canned patch. A `FixGenerator`
+ * MUST NOT throw — it encodes "no patch" as `{ kind: 'none', reason }`.
+ */
+export interface FixGenerator {
+  /**
+   * Propose a unified-diff patch for one regression.
+   *
+   * @param request - The structured {@link FixGenRequest}.
+   * @returns A {@link FixGenOutput} — a candidate patch or an explicit "none".
+   */
+  propose(request: FixGenRequest): Promise<FixGenOutput>;
+}
+
+/** The terminal outcome of {@link generateFixPatch}. */
+export type FixGenResult =
+  | {
+      /** A validated patch was written to {@link FixGenResultWritten.patchPath}. */
+      readonly kind: 'written';
+      /** Absolute path the patch was written to. */
+      readonly patchPath: string;
+      /** Byte length of the written patch. */
+      readonly bytes: number;
+      /** The model id that produced the patch. */
+      readonly model: string;
+    }
+  | {
+      /** No patch was written; the egress guard will skip the PR. */
+      readonly kind: 'skipped';
+      /** Machine-stable reason recorded on the DHQ evidence. */
+      readonly reason: string;
+    };
+
+/**
+ * Options for {@link generateFixPatch}.
+ */
+export interface GenerateFixPatchOptions {
+  /** The structured fix-generation request. */
+  readonly request: FixGenRequest;
+  /** The injected generator (real LLM impl or a test fake). */
+  readonly generator: FixGenerator;
+  /**
+   * Working directory the patch path is resolved against — MUST match the `cwd`
+   * the downstream {@link "./draft-pr.js".openDraftPr} uses, so the file it writes
+   * is the file the egress finds.
+   */
+  readonly cwd?: string;
+  /** Injectable logger (defaults to the module logger). */
+  readonly logger?: Logger;
+}
+
+/**
+ * Compute the patch path the draft-PR egress expects for a scenario:
+ * `<cwd>/selfimprove-<scenario>.patch`. The scenario is sanitized to a safe file
+ * stem so a hostile scenario name cannot escape the cwd.
+ *
+ * @param scenario - The scenario name.
+ * @param cwd - The working directory to resolve against (defaults to `process.cwd`).
+ * @returns The absolute patch path.
+ */
+export function fixPatchPath(scenario: string, cwd?: string): string {
+  const safeScenario = scenario.replace(/[^a-z0-9-]/gi, '-');
+  return resolvePath(cwd ?? processCwd(), `selfimprove-${safeScenario}.patch`);
+}
+
+/**
+ * Is `text` a plausible unified diff?
+ *
+ * A real `git apply`-able patch always carries at least one of the canonical
+ * unified-diff markers ({@link UNIFIED_DIFF_MARKERS}). An LLM that returns prose,
+ * an apology, or an empty string fails this guard, so the loop degrades to "no
+ * patch" rather than writing junk the egress would then fail to `git apply`.
+ *
+ * This is a cheap structural sniff, NOT a full parse — the authoritative
+ * applicability check is `git apply` inside the egress (which fails the PR cut on
+ * a bad patch, never `main`).
+ *
+ * @param text - Candidate patch text.
+ * @returns `true` when the text looks like a unified diff.
+ */
+export function looksLikeUnifiedDiff(text: string): boolean {
+  if (text.trim().length === 0) return false;
+  return UNIFIED_DIFF_MARKERS.some((marker) => text.includes(marker));
+}
+
+/**
+ * Build the system + user prompt the real generator sends to the LLM. Pure
+ * (no IO) so it is unit-testable in isolation. The prompt is deliberately strict:
+ * "respond with ONLY a unified diff" — anything else fails
+ * {@link looksLikeUnifiedDiff} downstream and degrades to "no patch".
+ *
+ * @param request - The fix-generation request.
+ * @returns The `{ system, user }` prompt pair.
+ */
+export function buildFixGenPrompt(request: FixGenRequest): { system: string; user: string } {
+  const system =
+    'You are an autonomous software-maintenance agent. You are given a detected ' +
+    'regression in a TypeScript monorepo (a divergence between a replayed scenario ' +
+    'and its golden expected output). Produce a MINIMAL fix as a single unified diff ' +
+    '(`git diff` format, with `diff --git`, `---`, `+++`, and `@@` hunk headers). ' +
+    'Respond with ONLY the unified diff and NOTHING else — no prose, no code fences, ' +
+    'no explanation. If you cannot propose a safe fix, respond with the single token ' +
+    'NO_PATCH.';
+  const lines = request.regressions.map(
+    (r) =>
+      `- op ${r.opCoord} (#${r.opIndex}) at path \`${r.path}\`: ` +
+      `actual=${JSON.stringify(r.actual)} expected=${JSON.stringify(r.expected)}`,
+  );
+  const user =
+    `Regression ${request.dhqId} in scenario \`${request.scenario}\` ` +
+    `(${request.regressions.length} diverging path(s)).\n` +
+    (request.repoContext.summary ? `Scenario summary: ${request.repoContext.summary}\n` : '') +
+    `Project root: ${request.repoContext.projectRoot}\n\n` +
+    `Diverging paths:\n${lines.join('\n')}\n\n` +
+    'Produce the unified diff that resolves these divergences.';
+  return { system, user };
+}
+
+/**
+ * Lazily-resolved module logger (import-time side-effect-free).
+ */
+let cachedLogger: Logger | undefined;
+async function getModuleLogger(): Promise<Logger> {
+  if (cachedLogger === undefined) {
+    const { getLogger } = await import('../logger.js');
+    cachedLogger = getLogger('selfimprove-fix-gen');
+  }
+  return cachedLogger;
+}
+
+/**
+ * Run the fix-generation stage: ask the injected {@link FixGenerator} for a patch,
+ * validate it as a unified diff, and write it to the egress-expected patch path.
+ *
+ * This function NEVER throws and NEVER mutates anything but the single patch file.
+ * On ANY degrade path — generator returns `'none'`, the generator throws, or the
+ * returned text is not a unified diff — it writes NO file and returns
+ * `{ kind: 'skipped', reason }`, so the downstream `existsSync` egress guard
+ * simply skips the PR. The caller records the `reason` on the DHQ evidence.
+ *
+ * @param opts - See {@link GenerateFixPatchOptions}.
+ * @returns A {@link FixGenResult}.
+ *
+ * @example
+ * ```ts
+ * const res = await generateFixPatch({
+ *   request: { dhqId: 'DHQ-abcd1234', scenario, questionHash, regressions, repoContext },
+ *   generator: createLlmFixGenerator(),
+ *   cwd: projectRoot,
+ * });
+ * if (res.kind === 'written') { // openDraftPr will now find selfimprove-<scenario>.patch }
+ * ```
+ */
+export async function generateFixPatch(opts: GenerateFixPatchOptions): Promise<FixGenResult> {
+  const logger = opts.logger ?? (await getModuleLogger());
+  const { request, generator } = opts;
+  const patchPath = fixPatchPath(request.scenario, opts.cwd);
+
+  let output: FixGenOutput;
+  try {
+    output = await generator.propose(request);
+  } catch (err) {
+    const reason = `fixgen-threw:${err instanceof Error ? err.message : String(err)}`;
+    logger.warn({ dhqId: request.dhqId, scenario: request.scenario, reason }, 'fix-gen degraded');
+    return { kind: 'skipped', reason };
+  }
+
+  if (output.kind === 'none') {
+    logger.info(
+      { dhqId: request.dhqId, scenario: request.scenario, reason: output.reason },
+      'fix-gen produced no patch (graceful skip — no PR)',
+    );
+    return { kind: 'skipped', reason: `fixgen-none:${output.reason}` };
+  }
+
+  if (!looksLikeUnifiedDiff(output.diff)) {
+    logger.warn(
+      { dhqId: request.dhqId, scenario: request.scenario },
+      'fix-gen output is not a unified diff (graceful skip — no PR)',
+    );
+    return { kind: 'skipped', reason: 'fixgen-not-a-diff' };
+  }
+
+  // Normalize a trailing newline so `git apply` accepts the hunk.
+  const diff = output.diff.endsWith('\n') ? output.diff : `${output.diff}\n`;
+  writeFileSync(patchPath, diff, 'utf8');
+  const bytes = Buffer.byteLength(diff, 'utf8');
+  logger.info(
+    { dhqId: request.dhqId, scenario: request.scenario, patchPath, bytes, model: output.model },
+    'fix-gen wrote candidate patch — egress will open a DRAFT PR',
+  );
+  return { kind: 'written', patchPath, bytes, model: output.model };
+}
+
+/**
+ * Construct the REAL fix generator — the one that drives the E9 LLM chokepoint.
+ *
+ * Resolution funnels through {@link resolveLLMForSystem}(`'task-executor'`) →
+ * {@link ModelRunner.build} → `session.send` (ONE non-streaming completion).
+ * It constructs NO raw provider client, reads NO API-key env, and hardcodes no
+ * model id (Gate-13). The plaintext credential is materialized ONLY at the
+ * `ModelRunner` wire boundary (E10) via the sealed handle. When no credential is
+ * reachable it returns `{ kind: 'none' }` — the loop degrades to "no patch", no
+ * PR. This function constructs nothing at call time (lazy dynamic imports keep the
+ * module import-time side-effect-free + the E9 deps off the hot import path).
+ *
+ * @param opts - Optional project root threaded into the resolver.
+ * @returns A {@link FixGenerator} backed by the E9 chokepoint.
+ *
+ * @example
+ * ```ts
+ * const gen = createLlmFixGenerator({ projectRoot });
+ * const out = await gen.propose(request); // resolves model via E9, never raw client
+ * ```
+ */
+export function createLlmFixGenerator(opts: { projectRoot?: string } = {}): FixGenerator {
+  return {
+    async propose(request: FixGenRequest): Promise<FixGenOutput> {
+      const logger = await getModuleLogger();
+      // Lazy imports: keep E9 deps off the module import path + side-effect-free.
+      const { resolveLLMForSystem } = await import('../llm/system-resolver.js');
+      const { ModelRunner } = await import('../llm/model-runner.js');
+
+      // 1. E9 resolution chokepoint. Never throws (resolver contract).
+      const projectRoot = opts.projectRoot ?? request.repoContext.projectRoot;
+      const resolved = await resolveLLMForSystem(FIXGEN_SYSTEM, { projectRoot });
+      if (!resolved.sealedCredential && resolved.authType !== 'aws_sdk') {
+        return { kind: 'none', reason: 'no-credential-resolved' };
+      }
+
+      // 2. Materialize the plaintext ONLY at the wire boundary (E10), build a
+      //    clean descriptor, and construct the transport inside ModelRunner.
+      const apiKey = resolved.sealedCredential
+        ? (await resolved.sealedCredential.fetch()).value
+        : null;
+      const built = await ModelRunner.build({
+        provider: resolved.provider,
+        model: resolved.model,
+        credential: resolved.credential
+          ? {
+              provider: resolved.credential.provider,
+              apiKey,
+              source: resolved.credential.source,
+              authType: resolved.credential.authType,
+            }
+          : null,
+        source: resolved.source,
+        ...(resolved.credentialLabel !== undefined
+          ? { credentialLabel: resolved.credentialLabel }
+          : {}),
+        apiMode: resolved.apiMode,
+        baseUrl: resolved.baseUrl,
+        authType: resolved.authType,
+        ...(resolved.capabilities !== undefined ? { capabilities: resolved.capabilities } : {}),
+      });
+
+      // 3. ONE non-streaming completion. The system prompt is threaded onto the
+      //    request via `systemSuffix` (ConcreteSession maps it to
+      //    `TransportRequest.system`); the user turn carries the regression detail.
+      const { system, user } = buildFixGenPrompt(request);
+      try {
+        const response = await built.session.send([{ role: 'user', content: user }], {
+          systemSuffix: system,
+        });
+        const text = (response.content ?? '').trim();
+        if (text.length === 0 || text === 'NO_PATCH') {
+          return { kind: 'none', reason: 'model-declined' };
+        }
+        return { kind: 'patch', diff: stripCodeFences(text), model: response.model };
+      } catch (err) {
+        logger.warn(
+          { system: FIXGEN_SYSTEM, err: err instanceof Error ? err.message : String(err) },
+          'fix-gen LLM call failed — degrading to no-patch',
+        );
+        return { kind: 'none', reason: 'llm-call-failed' };
+      }
+    },
+  };
+}
+
+/**
+ * Strip a single surrounding markdown code fence (```diff … ```), if present, so a
+ * model that wraps its diff still yields an applyable patch. A bare diff passes
+ * through untouched.
+ *
+ * @param text - Candidate patch text (already trimmed).
+ * @returns The fence-stripped text.
+ */
+export function stripCodeFences(text: string): string {
+  const fence = /^```[a-z]*\n([\s\S]*?)\n```$/i;
+  const m = text.match(fence);
+  return m?.[1] !== undefined ? m[1].trim() : text;
+}

--- a/packages/core/src/selfimprove/run-loop.ts
+++ b/packages/core/src/selfimprove/run-loop.ts
@@ -17,8 +17,15 @@
  *   4. on a regression, **emit ONE DHQ** row via the leased
  *      {@link "./dhq-adapter.js".DhqAdapter} (UPSERT under
  *      `withWriterLease('project','bulk',…)`) — ONLY when `execute` is set;
+ *   4b. **generate a fix** ({@link "./fix-gen.js".generateFixPatch}, T11975) — ONLY
+ *      when `execute` AND `CLEO_PI_RUNNER_ENABLED=1`. Drives the LLM strictly via
+ *      the E9 chokepoint to produce a unified-diff patch at the path the egress
+ *      expects (`<cwd>/selfimprove-<scenario>.patch`). Degrades gracefully (no
+ *      patch ⇒ the egress guard skips the PR); the outcome is recorded back onto
+ *      the DHQ row. NEVER throws a rogue mutation, NEVER auto-merges;
  *   5. **open ONE DRAFT PR** ({@link "./draft-pr.js".openDraftPr}, dry-run unless
- *      `execute`) and record its URL back on the DHQ row.
+ *      `execute`) and record its URL back on the DHQ row — fires only when the
+ *      fix-gen stage wrote a patch file (the existing `existsSync` egress guard).
  *
  * Self-dogfooding guardrails (NON-NEGOTIABLE, P5 spec §B.7):
  *   - **Default OFF.** Mutation + egress require `opts.execute === true`. Without
@@ -30,8 +37,12 @@
  *   - **Budget caps** (in-code): `maxTokens` / `maxUsd` / `maxPrs = 1` /
  *     `maxWorktrees = 1`, checked PRE-FLIGHT before each costed step. `MemoryMax=32G`
  *     is an operational launch-wrapper, not an in-code cap.
- *   - **NO autonomous fix-gen, NO auto-merge, NO end-user mode in v1.** The loop
- *     surfaces regressions as DHQs + draft PRs; a human drives the fix.
+ *   - **Fix-gen is GATED + DRAFT-PR-ONLY (T11975).** The autonomous fix-generation
+ *     stage runs ONLY behind BOTH `execute` AND `CLEO_PI_RUNNER_ENABLED=1` (the
+ *     same gates guarding the rest of the loop). It produces a candidate patch via
+ *     the E9 LLM chokepoint and lets the EXISTING egress open a DRAFT PR — NEVER
+ *     an auto-merge, NEVER an end-user mode, NEVER a `main` push. A failed or empty
+ *     fix-gen degrades to "no patch" and the egress simply skips the PR.
  *
  * CORE-first: this engine lives in `core` and owns the `ReplayDispatch` port TYPE;
  * the cleo dispatch handler supplies the concrete adapter (dependency inversion —
@@ -56,8 +67,15 @@ import {
   type SelfImproveBudget,
 } from './budget.js';
 import { createDhqAdapter, type DhqAdapter } from './dhq-adapter.js';
-import { type DraftPrResult, openDraftPr } from './draft-pr.js';
+import { type CommandRunner, type DraftPrResult, openDraftPr } from './draft-pr.js';
 import { computeQuestionHash, type DiffEntry, diffEnvelopes } from './envelope-diff.js';
+import {
+  createLlmFixGenerator,
+  type FixGenerator,
+  type FixGenResult,
+  fixPatchPath,
+  generateFixPatch,
+} from './fix-gen.js';
 import { type ReplayDispatch, replayScenario } from './replay.js';
 import { type LoadedScenario, loadScenario } from './scenario.js';
 
@@ -100,6 +118,27 @@ export interface RunSelfImproveOptions {
   readonly gateRedCheck?: () => Promise<boolean>;
   /** Test seam: inject a DHQ adapter (defaults to the real leased adapter). */
   readonly adapter?: DhqAdapter;
+  /**
+   * Test seam: inject the fix generator (the LLM dependency). Defaults to the real
+   * {@link "./fix-gen.js".createLlmFixGenerator} backed by the E9 chokepoint — unit
+   * tests inject a deterministic fake returning a canned patch so NO real LLM is
+   * reached. The fix-gen stage only runs when BOTH `execute` is set AND the
+   * Pi-runner gate (`CLEO_PI_RUNNER_ENABLED=1`) is on, unless `piRunnerEnabled` is
+   * supplied (test seam) to override the env read.
+   */
+  readonly fixGenerator?: FixGenerator;
+  /**
+   * Test seam: override the `CLEO_PI_RUNNER_ENABLED` env gate that arms fix-gen.
+   * Defaults to `process.env.CLEO_PI_RUNNER_ENABLED === '1'`. Supplied explicitly
+   * by tests so the deterministic fake runs without mutating process env.
+   */
+  readonly piRunnerEnabled?: boolean;
+  /**
+   * Test seam: inject the draft-PR egress command runner (captures the git/gh
+   * shell-out). Defaults to the real `execFileSync`-backed runner. Supplied by
+   * tests so the capstone proves the egress WITHOUT a real `gh`/`git` invocation.
+   */
+  readonly draftPrRun?: CommandRunner;
   /** Test seam: inject the guard backing the in-process fallback env. */
   readonly guard?: ToolGuard;
   /** Test seam: inject the run id (defaults to a timestamped id). */
@@ -135,6 +174,13 @@ export interface SelfImproveResult {
   readonly questionHash: string | null;
   /** The draft-PR egress result, or `null` when none fired (green / dry-run-no-egress). */
   readonly draftPr: DraftPrResult | null;
+  /**
+   * The fix-generation outcome (T11975), or `null` when the stage did not run
+   * (green run, dry-run, gate off, or breaker tripped before persist). `'written'`
+   * means a candidate patch was produced and the egress was armed; `'skipped'`
+   * means fix-gen degraded gracefully (no patch ⇒ no PR).
+   */
+  readonly fixGen: FixGenResult | null;
   /** The final circuit-breaker state. */
   readonly breaker: CircuitBreakerState;
 }
@@ -193,6 +239,7 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
     regressions,
     questionHash,
     draftPr: null,
+    fixGen: null,
     breaker: breaker.state,
   });
 
@@ -230,6 +277,7 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
         regressions: [],
         questionHash: null,
         draftPr: null,
+        fixGen: null,
         breaker: breaker.state,
       };
     }
@@ -260,17 +308,20 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
         regressions: diff.regressions,
         questionHash,
         draftPr: null,
+        fixGen: null,
         breaker: breaker.state,
       };
     }
 
     // ── 4. emit ONE leased DHQ (require-mode lease throw ⇒ breaker trip) ────────
+    const dhqId = `DHQ-${questionHash.slice(0, 8)}`;
+    const dhqTitle = `selfimprove regression in '${opts.scenario}' (${diff.regressions.length} path(s))`;
     try {
       await adapter.upsertOpenDhq({
-        dhqId: `DHQ-${questionHash.slice(0, 8)}`,
+        dhqId,
         scenario: opts.scenario,
         questionHash,
-        title: `selfimprove regression in '${opts.scenario}' (${diff.regressions.length} path(s))`,
+        title: dhqTitle,
         regressionJson: JSON.stringify(diff),
         severity: null,
         runId,
@@ -288,17 +339,76 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
       );
     }
 
+    // ── 4b. AUTONOMOUS FIX-GENERATION (T11975) — gated, DRAFT-PR-ONLY ───────────
+    // Runs ONLY behind BOTH `execute` AND the Pi-runner gate. Produces a candidate
+    // unified-diff patch via the E9 LLM chokepoint at the exact path the egress
+    // below `existsSync`-checks. Degrades gracefully (no patch ⇒ the egress guard
+    // skips the PR) and NEVER throws a rogue mutation. The outcome is folded back
+    // onto the DHQ row (refresh-UPSERT — same leased, idempotent path).
+    const piRunnerEnabled = opts.piRunnerEnabled ?? process.env.CLEO_PI_RUNNER_ENABLED === '1';
+    let fixGen: FixGenResult | null = null;
+    if (piRunnerEnabled) {
+      const generator = opts.fixGenerator ?? createLlmFixGenerator({ projectRoot: workspaceRoot });
+      fixGen = await generateFixPatch({
+        request: {
+          dhqId,
+          scenario: opts.scenario,
+          questionHash,
+          regressions: diff.regressions,
+          repoContext: {
+            projectRoot: workspaceRoot,
+            summary: loaded.scenario.description,
+          },
+        },
+        generator,
+        ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+        logger,
+      });
+      // Record the fix-gen outcome back onto the open DHQ row (leased, idempotent).
+      // A throw here trips the breaker exactly like the initial emit (lease-denial).
+      try {
+        await adapter.upsertOpenDhq({
+          dhqId,
+          scenario: opts.scenario,
+          questionHash,
+          title: dhqTitle,
+          regressionJson: JSON.stringify({ diff, fixGen }),
+          severity: null,
+          runId,
+        });
+      } catch (err) {
+        return tripFromError(
+          breaker,
+          err,
+          logger,
+          opts.scenario,
+          runId,
+          execute,
+          diff.regressions,
+          questionHash,
+        );
+      }
+    } else {
+      logger.info(
+        { scenario: opts.scenario, runId },
+        'self-improve fix-gen SKIPPED (CLEO_PI_RUNNER_ENABLED!=1) — DHQ emitted, no patch generated',
+      );
+    }
+
     // ── 5. open ONE DRAFT PR (counts against maxPrs=1) + record url back ────────
     let draftPr: DraftPrResult | null = null;
     try {
       breaker.chargeOrTrip({ prs: 1 });
       draftPr = await openDraftPr({
         scenario: opts.scenario,
-        diffPath: `selfimprove-${opts.scenario}.patch`,
+        // SAME path fix-gen writes to (sanitized, resolved against cwd) so the
+        // egress `existsSync` guard finds exactly the file 4b produced.
+        diffPath: fixPatchPath(opts.scenario, opts.cwd),
         title: `fix(selfimprove): ${opts.scenario} regression`,
         body: `Auto-detected regression in the \`${opts.scenario}\` dogfood scenario (run ${runId}).`,
         execute,
         ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+        ...(opts.draftPrRun !== undefined ? { run: opts.draftPrRun } : {}),
       });
       if (draftPr.kind === 'ok') {
         await adapter.recordPrUrl(questionHash, draftPr.prUrl);
@@ -324,6 +434,7 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
       regressions: diff.regressions,
       questionHash,
       draftPr,
+      fixGen,
       breaker: breaker.state,
     };
   } finally {
@@ -368,6 +479,7 @@ function tripFromError(
     regressions,
     questionHash,
     draftPr: null,
+    fixGen: null,
     breaker: breaker.state,
   };
 }


### PR DESCRIPTION
## What

Closes the autonomous self-improvement pipeline by adding the **fix-GENERATION** stage the v1 loop explicitly stubbed out (`run-loop.ts`: "NO autonomous fix-gen in v1"). A detected regression now becomes an **LLM-generated unified-diff patch** that feeds the existing DRAFT-PR egress — so the loop mechanically closes `regression → leased DHQ → fix → draft PR`.

Task: **T11975** (parent epic T11889).

## Design

New `packages/core/src/selfimprove/fix-gen.ts`:
- **`FixGenerator` seam** — injectable LLM port (CORE owns the type). Real impl `createLlmFixGenerator()` resolves its model **ONLY via the E9 chokepoint** (`resolveLLMForSystem('task-executor')` → `ModelRunner.build` → `session.send`). NO raw provider client, NO `*_API_KEY` env read, NO hardcoded model id (Gate-13 clean). Plaintext token materialized only at the wire boundary (E10).
- **`generateFixPatch()`** — validates the LLM output is a unified diff (`looksLikeUnifiedDiff`), strips code fences, writes it to the egress-expected path `<cwd>/selfimprove-<scenario>.patch`, and returns a typed `FixGenResult`.

Wired into `run-loop.ts` **AFTER** the leased-DHQ emit and **BEFORE** `openDraftPr`. The outcome is recorded back onto the leased DHQ row (same idempotent `(project,bulk)`-leased path). The egress now resolves the SAME sanitized patch path fix-gen writes, so the `existsSync` guard finds exactly the produced file.

## Safety gates preserved (default-OFF posture unchanged)

- **Gated behind BOTH `--execute` AND `CLEO_PI_RUNNER_ENABLED=1`** — the same gates already guarding the loop. With either off, fix-gen never runs.
- **Draft-PR-ONLY, never auto-merge, never a `main` push** — this stage produces a PATCH FILE only; the existing egress always opens a `--draft` PR on a feature branch.
- **Graceful degrade, never a rogue mutation** — no credential / LLM error / empty / non-diff output → `{kind:'skipped'}`, NO file written, NO throw → the existing `existsSync` egress guard simply skips the PR. The skip reason is recorded on the DHQ evidence.
- Circuit-breaker, budget caps (`maxPrs=1`/`maxWorktrees=1`), and the leased DHQ write are all untouched.

## Test approach (deterministic, no real LLM)

`__tests__/fix-gen.test.ts` (10 cases): pure helpers + `generateFixPatch` degrade paths (none / non-diff / throw → skipped, no file) + the **CAPSTONE** run-loop integration — regression replay → leased DHQ (real temp DB) → **deterministic FAKE fix-gen writes the patch** → egress opens a **DRAFT PR** (git/gh fully mocked via the injected `draftPrRun` runner; asserts `--draft`, `--base`, NO `push main`) → DHQ row records the `written` outcome. A complementary GATE-OFF case proves: no patch written + egress no-patch skip. NO real LLM is reached.

## Gates

- `biome ci .` — 0/0 (3780 files)
- `pnpm run build` — success
- `pnpm run typecheck` (full) — exit 0
- `pnpm --filter @cleocode/core run test` (full) — selfimprove suites all green; only the documented pre-existing `worktree-*`/`audit` git-env failures remain
- `cleo check arch` — 6/6 pass
- LLM chokepoint guard (Gate-13) — baseline unchanged (no new violations)

## Live demo (honest)

Ran one real pass (`CLEO_PI_RUNNER_ENABLED=1 … selfimprove run --scenario dhq-replay-find --execute --backend in-process`). The pipeline **mechanically closed end-to-end**: regression detected → leased DHQ emitted → **fix-gen reached the LLM via the E9 chokepoint** (`subsystem: selfimprove-fix-gen`, `system: task-executor`). The live anthropic `oauth-login` cred returned `400 status code (no body)`, so fix-gen **degraded gracefully** (`fixGen: {kind:'skipped', reason:'fixgen-none:llm-call-failed'}`) → no patch → egress correctly skipped the PR (`draftPr.code: E_NOT_FOUND`), breaker stayed CLOSED. So **no draft PR opened in the live run** — but every wire connected and the degrade path behaved exactly as designed. The deterministic test proves the success path (patch written → draft PR opened). No PR was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)