### PR TITLE
feat(T11989): log declined fix-gen replies (redacted, truncated) onto DHQ evidence row

### DIFF
--- a/.changeset/t11989-log-declined-replies.md
+++ b/.changeset/t11989-log-declined-replies.md
@@ -1,0 +1,36 @@
+---
+id: t11989-log-declined-replies
+tasks: [T11989]
+kind: feat
+summary: "fix-gen logs redacted, truncated model reply on model-declined and fixgen-not-a-diff outcomes; reply excerpt persisted on DHQ evidence row"
+---
+
+Closes DHQ-091: when the self-improvement fix-gen stage declines to produce a patch
+(`model-declined` or `fixgen-not-a-diff`), the model's actual reply was silently
+discarded, making diagnosis impossible without a code walk. This change captures and
+safely surfaces that reply.
+
+**Changes:**
+
+- **`packages/core/src/selfimprove/fix-gen.ts`** (modified):
+  - New `truncateReply(reply)` export — credential-redacts via `@cleocode/utils redact`
+    then byte-caps at 3072 bytes (`REPLY_EXCERPT_MAX_BYTES`) with a
+    `…[truncated N bytes]` overflow marker. Pre-sanitized output is safe to log or persist.
+  - `FixGenOutput` `'none'` variant gains an optional `rawReply?: string` field.
+    `createLlmFixGenerator.propose()` populates it with `truncateReply(text)` on
+    `model-declined` (non-empty reply only; empty reply = no excerpt).
+  - `FixGenResult` `'skipped'` variant gains an optional `replyExcerpt?: string` field.
+    `generateFixPatch` propagates `rawReply` from `FixGenOutput` into `replyExcerpt` for
+    the `model-declined` path (debug log) and calls `truncateReply(output.diff)` for the
+    `fixgen-not-a-diff` path (warn log). The `replyExcerpt` flows into the JSON the
+    run-loop serializes onto the `selfimprove_dhq` evidence row, enabling the operator to
+    diagnose the model's actual output without re-running.
+
+**Tests added (`fix-gen.test.ts`):**
+
+- `(a)` declined reply lands in `FixGenResult.replyExcerpt` truncated at 3 KiB.
+- `(b)` seeded `sk-ant-...` / `Bearer ...` credential strings in the reply are redacted.
+- `(c)` valid-diff path logs nothing extra (`replyExcerpt` absent on `written` result).
+- `fixgen-not-a-diff` path attaches `replyExcerpt` from the non-diff output.
+- New capstone test: `model-declined` reply excerpt is persisted on the leased DHQ
+  evidence row (asserts `evidence.fixGen.replyExcerpt` via real adapter + in-memory DB).

--- a/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
+++ b/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
@@ -46,6 +46,7 @@ import {
   generateFixPatch,
   looksLikeUnifiedDiff,
   stripCodeFences,
+  truncateReply,
 } from '../fix-gen.js';
 import type { LoadedFileContext } from '../fix-gen-context.js';
 import type { ReplayDispatch } from '../replay.js';
@@ -230,6 +231,89 @@ describe('fix-gen — generateFixPatch with a deterministic fake', () => {
   });
 });
 
+// ── T11989 — reply-logging tests ─────────────────────────────────────────────
+describe('T11989 — declined/not-a-diff outcomes log + attach reply excerpt', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `fixgen-t11989-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('(a) declined reply lands in the FixGenResult replyExcerpt truncated at 3 KiB', async () => {
+    // Build a reply that exceeds the 3072-byte cap so we exercise truncation.
+    const longReply = 'NO_PATCH — reason: ' + 'x'.repeat(4000);
+    const generator: FixGenerator = {
+      propose: vi.fn(async () => ({
+        kind: 'none' as const,
+        reason: 'model-declined',
+        rawReply: truncateReply(longReply),
+      })),
+    };
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+
+    expect(res.kind).toBe('skipped');
+    if (res.kind !== 'skipped') throw new Error('unreachable');
+    expect(res.reason).toContain('model-declined');
+    // replyExcerpt must be present and bounded.
+    expect(res.replyExcerpt).toBeDefined();
+    const excerpt = res.replyExcerpt!;
+    // Must be truncated (original is > 3072 bytes).
+    expect(excerpt).toContain('…[truncated');
+    // Must not exceed the budget (the marker itself may add a few chars, but the
+    // original content portion is capped).
+    expect(Buffer.byteLength(excerpt, 'utf8')).toBeLessThan(3200);
+    // No patch file written.
+    expect(existsSync(join(root, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+  });
+
+  it('(b) a seeded credential string in the reply is redacted', async () => {
+    const secretApiKey = 'sk-ant-api03-ShouldNotAppearInLogs';
+    const bearerToken = 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fake';
+    const replyWithSecrets = `I cannot fix this. Token: ${secretApiKey} Auth: ${bearerToken}`;
+
+    // Call truncateReply directly (the path exercised by createLlmFixGenerator).
+    const excerpt = truncateReply(replyWithSecrets);
+
+    expect(excerpt).not.toContain(secretApiKey);
+    expect(excerpt).not.toContain(bearerToken);
+    // The redaction marker '[REDACTED]' should be present.
+    expect(excerpt).toContain('[REDACTED]');
+  });
+
+  it('(c) valid-diff path logs nothing extra (replyExcerpt is absent on written result)', async () => {
+    const generator = fakeGenerator({ kind: 'patch', diff: CANNED_PATCH, model: 'fake-model' });
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+
+    expect(res.kind).toBe('written');
+    // The written variant has no replyExcerpt field — confirm the type contract.
+    expect('replyExcerpt' in res).toBe(false);
+  });
+
+  it('fixgen-not-a-diff path attaches replyExcerpt from the non-diff output', async () => {
+    const proseReply = 'Sorry, I cannot propose a fix for this regression.';
+    const generator = fakeGenerator({ kind: 'patch', diff: proseReply, model: 'm' });
+    const res = await generateFixPatch({ request: makeRequest(root), generator, cwd: root });
+
+    expect(res.kind).toBe('skipped');
+    if (res.kind !== 'skipped') throw new Error('unreachable');
+    expect(res.reason).toBe('fixgen-not-a-diff');
+    // replyExcerpt must carry the (redacted) prose.
+    expect(res.replyExcerpt).toBeDefined();
+    expect(res.replyExcerpt).toContain('Sorry');
+    // No patch file written.
+    expect(existsSync(join(root, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+  });
+});
+
 /**
  * Build a dispatch port that DIVERGES from the golden so the loop finds a
  * regression (mirrors the run-loop test's regressionDispatch).
@@ -369,5 +453,46 @@ describe('run-loop CAPSTONE — regression → fix-gen → DRAFT PR (determinist
     if (res.draftPr?.kind === 'error') {
       expect(res.draftPr.code).toBe('E_NOT_FOUND');
     }
+  });
+
+  it('T11989: model-declined reply excerpt is persisted on the DHQ evidence row', async () => {
+    // Simulate a generator that declines with a pre-sanitized rawReply excerpt
+    // (as createLlmFixGenerator would produce after truncateReply).
+    const declineExcerpt = 'I cannot produce a fix for this regression.';
+    const generator: FixGenerator = {
+      propose: vi.fn(async () => ({
+        kind: 'none' as const,
+        reason: 'model-declined',
+        rawReply: declineExcerpt,
+      })),
+    };
+
+    const res = await runSelfImprove({
+      scenario: SCENARIO,
+      dispatch: regressionDispatch(),
+      backend: 'in-process',
+      guard,
+      adapter: realAdapter,
+      cwd: projectRoot,
+      execute: true,
+      piRunnerEnabled: true,
+      fixGenerator: generator,
+    });
+
+    // Fix-gen must have run and returned skipped (no patch written).
+    expect(res.fixGen?.kind).toBe('skipped');
+    if (res.fixGen?.kind === 'skipped') {
+      expect(res.fixGen.reason).toContain('model-declined');
+      // The replyExcerpt propagates through generateFixPatch → FixGenResult.
+      expect(res.fixGen.replyExcerpt).toBe(declineExcerpt);
+    }
+
+    // The evidence row stored on the DHQ must contain the excerpt so the
+    // operator can diagnose the model's actual output.
+    const evidenceRaw = openRegressionJson();
+    expect(evidenceRaw).not.toBeNull();
+    const evidence = JSON.parse(evidenceRaw!);
+    expect(evidence.fixGen).toBeDefined();
+    expect(evidence.fixGen.replyExcerpt).toBe(declineExcerpt);
   });
 });

--- a/packages/core/src/selfimprove/fix-gen.ts
+++ b/packages/core/src/selfimprove/fix-gen.ts
@@ -41,6 +41,7 @@
 import { writeFileSync } from 'node:fs';
 import { resolve as resolvePath } from 'node:path';
 import { cwd as processCwd } from 'node:process';
+import { redact } from '@cleocode/utils';
 import type { Logger } from 'pino';
 import type { DiffEntry } from './envelope-diff.js';
 import {
@@ -49,6 +50,13 @@ import {
   loadFileContext,
   renderFileContextSection,
 } from './fix-gen-context.js';
+
+/**
+ * Maximum byte length of a model-reply excerpt stored in DHQ evidence or logs.
+ * Replies beyond this threshold are truncated with a marker so logs stay bounded
+ * while preserving enough context for diagnosis.
+ */
+const REPLY_EXCERPT_MAX_BYTES = 3072;
 
 /**
  * The E9 system-of-use label the fix-generator resolves its model under. Maps to
@@ -118,6 +126,13 @@ export type FixGenOutput =
       readonly kind: 'none';
       /** Machine-stable reason for the absence. */
       readonly reason: string;
+      /**
+       * Credential-redacted, byte-bounded excerpt of the raw model reply (when the
+       * reason is `'model-declined'`). Absent for failure modes that have no reply
+       * (e.g. `'no-credential-resolved'`). Callers that log or persist this field
+       * MUST NOT additionally redact — it is pre-sanitized by the generator.
+       */
+      readonly rawReply?: string;
     };
 
 /**
@@ -154,6 +169,14 @@ export type FixGenResult =
       readonly kind: 'skipped';
       /** Machine-stable reason recorded on the DHQ evidence. */
       readonly reason: string;
+      /**
+       * Credential-redacted, byte-bounded excerpt of the raw model reply for
+       * `'model-declined'` and `'fixgen-not-a-diff'` outcomes. Absent for
+       * generator errors and other failure modes that have no usable reply text.
+       * Persisted on the DHQ evidence row so the loop operator can diagnose the
+       * model's actual output without re-running.
+       */
+      readonly replyExcerpt?: string;
     };
 
 /**
@@ -275,6 +298,28 @@ export function buildFixGenPrompt(
 }
 
 /**
+ * Produce a credential-redacted, byte-bounded excerpt of a raw model reply for
+ * safe logging and DHQ evidence attachment.
+ *
+ * The excerpt is at most {@link REPLY_EXCERPT_MAX_BYTES} UTF-8 bytes. When the
+ * reply is longer a `…[truncated <N> bytes]` marker replaces the tail so the
+ * caller can distinguish a genuinely-short reply from a truncated one. The
+ * returned string is already passed through {@link redact} so no downstream
+ * scrubbing is needed.
+ *
+ * @param reply - The raw model reply text.
+ * @returns A scrubbed, bounded excerpt string.
+ */
+export function truncateReply(reply: string): string {
+  const scrubbed = redact(reply);
+  const buf = Buffer.from(scrubbed, 'utf8');
+  if (buf.byteLength <= REPLY_EXCERPT_MAX_BYTES) return scrubbed;
+  const truncated = buf.subarray(0, REPLY_EXCERPT_MAX_BYTES).toString('utf8');
+  const overflow = buf.byteLength - REPLY_EXCERPT_MAX_BYTES;
+  return `${truncated}…[truncated ${overflow} bytes]`;
+}
+
+/**
  * Lazily-resolved module logger (import-time side-effect-free).
  */
 let cachedLogger: Logger | undefined;
@@ -324,19 +369,37 @@ export async function generateFixPatch(opts: GenerateFixPatchOptions): Promise<F
   }
 
   if (output.kind === 'none') {
-    logger.info(
-      { dhqId: request.dhqId, scenario: request.scenario, reason: output.reason },
-      'fix-gen produced no patch (graceful skip — no PR)',
-    );
-    return { kind: 'skipped', reason: `fixgen-none:${output.reason}` };
+    // For model-declined the generator already pre-sanitized the rawReply field;
+    // log it at debug so the reply is visible without noise on green runs.
+    const replyExcerpt = output.rawReply;
+    if (replyExcerpt !== undefined) {
+      logger.debug(
+        { dhqId: request.dhqId, scenario: request.scenario, reason: output.reason, replyExcerpt },
+        'fix-gen model declined — raw reply excerpt (redacted, truncated) attached to DHQ evidence',
+      );
+    } else {
+      logger.info(
+        { dhqId: request.dhqId, scenario: request.scenario, reason: output.reason },
+        'fix-gen produced no patch (graceful skip — no PR)',
+      );
+    }
+    return {
+      kind: 'skipped',
+      reason: `fixgen-none:${output.reason}`,
+      ...(replyExcerpt !== undefined ? { replyExcerpt } : {}),
+    };
   }
 
   if (!looksLikeUnifiedDiff(output.diff)) {
+    // The model returned something but it is not a unified diff. Log the reply
+    // excerpt at warn (actionable — the model may need a prompt tweak) and
+    // attach it to the DHQ evidence row for the operator.
+    const replyExcerpt = truncateReply(output.diff);
     logger.warn(
-      { dhqId: request.dhqId, scenario: request.scenario },
-      'fix-gen output is not a unified diff (graceful skip — no PR)',
+      { dhqId: request.dhqId, scenario: request.scenario, replyExcerpt },
+      'fix-gen output is not a unified diff (graceful skip — no PR); raw reply attached to DHQ evidence',
     );
-    return { kind: 'skipped', reason: 'fixgen-not-a-diff' };
+    return { kind: 'skipped', reason: 'fixgen-not-a-diff', replyExcerpt };
   }
 
   // Normalize a trailing newline so `git apply` accepts the hunk.
@@ -422,7 +485,16 @@ export function createLlmFixGenerator(opts: { projectRoot?: string } = {}): FixG
         });
         const text = (response.content ?? '').trim();
         if (text.length === 0 || text === 'NO_PATCH') {
-          return { kind: 'none', reason: 'model-declined' };
+          // Attach a redacted, bounded excerpt so the caller can log it onto
+          // the DHQ evidence row without having to re-run. The empty-reply case
+          // carries no useful excerpt; only the non-empty case (e.g. prose like
+          // "I cannot fix this") is worth capturing.
+          const rawReply = text.length > 0 ? truncateReply(text) : undefined;
+          return {
+            kind: 'none',
+            reason: 'model-declined',
+            ...(rawReply !== undefined ? { rawReply } : {}),
+          };
         }
         return { kind: 'patch', diff: stripCodeFences(text), model: response.model };
       } catch (err) {


### PR DESCRIPTION
## Summary

- Adds `truncateReply()` — credential-redacts via `@cleocode/utils redact`, then byte-caps model replies at 3072 bytes with a `…[truncated N bytes]` marker
- `FixGenOutput` `'none'` variant gains `rawReply?: string` (populated by `createLlmFixGenerator` on `model-declined`)
- `FixGenResult` `'skipped'` variant gains `replyExcerpt?: string`, which flows into the `selfimprove_dhq` evidence row JSON so operators can diagnose model output without re-running
- `generateFixPatch` logs `model-declined` at debug (with `replyExcerpt`), `fixgen-not-a-diff` at warn; both paths persist the excerpt on the DHQ row
- Valid-diff (`written`) path is unchanged — no extra logging, no `replyExcerpt`

## Test plan

- [x] `(a)` declined reply truncated at 3 KiB in `FixGenResult.replyExcerpt`
- [x] `(b)` seeded `sk-ant-...` / `Bearer ...` credential strings are redacted via `@cleocode/utils redact`
- [x] `(c)` valid-diff path has no `replyExcerpt` on the `written` result
- [x] `fixgen-not-a-diff` path attaches excerpt from the non-diff output
- [x] Capstone (run-loop + real adapter + in-memory DB): `model-declined` excerpt persists as `evidence.fixGen.replyExcerpt` on the leased `selfimprove_dhq` row
- [x] All 17 tests pass (`fix-gen.test.ts`)

## Changed files

- `packages/core/src/selfimprove/fix-gen.ts` — `truncateReply`, `REPLY_EXCERPT_MAX_BYTES`, `FixGenOutput.rawReply`, `FixGenResult.replyExcerpt`, reply logging + excerpt attachment
- `packages/core/src/selfimprove/__tests__/fix-gen.test.ts` — 5 new tests covering the 3 acceptance criteria + 2 extras
- `.changeset/t11989-log-declined-replies.md` — changeset entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)