### PR TITLE
feat(T11994): ResourceMonitor — PSI + MemAvailable sensing, daemon-off, pluggable backend

### DIFF
--- a/.changeset/t11994-resource-monitor.md
+++ b/.changeset/t11994-resource-monitor.md
@@ -1,0 +1,59 @@
+---
+id: t11994-resource-monitor
+tasks: [T11994]
+kind: feat
+summary: "ResourceMonitor library — PSI + MemAvailable sensing, daemon-off capable"
+---
+
+Adds `packages/core/src/resources/` — a net-new sensor layer for host memory
+state that CLEO had zero visibility into (confirmed grep: 0 hits on PSI/freemem
+reads anywhere in packages/runtime/src or packages/core/src/sentient).
+
+**New files:**
+
+- `packages/core/src/resources/backend.ts` — `ResourceBackend` interface +
+  raw sample/sweep types. Defines the pluggable platform backend surface for
+  macOS parity. `sweepChildRss()` is structurally separated from `sample()` so
+  ms-scale smaps_rollup reads can never enter the hot polling path (Amendment 2).
+
+- `packages/core/src/resources/linux-backend.ts` — Linux implementation.
+  Reads `/proc/pressure/memory` (global PSI), an optional cgroup v2 slice
+  `memory.pressure` file, `/proc/meminfo` (MemAvailable), and N SQLite `-wal`
+  sidecar stat calls for WAL growth signal (DHQ-050 starvation class, Amendment 3).
+  Injectable `readFileFn` / `statFileFn` allow tests to assert bounded read-count
+  without relying on wall-clock timing (Amendment 1 — CI-stable formulation).
+
+- `packages/core/src/resources/monitor.ts` — `ResourceMonitor` with:
+  - **Point-in-time mode** (`sample()`) — daemon-off governor acquire path
+  - **Continuous mode** (`startContinuous()`) — daemon/supervisor polling at
+    configurable `pollIntervalMs`, emitting `ok`/`hold`/`backoff` state
+    transitions with hysteresis (hold threshold – 3 pp floor prevents thrash)
+  - **Degraded mode** — when PSI interface absent (unprivileged/non-Linux),
+    falls back to availability-only sampling using `memAvailableBytes`
+  - Default thresholds: hold at some avg10 >10% / full avg10 >5%; backoff at
+    some avg10 >20% / full avg10 >10%. All far below systemd-oomd's Fedora
+    kill line of **80%/20s on user@1000.service** (not the 50%/20s figure in
+    older research — Amendment 4).
+
+- `packages/core/src/resources/__tests__/monitor.test.ts` — 50 tests covering:
+  parsing helpers, bounded read-count assertion via injected reader,
+  degraded mode, WAL observation, threshold crossing, hysteresis, continuous
+  mode transitions, idempotent stop, error resilience.
+
+**Contracts addition (additive-only, Amendment 5):**
+
+- Added `ResourcesConfig` + `ResourcesPsiConfig` interfaces to
+  `packages/contracts/src/config.ts` under the `resources.psi.*` and
+  `resources.headroomMb` namespaces
+- Added optional `resources?: ResourcesConfig` field to `CleoConfig`
+- Exported both types from `packages/contracts/src/index.ts`
+
+**Amendments resolved:**
+
+1. CI-stable sampling budget — bounded read-count asserted via injected reader
+2. smaps_rollup separation — structurally impossible to reach from `sample()`
+3. WAL growth signal — `walPaths` config + `WalSizeObservation` in sample
+4. oomd facts — corrected to Fedora default 80%/20s throughout
+
+**Conflict-free with T11993:** no shared barrel/index.ts created for the
+resources dir; spawn-wrapper files untouched.

--- a/packages/contracts/src/config.ts
+++ b/packages/contracts/src/config.ts
@@ -782,6 +782,67 @@ export interface DaemonConfig {
   autoStart: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Resources config (T11994 · PSI + MemAvailable sensing)
+// ---------------------------------------------------------------------------
+
+/**
+ * PSI pressure thresholds for the ResourceMonitor.
+ *
+ * Values are percentage points (0–100) for `avg10` exponential moving averages.
+ * Defaults sit far below systemd-oomd's Fedora kill line (80%/20s on
+ * user@1000.service).
+ *
+ * @task T11994
+ */
+export interface ResourcesPsiConfig {
+  /**
+   * Enter `hold` state when `some avg10` exceeds this value.
+   * @defaultValue 10
+   */
+  holdSomeAvg10?: number;
+  /**
+   * Enter `backoff` state when `some avg10` exceeds this value.
+   * @defaultValue 20
+   */
+  backoffSomeAvg10?: number;
+  /**
+   * Enter `hold` state when `full avg10` exceeds this value.
+   * @defaultValue 5
+   */
+  holdFullAvg10?: number;
+  /**
+   * Enter `backoff` state when `full avg10` exceeds this value.
+   * @defaultValue 10
+   */
+  backoffFullAvg10?: number;
+}
+
+/**
+ * Resource monitor configuration.
+ *
+ * Optional block — all fields have safe defaults. Maps to the
+ * `resources.*` config namespace (Amendment 5 · T11994).
+ *
+ * @task T11994
+ */
+export interface ResourcesConfig {
+  /**
+   * PSI pressure thresholds (percentage points).
+   *
+   * @defaultValue undefined (monitor uses built-in defaults)
+   */
+  psi?: ResourcesPsiConfig;
+  /**
+   * Minimum free memory headroom in MiB.
+   *
+   * Used in degraded mode (PSI absent) as the sole availability signal.
+   *
+   * @defaultValue 256
+   */
+  headroomMb?: number;
+}
+
 /** CLEO project configuration (config.json). */
 export interface CleoConfig {
   /** Configuration schema version string. */
@@ -880,6 +941,17 @@ export interface CleoConfig {
    * @task T11984
    */
   daemon?: DaemonConfig;
+  /**
+   * Resource monitor configuration — PSI pressure thresholds and memory
+   * headroom for the daemon-off governor and continuous supervisor mode.
+   *
+   * When absent, the ResourceMonitor uses built-in defaults which sit well
+   * below systemd-oomd's Fedora kill line (80%/20s on user@1000.service).
+   *
+   * @defaultValue undefined (ResourceMonitor uses built-in defaults)
+   * @task T11994
+   */
+  resources?: ResourcesConfig;
 }
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -286,6 +286,8 @@ export type {
   OutputFormat,
   ProviderConfig,
   ResolvedValue,
+  ResourcesConfig,
+  ResourcesPsiConfig,
   RoleName,
   SessionConfig,
   SessionSummaryInput,

--- a/packages/core/src/resources/__tests__/monitor.test.ts
+++ b/packages/core/src/resources/__tests__/monitor.test.ts
@@ -1,0 +1,791 @@
+/**
+ * Tests for ResourceMonitor (T11994).
+ *
+ * Coverage:
+ *   - parsePressureLine: valid, partial, malformed
+ *   - parsePsiFile: some+full, some-only, empty, malformed
+ *   - parseMemAvailable: valid, absent, non-Linux
+ *   - parseSmapsRollup: valid, partial
+ *   - LinuxResourceBackend.sample: bounded read-count (Amendment 1),
+ *       degraded mode (PSI absent), WAL observations
+ *   - evaluateState: ok→hold, hold→ok with hysteresis, hold→backoff,
+ *       backoff→ok with hysteresis, degraded mode threshold
+ *   - ResourceMonitor: point-in-time sample, continuous mode transitions,
+ *       stop is idempotent, duplicate startContinuous is no-op,
+ *       missing-interface degradation (Amendment 2 from base AC)
+ *
+ * ## Read-count assertion (Amendment 1 / CI-stable formulation)
+ *
+ * Tests inject a counting reader and assert the bounded read-count
+ * WITHOUT relying on wall-clock timing (Amendment 1).
+ *
+ * @task T11994
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PsiData, ResourceSample } from '../backend.js';
+import {
+  LinuxResourceBackend,
+  parseMemAvailable,
+  parsePressureLine,
+  parsePsiFile,
+  parseSmapsRollup,
+} from '../linux-backend.js';
+import { evaluateState, type PressureState, ResourceMonitor } from '../monitor.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MB = 1024 * 1024;
+const GB = 1024 * MB;
+
+/** Build a minimal passing ResourceSample with pressure available. */
+function makeSample(overrides: Partial<ResourceSample> = {}): ResourceSample {
+  const globalPressure: PsiData = {
+    some: { avg10: 0, avg60: 0, avg300: 0, totalUs: 0 },
+    full: { avg10: 0, avg60: 0, avg300: 0, totalUs: 0 },
+  };
+  return {
+    sampledAtMs: Date.now(),
+    pressureAvailable: true,
+    memAvailableBytes: 4 * GB,
+    globalPressure,
+    slicePressure: null,
+    walObservations: [],
+    ...overrides,
+  };
+}
+
+/** Build a sample with specific some/full avg10 values. */
+function makePressureSample(someAvg10: number, fullAvg10: number): ResourceSample {
+  return makeSample({
+    globalPressure: {
+      some: { avg10: someAvg10, avg60: 0, avg300: 0, totalUs: 0 },
+      full: { avg10: fullAvg10, avg60: 0, avg300: 0, totalUs: 0 },
+    },
+  });
+}
+
+/** Default resolved thresholds (mirroring DEFAULTS in monitor.ts). */
+const DEFAULT_THRESHOLDS = {
+  holdSomeAvg10: 10,
+  backoffSomeAvg10: 20,
+  holdFullAvg10: 5,
+  backoffFullAvg10: 10,
+  hysteresisPoints: 3,
+  headroomBytes: 256 * MB,
+  walWarnThresholdBytes: 256 * MB,
+  pollIntervalMs: 1500,
+};
+
+// ---------------------------------------------------------------------------
+// parsePressureLine
+// ---------------------------------------------------------------------------
+
+describe('parsePressureLine', () => {
+  it('parses a valid "some" line', () => {
+    const result = parsePressureLine('some avg10=0.42 avg60=0.31 avg300=0.20 total=1234567');
+    expect(result).not.toBeNull();
+    expect(result!.avg10).toBeCloseTo(0.42, 5);
+    expect(result!.avg60).toBeCloseTo(0.31, 5);
+    expect(result!.avg300).toBeCloseTo(0.2, 5);
+    expect(result!.totalUs).toBe(1234567);
+  });
+
+  it('parses a line with zero values', () => {
+    const result = parsePressureLine('some avg10=0.00 avg60=0.00 avg300=0.00 total=0');
+    expect(result).not.toBeNull();
+    expect(result!.avg10).toBe(0);
+    expect(result!.totalUs).toBe(0);
+  });
+
+  it('parses a line with high avg10 (near 100)', () => {
+    const result = parsePressureLine('full avg10=99.99 avg60=50.00 avg300=30.00 total=9999999');
+    expect(result!.avg10).toBeCloseTo(99.99, 2);
+  });
+
+  it('returns null for a completely malformed line', () => {
+    expect(parsePressureLine('not a pressure line')).toBeNull();
+  });
+
+  it('returns null when avg10 field is missing', () => {
+    expect(parsePressureLine('some avg60=0.31 avg300=0.20 total=100')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePsiFile
+// ---------------------------------------------------------------------------
+
+describe('parsePsiFile', () => {
+  it('parses a standard PSI file with both some and full lines', () => {
+    const content = [
+      'some avg10=2.50 avg60=1.20 avg300=0.80 total=500000',
+      'full avg10=0.30 avg60=0.10 avg300=0.05 total=100000',
+    ].join('\n');
+    const result = parsePsiFile(content);
+    expect(result).not.toBeNull();
+    expect(result!.some.avg10).toBeCloseTo(2.5, 5);
+    expect(result!.full?.avg10).toBeCloseTo(0.3, 5);
+  });
+
+  it('parses a PSI file with only the "some" line (no "full")', () => {
+    const content = 'some avg10=1.00 avg60=0.50 avg300=0.20 total=200000';
+    const result = parsePsiFile(content);
+    expect(result).not.toBeNull();
+    expect(result!.some.avg10).toBeCloseTo(1.0, 5);
+    expect(result!.full).toBeNull();
+  });
+
+  it('returns null for empty content', () => {
+    expect(parsePsiFile('')).toBeNull();
+  });
+
+  it('returns null when only the "full" line is present (no "some")', () => {
+    const content = 'full avg10=0.10 avg60=0.05 avg300=0.02 total=50000';
+    expect(parsePsiFile(content)).toBeNull();
+  });
+
+  it('handles trailing newline in PSI file', () => {
+    const content =
+      'some avg10=0.10 avg60=0.05 avg300=0.02 total=1000\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n';
+    const result = parsePsiFile(content);
+    expect(result).not.toBeNull();
+    expect(result!.some.avg10).toBeCloseTo(0.1, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMemAvailable
+// ---------------------------------------------------------------------------
+
+describe('parseMemAvailable', () => {
+  it('parses MemAvailable from /proc/meminfo content', () => {
+    const content = [
+      'MemTotal:       65536000 kB',
+      'MemFree:        10240000 kB',
+      'MemAvailable:   42233788 kB',
+      'Buffers:         1234567 kB',
+    ].join('\n');
+    const result = parseMemAvailable(content);
+    expect(result).toBe(42233788 * 1024);
+  });
+
+  it('returns null when MemAvailable is absent', () => {
+    const content = 'MemTotal:       65536000 kB\nMemFree:        10240000 kB\n';
+    expect(parseMemAvailable(content)).toBeNull();
+  });
+
+  it('returns null for empty content', () => {
+    expect(parseMemAvailable('')).toBeNull();
+  });
+
+  it('handles single-space formatting in MemAvailable', () => {
+    const content = 'MemAvailable: 1024 kB\n';
+    const result = parseMemAvailable(content);
+    expect(result).toBe(1024 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSmapsRollup
+// ---------------------------------------------------------------------------
+
+describe('parseSmapsRollup', () => {
+  it('parses Rss and Pss from smaps_rollup content', () => {
+    const content = [
+      'VmFlags:',
+      'Rss:           12288 kB',
+      'Pss:            9216 kB',
+      'Shared_Clean:   3072 kB',
+      'Private_Dirty:  9216 kB',
+    ].join('\n');
+    const result = parseSmapsRollup(content);
+    expect(result).not.toBeNull();
+    expect(result!.rssBytes).toBe(12288 * 1024);
+    expect(result!.pssBytes).toBe(9216 * 1024);
+  });
+
+  it('returns null when Rss is missing', () => {
+    const content = 'Pss: 1024 kB\n';
+    expect(parseSmapsRollup(content)).toBeNull();
+  });
+
+  it('returns null when Pss is missing', () => {
+    const content = 'Rss: 1024 kB\n';
+    expect(parseSmapsRollup(content)).toBeNull();
+  });
+
+  it('returns null for empty content', () => {
+    expect(parseSmapsRollup('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LinuxResourceBackend — bounded read-count (Amendment 1)
+// ---------------------------------------------------------------------------
+
+describe('LinuxResourceBackend.sample — bounded read-count', () => {
+  it('performs exactly 3 file reads when PSI available and no WAL paths', async () => {
+    const readLog: string[] = [];
+
+    const fakeRead = async (path: string): Promise<string> => {
+      readLog.push(path);
+      if (path === '/proc/pressure/memory') {
+        return [
+          'some avg10=2.00 avg60=1.00 avg300=0.50 total=100000',
+          'full avg10=0.10 avg60=0.05 avg300=0.02 total=10000',
+        ].join('\n');
+      }
+      if (path === '/proc/meminfo') {
+        return 'MemAvailable:   4194304 kB\n';
+      }
+      throw new Error(`unexpected read: ${path}`);
+    };
+
+    const backend = new LinuxResourceBackend({
+      readFileFn: fakeRead,
+      statFileFn: async () => null,
+    });
+    const sample = await backend.sample();
+
+    // Exactly 2 reads: /proc/pressure/memory + /proc/meminfo
+    // (no cgroupSlicePressurePath configured → no slice read)
+    expect(readLog).toHaveLength(2);
+    expect(readLog).toContain('/proc/pressure/memory');
+    expect(readLog).toContain('/proc/meminfo');
+    expect(sample.pressureAvailable).toBe(true);
+    expect(sample.memAvailableBytes).toBe(4194304 * 1024);
+    expect(sample.walObservations).toHaveLength(0);
+  });
+
+  it('performs exactly 3 reads when slice path is configured', async () => {
+    const readLog: string[] = [];
+    const SLICE_PATH = '/sys/fs/cgroup/user.slice/memory.pressure';
+
+    const fakeRead = async (path: string): Promise<string> => {
+      readLog.push(path);
+      if (path === '/proc/pressure/memory') {
+        return 'some avg10=1.00 avg60=0.50 avg300=0.20 total=50000\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n';
+      }
+      if (path === SLICE_PATH) {
+        return 'some avg10=0.50 avg60=0.20 avg300=0.10 total=25000\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n';
+      }
+      if (path === '/proc/meminfo') {
+        return 'MemAvailable:   2097152 kB\n';
+      }
+      throw new Error(`unexpected read: ${path}`);
+    };
+
+    const backend = new LinuxResourceBackend({
+      globalPressurePath: '/proc/pressure/memory',
+      cgroupSlicePressurePath: SLICE_PATH,
+      readFileFn: fakeRead,
+      statFileFn: async () => null,
+    });
+    const sample = await backend.sample();
+
+    expect(readLog).toHaveLength(3);
+    expect(sample.pressureAvailable).toBe(true);
+    expect(sample.slicePressure).not.toBeNull();
+    expect(sample.slicePressure!.some.avg10).toBeCloseTo(0.5, 5);
+  });
+
+  it('adds N stat calls for N WAL paths and no extra reads', async () => {
+    const readLog: string[] = [];
+    const statLog: string[] = [];
+
+    const fakeRead = async (path: string): Promise<string> => {
+      readLog.push(path);
+      if (path === '/proc/pressure/memory') {
+        return 'some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n';
+      }
+      if (path === '/proc/meminfo') {
+        return 'MemAvailable: 8388608 kB\n';
+      }
+      throw new Error(`unexpected read: ${path}`);
+    };
+    const fakeStat = async (path: string): Promise<{ size: number } | null> => {
+      statLog.push(path);
+      return { size: 1024 * 1024 };
+    };
+
+    const walPaths = ['/data/tasks.db-wal', '/data/brain.db-wal'];
+    const backend = new LinuxResourceBackend({
+      walPaths,
+      readFileFn: fakeRead,
+      statFileFn: fakeStat,
+    });
+    const sample = await backend.sample();
+
+    // 2 reads (global PSI + meminfo), 2 stat calls
+    expect(readLog).toHaveLength(2);
+    expect(statLog).toHaveLength(2);
+    expect(sample.walObservations).toHaveLength(2);
+    expect(sample.walObservations[0].walPath).toBe('/data/tasks.db-wal');
+    expect(sample.walObservations[0].sizeBytes).toBe(1024 * 1024);
+  });
+
+  it('reports WAL as null size when file does not exist', async () => {
+    const backend = new LinuxResourceBackend({
+      walPaths: ['/nonexistent.db-wal'],
+      readFileFn: async () =>
+        'some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\nMemAvailable: 1024 kB\n',
+      statFileFn: async () => null,
+    });
+    // Use simpler per-path fake
+    const readMap: Record<string, string> = {
+      '/proc/pressure/memory':
+        'some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n',
+      '/proc/meminfo': 'MemAvailable: 1024 kB\n',
+    };
+    const backend2 = new LinuxResourceBackend({
+      walPaths: ['/nonexistent.db-wal'],
+      readFileFn: async (path) => {
+        const v = readMap[path];
+        if (!v) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return v;
+      },
+      statFileFn: async () => null,
+    });
+    const sample = await backend2.sample();
+    expect(sample.walObservations[0].sizeBytes).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LinuxResourceBackend — degraded mode (PSI absent)
+// ---------------------------------------------------------------------------
+
+describe('LinuxResourceBackend.sample — degraded mode', () => {
+  it('returns pressureAvailable=false when /proc/pressure/memory throws', async () => {
+    const backend = new LinuxResourceBackend({
+      readFileFn: async (path) => {
+        if (path === '/proc/pressure/memory') {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        }
+        if (path === '/proc/meminfo') {
+          return 'MemAvailable: 4096000 kB\n';
+        }
+        throw new Error(`unexpected: ${path}`);
+      },
+      statFileFn: async () => null,
+    });
+    const sample = await backend.sample();
+    expect(sample.pressureAvailable).toBe(false);
+    expect(sample.globalPressure).toBeNull();
+    expect(sample.memAvailableBytes).toBe(4096000 * 1024);
+  });
+
+  it('returns memAvailableBytes=null when /proc/meminfo is unreadable', async () => {
+    const backend = new LinuxResourceBackend({
+      readFileFn: async (path) => {
+        if (path === '/proc/pressure/memory') {
+          return 'some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n';
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+      statFileFn: async () => null,
+    });
+    const sample = await backend.sample();
+    expect(sample.memAvailableBytes).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LinuxResourceBackend — sweepChildRss (separate path)
+// ---------------------------------------------------------------------------
+
+describe('LinuxResourceBackend.sweepChildRss', () => {
+  it('sweeps RSS for known PIDs via smaps_rollup', async () => {
+    const readMap: Record<string, string> = {
+      '/proc/1234/smaps_rollup': 'Rss: 20480 kB\nPss: 15360 kB\n',
+      '/proc/5678/smaps_rollup': 'Rss: 8192 kB\nPss: 6144 kB\n',
+    };
+    const backend = new LinuxResourceBackend({
+      readFileFn: async (path) => {
+        const v = readMap[path];
+        if (!v) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return v;
+      },
+      statFileFn: async () => null,
+    });
+    const sweep = await backend.sweepChildRss([1234, 5678]);
+    expect(sweep.entries).toHaveLength(2);
+    const e1 = sweep.entries.find((e) => e.pid === 1234);
+    expect(e1?.rssBytes).toBe(20480 * 1024);
+    expect(e1?.pssBytes).toBe(15360 * 1024);
+  });
+
+  it('silently skips dead PIDs', async () => {
+    const backend = new LinuxResourceBackend({
+      readFileFn: async () => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+      statFileFn: async () => null,
+    });
+    const sweep = await backend.sweepChildRss([9999]);
+    expect(sweep.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateState — threshold crossing
+// ---------------------------------------------------------------------------
+
+describe('evaluateState', () => {
+  it('returns ok when pressure is zero', () => {
+    const { state } = evaluateState(makePressureSample(0, 0), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('ok');
+  });
+
+  it('returns hold when some avg10 exceeds hold threshold', () => {
+    const { state } = evaluateState(makePressureSample(11, 0), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('hold');
+  });
+
+  it('returns hold when full avg10 exceeds hold threshold', () => {
+    const { state } = evaluateState(makePressureSample(0, 6), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('hold');
+  });
+
+  it('returns backoff when some avg10 exceeds backoff threshold', () => {
+    const { state } = evaluateState(makePressureSample(21, 0), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('backoff');
+  });
+
+  it('returns backoff when full avg10 exceeds backoff threshold', () => {
+    const { state } = evaluateState(makePressureSample(0, 11), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('backoff');
+  });
+
+  it('returns ok when pressure is exactly at hold threshold (not above)', () => {
+    // holdSomeAvg10=10 — exactly 10 is NOT above, so ok
+    const { state } = evaluateState(makePressureSample(10, 0), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('ok');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateState — hysteresis
+// ---------------------------------------------------------------------------
+
+describe('evaluateState — hysteresis', () => {
+  // holdSomeAvg10=10, hysteresisPoints=3 → floor = 7
+  it('stays in hold when pressure drops below hold but above hysteresis floor', () => {
+    // some avg10=8 > floor(7), state='hold' → should stay hold
+    const { state } = evaluateState(makePressureSample(8, 0), DEFAULT_THRESHOLDS, 'hold');
+    expect(state).toBe('hold');
+  });
+
+  it('drops to ok when pressure falls below hysteresis floor', () => {
+    // some avg10=6 < floor(7), state='hold' → should drop to ok
+    const { state } = evaluateState(makePressureSample(6, 0), DEFAULT_THRESHOLDS, 'hold');
+    expect(state).toBe('ok');
+  });
+
+  it('clamps backoff→hold (not backoff→ok) in hysteresis band', () => {
+    // Coming from backoff, pressure dropped below backoff but above hold
+    // some avg10=12, state='backoff' → hold (not backoff or ok)
+    const { state } = evaluateState(makePressureSample(12, 0), DEFAULT_THRESHOLDS, 'backoff');
+    expect(state).toBe('hold');
+  });
+
+  it('drops directly from backoff to ok when far below hysteresis floor', () => {
+    // some avg10=2, state='backoff' → well below floor(7) → ok
+    const { state } = evaluateState(makePressureSample(2, 0), DEFAULT_THRESHOLDS, 'backoff');
+    expect(state).toBe('ok');
+  });
+
+  it('ok→hold does not trigger hysteresis (only applies to hold/backoff→lower)', () => {
+    // Coming from ok, pressure at 11 (above hold) → hold immediately
+    const { state } = evaluateState(makePressureSample(11, 0), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('hold');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateState — degraded mode (PSI absent)
+// ---------------------------------------------------------------------------
+
+describe('evaluateState — degraded mode', () => {
+  const degradedSample = (memAvailableBytes: number): ResourceSample =>
+    makeSample({
+      pressureAvailable: false,
+      globalPressure: null,
+      memAvailableBytes,
+    });
+
+  it('returns ok in degraded mode when memAvailable is above headroom', () => {
+    const { state } = evaluateState(degradedSample(512 * MB), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('ok');
+  });
+
+  it('returns hold in degraded mode when memAvailable falls below headroom', () => {
+    // headroomBytes = 256 MiB; 128 MiB < 256 MiB → hold
+    const { state } = evaluateState(degradedSample(128 * MB), DEFAULT_THRESHOLDS, 'ok');
+    expect(state).toBe('hold');
+  });
+
+  it('returns ok in degraded mode when memAvailableBytes is null', () => {
+    const { state } = evaluateState(
+      makeSample({ pressureAvailable: false, globalPressure: null, memAvailableBytes: null }),
+      DEFAULT_THRESHOLDS,
+      'ok',
+    );
+    expect(state).toBe('ok');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ResourceMonitor — point-in-time sample
+// ---------------------------------------------------------------------------
+
+describe('ResourceMonitor.sample()', () => {
+  it('returns a sample from the backend without updating state', async () => {
+    const fakeSample = makePressureSample(5, 0);
+    const fakeBackend = {
+      sample: vi.fn().mockResolvedValue(fakeSample),
+      sweepChildRss: vi.fn(),
+    };
+    const monitor = new ResourceMonitor({ backend: fakeBackend });
+    const result = await monitor.sample();
+    expect(result).toBe(fakeSample);
+    expect(monitor.state).toBe('ok'); // state unchanged by point-in-time call
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ResourceMonitor — continuous mode
+// ---------------------------------------------------------------------------
+
+describe('ResourceMonitor continuous mode', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits "transition" from ok→hold when pressure crosses threshold', async () => {
+    const highPressureSample = makePressureSample(15, 0); // above holdSomeAvg10=10
+
+    const fakeBackend = {
+      sample: vi.fn().mockResolvedValue(highPressureSample),
+      sweepChildRss: vi.fn(),
+    };
+
+    const monitor = new ResourceMonitor({
+      backend: fakeBackend,
+      pollIntervalMs: 1000,
+    });
+
+    const transitions: Array<{ from: PressureState; to: PressureState }> = [];
+    monitor.on('transition', (t) => transitions.push({ from: t.from, to: t.to }));
+
+    const stop = monitor.startContinuous();
+    await vi.advanceTimersByTimeAsync(1100);
+    stop();
+
+    expect(transitions.length).toBeGreaterThanOrEqual(1);
+    expect(transitions[0]).toEqual({ from: 'ok', to: 'hold' });
+  });
+
+  it('emits "transition" from hold→backoff when pressure spikes further', async () => {
+    const samples = [
+      makePressureSample(15, 0), // ok → hold
+      makePressureSample(25, 0), // hold → backoff
+    ];
+    let callCount = 0;
+    const fakeBackend = {
+      sample: vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(samples[Math.min(callCount++, samples.length - 1)]),
+        ),
+      sweepChildRss: vi.fn(),
+    };
+
+    const monitor = new ResourceMonitor({
+      backend: fakeBackend,
+      pollIntervalMs: 1000,
+    });
+
+    const transitions: Array<{ from: PressureState; to: PressureState }> = [];
+    monitor.on('transition', (t) => transitions.push({ from: t.from, to: t.to }));
+
+    const stop = monitor.startContinuous();
+    await vi.advanceTimersByTimeAsync(2200);
+    stop();
+
+    expect(transitions).toContainEqual({ from: 'ok', to: 'hold' });
+    expect(transitions).toContainEqual({ from: 'hold', to: 'backoff' });
+  });
+
+  it('emits "transition" from hold→ok when pressure drops past hysteresis floor', async () => {
+    // holdSomeAvg10=10, hysteresisPoints=3 → floor=7
+    const samples = [
+      makePressureSample(11, 0), // ok → hold
+      makePressureSample(6, 0), // hold → ok (below floor 7)
+    ];
+    let callCount = 0;
+    const fakeBackend = {
+      sample: vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(samples[Math.min(callCount++, samples.length - 1)]),
+        ),
+      sweepChildRss: vi.fn(),
+    };
+
+    const monitor = new ResourceMonitor({
+      backend: fakeBackend,
+      pollIntervalMs: 1000,
+    });
+
+    const transitions: Array<{ from: PressureState; to: PressureState }> = [];
+    monitor.on('transition', (t) => transitions.push({ from: t.from, to: t.to }));
+
+    const stop = monitor.startContinuous();
+    await vi.advanceTimersByTimeAsync(2200);
+    stop();
+
+    expect(transitions).toContainEqual({ from: 'ok', to: 'hold' });
+    expect(transitions).toContainEqual({ from: 'hold', to: 'ok' });
+  });
+
+  it('does NOT emit transition when pressure stays in hysteresis band', async () => {
+    // holdSomeAvg10=10, hysteresisPoints=3 → floor=7
+    // First poll goes to hold, then stays in 7–10 band — no transition
+    const samples = [
+      makePressureSample(11, 0), // ok → hold
+      makePressureSample(8, 0), // in hysteresis band → stays hold
+    ];
+    let callCount = 0;
+    const fakeBackend = {
+      sample: vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(samples[Math.min(callCount++, samples.length - 1)]),
+        ),
+      sweepChildRss: vi.fn(),
+    };
+
+    const monitor = new ResourceMonitor({
+      backend: fakeBackend,
+      pollIntervalMs: 1000,
+    });
+
+    const transitions: Array<{ from: PressureState; to: PressureState }> = [];
+    monitor.on('transition', (t) => transitions.push({ from: t.from, to: t.to }));
+
+    const stop = monitor.startContinuous();
+    await vi.advanceTimersByTimeAsync(2200);
+    stop();
+
+    // Should only have the ok→hold transition (not hold→anything)
+    expect(transitions.filter((t) => t.from === 'hold')).toHaveLength(0);
+    expect(transitions).toContainEqual({ from: 'ok', to: 'hold' });
+  });
+
+  it('stop() is idempotent', () => {
+    const fakeBackend = {
+      sample: vi.fn().mockResolvedValue(makeSample()),
+      sweepChildRss: vi.fn(),
+    };
+    const monitor = new ResourceMonitor({ backend: fakeBackend });
+    const stop = monitor.startContinuous();
+    expect(() => {
+      stop();
+      stop();
+      monitor.stop();
+    }).not.toThrow();
+    expect(monitor.running).toBe(false);
+  });
+
+  it('duplicate startContinuous() returns without starting a second loop', () => {
+    const fakeBackend = {
+      sample: vi.fn().mockResolvedValue(makeSample()),
+      sweepChildRss: vi.fn(),
+    };
+    const monitor = new ResourceMonitor({ backend: fakeBackend, pollIntervalMs: 10000 });
+    const stop1 = monitor.startContinuous();
+    const stop2 = monitor.startContinuous(); // no-op
+    expect(monitor.running).toBe(true);
+    stop1();
+    stop2();
+    expect(monitor.running).toBe(false);
+  });
+
+  it('emits "error" when backend throws and continues polling', async () => {
+    let callCount = 0;
+    const fakeBackend = {
+      sample: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(new Error('transient failure'));
+        return Promise.resolve(makeSample());
+      }),
+      sweepChildRss: vi.fn(),
+    };
+
+    const monitor = new ResourceMonitor({ backend: fakeBackend, pollIntervalMs: 1000 });
+    const errors: Error[] = [];
+    monitor.on('error', (err) => errors.push(err));
+
+    const stop = monitor.startContinuous();
+    await vi.advanceTimersByTimeAsync(2200);
+    stop();
+
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].message).toBe('transient failure');
+    // Loop continued after error
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('emits "sample" on every poll even when state does not change', async () => {
+    const fakeBackend = {
+      sample: vi.fn().mockResolvedValue(makeSample()),
+      sweepChildRss: vi.fn(),
+    };
+
+    const monitor = new ResourceMonitor({ backend: fakeBackend, pollIntervalMs: 1000 });
+    const samples: ResourceSample[] = [];
+    monitor.on('sample', (s) => samples.push(s));
+
+    const stop = monitor.startContinuous();
+    await vi.advanceTimersByTimeAsync(3100);
+    stop();
+
+    // 3 polls in 3100ms with 1000ms interval
+    expect(samples.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ResourceMonitor — configurable thresholds
+// ---------------------------------------------------------------------------
+
+describe('ResourceMonitor — configurable thresholds', () => {
+  it('respects custom holdSomeAvg10 threshold', async () => {
+    const monitor = new ResourceMonitor({
+      psi: { holdSomeAvg10: 30, backoffSomeAvg10: 60 },
+    });
+    // At some avg10=25 (below custom hold 30), should be ok
+    const { state: s1 } = evaluateState(
+      makePressureSample(25, 0),
+      { ...DEFAULT_THRESHOLDS, holdSomeAvg10: 30, backoffSomeAvg10: 60 },
+      'ok',
+    );
+    expect(s1).toBe('ok');
+
+    // At some avg10=35 (above custom hold 30), should be hold
+    const { state: s2 } = evaluateState(
+      makePressureSample(35, 0),
+      { ...DEFAULT_THRESHOLDS, holdSomeAvg10: 30, backoffSomeAvg10: 60 },
+      'ok',
+    );
+    expect(s2).toBe('hold');
+  });
+});

--- a/packages/core/src/resources/backend.ts
+++ b/packages/core/src/resources/backend.ts
@@ -1,0 +1,179 @@
+/**
+ * ResourceMonitor platform backend interface.
+ *
+ * Concrete implementations read OS-level pressure/memory data.
+ * The Linux backend is complete; other platforms register here for parity.
+ *
+ * ## Sampling discipline
+ *
+ * The {@link ResourceBackend.sample} call MUST:
+ * - Spawn NO child process
+ * - Perform a BOUNDED number of file reads (PSI + meminfo + slice-pressure only)
+ * - Return quickly — callers validate read-count via injected readers in tests
+ *
+ * Per-child `/proc/<pid>/smaps_rollup` PSS sweeps are ms-scale per multi-GB
+ * process and MUST NEVER appear in this interface. See {@link ResourceBackend.sweepChildRss}
+ * for the separate low-frequency telemetry surface.
+ *
+ * @module resources/backend
+ * @task T11994
+ * @epic T11992
+ */
+
+// ---------------------------------------------------------------------------
+// Raw sample types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single PSI pressure line parsed from `/proc/pressure/memory` or a
+ * cgroup `memory.pressure` file.
+ *
+ * PSI line format example:
+ *   `some avg10=0.42 avg60=0.31 avg300=0.20 total=1234567`
+ */
+export interface PressureLine {
+  /** 10-second exponential moving average (0–100). */
+  readonly avg10: number;
+  /** 60-second exponential moving average (0–100). */
+  readonly avg60: number;
+  /** 300-second exponential moving average (0–100). */
+  readonly avg300: number;
+  /** Cumulative stall time in microseconds. */
+  readonly totalUs: number;
+}
+
+/**
+ * Parsed PSI data from a single pressure file (some + full lines).
+ *
+ * `full` is `null` when the kernel omits it (e.g. some older kernels or
+ * non-memory cgroups).
+ */
+export interface PsiData {
+  readonly some: PressureLine;
+  readonly full: PressureLine | null;
+}
+
+/**
+ * WAL sidecar size observation.
+ *
+ * Addresses the DHQ-050 multi-GB WAL class: a throttled reader holding a
+ * read-mark can starve checkpoints, causing unbounded WAL growth.
+ * The monitor surfaces this as a pressure/starvation input signal.
+ */
+export interface WalSizeObservation {
+  /** Absolute path to the `-wal` file. */
+  readonly walPath: string;
+  /** Current file size in bytes, or `null` if the file does not exist. */
+  readonly sizeBytes: number | null;
+}
+
+/**
+ * A complete point-in-time resource sample.
+ *
+ * Produced by {@link ResourceBackend.sample} on every poll interval.
+ * The sample NEVER includes per-child RSS data — see {@link ChildRssSweep}.
+ */
+export interface ResourceSample {
+  /** Monotonic timestamp (ms) when the sample was taken. */
+  readonly sampledAtMs: number;
+
+  /**
+   * `true` when the PSI interface was reachable.
+   * `false` triggers degraded mode — only `memAvailableBytes` is meaningful.
+   */
+  readonly pressureAvailable: boolean;
+
+  /**
+   * MemAvailable from `/proc/meminfo` in bytes, or `null` on non-Linux /
+   * read error.
+   */
+  readonly memAvailableBytes: number | null;
+
+  /**
+   * Global memory pressure from `/proc/pressure/memory`.
+   * `null` when {@link pressureAvailable} is `false`.
+   */
+  readonly globalPressure: PsiData | null;
+
+  /**
+   * cleo.slice scoped memory pressure (from the slice's `memory.pressure`).
+   * `null` when the cgroup v2 slice path is absent or unreadable.
+   */
+  readonly slicePressure: PsiData | null;
+
+  /**
+   * WAL sidecar size observations for configured DB paths.
+   * Empty array when no WAL paths are configured.
+   */
+  readonly walObservations: readonly WalSizeObservation[];
+}
+
+// ---------------------------------------------------------------------------
+// Per-child RSS sweep (separate low-frequency surface — NEVER in sample path)
+// ---------------------------------------------------------------------------
+
+/**
+ * RSS telemetry for a single child process, read from
+ * `/proc/<pid>/smaps_rollup`.
+ *
+ * **IMPORTANT**: smaps_rollup reads are ms-scale per multi-GB process.
+ * This type is produced by {@link ResourceBackend.sweepChildRss}, which
+ * exists on a SEPARATE low-frequency cadence and MUST NOT be called from
+ * the hot sampling path.
+ */
+export interface ChildRssEntry {
+  readonly pid: number;
+  /** PSS (proportional set size) in bytes. */
+  readonly pssBytes: number;
+  /** RSS in bytes. */
+  readonly rssBytes: number;
+}
+
+/**
+ * Result of a per-child RSS sweep.
+ */
+export interface ChildRssSweep {
+  readonly sampledAtMs: number;
+  readonly entries: readonly ChildRssEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Backend interface
+// ---------------------------------------------------------------------------
+
+/**
+ * ResourceMonitor platform backend.
+ *
+ * Implement this interface to add support for a new platform (e.g. macOS).
+ * The Linux implementation (`LinuxResourceBackend`) is complete.
+ *
+ * ### Read-count contract (Amendment 1 / CI-stable sampling)
+ *
+ * `sample()` reads AT MOST:
+ *   1. `/proc/pressure/memory` (global PSI)
+ *   2. One cgroup `memory.pressure` file (slice PSI)
+ *   3. `/proc/meminfo` (MemAvailable)
+ *   4. One `-wal` size stat per configured WAL path
+ *
+ * The injected `readFileFn` and `statFileFn` let tests assert read-count
+ * without relying on wall-clock timing.
+ */
+export interface ResourceBackend {
+  /**
+   * Take a bounded point-in-time resource sample.
+   *
+   * Spawns NO child process. Bounded file reads only (see class-level doc).
+   */
+  sample(): Promise<ResourceSample>;
+
+  /**
+   * Sweep per-child RSS via `/proc/<pid>/smaps_rollup`.
+   *
+   * **LOW-FREQUENCY ONLY** — never call from the sampling hot path.
+   * Suitable for periodic telemetry (e.g. every 60s) or triggered by a
+   * backoff→hold state transition.
+   *
+   * @param pids - PIDs to sweep. Unknown/dead PIDs are silently skipped.
+   */
+  sweepChildRss(pids: readonly number[]): Promise<ChildRssSweep>;
+}

--- a/packages/core/src/resources/linux-backend.ts
+++ b/packages/core/src/resources/linux-backend.ts
@@ -1,0 +1,360 @@
+/**
+ * Linux ResourceMonitor backend.
+ *
+ * Reads:
+ *   - `/proc/pressure/memory` — global PSI (some + full)
+ *   - `<cgroupSlicePath>/memory.pressure` — cleo.slice scoped PSI
+ *   - `/proc/meminfo` — MemAvailable
+ *   - `<walPath>` size stat — WAL growth signal (DHQ-050 starvation class)
+ *   - `/proc/<pid>/smaps_rollup` — per-child RSS (SEPARATE low-frequency path)
+ *
+ * ## Read-count discipline (Amendment 1)
+ *
+ * `sample()` calls the injected reader at most:
+ *   - 1× for `/proc/pressure/memory`
+ *   - 1× for the slice `memory.pressure` (if configured)
+ *   - 1× for `/proc/meminfo`
+ *   - N× stat calls for N configured WAL paths
+ *
+ * smaps_rollup reads are on a SEPARATE `sweepChildRss()` method and are
+ * structurally impossible to reach from the `sample()` hot path.
+ *
+ * ## oomd threshold facts (Amendment 4)
+ *
+ * systemd-oomd on Fedora defaults to 80%/20s on user@1000.service.
+ * Our hold/backoff thresholds (some avg10 >10% / full avg10 >5%) sit far
+ * below that line, ensuring cleo always throttles before oomd kills.
+ *
+ * @module resources/linux-backend
+ * @task T11994
+ * @epic T11992
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import type {
+  ChildRssEntry,
+  ChildRssSweep,
+  PressureLine,
+  PsiData,
+  ResourceBackend,
+  ResourceSample,
+  WalSizeObservation,
+} from './backend.js';
+
+// ---------------------------------------------------------------------------
+// Injected reader types (allow tests to count and fake reads)
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable file-read function. Defaults to `fs/promises.readFile`.
+ *
+ * Tests inject a counting wrapper to assert bounded read-count without
+ * relying on wall-clock timing (Amendment 1 — CI-stable formulation).
+ */
+export type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
+
+/**
+ * Injectable stat function. Defaults to `fs/promises.stat`.
+ *
+ * Returns `null` when the file does not exist (ENOENT) or is unreadable.
+ */
+export type StatFileFn = (path: string) => Promise<{ size: number } | null>;
+
+// ---------------------------------------------------------------------------
+// Parsing helpers (tested in isolation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single PSI line.
+ *
+ * Format: `some avg10=0.42 avg60=0.31 avg300=0.20 total=1234567`
+ *
+ * Returns `null` when the line does not match the expected format.
+ */
+export function parsePressureLine(line: string): PressureLine | null {
+  const avg10Match = /avg10=([\d.]+)/.exec(line);
+  const avg60Match = /avg60=([\d.]+)/.exec(line);
+  const avg300Match = /avg300=([\d.]+)/.exec(line);
+  const totalMatch = /total=(\d+)/.exec(line);
+
+  if (!avg10Match?.[1] || !avg60Match?.[1] || !avg300Match?.[1] || !totalMatch?.[1]) {
+    return null;
+  }
+
+  return {
+    avg10: parseFloat(avg10Match[1]),
+    avg60: parseFloat(avg60Match[1]),
+    avg300: parseFloat(avg300Match[1]),
+    totalUs: parseInt(totalMatch[1], 10),
+  };
+}
+
+/**
+ * Parse a PSI file (two lines: `some ...` and `full ...`).
+ *
+ * Returns `null` when the content is unreadable / unparseable — callers
+ * treat this as "pressure interface absent" (degraded mode).
+ */
+export function parsePsiFile(content: string): PsiData | null {
+  const lines = content
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  let some: PressureLine | null = null;
+  let full: PressureLine | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith('some ')) {
+      some = parsePressureLine(line);
+    } else if (line.startsWith('full ')) {
+      full = parsePressureLine(line);
+    }
+  }
+
+  if (!some) {
+    return null;
+  }
+
+  return { some, full };
+}
+
+/**
+ * Parse `MemAvailable` from `/proc/meminfo`.
+ *
+ * Format: `MemAvailable:   42233788 kB`
+ *
+ * Returns `null` when the field is absent (non-Linux / old kernel).
+ * Reuses the same parsing pattern as `packages/core/src/llm/local-model-fit.ts:269`.
+ */
+export function parseMemAvailable(content: string): number | null {
+  for (const line of content.split('\n')) {
+    if (line.startsWith('MemAvailable:')) {
+      // Format: "MemAvailable:   42233788 kB"
+      const match = /MemAvailable:\s+(\d+)\s+kB/.exec(line);
+      if (match?.[1]) {
+        return parseInt(match[1], 10) * 1024;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a `/proc/<pid>/smaps_rollup` file for RSS and PSS.
+ *
+ * Relevant fields:
+ *   `Rss:       12345 kB`
+ *   `Pss:        9876 kB`
+ *
+ * Returns `null` when either field is absent.
+ */
+export function parseSmapsRollup(content: string): { rssBytes: number; pssBytes: number } | null {
+  let rssKb: number | null = null;
+  let pssKb: number | null = null;
+
+  for (const line of content.split('\n')) {
+    if (line.startsWith('Rss:')) {
+      const m = /Rss:\s+(\d+)\s+kB/.exec(line);
+      if (m?.[1]) rssKb = parseInt(m[1], 10);
+    } else if (line.startsWith('Pss:')) {
+      const m = /Pss:\s+(\d+)\s+kB/.exec(line);
+      if (m?.[1]) pssKb = parseInt(m[1], 10);
+    }
+  }
+
+  if (rssKb === null || pssKb === null) return null;
+  return { rssBytes: rssKb * 1024, pssBytes: pssKb * 1024 };
+}
+
+// ---------------------------------------------------------------------------
+// Linux backend configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link LinuxResourceBackend}.
+ */
+export interface LinuxBackendOptions {
+  /**
+   * Path to the global PSI memory pressure file.
+   * @defaultValue '/proc/pressure/memory'
+   */
+  readonly globalPressurePath?: string;
+
+  /**
+   * Path to the cleo.slice cgroup v2 `memory.pressure` file.
+   *
+   * Common paths:
+   *   `/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/cleo.slice/memory.pressure`
+   *
+   * Set to `null` to disable slice-scoped sampling.
+   * @defaultValue undefined (auto-detect disabled; callers supply the path)
+   */
+  readonly cgroupSlicePressurePath?: string | null;
+
+  /**
+   * Absolute paths to SQLite `-wal` sidecar files to watch.
+   *
+   * WAL growth is a starvation signal (DHQ-050 class): a throttled reader
+   * holding a read-mark prevents checkpoint → WAL regrows unboundedly.
+   * Monitoring WAL size lets the governor correlate write-stall with
+   * memory pressure.
+   *
+   * @defaultValue []
+   */
+  readonly walPaths?: readonly string[];
+
+  /**
+   * Injectable file-read function (for testing).
+   * @defaultValue fs/promises.readFile
+   */
+  readonly readFileFn?: ReadFileFn;
+
+  /**
+   * Injectable stat function (for testing).
+   * @defaultValue fs/promises.stat (ENOENT → null)
+   */
+  readonly statFileFn?: StatFileFn;
+}
+
+// ---------------------------------------------------------------------------
+// Default injectable implementations
+// ---------------------------------------------------------------------------
+
+const defaultReadFile: ReadFileFn = (path, encoding) => readFile(path, encoding);
+
+const defaultStat: StatFileFn = async (path) => {
+  try {
+    const s = await stat(path);
+    return { size: s.size };
+  } catch {
+    return null;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Linux backend
+// ---------------------------------------------------------------------------
+
+/**
+ * Linux implementation of {@link ResourceBackend}.
+ *
+ * Uses injected `readFileFn` / `statFileFn` so unit tests can:
+ *   1. Fake file contents (threshold-crossing, degraded mode)
+ *   2. Count reads to assert the bounded-read contract (Amendment 1)
+ */
+export class LinuxResourceBackend implements ResourceBackend {
+  private readonly globalPressurePath: string;
+  private readonly cgroupSlicePressurePath: string | null;
+  private readonly walPaths: readonly string[];
+  private readonly readFileFn: ReadFileFn;
+  private readonly statFileFn: StatFileFn;
+
+  constructor(opts: LinuxBackendOptions = {}) {
+    this.globalPressurePath = opts.globalPressurePath ?? '/proc/pressure/memory';
+    this.cgroupSlicePressurePath = opts.cgroupSlicePressurePath ?? null;
+    this.walPaths = opts.walPaths ?? [];
+    this.readFileFn = opts.readFileFn ?? defaultReadFile;
+    this.statFileFn = opts.statFileFn ?? defaultStat;
+  }
+
+  /**
+   * Take a bounded point-in-time resource sample.
+   *
+   * Read-count (bounded by Amendment 1):
+   *   - 1 read: `/proc/pressure/memory`
+   *   - 0–1 reads: slice `memory.pressure` (if configured)
+   *   - 1 read: `/proc/meminfo`
+   *   - N stat calls: one per WAL path in `walPaths`
+   *
+   * Never spawns a child process.
+   */
+  async sample(): Promise<ResourceSample> {
+    const sampledAtMs = Date.now();
+
+    // Read 1: global PSI
+    const globalPressure = await this._readPsi(this.globalPressurePath);
+    const pressureAvailable = globalPressure !== null;
+
+    // Read 2 (optional): slice PSI
+    let slicePressure: PsiData | null = null;
+    if (this.cgroupSlicePressurePath) {
+      slicePressure = await this._readPsi(this.cgroupSlicePressurePath);
+    }
+
+    // Read 3: MemAvailable
+    const memAvailableBytes = await this._readMemAvailable();
+
+    // Read N: WAL stat observations
+    const walObservations = await this._readWalObservations();
+
+    return {
+      sampledAtMs,
+      pressureAvailable,
+      memAvailableBytes,
+      globalPressure,
+      slicePressure,
+      walObservations,
+    };
+  }
+
+  /**
+   * Sweep per-child RSS via `/proc/<pid>/smaps_rollup`.
+   *
+   * **STRUCTURALLY SEPARATED from sample()** — smaps_rollup reads are
+   * ms-scale per multi-GB process and must never appear in the hot path.
+   * Call on a separate low-frequency cadence (e.g. every 60s or on
+   * backoff→hold state transition).
+   *
+   * @param pids - PIDs to sweep. Dead/unknown PIDs are silently skipped.
+   */
+  async sweepChildRss(pids: readonly number[]): Promise<ChildRssSweep> {
+    const sampledAtMs = Date.now();
+    const entries: ChildRssEntry[] = [];
+
+    for (const pid of pids) {
+      try {
+        const content = await this.readFileFn(`/proc/${pid}/smaps_rollup`, 'utf-8');
+        const parsed = parseSmapsRollup(content);
+        if (parsed) {
+          entries.push({ pid, ...parsed });
+        }
+      } catch {
+        // Dead or inaccessible PID — skip silently
+      }
+    }
+
+    return { sampledAtMs, entries };
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async _readPsi(path: string): Promise<PsiData | null> {
+    try {
+      const content = await this.readFileFn(path, 'utf-8');
+      return parsePsiFile(content);
+    } catch {
+      return null;
+    }
+  }
+
+  private async _readMemAvailable(): Promise<number | null> {
+    try {
+      const content = await this.readFileFn('/proc/meminfo', 'utf-8');
+      return parseMemAvailable(content);
+    } catch {
+      return null;
+    }
+  }
+
+  private async _readWalObservations(): Promise<WalSizeObservation[]> {
+    const results: WalSizeObservation[] = [];
+    for (const walPath of this.walPaths) {
+      const info = await this.statFileFn(walPath);
+      results.push({ walPath, sizeBytes: info?.size ?? null });
+    }
+    return results;
+  }
+}

--- a/packages/core/src/resources/monitor.ts
+++ b/packages/core/src/resources/monitor.ts
@@ -1,0 +1,421 @@
+/**
+ * ResourceMonitor — PSI + MemAvailable sensing, daemon-off capable.
+ *
+ * Two operational modes:
+ *
+ * 1. **Point-in-time sample** (`ResourceMonitor.sample()`): used inside the
+ *    governor acquire path when the daemon is off. Single call, bounded reads.
+ *
+ * 2. **Continuous loop** (`ResourceMonitor.startContinuous()`): used by the
+ *    daemon/supervisor. Polls at `pollIntervalMs` and emits `ok` → `hold` →
+ *    `backoff` state transitions with hysteresis.
+ *
+ * ## State machine
+ *
+ *   ok  ──── pressure > holdThreshold ──────→  hold
+ *   hold ─── pressure < holdThreshold - hyst ─→ ok
+ *   hold ─── pressure > backoffThreshold ─────→ backoff
+ *   backoff ─ pressure < holdThreshold - hyst ─→ ok
+ *
+ * Default thresholds (far below systemd-oomd's Fedora 80%/20s kill line):
+ *   - hold:    some avg10 > 10% OR full avg10 > 5%
+ *   - backoff: some avg10 > 20% OR full avg10 > 10%
+ *   - hysteresis: 3 percentage points (prevents thrash on threshold edge)
+ *
+ * ## Degraded mode
+ *
+ * When the PSI interface is absent (non-Linux, locked-down container,
+ * unprivileged environment), the monitor falls back to availability-only
+ * sampling: `pressureAvailable = false`, `state = 'ok'` unless
+ * `memAvailableBytes` is below `headroomMb`.
+ *
+ * ## oomd facts (Amendment 4)
+ *
+ * systemd-oomd on Fedora defaults to 80%/20s on user@1000.service (NOT
+ * the 50%/20s figure cited in older research). Our hold/backoff thresholds
+ * sit far below that line — cleo always throttles before oomd kills.
+ *
+ * ## WAL growth signal (Amendment 3)
+ *
+ * The monitor accepts an optional watch on SQLite `-wal` sidecar file sizes.
+ * A size above `walWarnThresholdBytes` is surfaced in the sample and can
+ * drive governor decisions independently of memory pressure.
+ *
+ * @module resources/monitor
+ * @task T11994
+ * @epic T11992
+ */
+
+import { EventEmitter } from 'node:events';
+import type { ResourceBackend, ResourceSample } from './backend.js';
+import { LinuxResourceBackend } from './linux-backend.js';
+
+// ---------------------------------------------------------------------------
+// State type
+// ---------------------------------------------------------------------------
+
+/**
+ * Memory pressure state transitions emitted by the continuous loop.
+ *
+ * - `ok`:      pressure below hold threshold — normal operation
+ * - `hold`:    pressure above hold threshold — slow down, avoid new allocs
+ * - `backoff`: pressure above backoff threshold — actively shed load
+ */
+export type PressureState = 'ok' | 'hold' | 'backoff';
+
+// ---------------------------------------------------------------------------
+// Transition event
+// ---------------------------------------------------------------------------
+
+/**
+ * Emitted by {@link ResourceMonitor} when the pressure state changes.
+ */
+export interface StateTransition {
+  readonly from: PressureState;
+  readonly to: PressureState;
+  readonly sample: ResourceSample;
+  readonly reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Thresholds for the `some avg10` dimension (percentage points, 0–100).
+ */
+export interface SomePressureThresholds {
+  /** Enter `hold` state when `some avg10` exceeds this value. Default: 10. */
+  readonly holdSomeAvg10: number;
+  /** Enter `backoff` state when `some avg10` exceeds this value. Default: 20. */
+  readonly backoffSomeAvg10: number;
+}
+
+/**
+ * Thresholds for the `full avg10` dimension (percentage points, 0–100).
+ */
+export interface FullPressureThresholds {
+  /** Enter `hold` state when `full avg10` exceeds this value. Default: 5. */
+  readonly holdFullAvg10: number;
+  /** Enter `backoff` state when `full avg10` exceeds this value. Default: 10. */
+  readonly backoffFullAvg10: number;
+}
+
+/**
+ * Configuration for {@link ResourceMonitor}.
+ *
+ * All fields are optional — the defaults are calibrated to sit well below
+ * systemd-oomd's Fedora kill line of 80%/20s.
+ */
+export interface ResourceMonitorConfig {
+  /**
+   * `some avg10` pressure thresholds (percentage points, 0–100).
+   *
+   * Maps to the `resources.psi` config namespace (Amendment 5).
+   */
+  readonly psi?: Partial<SomePressureThresholds & FullPressureThresholds>;
+
+  /**
+   * Hysteresis band (percentage points).
+   *
+   * The monitor does NOT drop back to `ok` until pressure falls below
+   * `(holdThreshold - hysteresisPoints)` to prevent state thrashing.
+   *
+   * @defaultValue 3
+   */
+  readonly hysteresisPoints?: number;
+
+  /**
+   * Minimum free memory to consider the system healthy (bytes).
+   *
+   * Used in degraded mode (PSI absent) as the sole availability signal.
+   * Maps to the `resources.headroomMb` config namespace.
+   *
+   * @defaultValue 256 * 1024 * 1024 (256 MiB)
+   */
+  readonly headroomBytes?: number;
+
+  /**
+   * WAL file size above which a warning observation is surfaced.
+   *
+   * @defaultValue 256 * 1024 * 1024 (256 MiB)
+   */
+  readonly walWarnThresholdBytes?: number;
+
+  /**
+   * Poll interval for continuous mode (milliseconds).
+   *
+   * @defaultValue 1500
+   */
+  readonly pollIntervalMs?: number;
+
+  /**
+   * Platform backend. Defaults to {@link LinuxResourceBackend}.
+   *
+   * Inject a different backend for macOS parity or test fakes.
+   */
+  readonly backend?: ResourceBackend;
+}
+
+// ---------------------------------------------------------------------------
+// Effective (resolved) thresholds
+// ---------------------------------------------------------------------------
+
+interface ResolvedThresholds {
+  readonly holdSomeAvg10: number;
+  readonly backoffSomeAvg10: number;
+  readonly holdFullAvg10: number;
+  readonly backoffFullAvg10: number;
+  readonly hysteresisPoints: number;
+  readonly headroomBytes: number;
+  readonly walWarnThresholdBytes: number;
+  readonly pollIntervalMs: number;
+}
+
+const DEFAULTS: ResolvedThresholds = {
+  holdSomeAvg10: 10,
+  backoffSomeAvg10: 20,
+  holdFullAvg10: 5,
+  backoffFullAvg10: 10,
+  hysteresisPoints: 3,
+  headroomBytes: 256 * 1024 * 1024,
+  walWarnThresholdBytes: 256 * 1024 * 1024,
+  pollIntervalMs: 1500,
+};
+
+function resolveThresholds(cfg: ResourceMonitorConfig): ResolvedThresholds {
+  return {
+    holdSomeAvg10: cfg.psi?.holdSomeAvg10 ?? DEFAULTS.holdSomeAvg10,
+    backoffSomeAvg10: cfg.psi?.backoffSomeAvg10 ?? DEFAULTS.backoffSomeAvg10,
+    holdFullAvg10: cfg.psi?.holdFullAvg10 ?? DEFAULTS.holdFullAvg10,
+    backoffFullAvg10: cfg.psi?.backoffFullAvg10 ?? DEFAULTS.backoffFullAvg10,
+    hysteresisPoints: cfg.hysteresisPoints ?? DEFAULTS.hysteresisPoints,
+    headroomBytes: cfg.headroomBytes ?? DEFAULTS.headroomBytes,
+    walWarnThresholdBytes: cfg.walWarnThresholdBytes ?? DEFAULTS.walWarnThresholdBytes,
+    pollIntervalMs: cfg.pollIntervalMs ?? DEFAULTS.pollIntervalMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate the pressure state given a sample and resolved thresholds.
+ *
+ * In degraded mode (PSI absent), the state is `hold` only when free memory
+ * falls below `headroomBytes`.
+ *
+ * @internal
+ */
+export function evaluateState(
+  sample: ResourceSample,
+  thresholds: ResolvedThresholds,
+  currentState: PressureState,
+): { state: PressureState; reason: string } {
+  if (!sample.pressureAvailable) {
+    // Degraded mode — availability-only
+    if (sample.memAvailableBytes !== null && sample.memAvailableBytes < thresholds.headroomBytes) {
+      return { state: 'hold', reason: 'degraded: memAvailable below headroom' };
+    }
+    return { state: 'ok', reason: 'degraded: PSI unavailable, memAvailable sufficient' };
+  }
+
+  const somePressure = sample.globalPressure?.some ?? sample.slicePressure?.some;
+  const fullPressure = sample.globalPressure?.full ?? sample.slicePressure?.full;
+
+  const someAvg10 = somePressure?.avg10 ?? 0;
+  const fullAvg10 = fullPressure?.avg10 ?? 0;
+
+  // Backoff threshold (highest severity)
+  if (someAvg10 > thresholds.backoffSomeAvg10 || fullAvg10 > thresholds.backoffFullAvg10) {
+    return {
+      state: 'backoff',
+      reason: `some avg10=${someAvg10.toFixed(2)} full avg10=${fullAvg10.toFixed(2)} — above backoff threshold`,
+    };
+  }
+
+  // Hold threshold
+  if (someAvg10 > thresholds.holdSomeAvg10 || fullAvg10 > thresholds.holdFullAvg10) {
+    return {
+      state: 'hold',
+      reason: `some avg10=${someAvg10.toFixed(2)} full avg10=${fullAvg10.toFixed(2)} — above hold threshold`,
+    };
+  }
+
+  // Hysteresis: only drop to 'ok' if we were already at 'ok', or
+  // pressure has fallen below (holdThreshold - hysteresis)
+  if (currentState !== 'ok') {
+    const hysteresisFloor = thresholds.holdSomeAvg10 - thresholds.hysteresisPoints;
+    const fullHysteresisFloor = thresholds.holdFullAvg10 - thresholds.hysteresisPoints;
+
+    if (someAvg10 > hysteresisFloor || fullAvg10 > fullHysteresisFloor) {
+      // Still in hysteresis band — stay in current state (clamp to max 'hold')
+      const clamped = currentState === 'backoff' ? 'hold' : currentState;
+      return {
+        state: clamped,
+        reason: `some avg10=${someAvg10.toFixed(2)} full avg10=${fullAvg10.toFixed(2)} — hysteresis hold (floor: some ${hysteresisFloor}, full ${fullHysteresisFloor})`,
+      };
+    }
+  }
+
+  return {
+    state: 'ok',
+    reason: `some avg10=${someAvg10.toFixed(2)} full avg10=${fullAvg10.toFixed(2)} — below thresholds`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ResourceMonitor
+// ---------------------------------------------------------------------------
+
+/**
+ * ResourceMonitor event map for typed EventEmitter usage.
+ */
+interface ResourceMonitorEvents {
+  transition: [transition: StateTransition];
+  sample: [sample: ResourceSample];
+  error: [err: Error];
+}
+
+/**
+ * ResourceMonitor — PSI + MemAvailable sensing, daemon-off capable.
+ *
+ * @example Point-in-time (daemon-off governor acquire):
+ * ```ts
+ * const monitor = new ResourceMonitor();
+ * const sample = await monitor.sample();
+ * if (sample.memAvailableBytes !== null && sample.memAvailableBytes < 256 * 1024 * 1024) {
+ *   throw new Error('insufficient memory');
+ * }
+ * ```
+ *
+ * @example Continuous mode (daemon supervisor):
+ * ```ts
+ * const monitor = new ResourceMonitor({ pollIntervalMs: 1500 });
+ * monitor.on('transition', ({ from, to, reason }) => {
+ *   logger.warn(`pressure: ${from} → ${to} (${reason})`);
+ * });
+ * const stop = monitor.startContinuous();
+ * // later:
+ * stop();
+ * ```
+ */
+export class ResourceMonitor extends EventEmitter<ResourceMonitorEvents> {
+  private readonly thresholds: ResolvedThresholds;
+  private readonly backend: ResourceBackend;
+
+  private _state: PressureState = 'ok';
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+  private _running = false;
+
+  constructor(cfg: ResourceMonitorConfig = {}) {
+    super();
+    this.thresholds = resolveThresholds(cfg);
+    this.backend = cfg.backend ?? new LinuxResourceBackend();
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Current pressure state (only meaningful after at least one sample).
+   */
+  get state(): PressureState {
+    return this._state;
+  }
+
+  /**
+   * `true` while the continuous loop is running.
+   */
+  get running(): boolean {
+    return this._running;
+  }
+
+  /**
+   * Take a single point-in-time resource sample.
+   *
+   * Safe to call with the daemon off (no child processes, bounded reads).
+   * Does NOT update `this.state` — use {@link startContinuous} for that.
+   */
+  async sample(): Promise<ResourceSample> {
+    return this.backend.sample();
+  }
+
+  /**
+   * Start the continuous polling loop.
+   *
+   * Returns a `stop()` function. Calling `stop()` is idempotent.
+   *
+   * Emits:
+   *   - `'sample'` on every poll (even if state did not change)
+   *   - `'transition'` when `PressureState` changes
+   *   - `'error'` if the backend throws (loop continues regardless)
+   */
+  startContinuous(): () => void {
+    if (this._running) {
+      return () => this._stopLoop();
+    }
+    this._running = true;
+    this._scheduleNext();
+    return () => this._stopLoop();
+  }
+
+  /**
+   * Stop the continuous polling loop. Idempotent.
+   */
+  stop(): void {
+    this._stopLoop();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private loop machinery
+  // -------------------------------------------------------------------------
+
+  private _scheduleNext(): void {
+    this._timer = setTimeout(() => {
+      void this._tick();
+    }, this.thresholds.pollIntervalMs);
+    // Allow the process to exit if this is the only pending callback
+    if (typeof this._timer.unref === 'function') {
+      this._timer.unref();
+    }
+  }
+
+  private async _tick(): Promise<void> {
+    if (!this._running) return;
+
+    try {
+      const sample = await this.backend.sample();
+      this.emit('sample', sample);
+
+      const { state: newState, reason } = evaluateState(sample, this.thresholds, this._state);
+
+      if (newState !== this._state) {
+        const transition: StateTransition = {
+          from: this._state,
+          to: newState,
+          sample,
+          reason,
+        };
+        this._state = newState;
+        this.emit('transition', transition);
+      }
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+    }
+
+    if (this._running) {
+      this._scheduleNext();
+    }
+  }
+
+  private _stopLoop(): void {
+    this._running = false;
+    if (this._timer !== null) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `packages/core/src/resources/` — net-new sensor layer for host memory pressure (CLEO had zero PSI/freemem visibility; confirmed by grep before implementation)
- **`backend.ts`**: `ResourceBackend` platform interface + `ResourceSample`/`ChildRssSweep` types; `sweepChildRss()` is structurally separated from `sample()` so smaps_rollup reads can never reach the hot polling path
- **`linux-backend.ts`**: reads `/proc/pressure/memory`, optional cgroup v2 slice `memory.pressure`, `/proc/meminfo` MemAvailable, and N WAL sidecar stat calls; injectable `readFileFn`/`statFileFn` for CI-stable bounded-read-count assertion
- **`monitor.ts`**: `ResourceMonitor` with point-in-time mode (daemon-off governor acquire), continuous mode (ok/hold/backoff state machine with hysteresis), degraded mode (PSI absent → availability-only)
- **50 tests** covering all amendment requirements: bounded read-count, degraded mode, WAL observations, threshold crossing, hysteresis, transition emission, idempotent stop, error resilience
- **Contracts addition (additive-only)**: `ResourcesConfig`/`ResourcesPsiConfig` + `CleoConfig.resources?` optional field

## Amendments resolved

1. **Sampling budget (CI-stable)**: bounded read-count asserted via injected reader (not wall-clock). `sample()` performs at most 1 + 0-or-1 + 1 file reads + N stat calls for N WAL paths.
2. **smaps_rollup separation**: `sweepChildRss()` is a separate method on the backend interface — structurally impossible to invoke from the `sample()` path.
3. **WAL growth signal**: `LinuxBackendOptions.walPaths` accepts SQLite `-wal` sidecar paths; `ResourceSample.walObservations` surfaces size/existence per path. DHQ-050 starvation class addressed.
4. **oomd facts corrected**: all doc comments cite Fedora default **80%/20s** on user@1000.service (not the 50%/20s figure in older research). Hold/backoff thresholds remain at some avg10 >10%/20% and full avg10 >5%/10% — well below the kill line.

## Conflict-free with T11993

No shared `resources/index.ts` barrel created. `spawn-wrapper.ts` untouched.

## Test plan

- [ ] `pnpm biome check packages/core/src/resources/ packages/contracts/src/config.ts packages/contracts/src/index.ts` — passes clean
- [ ] `pnpm --filter @cleocode/contracts run build` — green
- [ ] `pnpm --filter @cleocode/core run build` — green
- [ ] 50/50 tests in `src/resources/__tests__/monitor.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)