### PR TITLE
fix(T11976): core tarball size gate — fix pnpm filter direction + raise to 30 MB (DHQ-079)

### DIFF
--- a/.github/workflows/core-tarball-size.yml
+++ b/.github/workflows/core-tarball-size.yml
@@ -2,12 +2,26 @@ name: Core Tarball Size Gate
 
 # @task T11342 — SG-RUNTIME-UNIFICATION R1 (T11252).
 # @task T11580 — R10-L1: worktree-napi joins the supervisor picker.
+# @task T11976 — DHQ-079 fix: filter bug + 25→30 MB budget (Studio headroom T11979).
 #
-# Asserts the packed @cleocode/core tarball stays <= 25 MB and bundles ONLY the
+# Asserts the packed @cleocode/core tarball stays <= 30 MB and bundles ONLY the
 # linux-x64-gnu fallback for each CLEO-managed native binary family
 # (cleo-supervisor + worktree-napi, Pattern P1). Fails the build with a
 # largest-contributors message when the budget is exceeded or an extra platform
 # binary sneaks in.
+#
+# Budget composition (v2026.6.14 baseline, binaries estimated from release builds):
+#   dist/.js files (runtime):         ~16.3 MB uncompressed / ~5.2 MB packed
+#   dist/.d.ts files (type decls):     ~7.5 MB uncompressed / ~2.1 MB packed
+#   dist/.js.map (source maps):        ~9.2 MB uncompressed / ~2.6 MB packed (optional trim)
+#   dist/.d.ts.map (decl maps):        ~1.9 MB uncompressed / ~0.5 MB packed (optional trim)
+#   migrations + schemas + templates:  ~1.9 MB uncompressed / ~0.4 MB packed
+#   cleo-supervisor binary (est.):     ~8-12 MB binary       / ~7-10 MB packed
+#   worktree-napi .node (measured):    ~3.1 MB binary        / ~2.8 MB packed
+#   ─────────────────────────────────────────────────────────────────────────
+#   Total estimate (today):           ~18-22 MB packed → 30 MB budget leaves ~8-12 MB headroom
+#   T11979 Studio assets (planned):   +3-5 MB packed (Svelte/JS bundles)
+#   → 30 MB accommodates today's content + Studio; maps are the first trim lever.
 #
 # Runs at RELEASE-TAG time (and on-demand), NOT on PRs/main: the assertion is only
 # meaningful once the cross-compiled linux-x64-gnu fallback binaries have been
@@ -22,7 +36,7 @@ on:
 
 jobs:
   tarball-size:
-    name: core tarball <= 25MB
+    name: core tarball <= 30MB
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -36,12 +50,19 @@ jobs:
           cache: pnpm
 
       - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile --filter '!@cleocode/studio'
+        # Install core + its transitive dependencies only (no studio or other consumers).
+        # `...@cleocode/core` = core and everything core depends on (leading `...`).
+        # The previous `--filter '!@cleocode/studio'` install + `@cleocode/core...`
+        # build filter was wrong: trailing `...` means "core and its dependents"
+        # (everything that depends on core, including studio), which caused the
+        # studio vite build to run and fail with missing @sveltejs/kit (T11976 / DHQ-079).
+        run: pnpm install --frozen-lockfile --filter '...@cleocode/core'
 
       # @cleocode/core's `files` includes `dist`, so it must be built before
       # `npm pack` reflects the real tarball contents.
       - name: Build @cleocode/core (+ deps)
-        run: pnpm --filter @cleocode/core... run build
+        # Same leading-... filter: build core and every package it depends on.
+        run: pnpm --filter '...@cleocode/core' run build
 
       # Stage the P1 fallback binary so the gate measures the REAL shipped
       # tarball (with the linux-x64-gnu fallback bundled), not a stripped one.

--- a/packages/core/scripts/check-core-tarball-size.mjs
+++ b/packages/core/scripts/check-core-tarball-size.mjs
@@ -18,11 +18,34 @@
  *
  * On failure it prints the largest contributors so the regression is obvious.
  *
+ * ## Budget rationale (T11976 / DHQ-079 — raised 25 MB → 30 MB)
+ *
+ * Baseline composition (v2026.6.14, binaries from release builds):
+ *
+ * | Category                          | Unpacked  | Packed (est.) |
+ * |-----------------------------------|-----------|---------------|
+ * | dist/.js runtime                  | ~16.3 MB  | ~5.2 MB       |
+ * | dist/.d.ts type declarations      |  ~7.5 MB  | ~2.1 MB       |
+ * | dist/.js.map source maps          |  ~9.2 MB  | ~2.6 MB       |
+ * | dist/.d.ts.map declaration maps   |  ~1.9 MB  | ~0.5 MB       |
+ * | migrations + schemas + templates  |  ~1.9 MB  | ~0.4 MB       |
+ * | cleo-supervisor binary (est.)     |  ~8-12 MB | ~7-10 MB      |
+ * | worktree-napi .node (measured)    |  ~3.1 MB  | ~2.8 MB       |
+ * | **Total today**                   |           | **~18-22 MB** |
+ * | T11979 Studio assets (planned)    |           | +3-5 MB       |
+ * | **Total with Studio**             |           | **~21-27 MB** |
+ *
+ * 30 MB gives ~3-9 MB headroom above the Studio-inclusive estimate.
+ * Source maps (.js.map + .d.ts.map, ~3.1 MB packed) are the first trim lever
+ * if a future change pushes past 30 MB. Do NOT trim selfimprove scenario
+ * fixtures (dist/selfimprove/scenarios/) — they are loaded at runtime (DHQ-078).
+ *
  * Usage:
  *   node packages/core/scripts/check-core-tarball-size.mjs
  *
  * @task T11342
  * @task T11580
+ * @task T11976
  */
 
 import { execFileSync } from 'node:child_process';
@@ -36,9 +59,14 @@ const PKG_ROOT = join(__dirname, '..');
 
 /**
  * The single named tarball-size threshold (no magic numbers scattered).
- * 25 MB packed, matching T11342 AC1 / the gen7 packaging budget.
+ *
+ * Raised from 25 MB → 30 MB (T11976 / DHQ-079):
+ * - Measured v2026.6.14 baseline (code-only, no binaries): 7.8 MB packed.
+ * - With compiled Rust binaries (supervisor + worktree-napi): ~18-22 MB packed.
+ * - T11979 will add Studio assets (~3-5 MB packed); 30 MB gives ~3-9 MB headroom.
+ * - Source maps are the first trim lever if this limit needs revisiting.
  */
-export const MAX_CORE_TARBALL_MB = 25;
+export const MAX_CORE_TARBALL_MB = 30;
 
 /** The threshold expressed in bytes for the size comparison. */
 export const MAX_CORE_TARBALL_BYTES = MAX_CORE_TARBALL_MB * 1024 * 1024;


### PR DESCRIPTION
## Summary

- **Root cause identified**: the Core Tarball Size Gate has NEVER run its actual size check across 20+ releases. The `pnpm --filter @cleocode/core... run build` step uses trailing `...` which in pnpm 10 means "core AND all its dependents" (consumers of core), pulling in `@cleocode/studio`. Since studio's devDependency `@sveltejs/kit` was excluded from the install step, the studio vite build always failed before `check-core-tarball-size.mjs` was ever reached.
- **Workflow fix**: changed both install and build steps to `--filter '...@cleocode/core'` (leading `...` = core and its own dependency chain, not its consumers).
- **Gate threshold raised 25 MB → 30 MB**: grounded in measured composition (code-only shipped tarball: 7.8 MB packed; estimated total with compiled Rust binaries: ~18-22 MB packed) plus headroom for T11979 Studio assets (~3-5 MB packed additional).
- **selfimprove fixtures preserved**: `dist/selfimprove/scenarios/` is explicitly called out as NOT a trim candidate (DHQ-078, runtime-loaded).

## Size breakdown table (v2026.6.14 baseline)

| Category | Unpacked | Packed (est.) |
|---|---|---|
| dist/.js runtime (1238 files) | ~16.3 MB | ~5.2 MB |
| dist/.d.ts type declarations (1238 files) | ~7.5 MB | ~2.1 MB |
| dist/.js.map source maps (1238 files) | ~9.2 MB | ~2.6 MB |
| dist/.d.ts.map declaration maps (1238 files) | ~1.9 MB | ~0.5 MB |
| migrations + schemas + templates | ~1.9 MB | ~0.4 MB |
| cleo-supervisor binary (est., unstripped release) | ~8-12 MB | ~7-10 MB |
| worktree-napi .node (measured release build) | 3.1 MB | ~2.8 MB |
| **Total today (estimated)** | | **~18-22 MB** |
| T11979 Studio assets (planned) | | +3-5 MB |
| **Total with Studio** | | **~21-27 MB** |

**30 MB budget leaves ~3-9 MB headroom above the Studio-inclusive estimate.**

Source maps (.js.map + .d.ts.map, ~3.1 MB packed combined) are documented as the first trim lever if the 30 MB limit ever needs defending.

## Decision rationale: raise vs trim

Trimming source maps would be a separate PR touching tsconfig (declarationMap, sourceMap) and potentially breaking IDE "go-to-source" workflows for library consumers. Given the gate has never successfully run and the immediate blocker is the workflow filter bug, the cheapest correct fix is: (1) fix the filter so the gate actually runs, (2) set the threshold where it will pass given real binary sizes, (3) document the composition for future decisions.

## Files changed

- `.github/workflows/core-tarball-size.yml` — fix pnpm filter direction; update job name to `<= 30MB`; add composition table to header comment.
- `packages/core/scripts/check-core-tarball-size.mjs` — raise `MAX_CORE_TARBALL_MB` from 25 to 30; add budget rationale table + trim-lever guidance to JSDoc.

## Test plan

- [ ] Verify the gate workflow runs to completion (reaches `check-core-tarball-size.mjs`) on next release tag — the filter fix is the primary validation target.
- [ ] Confirm the gate passes (tarball under 30 MB) on the next release with compiled Rust binaries.
- [ ] No functional code changes — only workflow YAML and a JSDoc + constant in a CI gate script.

Closes DHQ-079. References T11979 (Studio assets headroom).

Generated with [Claude Code](https://claude.com/claude-code)