### PR TITLE
fix(T11990): gemma3→gemma4 edge-model family in ollama fallback + fit table

### DIFF
--- a/.changeset/t11990-gemma4-edge-models.md
+++ b/.changeset/t11990-gemma4-edge-models.md
@@ -1,0 +1,14 @@
+---
+id: t11990-gemma4-edge-models
+tasks: [T11990]
+kind: fix
+summary: "fix(T11990): gemma3→gemma4 edge-model family in ollama fallback + fit table (live-verified)"
+---
+
+Corrects stale gemma3 model literals to the current gemma4 family (owner-flagged 2026-06-11).
+
+- **`packages/core/src/llm/provider-registry/builtin/ollama.ts`** — `defaultModel` updated `gemma3:4b` → `gemma4:e4b` (≥8 GB RAM tier); `defaultAuxModel` updated `gemma3:1b` → `gemma4:e2b` (≥4 GB RAM tier). Tags live-verified on ollama.com/library/gemma4 2026-06-11.
+- **`packages/core/src/llm/local-model-fit.ts`** — `LOCAL_MODEL_CANDIDATES` table updated: three gemma3 entries replaced with `gemma4:e2b` (7.2 GB, 128k ctx), `gemma4:e4b` (9.6 GB, 128k ctx), `gemma4:12b` (7.6 GB QAT, 256k ctx); RAM/VRAM rows recalibrated from live Ollama tag data; `family` union updated `'gemma3'` → `'gemma4'`.
+- **`packages/core/src/llm/cross-provider-selector.ts`** — `ollamaDefaultModelForTier` literals updated `gemma3:4b` → `gemma4:e4b`, `gemma3:1b` → `gemma4:e2b`; catalog hint log updated to check gemma4 family; inline fallback literal in `selectBestProvisioned` updated.
+- **Tests** — RAM-gate + fit-ranking expectations in `__tests__/cross-provider-selector.test.ts` and `__tests__/local-model-fit.test.ts` updated to gemma4 tags.
+- **RECOMMEND-NEVER-KILL semantics preserved**: local models remain recommended only; no auto-pull, no forced selection; <4 GB floor still routes to cloud-only with reason; fit envelope remains agent-readable.

--- a/packages/core/src/llm/__tests__/cross-provider-selector.test.ts
+++ b/packages/core/src/llm/__tests__/cross-provider-selector.test.ts
@@ -220,28 +220,28 @@ describe('scoreProvider — frontier bias (Q1 ratification)', () => {
 // (f) RAM-gate: gemma3:1b under low RAM, gemma3:4b at ≥8GB
 // ---------------------------------------------------------------------------
 
-describe('ollamaDefaultModelForTier — RAM gating (Q2 ratification)', () => {
-  it('(f) returns gemma3:4b for frontier tasks on a machine with ≥8GB RAM', () => {
+describe('ollamaDefaultModelForTier — RAM gating (Q2 ratification · T11990)', () => {
+  it('(f) returns gemma4:e4b for frontier tasks on a machine with ≥8GB RAM', () => {
     const model = ollamaDefaultModelForTier('frontier', 8 * 1024 ** 3); // exactly 8 GB
-    expect(model).toBe('gemma3:4b');
+    expect(model).toBe('gemma4:e4b');
   });
 
-  it('(f) returns gemma3:4b for standard tasks on ≥8GB RAM machine', () => {
+  it('(f) returns gemma4:e4b for standard tasks on ≥8GB RAM machine', () => {
     const model = ollamaDefaultModelForTier('standard', 16 * 1024 ** 3); // 16 GB
-    expect(model).toBe('gemma3:4b');
+    expect(model).toBe('gemma4:e4b');
   });
 
-  it('(f) returns gemma3:1b for fast/local tasks on ≥8GB RAM machine', () => {
+  it('(f) returns gemma4:e2b for fast/local tasks on ≥8GB RAM machine', () => {
     const model = ollamaDefaultModelForTier('fast', 8 * 1024 ** 3);
-    expect(model).toBe('gemma3:1b');
+    expect(model).toBe('gemma4:e2b');
   });
 
-  it('(f) returns gemma3:1b on machine with 4GB ≤ RAM < 8GB for any tier', () => {
+  it('(f) returns gemma4:e2b on machine with 4GB ≤ RAM < 8GB for any tier', () => {
     const model4gb = ollamaDefaultModelForTier('frontier', 4 * 1024 ** 3); // exactly 4 GB
-    expect(model4gb).toBe('gemma3:1b');
+    expect(model4gb).toBe('gemma4:e2b');
 
     const model6gb = ollamaDefaultModelForTier('standard', 6 * 1024 ** 3);
-    expect(model6gb).toBe('gemma3:1b');
+    expect(model6gb).toBe('gemma4:e2b');
   });
 
   it('(f) returns qwen2:0.5b (proof-of-life) on machine with < 4GB RAM', () => {

--- a/packages/core/src/llm/__tests__/local-model-fit.test.ts
+++ b/packages/core/src/llm/__tests__/local-model-fit.test.ts
@@ -1,16 +1,17 @@
 /**
- * Tests for `llm/local-model-fit.ts` (T11982).
+ * Tests for `llm/local-model-fit.ts` (T11982 · T11990).
  *
  * Coverage:
  *   - low-RAM floor (< 4 GB → no recommendation)
- *   - 8 GB RAM pick (gemma3:4b-class should rank highly)
- *   - 32 GB RAM pick (gemma3:12b eligible)
+ *   - 8 GB RAM pick (gemma4:e4b-class should rank highly)
+ *   - 32 GB RAM pick (gemma4:12b eligible)
  *   - 62 GB RAM + VRAM present → VRAM boost ranks larger models
  *   - already-pulled model gets bonus and surfaces in `alreadyPulled`
  *   - Ollama running + model in /api/tags → `alreadyPulled: true`
  *   - Ollama not running → empty pulledModels, `ollamaRunning: false`
  *
  * @task T11982
+ * @task T11990
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -128,12 +129,12 @@ describe('captureHardwareSnapshot', () => {
 describe('listOllamaPulledModels', () => {
   it('parses /api/tags response correctly', async () => {
     const mockFetch = makeMockFetch([
-      { name: 'gemma3:4b', paramSize: '4B', quant: 'Q4_K_M', family: 'gemma' },
+      { name: 'gemma4:e4b', paramSize: '4B', quant: 'Q4_K_M', family: 'gemma4' },
       { name: 'qwen2.5-coder:3b', paramSize: '3.1B', quant: 'Q4_K_M', family: 'qwen2' },
     ]);
     const models = await listOllamaPulledModels('http://localhost:11434', mockFetch);
     expect(models).toHaveLength(2);
-    expect(models[0]?.name).toBe('gemma3:4b');
+    expect(models[0]?.name).toBe('gemma4:e4b');
     expect(models[1]?.name).toBe('qwen2.5-coder:3b');
   });
 
@@ -249,7 +250,7 @@ describe('rankLocalModelFit — 8 GB RAM, no VRAM', () => {
 // ---------------------------------------------------------------------------
 
 describe('rankLocalModelFit — 32 GB RAM, no VRAM', () => {
-  it('includes gemma3:12b in recommendations at 32 GB', async () => {
+  it('includes gemma4:12b in recommendations at 32 GB', async () => {
     const result = await rankLocalModelFit({
       hardwareOverride: {
         totalRamBytes: 32 * GB,
@@ -260,7 +261,7 @@ describe('rankLocalModelFit — 32 GB RAM, no VRAM', () => {
       pulledModelsOverride: [],
     });
     const tags = result.recommendations.map((r) => r.candidate.modelTag);
-    expect(tags).toContain('gemma3:12b');
+    expect(tags).toContain('gemma4:12b');
   });
 
   it('does not recommend models requiring more RAM than available', async () => {
@@ -350,7 +351,7 @@ describe('rankLocalModelFit — VRAM present boosts scores', () => {
 describe('rankLocalModelFit — already-pulled status', () => {
   it('marks a model as alreadyPulled when it appears in pulledModels list', async () => {
     const pulled: OllamaPulledModel[] = [
-      { name: 'gemma3:4b', parameterSize: '4B', quantizationLevel: 'Q4_K_M', family: 'gemma' },
+      { name: 'gemma4:e4b', parameterSize: '4B', quantizationLevel: 'Q4_K_M', family: 'gemma4' },
     ];
 
     const result = await rankLocalModelFit({
@@ -363,7 +364,7 @@ describe('rankLocalModelFit — already-pulled status', () => {
       pulledModelsOverride: pulled,
     });
 
-    const gemmaRec = result.recommendations.find((r) => r.candidate.modelTag === 'gemma3:4b');
+    const gemmaRec = result.recommendations.find((r) => r.candidate.modelTag === 'gemma4:e4b');
     expect(gemmaRec).toBeDefined();
     expect(gemmaRec?.alreadyPulled).toBe(true);
     expect(gemmaRec?.reasons).toContain('already pulled — no download needed');
@@ -430,7 +431,7 @@ describe('rankLocalModelFit — Ollama liveness', () => {
     mockProbeOllamaAlive.mockResolvedValue(true);
 
     const mockFetch = makeMockFetch([
-      { name: 'gemma3:1b', paramSize: '1B', quant: 'Q4_K_M', family: 'gemma' },
+      { name: 'gemma4:e2b', paramSize: '2B', quant: 'Q4_K_M', family: 'gemma4' },
     ]);
 
     const result = await rankLocalModelFit({
@@ -445,7 +446,7 @@ describe('rankLocalModelFit — Ollama liveness', () => {
 
     expect(result.ollamaRunning).toBe(true);
     expect(result.pulledModels).toHaveLength(1);
-    expect(result.pulledModels[0]?.name).toBe('gemma3:1b');
+    expect(result.pulledModels[0]?.name).toBe('gemma4:e2b');
   });
 
   it('sets ollamaRunning=false and returns empty pulledModels when Ollama is down', async () => {

--- a/packages/core/src/llm/cross-provider-selector.ts
+++ b/packages/core/src/llm/cross-provider-selector.ts
@@ -265,8 +265,8 @@ export async function probeOllamaAlive(baseUrl: string): Promise<boolean> {
  * VRAM detection is out-of-scope (deferred to T11982 wizard task).
  *
  * Resolution:
- *   - RAM ≥ 8 GB → `gemma3:4b` for frontier/standard; `gemma3:1b` for fast/local.
- *   - 4 GB ≤ RAM < 8 GB → `gemma3:1b` for all tiers.
+ *   - RAM ≥ 8 GB → `gemma4:e4b` for frontier/standard; `gemma4:e2b` for fast/local.
+ *   - 4 GB ≤ RAM < 8 GB → `gemma4:e2b` for all tiers.
  *   - RAM < 4 GB → `qwen2:0.5b` (proof-of-life only; logged as WARNING).
  *
  * Note: `qwen2:0.5b` MUST NOT be selected as a resolver default. It is a
@@ -278,8 +278,10 @@ export async function probeOllamaAlive(baseUrl: string): Promise<boolean> {
  * the selector reads them via `getProviderProfile('ollama')` when available
  * and only falls back to these when the profile is unavailable (defensive).
  *
- * PROPOSED-for-owner (Q2): `gemma3:4b` is the recommended default.
- * If the catalog does not yet have a `gemma3` family entry, the resolver
+ * Tags live-verified 2026-06-11 on ollama.com/library/gemma4:
+ *   - gemma4:e2b = 7.2 GB (Q4_K_M), edge 2B effective params, ≥ 4 GB RAM
+ *   - gemma4:e4b = 9.6 GB (Q4_K_M), edge 4B effective params, ≥ 8 GB RAM
+ * If the catalog does not yet have a `gemma4` family entry, the resolver
  * logs a hint to run `cleo llm refresh-catalog`.
  *
  * @param tier - The task tier for which a model is being selected.
@@ -293,12 +295,12 @@ export function ollamaDefaultModelForTier(tier: ProviderTier, ramBytesOverride?:
   const gb = ramBytes / 1024 ** 3;
 
   if (gb >= 8) {
-    // High-RAM: use gemma3:4b for standard/frontier, gemma3:1b for fast/local
-    return tier === 'fast' || tier === 'local' ? 'gemma3:1b' : 'gemma3:4b';
+    // High-RAM: use gemma4:e4b for standard/frontier, gemma4:e2b for fast/local
+    return tier === 'fast' || tier === 'local' ? 'gemma4:e2b' : 'gemma4:e4b';
   }
   if (gb >= 4) {
-    // Mid-RAM: gemma3:1b for all tiers
-    return 'gemma3:1b';
+    // Mid-RAM: gemma4:e2b for all tiers
+    return 'gemma4:e2b';
   }
   // Low-RAM proof-of-life floor — NEVER a default for any task tier
   logger.warn(
@@ -680,19 +682,19 @@ export async function selectBestProvisioned(
           ? ollamaProfile?.defaultAuxModel
           : ollamaProfile?.defaultModel) ?? ollamaDefaultModelForTier(winner.tier);
     } else if (gb >= 4) {
-      model = ollamaProfile?.defaultAuxModel ?? 'gemma3:1b';
+      model = ollamaProfile?.defaultAuxModel ?? 'gemma4:e2b';
     } else {
       // Proof-of-life floor — logged as warning by ollamaDefaultModelForTier.
       model = ollamaDefaultModelForTier(winner.tier, ramBytes);
     }
 
-    // Log hint if gemma3 family is not in catalog
+    // Log hint if gemma4 family is not in catalog
     const catalogKey = catalogKeyForProvider(winner.id);
     const catalogModel = resolveProviderDefaultModel(catalogKey);
-    if (!catalogModel?.startsWith('gemma3')) {
+    if (!catalogModel?.startsWith('gemma4')) {
       logger.info(
         { provider: 'ollama', selectedModel: model },
-        'cross-provider-selector: gemma3 family not in catalog snapshot — run `cleo llm refresh-catalog` to pull latest',
+        'cross-provider-selector: gemma4 family not in catalog snapshot — run `cleo llm refresh-catalog` to pull latest',
       );
     }
   } else {

--- a/packages/core/src/llm/local-model-fit.ts
+++ b/packages/core/src/llm/local-model-fit.ts
@@ -68,7 +68,7 @@ export interface LocalModelCandidate {
   /** Human-readable display name. */
   readonly displayName: string;
   /** Model family (for grouping in the wizard). */
-  readonly family: 'gemma3' | 'qwen3' | 'llama3.2' | 'qwen2.5-coder' | 'phi4';
+  readonly family: 'gemma4' | 'qwen3' | 'llama3.2' | 'qwen2.5-coder' | 'phi4';
   /** Minimum RAM required to run (worst-case, CPU inference), in GiB. */
   readonly minRamGb: number;
   /** Recommended RAM for comfortable CPU inference, in GiB. */
@@ -104,43 +104,49 @@ export interface LocalModelCandidate {
  */
 export const LOCAL_MODEL_CANDIDATES: ReadonlyArray<LocalModelCandidate> = [
   {
-    modelTag: 'gemma3:1b',
-    displayName: 'Gemma 3 1B',
-    family: 'gemma3',
-    minRamGb: 3,
-    recommendedRamGb: 4,
-    minVramGb: 2,
-    recommendedVramGb: 3,
-    diskSizeGb: 0.8,
+    // Live-verified 2026-06-11: ollama.com/library/gemma4 · gemma4:e2b = 7.2 GB (Q4_K_M)
+    // Edge 2B effective parameters, 128k context, multimodal (text + image).
+    modelTag: 'gemma4:e2b',
+    displayName: 'Gemma 4 E2B (edge)',
+    family: 'gemma4',
+    minRamGb: 4,
+    recommendedRamGb: 6,
+    minVramGb: 3,
+    recommendedVramGb: 5,
+    diskSizeGb: 7.2,
     quantNote: 'Q4_K_M (default pull)',
     codeSpecialist: false,
     contextLengthK: 128,
   },
   {
-    modelTag: 'gemma3:4b',
-    displayName: 'Gemma 3 4B',
-    family: 'gemma3',
+    // Live-verified 2026-06-11: ollama.com/library/gemma4 · gemma4:e4b = 9.6 GB (Q4_K_M)
+    // Edge 4B effective parameters, 128k context, multimodal (text + image).
+    modelTag: 'gemma4:e4b',
+    displayName: 'Gemma 4 E4B (edge)',
+    family: 'gemma4',
     minRamGb: 6,
     recommendedRamGb: 8,
-    minVramGb: 5,
-    recommendedVramGb: 6,
-    diskSizeGb: 3.1,
+    minVramGb: 6,
+    recommendedVramGb: 8,
+    diskSizeGb: 9.6,
     quantNote: 'Q4_K_M (default pull)',
     codeSpecialist: false,
     contextLengthK: 128,
   },
   {
-    modelTag: 'gemma3:12b',
-    displayName: 'Gemma 3 12B',
-    family: 'gemma3',
+    // Live-verified 2026-06-11: ollama.com/library/gemma4 · gemma4:12b = 7.6 GB (QAT)
+    // 12B parameters, 256k context, multimodal (text + image).
+    modelTag: 'gemma4:12b',
+    displayName: 'Gemma 4 12B',
+    family: 'gemma4',
     minRamGb: 10,
     recommendedRamGb: 16,
-    minVramGb: 9,
+    minVramGb: 8,
     recommendedVramGb: 12,
-    diskSizeGb: 8.1,
-    quantNote: 'Q4_K_M (default pull)',
+    diskSizeGb: 7.6,
+    quantNote: 'QAT (default pull)',
     codeSpecialist: false,
-    contextLengthK: 128,
+    contextLengthK: 256,
   },
   {
     modelTag: 'qwen3:1.7b',

--- a/packages/core/src/llm/provider-registry/builtin/ollama.ts
+++ b/packages/core/src/llm/provider-registry/builtin/ollama.ts
@@ -37,30 +37,34 @@ import type { ProviderProfile } from '@cleocode/contracts';
  * store API, but local Ollama deployments do not require an actual key —
  * users may leave it empty or store a token for remote/proxied deployments.
  *
- * ## Default model selection (DHQ-081 · T11978)
+ * ## Default model selection (DHQ-081 · T11978 · T11990)
  *
- * `defaultModel` is `gemma3:4b` (standard/frontier tasks, requires ≥ 8 GB RAM).
- * `defaultAuxModel` is `gemma3:1b` (fast/aux tasks, requires ≥ 4 GB RAM).
+ * `defaultModel` is `gemma4:e4b` (standard/frontier tasks, requires ≥ 8 GB RAM).
+ * `defaultAuxModel` is `gemma4:e2b` (fast/aux tasks, requires ≥ 4 GB RAM).
+ *
+ * Tags live-verified on ollama.com/library/gemma4 2026-06-11:
+ *   - gemma4:e2b  = 7.2 GB download (Q4_K_M), edge 2B effective params
+ *   - gemma4:e4b  = 9.6 GB download (Q4_K_M), edge 4B effective params
+ *   - gemma4:12b  = 7.6 GB download (QAT), 12B params, 256k context
  *
  * The cross-provider selector (`cross-provider-selector.ts`) gates model selection
  * on `os.totalmem()` and falls through to `qwen2:0.5b` only as a proof-of-life
  * last resort when RAM is below 4 GB. These are the provider-registry SSoT
  * constants; the selector reads them via `getProviderProfile('ollama')`.
  *
- * PROPOSED-for-owner (Q2): changing from `llama3` to `gemma3:4b` requires users
- * to run `ollama pull gemma3:4b`. If the catalog does not yet have a `gemma3`
- * family entry, the resolver logs a hint to run `cleo llm refresh-catalog`.
+ * If the catalog does not yet have a `gemma4` family entry, the resolver logs a
+ * hint to run `cleo llm refresh-catalog`.
  */
 export const ollamaProfile: ProviderProfile = {
   name: 'ollama',
   displayName: 'Ollama (local)',
   authTypes: ['api_key'],
   baseUrl: 'http://localhost:11434',
-  defaultModel: 'gemma3:4b',
+  defaultModel: 'gemma4:e4b',
   aliases: ['ollama-local'],
   // Hermes-parity routing/catalog fields (T11756). Local on-device tier.
   tier: 'local',
-  defaultAuxModel: 'gemma3:1b',
+  defaultAuxModel: 'gemma4:e2b',
   defaultMaxTokens: 2048,
   envVars: ['OLLAMA_API_KEY', 'OLLAMA_BASE_URL'],
   supportsThinkingBudget: false,


### PR DESCRIPTION
## Summary

- **gemma3 is outdated** — current Google open-weight family is gemma4. Session-5 shipped stale gemma3:1b/4b as the RAM-gated ollama fallback (#1069, #1077).
- Pure data change in 3 source files + 2 test files + 1 changeset. No logic changes.
- RECOMMEND-NEVER-KILL semantics preserved throughout: local models remain recommended only; never auto-pulled; <4 GB floor routes to cloud-only with reason; fit envelope stays agent-readable.

## Live-Verified Tags (ollama.com/library/gemma4 — 2026-06-11)

| Tag | Download Size | Quant | Context | Notes |
|-----|--------------|-------|---------|-------|
| gemma4:e2b | 7.2 GB | Q4_K_M | 128k | Edge 2B effective params; ≥4 GB RAM tier |
| gemma4:e4b | 9.6 GB | Q4_K_M | 128k | Edge 4B effective params; ≥8 GB RAM tier |
| gemma4:12b | 7.6 GB | QAT | 256k | 12B params; ≥10 GB RAM |
| gemma4:26b | 18 GB | Q4_K_M | 256k | (not in fit table — too large for floor tier) |
| gemma4:31b | 20 GB | Q4_K_M | 256k | (not in fit table) |

## Changed Files

- `packages/core/src/llm/provider-registry/builtin/ollama.ts` — `defaultModel` `gemma3:4b`→`gemma4:e4b`; `defaultAuxModel` `gemma3:1b`→`gemma4:e2b`
- `packages/core/src/llm/local-model-fit.ts` — `LOCAL_MODEL_CANDIDATES`: 3 gemma3 entries replaced with gemma4:e2b/e4b/12b; RAM/VRAM rows recalibrated; `family` union updated `'gemma3'`→`'gemma4'`
- `packages/core/src/llm/cross-provider-selector.ts` — `ollamaDefaultModelForTier` literals updated; inline fallback updated; catalog hint updated
- `packages/core/src/llm/__tests__/local-model-fit.test.ts` — gemma3 tag expectations → gemma4
- `packages/core/src/llm/__tests__/cross-provider-selector.test.ts` — RAM-gate expectations → gemma4:e4b/e2b
- `.changeset/t11990-gemma4-edge-models.md` — changeset for v2026.6.15 changelog

## Fit-Proof (62 GB machine, compiled module)

```
Hardware: { totalRamGb: 62, availableRamGb: 40, vramTotalGb: null, vramMethod: 'none' }
Recommendations:
  [good] gemma4:12b  — score=28  | pullCommand: ollama pull gemma4:12b
    reasons: no GPU detected; 40.0 GB available RAM (recommended: 16 GB); 256k context window
  [good] gemma4:e2b  — score=28  | pullCommand: ollama pull gemma4:e2b
    reasons: no GPU detected; 40.0 GB available RAM (recommended: 6 GB); 128k context window
  [good] gemma4:e4b  — score=28  | pullCommand: ollama pull gemma4:e4b
    reasons: no GPU detected; 40.0 GB available RAM (recommended: 8 GB); 128k context window

Any gemma3? false
Any gemma4? true
```

## Test Results

- **47/47 tests pass** (vitest, scoped to changed files, 1.84s)
- `local-model-fit.test.ts`: 27 passed
- `cross-provider-selector.test.ts`: 20 passed
- Zero new failures

## Branch Head

`b97b627eee01d43a7962e6877accec8972cbc805`

🤖 Generated with [Claude Code](https://claude.com/claude-code)