### PR TITLE
chore(release): changelog section 2026.6.16 → 2026.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [2026.6.16] (2026-06-12)
+## [2026.6.17] (2026-06-12)
+
+> Published as v2026.6.17 — the v2026.6.16 tag was never published (its release run failed on the new studio-dist gate; fixed by #1100 which this release includes).
 
 ### Added
 


### PR DESCRIPTION
v2026.6.16's release run failed on the new (correct) studio-dist gate before publishing; #1100 fixed the studio build. Retitling the changelog section so the v2026.6.17 tag passes validate-changelog. Content unchanged plus a supersede note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)