### PR TITLE
fix(T11984): postinstall respects operator daemon state (+ daemon.autoStart opt-out)

### DIFF
--- a/.changeset/t11984-postinstall-operator-state.md
+++ b/.changeset/t11984-postinstall-operator-state.md
@@ -1,0 +1,38 @@
+---
+id: t11984-postinstall-operator-state
+tasks: [T11984]
+kind: fix
+summary: "postinstall respects operator daemon state — no silent re-enable on upgrade"
+---
+
+Fixes the footgun where `npm install -g @cleocode/cleo` (upgrade) unconditionally
+ran `systemctl --user enable --now cleo-daemon`, silently resurrecting a service the
+operator had deliberately disabled.
+
+**Root cause** (`packages/cleo/scripts/install-daemon-service.mjs` line ~432):
+`installSystemd()` called `systemctl --user enable --now cleo-daemon` with no check
+of the existing enabled/disabled state. The only escape was `CLEO_DAEMON_DISABLE=1`,
+which is not persisted and must be set on every upgrade.
+
+**Changes:**
+
+- Extracted a pure `decideDaemonAction({ firstInstall, isEnabledState, autoStartConfig, envDisable })` helper (exported for testing) that implements the operator-state decision table — no I/O, no side-effects.
+- `installSystemd()` now calls `systemctl --user is-enabled cleo-daemon` before deciding whether to enable. On upgrade with state `disabled` or `masked`: prints a one-line notice and exits without enabling. On upgrade with state `enabled`: restarts only if the unit content changed. On first install: current behaviour (enable + start).
+- `installLaunchd()` receives the same treatment: checks whether the plist existed before this run and whether the agent is loaded (`launchctl list`); honors the operator's prior `launchctl bootout` on upgrade.
+- Added `DaemonConfig` type (`packages/contracts/src/config.ts`) and `daemon?: DaemonConfig` field on `CleoConfig`. `daemon.autoStart = false` (set in `~/.local/share/cleo/config.json`) is a persistent opt-out that survives all future upgrades — postinstall never enables or starts regardless of first-install vs upgrade.
+- Added `readGlobalAutoStart()` in the installer script — a minimal tolerant JSON read that does not require compiled core.
+- Added drop-in documentation comment in `buildSystemdUnit()` explaining that a `~/.config/systemd/user/cleo-daemon.service.d/10-memory-cap.conf` drop-in overrides the unit's `MemoryMax=2G` and that re-running postinstall never removes drop-ins.
+- `CLEO_DAEMON_DISABLE=1` continues to work as before (highest priority, per-session override).
+- Added 17 table-driven vitest cases for `decideDaemonAction` covering all decision-table rows.
+
+**Decision table:**
+
+| firstInstall | isEnabledState    | autoStartConfig | envDisable | action             |
+|:------------:|:-----------------:|:---------------:|:----------:|:------------------ |
+| any          | any               | any             | true       | skip               |
+| any          | any               | false           | false      | skip               |
+| true         | not-found / other | true            | false      | enable-and-start   |
+| false        | enabled           | true            | false      | restart-if-changed |
+| false        | disabled          | true            | false      | leave-disabled     |
+| false        | masked            | true            | false      | leave-disabled     |
+| false        | other / unknown   | true            | false      | enable-and-start   |

--- a/packages/cleo/scripts/install-daemon-service.mjs
+++ b/packages/cleo/scripts/install-daemon-service.mjs
@@ -229,7 +229,26 @@ function isWSL() {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Environment variable that disables daemon auto-start (CI/container path). */
+/**
+ * Environment variable that disables daemon auto-start for the duration of a
+ * single install invocation (CI/container path).
+ *
+ * Unlike `daemon.autoStart = false` in the global config, this env var is NOT
+ * persisted — it must be set on every install invocation. For a durable
+ * opt-out that survives upgrades, set `daemon.autoStart = false` in the CLEO
+ * global config file (printed path: `~/.local/share/cleo/config.json` on
+ * Linux / `~/Library/Application Support/cleo/config.json` on macOS):
+ *
+ *   ```json
+ *   { "daemon": { "autoStart": false } }
+ *   ```
+ *
+ * Priority (highest wins):
+ *   1. CLEO_DAEMON_DISABLE=1        — env override (non-persistent; CI/container)
+ *   2. daemon.autoStart === false   — config-file opt-out (persistent across upgrades)
+ *   3. systemd/launchd enabled state — operator's prior `disable` is respected on upgrade
+ *   4. Default: enable+start on first install; keep-enabled on upgrade where enabled
+ */
 const DAEMON_DISABLE_ENV = 'CLEO_DAEMON_DISABLE';
 
 /**
@@ -309,6 +328,112 @@ function runBin(bin, args) {
 }
 
 // ---------------------------------------------------------------------------
+// Config helpers — daemon.autoStart persistent opt-out (T11984)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read `daemon.autoStart` from the CLEO global config file.
+ *
+ * This is a minimal, tolerant JSON read — it does NOT import compiled core
+ * because postinstall runs before the package's own TypeScript is compiled.
+ * If the config file is absent, unreadable, or missing the key, returns
+ * `true` (the safe default: honour existing enable/start logic).
+ *
+ * Config file location: `{cleoHome}/config.json`
+ *   Linux:  ~/.local/share/cleo/config.json
+ *   macOS:  ~/Library/Application Support/cleo/config.json
+ *   Windows: %LOCALAPPDATA%\cleo\Data\config.json
+ *
+ * @returns {boolean} `false` only when `daemon.autoStart` is explicitly set
+ *   to `false` in the global config. Returns `true` in all other cases.
+ */
+function readGlobalAutoStart() {
+  try {
+    const paths = getPlatformPaths();
+    const configPath = join(paths.data, 'config.json');
+    if (!existsSync(configPath)) return true;
+    const raw = readFileSync(configPath, 'utf8');
+    const cfg = JSON.parse(raw);
+    // Explicit false opt-out only — missing key = default true.
+    if (
+      cfg !== null &&
+      typeof cfg === 'object' &&
+      typeof cfg.daemon === 'object' &&
+      cfg.daemon !== null &&
+      cfg.daemon.autoStart === false
+    ) {
+      return false;
+    }
+    return true;
+  } catch {
+    // Config unreadable or malformed JSON — safe default: allow auto-start.
+    return true;
+  }
+}
+
+/**
+ * Decide what action the postinstall hook should take for daemon activation.
+ *
+ * This is a pure function (no side-effects, no I/O) that implements the
+ * operator-state-respecting decision table. It can be unit-tested in
+ * isolation without systemd or launchd being present.
+ *
+ * Decision table:
+ *
+ * | firstInstall | isEnabledState     | autoStartConfig | envDisable | action              |
+ * |:------------:|:------------------:|:---------------:|:----------:|:--------------------|
+ * | any          | any                | any             | true       | 'skip'              |
+ * | any          | any                | false           | false      | 'skip'              |
+ * | true         | 'not-found'/other  | true            | false      | 'enable-and-start'  |
+ * | false        | 'enabled'          | true            | false      | 'restart-if-changed'|
+ * | false        | 'disabled'         | true            | false      | 'leave-disabled'    |
+ * | false        | 'masked'           | true            | false      | 'leave-disabled'    |
+ * | false        | other/unknown      | true            | false      | 'enable-and-start'  |
+ *
+ * @param {object} opts
+ * @param {boolean} opts.firstInstall   - True when the unit/plist file did not
+ *   exist before this postinstall run (i.e. `writeIfChanged` wrote a new file).
+ * @param {string}  opts.isEnabledState - Output of `systemctl --user is-enabled
+ *   <unit>` (or equivalent), e.g. 'enabled', 'disabled', 'masked',
+ *   'not-found', 'static', 'indirect', ''. On macOS use 'not-found' for a
+ *   missing plist and 'enabled' for a loaded agent.
+ * @param {boolean} opts.autoStartConfig - Value of `daemon.autoStart` from the
+ *   global config (via `readGlobalAutoStart()`). Default: true.
+ * @param {boolean} opts.envDisable     - Whether `CLEO_DAEMON_DISABLE=1` is set.
+ *
+ * @returns {'enable-and-start' | 'restart-if-changed' | 'leave-disabled' | 'skip'}
+ *
+ * @task T11984
+ */
+export function decideDaemonAction({ firstInstall, isEnabledState, autoStartConfig, envDisable }) {
+  // Highest priority: env override or persistent config opt-out.
+  if (envDisable || autoStartConfig === false) {
+    return 'skip';
+  }
+
+  // First install (unit file did not previously exist): safe to enable+start.
+  if (firstInstall) {
+    return 'enable-and-start';
+  }
+
+  // Upgrade path: inspect the current enabled state.
+  const state = (isEnabledState ?? '').trim().toLowerCase();
+
+  if (state === 'disabled' || state === 'masked') {
+    // Operator explicitly disabled the unit — honour that decision.
+    return 'leave-disabled';
+  }
+
+  if (state === 'enabled') {
+    // Already enabled; only restart if the unit content changed (handled by caller).
+    return 'restart-if-changed';
+  }
+
+  // Unknown / 'not-found' / 'static' / 'indirect' / empty — treat as first-like install.
+  return 'enable-and-start';
+}
+
+// ---------------------------------------------------------------------------
 // Linux — systemd user unit
 // ---------------------------------------------------------------------------
 
@@ -375,8 +500,20 @@ function buildSystemdUnit(cleoExec, scope) {
   //     OOM-killed. systemd now stops restarting after 5 failures in 60 s.
   //   - NODE_OPTIONS=--max-old-space-size: a runaway daemon tick throws a
   //     recoverable single-process JS heap OOM instead of growing unbounded.
-  //   - MemoryMax: best-effort soft cgroup ceiling (enforced only when the user
-  //     manager has memory-cgroup delegation; harmless otherwise).
+  //   - MemoryMax=2G: best-effort soft cgroup ceiling (enforced only when the
+  //     user manager has memory-cgroup delegation; harmless otherwise).
+  //
+  // Drop-in overrides (T11984 / DHQ-D):
+  //   Operators may tighten MemoryMax — or any other [Service] directive —
+  //   by placing a drop-in file at:
+  //     ~/.config/systemd/user/cleo-daemon.service.d/10-memory-cap.conf
+  //   Example content:
+  //     [Service]
+  //     MemoryHigh=768M
+  //     MemoryMax=1G
+  //   A drop-in's directives override the unit's values; re-running postinstall
+  //   rewrites the BASE unit file but does NOT touch or remove any drop-ins.
+  //   Run `systemctl --user daemon-reload` after adding/changing a drop-in.
   return `[Unit]
 Description=${description}
 Documentation=https://github.com/kryptobaseddev/cleocode
@@ -403,12 +540,19 @@ WantedBy=default.target
 /**
  * Install and optionally activate the systemd user unit.
  *
+ * Respects operator state (T11984): if the unit already exists and is
+ * currently disabled or masked, the postinstall hook does NOT re-enable it.
+ * The operator's explicit `systemctl --user disable cleo-daemon` survives
+ * upgrades. See `decideDaemonAction` for the full decision table.
+ *
  * @param {string} cleoExec - Absolute path to the `cleo` binary.
  * @param {{ scopeSagaId?: string; scopeEpicId?: string }} [scope] - Optional scope filter (T11497 AC3).
  */
 function installSystemd(cleoExec, scope) {
   const unitFile = getSystemdUnitFile();
   const unit = buildSystemdUnit(cleoExec, scope);
+  // firstInstall = true when the file did NOT exist before this write.
+  const fileExistedBefore = existsSync(unitFile);
   const written = writeIfChanged(unitFile, unit);
 
   if (written) {
@@ -422,14 +566,54 @@ function installSystemd(cleoExec, scope) {
     console.log('CLEO: systemd unit already up-to-date — skipping write.');
   }
 
-  if (process.env[DAEMON_DISABLE_ENV] === '1') {
+  // Determine the operator's current enabled state (needed for upgrade path).
+  const isEnabledResult = runBin('systemctl', ['--user', 'is-enabled', SYSTEMD_UNIT_NAME]);
+  const isEnabledState = isEnabledResult.output.trim();
+
+  const action = decideDaemonAction({
+    firstInstall: !fileExistedBefore,
+    isEnabledState,
+    autoStartConfig: readGlobalAutoStart(),
+    envDisable: process.env[DAEMON_DISABLE_ENV] === '1',
+  });
+
+  if (action === 'skip') {
+    const reason = process.env[DAEMON_DISABLE_ENV] === '1'
+      ? `${DAEMON_DISABLE_ENV}=1 (CI/container path)`
+      : 'daemon.autoStart=false in global config';
     console.log(
-      `CLEO: ${DAEMON_DISABLE_ENV}=1 — unit written but activation skipped (CI/container path).`,
+      `CLEO: Unit written but activation skipped (${reason}).`,
     );
+    console.log("CLEO: To enable later: run 'cleo daemon enable' or 'systemctl --user enable --now cleo-daemon'");
     return;
   }
 
-  // Enable + start the service.
+  if (action === 'leave-disabled') {
+    console.log(
+      `CLEO: cleo-daemon left ${isEnabledState} (operator state respected — skipping re-enable).`,
+    );
+    console.log("CLEO: To re-enable: run 'cleo daemon enable' or 'systemctl --user enable --now cleo-daemon'");
+    return;
+  }
+
+  if (action === 'restart-if-changed') {
+    if (written) {
+      // Unit content changed on an already-enabled service — restart to pick up changes.
+      const restart = runBin('systemctl', ['--user', 'restart', SYSTEMD_UNIT_NAME]);
+      if (restart.ok) {
+        console.log('CLEO: systemd user service restarted (unit updated).');
+      } else {
+        console.log(
+          `CLEO: systemctl restart skipped (${restart.output || 'systemctl unavailable'}).`,
+        );
+      }
+    } else {
+      console.log('CLEO: systemd unit unchanged and already enabled — no restart needed.');
+    }
+    return;
+  }
+
+  // action === 'enable-and-start': first install or unknown prior state.
   const enable = runBin('systemctl', ['--user', 'enable', '--now', SYSTEMD_UNIT_NAME]);
   if (enable.ok) {
     console.log('CLEO: systemd user service enabled and started.');
@@ -541,7 +725,29 @@ function buildLaunchdPlist(cleoExec, scope) {
 }
 
 /**
+ * Check whether the launchd agent is currently loaded (macOS).
+ *
+ * Uses `launchctl list <label>` — exit 0 with output = loaded; non-zero or
+ * empty = not loaded (disabled / never loaded).
+ *
+ * @returns {'enabled' | 'disabled' | 'not-found'} Launchd agent state.
+ */
+function getLaunchdEnabledState() {
+  const result = runBin('launchctl', ['list', LAUNCHD_PLIST_LABEL]);
+  if (result.ok && result.output.trim()) {
+    return 'enabled';
+  }
+  // Non-zero means 'not in the service manager' — treat same as 'disabled'.
+  return 'disabled';
+}
+
+/**
  * Install and optionally load the launchd plist.
+ *
+ * Respects operator state (T11984): if the plist already exists and the agent
+ * is NOT currently loaded, the postinstall hook does NOT reload it. The
+ * operator's explicit `launchctl bootout` survives upgrades. See
+ * `decideDaemonAction` for the full decision table.
  *
  * @param {string} cleoExec - Absolute path to the `cleo` binary.
  * @param {{ scopeSagaId?: string; scopeEpicId?: string }} [scope] - Optional scope filter (T11497 AC3).
@@ -549,6 +755,8 @@ function buildLaunchdPlist(cleoExec, scope) {
 function installLaunchd(cleoExec, scope) {
   const plistFile = getLaunchdPlistFile();
   const plist = buildLaunchdPlist(cleoExec, scope);
+  // firstInstall = true when the file did NOT exist before this write.
+  const fileExistedBefore = existsSync(plistFile);
   const written = writeIfChanged(plistFile, plist);
 
   if (written) {
@@ -557,14 +765,55 @@ function installLaunchd(cleoExec, scope) {
     console.log('CLEO: launchd plist already up-to-date — skipping write.');
   }
 
-  if (process.env[DAEMON_DISABLE_ENV] === '1') {
+  // Determine the operator's current loaded state (needed for upgrade path).
+  const isEnabledState = fileExistedBefore ? getLaunchdEnabledState() : 'not-found';
+
+  const action = decideDaemonAction({
+    firstInstall: !fileExistedBefore,
+    isEnabledState,
+    autoStartConfig: readGlobalAutoStart(),
+    envDisable: process.env[DAEMON_DISABLE_ENV] === '1',
+  });
+
+  if (action === 'skip') {
+    const reason = process.env[DAEMON_DISABLE_ENV] === '1'
+      ? `${DAEMON_DISABLE_ENV}=1 (CI/container path)`
+      : 'daemon.autoStart=false in global config';
     console.log(
-      `CLEO: ${DAEMON_DISABLE_ENV}=1 — plist written but activation skipped (CI/container path).`,
+      `CLEO: Plist written but activation skipped (${reason}).`,
     );
+    console.log(`CLEO: To enable later: launchctl load "${plistFile}"`);
     return;
   }
 
-  // Try bootstrap (macOS 10.13+) first; fall back to legacy launchctl load.
+  if (action === 'leave-disabled') {
+    console.log(
+      'CLEO: cleo-daemon launchd agent left unloaded (operator state respected — skipping re-load).',
+    );
+    console.log(`CLEO: To re-enable: launchctl load "${plistFile}"`);
+    return;
+  }
+
+  if (action === 'restart-if-changed') {
+    const uid = process.getuid ? String(process.getuid()) : '';
+    if (written && uid) {
+      // Plist content changed on an already-loaded agent — reload to pick up changes.
+      runBin('launchctl', ['bootout', `gui/${uid}`, plistFile]);
+      const reload = runBin('launchctl', ['bootstrap', `gui/${uid}`, plistFile]);
+      if (reload.ok) {
+        console.log(`CLEO: launchd agent reloaded (plist updated, gui/${uid}).`);
+      } else {
+        console.log(
+          `CLEO: launchctl reload skipped (${reload.output || 'launchctl unavailable'}).`,
+        );
+      }
+    } else {
+      console.log('CLEO: launchd plist unchanged and already loaded — no reload needed.');
+    }
+    return;
+  }
+
+  // action === 'enable-and-start': first install or unknown prior state.
   const uid = process.getuid ? String(process.getuid()) : '';
   if (uid) {
     const bootstrap = runBin('launchctl', [

--- a/packages/cleo/src/cli/__tests__/daemon-service.test.ts
+++ b/packages/cleo/src/cli/__tests__/daemon-service.test.ts
@@ -124,6 +124,155 @@ describe('uninstallDaemonService — typed result', () => {
 });
 
 // ---------------------------------------------------------------------------
+// T11984 — decideDaemonAction decision table (pure function, no I/O)
+// ---------------------------------------------------------------------------
+
+describe('decideDaemonAction — decision table (T11984)', () => {
+  type Params = {
+    firstInstall: boolean;
+    isEnabledState: string;
+    autoStartConfig: boolean;
+    envDisable: boolean;
+  };
+  type Action = 'enable-and-start' | 'restart-if-changed' | 'leave-disabled' | 'skip';
+
+  const cases: Array<[string, Params, Action]> = [
+    // CLEO_DAEMON_DISABLE=1 always wins (skip), regardless of everything else
+    [
+      'envDisable=true → skip (first install)',
+      { firstInstall: true, isEnabledState: 'not-found', autoStartConfig: true, envDisable: true },
+      'skip',
+    ],
+    [
+      'envDisable=true → skip (upgrade, enabled)',
+      { firstInstall: false, isEnabledState: 'enabled', autoStartConfig: true, envDisable: true },
+      'skip',
+    ],
+    [
+      'envDisable=true → skip (upgrade, disabled)',
+      { firstInstall: false, isEnabledState: 'disabled', autoStartConfig: true, envDisable: true },
+      'skip',
+    ],
+    // autoStartConfig=false always wins (skip), regardless of enabled state
+    [
+      'autoStartConfig=false → skip (first install)',
+      {
+        firstInstall: true,
+        isEnabledState: 'not-found',
+        autoStartConfig: false,
+        envDisable: false,
+      },
+      'skip',
+    ],
+    [
+      'autoStartConfig=false → skip (upgrade, enabled)',
+      { firstInstall: false, isEnabledState: 'enabled', autoStartConfig: false, envDisable: false },
+      'skip',
+    ],
+    [
+      'autoStartConfig=false → skip (upgrade, disabled)',
+      {
+        firstInstall: false,
+        isEnabledState: 'disabled',
+        autoStartConfig: false,
+        envDisable: false,
+      },
+      'skip',
+    ],
+    // First install (unit did not exist before): enable+start
+    [
+      'first install, not-found → enable-and-start',
+      { firstInstall: true, isEnabledState: 'not-found', autoStartConfig: true, envDisable: false },
+      'enable-and-start',
+    ],
+    [
+      'first install, empty state → enable-and-start',
+      { firstInstall: true, isEnabledState: '', autoStartConfig: true, envDisable: false },
+      'enable-and-start',
+    ],
+    // Upgrade, operator previously enabled: restart if content changed
+    [
+      'upgrade, enabled → restart-if-changed',
+      { firstInstall: false, isEnabledState: 'enabled', autoStartConfig: true, envDisable: false },
+      'restart-if-changed',
+    ],
+    // Upgrade, operator explicitly disabled: leave-disabled (respect intent)
+    [
+      'upgrade, disabled → leave-disabled',
+      { firstInstall: false, isEnabledState: 'disabled', autoStartConfig: true, envDisable: false },
+      'leave-disabled',
+    ],
+    [
+      'upgrade, masked → leave-disabled',
+      { firstInstall: false, isEnabledState: 'masked', autoStartConfig: true, envDisable: false },
+      'leave-disabled',
+    ],
+    // Upgrade, unknown/other states: treat as first-like install
+    [
+      'upgrade, static → enable-and-start',
+      { firstInstall: false, isEnabledState: 'static', autoStartConfig: true, envDisable: false },
+      'enable-and-start',
+    ],
+    [
+      'upgrade, indirect → enable-and-start',
+      { firstInstall: false, isEnabledState: 'indirect', autoStartConfig: true, envDisable: false },
+      'enable-and-start',
+    ],
+    [
+      'upgrade, not-found → enable-and-start',
+      {
+        firstInstall: false,
+        isEnabledState: 'not-found',
+        autoStartConfig: true,
+        envDisable: false,
+      },
+      'enable-and-start',
+    ],
+    [
+      'upgrade, empty state → enable-and-start',
+      { firstInstall: false, isEnabledState: '', autoStartConfig: true, envDisable: false },
+      'enable-and-start',
+    ],
+  ];
+
+  it.each(cases)('%s', async (_, params, expected) => {
+    const mod = await import(resolveInstallerScript());
+    expect(mod.decideDaemonAction(params)).toBe(expected);
+  });
+
+  it('envDisable beats autoStartConfig=false (both skip, env reason wins)', async () => {
+    const mod = await import(resolveInstallerScript());
+    const result = mod.decideDaemonAction({
+      firstInstall: true,
+      isEnabledState: 'not-found',
+      autoStartConfig: false,
+      envDisable: true,
+    });
+    expect(result).toBe('skip');
+  });
+
+  it('isEnabledState comparison is case-insensitive', async () => {
+    const mod = await import(resolveInstallerScript());
+    expect(
+      mod.decideDaemonAction({
+        firstInstall: false,
+        isEnabledState: 'DISABLED',
+        autoStartConfig: true,
+        envDisable: false,
+      }),
+    ).toBe('leave-disabled');
+    expect(
+      mod.decideDaemonAction({
+        firstInstall: false,
+        isEnabledState: 'ENABLED',
+        autoStartConfig: true,
+        envDisable: false,
+      }),
+    ).toBe('restart-if-changed');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // T11497 E5-HEADLESS AC3 — saga-scoped installDaemonService
 // ---------------------------------------------------------------------------
 

--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -751,6 +751,37 @@ export interface LeadRollupConfig {
   mode?: LeadRollupMode;
 }
 
+/**
+ * Daemon lifecycle configuration.
+ *
+ * Controls whether the postinstall hook is allowed to auto-enable and start
+ * the cleo-daemon service. When `autoStart` is `false`, postinstall NEVER
+ * enables or starts the service — even on a fresh install. This flag persists
+ * across upgrades so the operator's intent survives `npm install -g`.
+ *
+ * Configure via `~/.local/share/cleo/config.json` (global config):
+ * ```json
+ * { "daemon": { "autoStart": false } }
+ * ```
+ * Or via env var override: `CLEO_DAEMON_DISABLE=1` (per-session, non-persistent).
+ *
+ * @task T11984
+ */
+export interface DaemonConfig {
+  /**
+   * Whether the postinstall hook may auto-enable and start the cleo-daemon.
+   *
+   * - `true` (default): first install enables+starts; upgrade respects the
+   *   current systemd/launchd enabled state.
+   * - `false`: postinstall NEVER enables or starts the daemon. The unit file
+   *   is still written so the operator can activate later via
+   *   `cleo daemon enable`.
+   *
+   * @defaultValue true
+   */
+  autoStart: boolean;
+}
+
 /** CLEO project configuration (config.json). */
 export interface CleoConfig {
   /** Configuration schema version string. */
@@ -838,6 +869,17 @@ export interface CleoConfig {
    * @saga T10377
    */
   leadRollup?: LeadRollupConfig;
+  /**
+   * Daemon lifecycle settings.
+   *
+   * When absent, defaults to `{ autoStart: true }` — matching the legacy
+   * install behaviour. Set `autoStart: false` to prevent postinstall from
+   * ever enabling or starting the cleo-daemon (persistent opt-out).
+   *
+   * @defaultValue undefined (treated as { autoStart: true })
+   * @task T11984
+   */
+  daemon?: DaemonConfig;
 }
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -261,6 +261,7 @@ export type {
   ClaudeSpawnMode,
   CleoConfig,
   ConfigSource,
+  DaemonConfig,
   DateFormat,
   DecisionsConfig,
   DepsRequiredAt,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -129,6 +129,12 @@ const DEFAULTS: CleoConfig = {
   leadRollup: {
     mode: 'passive',
   },
+  // T11984: daemon lifecycle — postinstall respects operator state by default.
+  // Set daemon.autoStart = false (via global config.json) for a persistent
+  // opt-out that survives npm upgrades.
+  daemon: {
+    autoStart: true,
+  },
 };
 
 /** Environment variable to config path mapping. */


### PR DESCRIPTION
## Summary

- **Footgun fixed**: `install-daemon-service.mjs` line ~432 called `systemctl --user enable --now cleo-daemon` unconditionally on every `npm install -g @cleocode/cleo`, silently resurrecting a service the operator had deliberately disabled. Now it checks the operator's current enabled state before deciding what to do.
- **Pure decision helper** (`decideDaemonAction`): extracted and exported so it can be unit-tested without systemd or launchd. Table-driven vitest coverage added (17 new tests; 28 total pass).
- **Persistent opt-out** (`daemon.autoStart`): a new `DaemonConfig` type + `daemon?: DaemonConfig` field on `CleoConfig`. Set `daemon.autoStart = false` in `~/.local/share/cleo/config.json` to prevent postinstall from EVER enabling or starting the daemon, surviving all future upgrades.

## Decision table implemented

| firstInstall | isEnabledState    | autoStartConfig | envDisable | action             |
|:------------:|:-----------------:|:---------------:|:----------:|:------------------ |
| any          | any               | any             | true       | skip               |
| any          | any               | false           | false      | skip               |
| true         | not-found / other | true            | false      | enable-and-start   |
| false        | enabled           | true            | false      | restart-if-changed |
| false        | disabled          | true            | false      | leave-disabled     |
| false        | masked            | true            | false      | leave-disabled     |
| false        | other / unknown   | true            | false      | enable-and-start   |

## What stays unchanged

- `CLEO_DAEMON_DISABLE=1` works exactly as before (highest priority, per-session non-persistent).
- First install behaviour: enable + start (same as before).
- Upgrade where operator left service enabled: restart only if unit content changed.
- The unit file is always written (hash-idempotent); only the enable/start is gated.

## Candidate DHQs (not filed)

- **DHQ-A** (filed as T11984): the footgun itself (fixed here).
- **DHQ-B**: `CLEO_DAEMON_DISABLE` non-persistent (addressed by `daemon.autoStart` in this PR).
- **DHQ-C**: stale sentient.lock — investigated; `acquireLock()` already handles PID liveness check + reclaim. No code change needed.
- **DHQ-D**: unit MemoryMax=2G vs drop-in 1G — documented in the unit-generation code comment; no code change needed.

## Touched files

- `packages/cleo/scripts/install-daemon-service.mjs` — core fix
- `packages/cleo/src/cli/__tests__/daemon-service.test.ts` — 17 new table-driven tests
- `packages/contracts/src/config.ts` — `DaemonConfig` + `CleoConfig.daemon?`
- `packages/contracts/src/index.ts` — export `DaemonConfig`
- `packages/core/src/config.ts` — default `daemon.autoStart: true`
- `.changeset/t11984-postinstall-operator-state.md` — changeset

## Test plan

- [ ] All 28 daemon-service tests pass (`28/28 ✓`)
- [ ] Biome CI clean on touched files (4 files, no fixes needed)
- [ ] contracts build succeeds
- [ ] `decideDaemonAction` logic verified via 16-case node script

🤖 Generated with [Claude Code](https://claude.com/claude-code)