### PR TITLE
fix(T12011): guard lafs health createRequire against Vite SSR bundler path shift

### DIFF
--- a/packages/lafs/src/health/index.ts
+++ b/packages/lafs/src/health/index.ts
@@ -9,11 +9,21 @@
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-let pkg: { version: string };
+// T12011: Both require() calls use relative paths that are valid when running
+// from the source/dist location but break when Vite's SSR bundler inlines this
+// module into a different output path (e.g. .svelte-kit/output/server/chunks/).
+// The outer catch guarantees that a version-resolution failure in a bundled
+// context never prevents the health middleware from loading.
+let pkg: { version: string } = { version: 'unknown' };
 try {
-  pkg = require('../../package.json');
+  try {
+    pkg = require('../../package.json') as { version: string };
+  } catch {
+    pkg = require('../../../package.json') as { version: string };
+  }
 } catch {
-  pkg = require('../../../package.json');
+  // Running from a bundled SSR context where relative require() paths do not
+  // resolve — version falls back to 'unknown'. Health checks still work.
 }
 
 /** Configuration for the {@link healthCheck} middleware. */


### PR DESCRIPTION
## Root cause (file:line + why CI-only)

`packages/lafs/src/health/index.ts` lines 11-17: the module uses `createRequire()` with relative paths to read its package version at startup:

```ts
const require = createRequire(import.meta.url);
try {
  pkg = require('../../package.json');   // from dist/src/health/ → packages/lafs/pkg.json ✓
} catch {
  pkg = require('../../../package.json'); // fallback
}
```

When Vite's SvelteKit SSR bundler inlines `@cleocode/lafs` into `.svelte-kit/output/server/chunks/src2.js` (due to `noExternal: [/^@cleocode\//]` in `vite.config.ts`), the relative paths are preserved but now resolve relative to the **bundled file's location** — not the source file. Both `require()` calls throw `MODULE_NOT_FOUND`. The inner `catch` only catches the first failure and re-throws from the second; the error propagates uncaught and kills `vite build`.

This is CI-only because a local dev `vite dev` uses unbundled module resolution (import from `node_modules/@cleocode/lafs` directly), while only the production `vite build` bundles `@cleocode/*` packages via SSR inlining.

The precise error chain in release run 27435975568:
```
.svelte-kit/output/server/chunks/src2.js:283
  require("../../../package.json");
→ Error: Cannot find module '../../../package.json'
→ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @cleocode/studio@2026.6.16 build: `vite build`
```

## Fix

Add an outer `try/catch` with a safe `{ version: 'unknown' }` default so that a resolve failure in a bundled SSR context never prevents the health middleware from loading. The inner `try/catch` still attempts both relative paths so native (non-bundled) consumers are unaffected.

Changed file: `packages/lafs/src/health/index.ts` — 1 file, +13/-3 lines.

## Staging shape (confirmed correct, no change needed)

`adapter-node` with `out: 'build'` emits:
```
packages/studio/build/
  index.js          ← server entry
  client/           ← static assets (what the gateway serves)
    _app/           ← SvelteKit immutable asset tree
  server/
  ...
```

`copy-studio-dist.mjs` copies `packages/studio/build/` → `packages/cleo/studio-dist/`.
The workflow assertion checks `packages/cleo/studio-dist/client` — this matches. No change to staging shape or workflow assertion needed.

## Local end-to-end proof

```
# 1. Reproduced the exact CI failure (before fix):
pnpm --filter @cleocode/studio run build
→ Error: Cannot find module '../../../package.json'
→ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL

# 2. After fix (rebuilt lafs + full workspace):
pnpm --filter @cleocode/studio run build → ✓ 4909 modules transformed, done
node packages/cleo/scripts/copy-studio-dist.mjs → [copy-studio-dist] Copied ...
[[ -d packages/cleo/studio-dist/client ]] → studio-dist/client present

# 3. Assert gate:
node scripts/assert-cleo-tarball.mjs
→ OK  studio-dist
→ OK  studio-dist/client/ (SvelteKit static assets present)
→ OK  studio-dist/client/_app/ (immutable asset tree present)
→ All assertions passed — @cleocode/cleo tarball is complete.

# 4. Parity + biome:
node scripts/lint-deployed-template-parity.mjs → PASS — deployed matches template
pnpm biome ci . → Checked 3820 files. No fixes applied.
```

## Checklist

- [x] Root cause identified: `lafs/src/health/index.ts` relative `require()` breaks when Vite SSR inlines the module
- [x] Fix: outer `try/catch` with `{ version: 'unknown' }` safe default
- [x] Studio build passes locally end-to-end
- [x] `assert-cleo-tarball.mjs` gate passes
- [x] Template parity passes
- [x] Biome CI clean
- [x] No changeset needed (workflow/internal toolchain fix, no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)