### PR TITLE
fix(T11985): codex complete() streams internally — backend mandates stream:true

### DIFF
--- a/packages/core/src/llm/__tests__/transports/codex-responses.test.ts
+++ b/packages/core/src/llm/__tests__/transports/codex-responses.test.ts
@@ -162,8 +162,11 @@ describe('resolveCodexUrl', () => {
 // ── 1. Wire shape ─────────────────────────────────────────────────────────────
 
 describe('CodexResponsesTransport — wire shape (request-shape builder)', () => {
-  it('sends store:false, stream:false for complete()', async () => {
-    const mockFetch = mockJsonFetch(fakeResponse());
+  it('sends store:false, stream:true, accept:text/event-stream for complete() (backend mandates stream:true)', async () => {
+    const mockFetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'Hello from Codex!' },
+      { type: 'response.completed', response: fakeResponse() },
+    ]);
     globalThis.fetch = mockFetch;
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
@@ -178,10 +181,12 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
       RequestInit,
     ];
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const hdrs = init.headers as Record<string, string>;
 
     expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
     expect(body['store']).toBe(false);
-    expect(body['stream']).toBe(false);
+    expect(body['stream']).toBe(true);
+    expect(hdrs['accept']).toBe('text/event-stream');
   });
 
   it('sends store:false, stream:true, OpenAI-Beta, accept:text/event-stream for stream()', async () => {
@@ -208,8 +213,7 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
   });
 
   it('sends Authorization, chatgpt-account-id, originator from defaultHeaders', async () => {
-    const mockFetch = mockJsonFetch(fakeResponse());
-    globalThis.fetch = mockFetch;
+    globalThis.fetch = mockSseFetch([{ type: 'response.completed', response: fakeResponse() }]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -218,7 +222,10 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
       maxTokens: 32,
     });
 
-    const [, init] = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     const hdrs = init.headers as Record<string, string>;
 
     expect(hdrs['Authorization']).toBe('Bearer oat-test-token');
@@ -227,8 +234,7 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
   });
 
   it('injects Authorization when not present in defaultHeaders', async () => {
-    const mockFetch = mockJsonFetch(fakeResponse());
-    globalThis.fetch = mockFetch;
+    globalThis.fetch = mockSseFetch([{ type: 'response.completed', response: fakeResponse() }]);
 
     const transport = new CodexResponsesTransport({ provider: 'openai', apiKey: 'sk-test' });
     await transport.complete({
@@ -237,14 +243,16 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
       maxTokens: 32,
     });
 
-    const [, init] = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     const hdrs = init.headers as Record<string, string>;
     expect(hdrs['Authorization']).toBe('Bearer sk-test');
   });
 
   it('sends instructions from system prompt', async () => {
-    const mockFetch = mockJsonFetch(fakeResponse());
-    globalThis.fetch = mockFetch;
+    globalThis.fetch = mockSseFetch([{ type: 'response.completed', response: fakeResponse() }]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -254,14 +262,16 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
       system: 'You are a helpful assistant.',
     });
 
-    const [, init] = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(body['instructions']).toBe('You are a helpful assistant.');
   });
 
   it('sends user messages as input items', async () => {
-    const mockFetch = mockJsonFetch(fakeResponse());
-    globalThis.fetch = mockFetch;
+    globalThis.fetch = mockSseFetch([{ type: 'response.completed', response: fakeResponse() }]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -270,7 +280,10 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
       maxTokens: 32,
     });
 
-    const [, init] = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     const input = body['input'] as Array<Record<string, unknown>>;
     expect(Array.isArray(input)).toBe(true);
@@ -285,8 +298,12 @@ describe('CodexResponsesTransport — wire shape (request-shape builder)', () =>
 // ── 2. Simple text turn ───────────────────────────────────────────────────────
 
 describe('CodexResponsesTransport — complete() — simple text turn', () => {
-  it('returns content and normalized usage from a text response', async () => {
-    globalThis.fetch = mockJsonFetch(fakeResponse());
+  it('aggregates SSE deltas and returns content+usage from response.completed', async () => {
+    globalThis.fetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'Hello ' },
+      { type: 'response.output_text.delta', delta: 'from Codex!' },
+      { type: 'response.completed', response: fakeResponse() },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     const response = await transport.complete({
@@ -304,16 +321,20 @@ describe('CodexResponsesTransport — complete() — simple text turn', () => {
   });
 
   it('populates cachedTokens when cached_tokens > 0', async () => {
-    globalThis.fetch = mockJsonFetch(
-      fakeResponse({
-        usage: {
-          input_tokens: 100,
-          output_tokens: 20,
-          total_tokens: 120,
-          input_tokens_details: { cached_tokens: 80 },
-        },
-      }),
-    );
+    globalThis.fetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'Cached answer.' },
+      {
+        type: 'response.completed',
+        response: fakeResponse({
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20,
+            total_tokens: 120,
+            input_tokens_details: { cached_tokens: 80 },
+          },
+        }),
+      },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     const response = await transport.complete({
@@ -335,7 +356,10 @@ describe('CodexResponsesTransport — complete() — simple text turn', () => {
 
 describe('CodexResponsesTransport — complete() — multimodal (image + text)', () => {
   it('converts image_url content block to input_image item', async () => {
-    globalThis.fetch = mockJsonFetch(fakeResponse({ output_text: 'I see a cat.' }));
+    globalThis.fetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'I see a cat.' },
+      { type: 'response.completed', response: fakeResponse({ output_text: 'I see a cat.' }) },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -376,7 +400,10 @@ describe('CodexResponsesTransport — complete() — multimodal (image + text)',
   });
 
   it('converts base64 image to data URL in input_image item', async () => {
-    globalThis.fetch = mockJsonFetch(fakeResponse({ output_text: 'Blue square.' }));
+    globalThis.fetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'Blue square.' },
+      { type: 'response.completed', response: fakeResponse({ output_text: 'Blue square.' }) },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -413,20 +440,23 @@ describe('CodexResponsesTransport — complete() — multimodal (image + text)',
 
 describe('CodexResponsesTransport — complete() — tool call + tool result replay', () => {
   it('sends tools as function-type items', async () => {
-    globalThis.fetch = mockJsonFetch(
-      fakeResponse({
-        output_text: '',
-        output: [
-          {
-            type: 'function_call',
-            id: 'fc_001',
-            call_id: 'call_001',
-            name: 'get_weather',
-            arguments: '{"city":"SF"}',
-          },
-        ],
-      }),
-    );
+    globalThis.fetch = mockSseFetch([
+      {
+        type: 'response.completed',
+        response: fakeResponse({
+          output_text: '',
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_001',
+              call_id: 'call_001',
+              name: 'get_weather',
+              arguments: '{"city":"SF"}',
+            },
+          ],
+        }),
+      },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -454,21 +484,24 @@ describe('CodexResponsesTransport — complete() — tool call + tool result rep
     });
   });
 
-  it('normalizes function_call output items as tool calls', async () => {
-    globalThis.fetch = mockJsonFetch(
-      fakeResponse({
-        output_text: '',
-        output: [
-          {
-            type: 'function_call',
-            id: 'fc_001',
-            call_id: 'call_abc123',
-            name: 'search',
-            arguments: '{"query":"cleo"}',
-          },
-        ],
-      }),
-    );
+  it('normalizes function_call output items as tool calls (via response.completed output array)', async () => {
+    globalThis.fetch = mockSseFetch([
+      {
+        type: 'response.completed',
+        response: fakeResponse({
+          output_text: '',
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_001',
+              call_id: 'call_abc123',
+              name: 'search',
+              arguments: '{"query":"cleo"}',
+            },
+          ],
+        }),
+      },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     const response = await transport.complete({
@@ -493,7 +526,10 @@ describe('CodexResponsesTransport — complete() — tool call + tool result rep
   });
 
   it('converts tool result messages to function_call_output items', async () => {
-    globalThis.fetch = mockJsonFetch(fakeResponse({ output_text: 'It is sunny in SF.' }));
+    globalThis.fetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'It is sunny in SF.' },
+      { type: 'response.completed', response: fakeResponse({ output_text: 'It is sunny in SF.' }) },
+    ]);
 
     const transport = new CodexResponsesTransport(BASE_OPTS);
     await transport.complete({
@@ -683,7 +719,10 @@ describe('CodexResponsesTransport — stream() — SSE iteration', () => {
 
 describe('CodexResponsesTransport — xAI profile', () => {
   it('uses provided baseUrl for endpoint', async () => {
-    globalThis.fetch = mockJsonFetch(fakeResponse({ output_text: 'Grok says hi.' }));
+    globalThis.fetch = mockSseFetch([
+      { type: 'response.output_text.delta', delta: 'Grok says hi.' },
+      { type: 'response.completed', response: fakeResponse({ output_text: 'Grok says hi.' }) },
+    ]);
 
     const transport = new CodexResponsesTransport({
       provider: 'xai',

--- a/packages/core/src/llm/transports/codex-responses.ts
+++ b/packages/core/src/llm/transports/codex-responses.ts
@@ -17,13 +17,13 @@
  * - `chatgpt-account-id: <jwt claim>`
  * - `originator: codex_cli_rs` (set by buildCodexOAuthHeaders)
  * - `OpenAI-Beta: responses=experimental`
- * - `accept: text/event-stream`  (for streaming; `application/json` for complete)
+ * - `accept: text/event-stream`  (always — backend mandates stream:true on every request)
  * - `content-type: application/json`
  *
  * Mandatory body fields:
  * - `model`, `input`, `instructions`
  * - `store: false`                 (codex backend rejects store:true or absent)
- * - `stream: true/false`
+ * - `stream: true`                (always — the Codex backend rejects stream:false)
  *
  * @module llm/transports/codex-responses
  * @task T11985
@@ -170,17 +170,20 @@ export class CodexResponsesTransport implements LlmTransport {
   /**
    * Execute a single (non-streaming) completion using the Responses API.
    *
-   * Makes a raw `fetch` POST to the codex endpoint with `store:false` and
-   * `stream:false`, then normalises the JSON response into a
-   * {@link NormalizedResponse}.
+   * The Codex ChatGPT backend mandates `stream: true` on every request and
+   * returns `400 {"detail":"Stream must be set to true"}` for `stream: false`.
+   * This method therefore always sends `stream: true` with
+   * `Accept: text/event-stream`, internally consumes the SSE stream, and
+   * aggregates text deltas + tool calls + usage into a {@link NormalizedResponse}
+   * — identical to calling `stream()` and collecting all chunks.
    *
    * @param request - Provider-neutral request parameters.
    * @param _ctx - Transport context (unused; `request.signal` handles abort).
    * @returns Normalized response envelope.
    */
   async complete(request: TransportRequest, _ctx?: TransportContext): Promise<NormalizedResponse> {
-    const body = this._buildBody(request, false);
-    const headers = this._buildHeaders(false);
+    const body = this._buildBody(request, true);
+    const headers = this._buildHeaders(true);
 
     const res = await fetch(this._endpointUrl, {
       method: 'POST',
@@ -193,8 +196,95 @@ export class CodexResponsesTransport implements LlmTransport {
       throw new Error(await buildHttpError(res));
     }
 
-    const json = (await res.json()) as Record<string, unknown>;
-    return this._normalize(json, request.model);
+    if (!res.body) {
+      throw new Error('codex_responses: response body is null (no SSE stream)');
+    }
+
+    // Aggregate SSE stream into a single NormalizedResponse.
+    const textParts: string[] = [];
+    const toolCalls: NormalizedToolCall[] = [];
+    let finalUsage: NormalizedUsage | null = null;
+    let finishReason: string | null = null;
+    let responseId: string | null = null;
+    let responseModel: string | null = null;
+
+    for await (const event of parseSSE(res.body, request.signal)) {
+      const evType = event['type'] as string | undefined;
+
+      if (evType === 'response.output_text.delta') {
+        const delta = event['delta'] as string | undefined;
+        if (delta) textParts.push(delta);
+        continue;
+      }
+
+      if (evType === 'response.output_item.done') {
+        // Capture function_call items emitted per-output-item.
+        const item = event['item'] as Record<string, unknown> | undefined;
+        if (item?.['type'] === 'function_call') {
+          toolCalls.push({
+            id: typeof item['call_id'] === 'string' ? item['call_id'] : null,
+            name: typeof item['name'] === 'string' ? item['name'] : 'unknown',
+            arguments: typeof item['arguments'] === 'string' ? item['arguments'] : '{}',
+            providerData: {
+              call_id: item['call_id'],
+              response_item_id: item['id'],
+            },
+          });
+        }
+        continue;
+      }
+
+      if (evType === 'response.completed') {
+        const completedResponse = event['response'] as Record<string, unknown> | undefined;
+        if (completedResponse) {
+          finishReason = (completedResponse['status'] as string | undefined) ?? 'completed';
+          responseId = (completedResponse['id'] as string | undefined) ?? null;
+          responseModel = (completedResponse['model'] as string | undefined) ?? null;
+          const usage = completedResponse['usage'] as Record<string, unknown> | undefined;
+          if (usage) finalUsage = normalizeUsage(usage);
+          // Also capture tool calls embedded in the completed output array.
+          const output = (completedResponse['output'] as Array<unknown> | undefined) ?? [];
+          const embeddedCalls = extractToolCallsFromOutput(
+            output as Array<Record<string, unknown>>,
+          );
+          if (embeddedCalls.length > 0 && toolCalls.length === 0) {
+            toolCalls.push(...embeddedCalls);
+          }
+        }
+        break;
+      }
+
+      if (evType === 'response.failed' || evType === 'response.incomplete') {
+        const failedResponse = event['response'] as Record<string, unknown> | undefined;
+        if (failedResponse) {
+          finishReason = (failedResponse['status'] as string | undefined) ?? evType;
+          const usage = failedResponse['usage'] as Record<string, unknown> | undefined;
+          if (usage) finalUsage = normalizeUsage(usage);
+        }
+        break;
+      }
+
+      if (evType === 'error') {
+        const code = event['code'] as string | undefined;
+        const message = event['message'] as string | undefined;
+        throw new Error(`Codex error: ${message ?? code ?? JSON.stringify(event)}`);
+      }
+    }
+
+    const content = textParts.join('') || null;
+
+    return {
+      id: responseId ?? `resp-${Date.now().toString(36)}`,
+      model: responseModel ?? request.model,
+      content,
+      toolCalls: toolCalls.length > 0 ? toolCalls : null,
+      stopReason: finishReason ?? 'completed',
+      usage: finalUsage ?? { inputTokens: 0, outputTokens: 0 },
+      providerData: {
+        codex_response_id: responseId,
+      },
+      raw: {},
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -301,7 +391,7 @@ export class CodexResponsesTransport implements LlmTransport {
    * mandatory Codex-specific headers:
    * - `OpenAI-Beta: responses=experimental`
    * - `content-type: application/json`
-   * - `accept: text/event-stream` (streaming) or `application/json` (complete)
+   * - `accept: text/event-stream` (always — both complete() and stream() use SSE)
    *
    * The Authorization header is injected only if not already present in
    * `_defaultHeaders` (OAuth callers pre-set it via buildCodexOAuthHeaders).
@@ -351,41 +441,6 @@ export class CodexResponsesTransport implements LlmTransport {
     const tools = buildTools(request.tools);
     if (tools.length > 0) body.tools = tools;
     return body;
-  }
-
-  /**
-   * Normalize a raw Responses API JSON response into a {@link NormalizedResponse}.
-   *
-   * @param response - Raw parsed JSON from the Responses API.
-   * @param requestedModel - Model string from the originating request.
-   * @returns Normalized response envelope.
-   */
-  private _normalize(
-    response: Record<string, unknown>,
-    requestedModel: string,
-  ): NormalizedResponse {
-    const outputText = response['output_text'] as string | undefined;
-    const output = (response['output'] as Array<unknown> | undefined) ?? [];
-    const content =
-      outputText && outputText.length > 0
-        ? outputText
-        : extractTextFromOutput(output as Array<Record<string, unknown>>);
-    const toolCalls = extractToolCallsFromOutput(output as Array<Record<string, unknown>>);
-    const usageRaw = response['usage'] as Record<string, unknown> | undefined;
-    const usage = normalizeUsage(usageRaw ?? {});
-
-    return {
-      id: (response['id'] as string | undefined) ?? `resp-${Date.now().toString(36)}`,
-      model: String((response['model'] as string | undefined) ?? requestedModel),
-      content: content || null,
-      toolCalls: toolCalls.length > 0 ? toolCalls : null,
-      stopReason: (response['status'] as string | undefined) ?? 'completed',
-      usage,
-      providerData: {
-        codex_response_id: response['id'],
-      },
-      raw: response,
-    };
   }
 }
 
@@ -551,27 +606,6 @@ function buildContentList(message: TransportMessage): Array<Record<string, unkno
       source.type === 'base64' ? `data:${source.mediaType};base64,${source.data}` : source.data;
     return { type: 'input_image', image_url: imageUrl, detail: 'auto' };
   });
-}
-
-/**
- * Extract plain text from a Responses API `output` item array.
- *
- * @param output - Array of ResponseOutputItem objects.
- * @returns Concatenated text content, or empty string.
- */
-function extractTextFromOutput(output: Array<Record<string, unknown>>): string {
-  const parts: string[] = [];
-  for (const item of output) {
-    if (item['type'] !== 'message') continue;
-    const content = item['content'];
-    if (!Array.isArray(content)) continue;
-    for (const part of content as Array<Record<string, unknown>>) {
-      if (part['type'] === 'output_text' && typeof part['text'] === 'string') {
-        parts.push(part['text']);
-      }
-    }
-  }
-  return parts.join('');
 }
 
 /**


### PR DESCRIPTION
## Summary

- The Codex ChatGPT backend returns `400 {"detail":"Stream must be set to true"}` for any non-streaming request; `complete()` was sending `stream: false`
- `complete()` now always sends `stream: true` + `Accept: text/event-stream`, internally consumes the SSE response via `parseSSE`, and aggregates text deltas + tool calls + usage into the same `NormalizedResponse` shape
- Removed the now-unreachable `_normalize()` method and `extractTextFromOutput()` helper (both were only used by the old non-streaming path)
- Tests: all `complete()` mocks switched from `mockJsonFetch` → `mockSseFetch`; wire-shape test now asserts `stream: true` and `accept: text/event-stream` in the outbound body/headers

## Test plan

- [x] 26/26 vitest tests pass (`packages/core/src/llm/__tests__/transports/codex-responses.test.ts`)
- [x] Biome check: no fixes applied
- [x] Gate-13 (LLM chokepoint lint): OK — 41 violations vs baseline 53 (12 resolved)
- [x] Live `complete()` proof: `content: "pong"`, `stopReason: "completed"`, `usage: {"inputTokens":11,"outputTokens":15}` — COMPLETE_PATH_OK
- [x] Live `stream()` proof: `content: "pong"` — STREAM_PATH_OK (unchanged behavior)

## Files changed

- `packages/core/src/llm/transports/codex-responses.ts`
- `packages/core/src/llm/__tests__/transports/codex-responses.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)