### PR TITLE
fix(T12012): derive Wave 7.5 utils-inline list + dist assert + packed-install smoke

### DIFF
--- a/.changeset/t12012-packaged-import-guard.md
+++ b/.changeset/t12012-packaged-import-guard.md
@@ -1,0 +1,24 @@
+---
+id: t12012-packaged-import-guard
+tasks: [T12012]
+kind: fix
+summary: derive Wave 7.5 utils-inline list from source scan + dist assert + packed-install smoke (v2026.6.17 dead-on-import)
+---
+
+Fixes the `v2026.6.17` packaged-install regression where every `cleo` invocation died with `ERR_MODULE_NOT_FOUND: Cannot find package '@cleocode/utils' imported from @cleocode/core/dist/selfimprove/fix-gen.js`. This is DHQ-099, the third packaged-only failure in 24h.
+
+Root cause: `build.mjs` Wave 7.5 surgically re-emits `@cleocode/utils`-consuming core source files via esbuild (inlining utils) to repair the bare import left by the playbooks `tsc -b` reference build. The list of files to re-emit was hardcoded. `T11989` (#1093) added a fourth consumer — `packages/core/src/selfimprove/fix-gen.ts` — and the hardcoded list was not updated. The workspace resolves `@cleocode/utils` via symlinks so all CI gates passed; only a packed `npm install` exposed the bare import.
+
+**Changes (T12012):**
+
+- **Derived list (kill the rot class)**: Wave 7.5 now scans `packages/core/src/**/*.ts` (excluding `__tests__/` and `*.test.ts`) at build time for files containing import specifiers that reference `@cleocode/utils`. The derived list is logged in build output. The hardcoded three-entry list is gone.
+
+- **Verify-after-emit**: after Wave 7.5 runs, a new build-time assertion scans ALL `packages/core/dist/**/*.js` files for surviving bare `@cleocode/utils` import specifiers and hard-fails the build with the offending file list. This converts the latent class into a build error that fires before any tarball is created.
+
+- **Bundle-budget AC1 gate extended**: `packages/core/scripts/check-core-bundle-budget.mjs` AC1 check now runs two passes — Pass A (original: exported submodule entry points) and Pass B (new: full dist tree sweep covering ALL `.js` files under `dist/`). Pass B is the canonical fallback guard for deep-linked files not in the exports map (e.g. `dist/selfimprove/fix-gen.js`). This is why the original AC1 missed the regression: it only probed the declared `package.json` exports.
+
+- **Packed-install smoke script**: new `scripts/packed-install-smoke.mjs` — `npm pack`s all 18 published `@cleocode/*` packages into a temp dir, `npm install`s `@cleocode/cleo` into an isolated app with `package.json` `overrides` mapping every `@cleocode/*` to its local tarball (no registry traffic), then runs `cleo --version` and asserts exit 0 + non-empty version string. Locally runnable; also wired as a hard gate in `release.yml`.
+
+- **Release pipeline gate**: new `release.yml` step "Packed-install smoke test (T12012)" runs `scripts/packed-install-smoke.mjs` after the existing tarball verification steps and before `pnpm publish`. Any `ERR_MODULE_NOT_FOUND` for an undeclared workspace-private package will surface here as a hard failure.
+
+- **DHQ ledger**: appended DHQ-099 (this regression), flipped DHQ-097 to `FIXED #1096` (T12010 merged).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,6 +426,21 @@ jobs:
       - name: Verify @cleocode/cleo tarball contents (T12011)
         run: node scripts/assert-cleo-tarball.mjs
 
+      # T12012: Hard gate — packed-install smoke test. Catches the class of
+      # regression where a published package's dist imports a workspace-private
+      # package that is NOT declared in that package's dependencies (and therefore
+      # absent from npm). This is the third packaged-install-only failure in 24h
+      # (DHQ-096 entry path, DHQ-098 studio-dist, DHQ-099 @cleocode/utils in
+      # selfimprove/fix-gen.js). The workspace resolves everything via symlinks so
+      # CI passes, but a fresh `npm install` trips ERR_MODULE_NOT_FOUND.
+      #
+      # Mechanism: npm pack all published packages into a temp dir, then npm
+      # install @cleocode/cleo into an isolated app with package.json `overrides`
+      # mapping every @cleocode/* to its local tarball (no registry traffic), then
+      # run `cleo --version` and assert exit 0 + non-empty version string.
+      - name: Packed-install smoke test (T12012)
+        run: node scripts/packed-install-smoke.mjs
+
       - name: Validate build output
         run: |
           declare -a required_artifacts=(

--- a/build.mjs
+++ b/build.mjs
@@ -877,34 +877,173 @@ export declare function is_canonical(skillPath: string, options?: IsCanonicalOpt
   // AC1 inlining check passes). @cleocode/utils is the one exception: it is
   // private (never published) and esbuild-inlined into the Wave-5 bundle — but
   // the playbooks `tsc -b` reference build (Wave 7) re-emits core's composite
-  // project via plain tsc, which does NOT apply the esbuild utils alias and
-  // leaves a bare `import '@cleocode/utils'` in the three leaf modules that
-  // consume it (memory/redaction.ts, llm/plugin-facade.ts, docs/export-document.ts).
+  // project via plain tsc for ALL files under packages/core/src/, which does NOT
+  // apply the esbuild utils alias and leaves bare `import '@cleocode/utils'`
+  // specifiers in every source file that consumes it.
   // With utils moved to devDependencies (T11654) that surviving import is
-  // unresolvable on npm (install 404 / runtime ERR_MODULE_NOT_FOUND) AND trips
-  // the bundle-budget gate's AC1 (undeclared @cleocode/* import).
+  // unresolvable on npm (install 404 / runtime ERR_MODULE_NOT_FOUND).
   //
   // Re-running the FULL core esbuild here would self-contain all ~625 entry
   // points and blow the dist size budget (T11582 — observed 1 GB). Instead,
-  // surgically re-emit ONLY core's three utils-consuming entry points with
-  // esbuild (utils inlined per the coreBuildOptions alias), overwriting the tsc
-  // output for just those files. The rest of the tsc-transpiled tree — incl.
-  // nested-subdir JS like store/exodus/index.js that the esbuild entry-point
-  // scan does not cover — is left untouched, so dist size is unaffected.
+  // surgically re-emit ONLY the utils-consuming source files with esbuild
+  // (utils inlined per the coreBuildOptions alias), overwriting the tsc output
+  // for just those files.
+  //
+  // DERIVED LIST (T12012): the set of files is scanned from source at build
+  // time rather than maintained as a hardcoded list. This prevents the class of
+  // rot that caused the v2026.6.17 dead-on-import regression (T11989 added a
+  // fourth consumer — selfimprove/fix-gen.ts — and the list was not updated).
+  // Exclusions: __tests__/ directories and *.test.ts files.
   // ---------------------------------------------------------------------------
-  console.log('\n[build] Wave 7.5: re-inline @cleocode/utils into core leaf files (T11654)');
-  await esbuild.build({
-    ...coreBuildOptions,
-    entryPoints: [
-      { in: 'packages/core/src/memory/redaction.ts', out: 'memory/redaction' },
-      { in: 'packages/core/src/llm/plugin-facade.ts', out: 'llm/plugin-facade' },
-      { in: 'packages/core/src/docs/export-document.ts', out: 'docs/export-document' },
-    ],
-  });
-  await sanitizeSourcemaps('packages/core/dist'); // T9184
-  console.log(
-    '  -> packages/core/dist/{memory/redaction,llm/plugin-facade,docs/export-document}.js (utils inlined)',
-  );
+
+  /**
+   * Scan packages/core/src for all TypeScript source files (excluding tests)
+   * that contain an import specifier for @cleocode/utils, and return them as
+   * esbuild { in, out } entry point objects suitable for Wave 7.5.
+   *
+   * @returns {{ in: string; out: string }[]}
+   */
+  function deriveUtilsConsumers() {
+    const coreSourceRoot = resolve(__dirname, 'packages/core/src');
+    /** @type {{ in: string; out: string }[]} */
+    const consumers = [];
+    // Regex matches any import/export from specifier containing @cleocode/utils.
+    // Anchored to actual import syntax to avoid matching comments or strings.
+    const utilsImportRe = /(?:\bfrom\s*|(?:^|\s)import\s*)\s*['"]@cleocode\/utils(?:\/[^'"]*)?['"]/;
+
+    /** @param {string} dir */
+    function walk(dir) {
+      let entries;
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === '__tests__') continue; // skip test dirs
+          walk(full);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        if (!entry.name.endsWith('.ts')) continue;
+        if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.test.ts')) continue;
+        let src;
+        try {
+          src = readFileSync(full, 'utf8');
+        } catch {
+          continue;
+        }
+        if (!utilsImportRe.test(src)) continue;
+        // Compute the out path: relative to coreSourceRoot, drop .ts extension.
+        const rel = full.slice(coreSourceRoot.length + 1).replace(/\.ts$/, '');
+        consumers.push({ in: full, out: rel });
+      }
+    }
+    walk(coreSourceRoot);
+    return consumers;
+  }
+
+  const wave75Entries = deriveUtilsConsumers();
+  console.log('\n[build] Wave 7.5: re-inline @cleocode/utils into core leaf files (T11654, T12012)');
+  console.log(`  Derived ${wave75Entries.length} utils-consuming source file(s):`);
+  for (const ep of wave75Entries) {
+    console.log(`    ${ep.in.slice(__dirname.length + 1)} -> packages/core/dist/${ep.out}.js`);
+  }
+  if (wave75Entries.length === 0) {
+    console.log('  (no utils consumers found — Wave 7.5 is a no-op)');
+  } else {
+    await esbuild.build({
+      ...coreBuildOptions,
+      entryPoints: wave75Entries,
+    });
+    await sanitizeSourcemaps('packages/core/dist'); // T9184
+    console.log('  Wave 7.5 complete — @cleocode/utils inlined into all consumers above.');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Wave 7.5 post-assertion: verify NO dist file under packages/core/dist/
+  // retains a bare @cleocode/utils import specifier (T12012).
+  //
+  // This is the canonical build-time guard for the class of bug where a new
+  // utils-consuming source file is added but the Wave 7.5 esbuild re-emit does
+  // not cover it (either because the scan missed it or because esbuild could not
+  // inline it). Hard-fails the build rather than shipping a broken tarball.
+  //
+  // Note: the bundle-budget gate's AC1 check only probes EXPORTED submodule
+  // entry points (the declared package.json exports map). Files emitted by the
+  // playbooks tsc -b reference build that are NOT in the exports map (e.g.
+  // deep-linked selfimprove/fix-gen.js) are invisible to AC1 — this assertion
+  // is the canonical fallback guard for those paths.
+  // ---------------------------------------------------------------------------
+  {
+    const coreDistRoot = resolve(__dirname, 'packages/core/dist');
+    /** @type {string[]} */
+    const offenders = [];
+    const bareUtilsRe =
+      /(?:\bfrom\s*|\bimport\s*|\brequire\s*\(\s*)['"](@cleocode\/utils(?:\/[^'"]*)?)['"]/g;
+
+    /** @param {string} dir */
+    function assertNoUtils(dir) {
+      let entries;
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          assertNoUtils(full);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith('.js')) continue;
+        let src;
+        try {
+          src = readFileSync(full, 'utf8');
+        } catch {
+          continue;
+        }
+        // Check line-by-line so we skip JSDoc/block-comment lines (starting with
+        // * or //) that may mention @cleocode/utils as a doc example.
+        const srcLines = src.split('\n');
+        let foundUtils = false;
+        for (const ln of srcLines) {
+          const trimmed = ln.trimStart();
+          if (trimmed.startsWith('*') || trimmed.startsWith('//')) continue;
+          if (bareUtilsRe.test(ln)) {
+            foundUtils = true;
+            break;
+          }
+          bareUtilsRe.lastIndex = 0;
+        }
+        bareUtilsRe.lastIndex = 0; // reset stateful regex
+        if (foundUtils) {
+          offenders.push(full.slice(coreDistRoot.length + 1));
+        }
+      }
+    }
+    assertNoUtils(coreDistRoot);
+
+    if (offenders.length > 0) {
+      console.error(
+        '\n[build] FATAL: Wave 7.5 post-assertion FAILED — the following dist files still ' +
+          'contain a bare @cleocode/utils import that will break on npm install (T12012):',
+      );
+      for (const f of offenders) {
+        console.error(`  packages/core/dist/${f}`);
+      }
+      console.error(
+        '\nFix: add the corresponding packages/core/src/**/*.ts source file to the scan ' +
+          'scope (ensure it is not accidentally excluded) so Wave 7.5 esbuild-inlines it.',
+      );
+      process.exit(1);
+    }
+    console.log(
+      '[build] Wave 7.5 assertion passed — no bare @cleocode/utils import survives in packages/core/dist/',
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // Wave 8: cleo esbuild bundle (deps adapters, playbooks, runtime — all ready)

--- a/docs/plan/dogfood-harness-question-ledger.md
+++ b/docs/plan/dogfood-harness-question-ledger.md
@@ -1293,7 +1293,7 @@ Fix (`T12009` / PR): replaced fixed-depth arithmetic with a walk up the director
 
 Meta-lesson (DHQ-086 class): merging a batteries-included AC (`T11980`) without a packaged-install e2e of the new spawn path means the regression only surfaces in production.
 
-### DHQ-097 — `cleo login` hangs after successful OAuth — process never exits — **OPEN** (`T12010` ← `T11679`)
+### DHQ-097 — `cleo login` hangs after successful OAuth — process never exits — **FIXED #1096** (`T12010` ← `T11679`)
 
 Owner surface: CORE OAuth login — process exit after token storage.
 
@@ -1307,3 +1307,13 @@ Owner surface: CORE release pipeline — `release.yml` build + publish phase.
 Observed auditing the installed v2026.6.15 package: `packages/cleo/package.json` `files[]` includes `"studio-dist"` but the installed `@cleocode/cleo` has no `studio-dist/` directory. npm silently omits `files[]` entries that do not exist at publish time. T11979/#1074 added the entry and the `copy-studio-dist.mjs` staging script but the `release.yml` publish job never built `@cleocode/studio` — so `packages/cleo/studio-dist/` was never created in CI, and npm silently dropped it. `cleo web` boots the gateway (post-T12009) but `/studio` returns `E_STUDIO_BUNDLE_ABSENT` from every global install.
 
 Answer vehicle: (1) add an explicit "Build Studio bundle and stage into packages/cleo" CI step running `@cleocode/brain` + `@cleocode/studio` builds + `copy-studio-dist.mjs` before any publish step; (2) new `scripts/assert-cleo-tarball.mjs` gate that asserts every `files[]` entry exists on disk and that `studio-dist/client/_app/` is present — hard fail with `::error::` annotation on any missing entry so the regression can never ship silently again. Also add missing transitive deps (`@cleocode/cant`, `@cleocode/caamp`, `jsonc-parser`) to `packages/studio/package.json` so pnpm links them for the SvelteKit adapter-node SSR build.
+
+### DHQ-099 — published core dist deep-imports unpublished @cleocode/utils (hardcoded Wave 7.5 list rotted); v2026.6.17 dead on import — **FIXED in this PR** (T12012)
+
+Owner surface: CORE build pipeline — `build.mjs` Wave 7.5 + `packages/core/scripts/check-core-bundle-budget.mjs` AC1 gate + `release.yml` packed-install smoke.
+
+Observed on installed v2026.6.17: EVERY cleo invocation including `--version` died with `ERR_MODULE_NOT_FOUND: Cannot find package '@cleocode/utils' imported from @cleocode/core/dist/selfimprove/fix-gen.js`. Root cause: `build.mjs` Wave 7.5 surgically re-emits `@cleocode/utils`-consuming core source files via esbuild (inlining utils) to repair the bare import left by the playbooks `tsc -b` reference build. This worked correctly for the three original consumers (memory/redaction, llm/plugin-facade, docs/export-document), but the list was HARDCODED. T11989 (#1093) added a fourth consumer — `packages/core/src/selfimprove/fix-gen.ts` — and the hardcoded list was not updated. The workspace resolves utils via symlinks so CI passed; packed npm install exploded.
+
+Two structural gates also failed to catch it: (1) the bundle-budget gate's AC1 check only probes EXPORTED submodule entry points in package.json `exports` — `selfimprove/fix-gen.js` is a deep-linked file not in the exports map, so AC1 never scanned it; (2) there was no packed-install smoke test in the release pipeline, making this the third packaged-only failure in 24h.
+
+Answer vehicle: (T12012) (1) replace Wave 7.5 hardcoded list with a runtime scan of `packages/core/src/**/*.ts` (excluding tests) for import specifiers matching `@cleocode/utils` — logged at build time, permanently self-maintaining; (2) add a Wave 7.5 post-build assertion that hard-fails the build if any `packages/core/dist/**/*.js` retains a bare `@cleocode/utils` import; (3) extend bundle-budget AC1 with a full-dist-tree sweep (Pass B) covering ALL `.js` files under `dist/`, not just exported submodule entry points; (4) new `scripts/packed-install-smoke.mjs` — packs all 18 published packages, installs @cleocode/cleo into an isolated tmp dir with local tarball `overrides` (no registry traffic), runs `cleo --version` and asserts exit 0; (5) wire the smoke script as a hard gate in `release.yml` after the existing tarball verification steps.

--- a/packages/core/scripts/check-core-bundle-budget.mjs
+++ b/packages/core/scripts/check-core-bundle-budget.mjs
@@ -235,11 +235,44 @@ function bareCleocodeImports(file) {
   const found = new Set();
   // Match the module specifier of import/export-from and require() forms only,
   // capturing the bare `@cleocode/<pkg>` package root (drops any /subpath).
+  //
+  // The `\b(from|import)\b` pattern must NOT match inside JSDoc comments where
+  // the commenter writes `* import { Foo } from '@cleocode/runtime'` as an
+  // example of what NOT to do. tsc-emitted dist retains JSDoc block comments,
+  // so we skip matches where the match begins on a line that starts with
+  // optional whitespace + `*` (i.e. is a JSDoc/block-comment line) or follows
+  // `//` (single-line comment).
   const specRe =
     /(?:\bfrom\s*|\bimport\s*|\brequire\s*\(\s*)['"](@cleocode\/[a-z0-9-]+)(?:\/[^'"]*)?['"]/g;
+  // Split into lines once for comment-line detection.
+  const lines = src.split('\n');
+  // Build a cumulative offset map: lineStart[i] = character offset of the
+  // first character on line i (0-indexed).
+  const lineStart = new Array(lines.length);
+  let offset = 0;
+  for (let i = 0; i < lines.length; i++) {
+    lineStart[i] = offset;
+    offset += lines[i].length + 1; // +1 for the newline
+  }
+  /** @param {number} charIndex @returns {string} the line text containing charIndex */
+  function lineAt(charIndex) {
+    // Binary search for the line whose start is <= charIndex.
+    let lo = 0;
+    let hi = lineStart.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStart[mid] <= charIndex) lo = mid;
+      else hi = mid - 1;
+    }
+    return lines[lo];
+  }
   let m;
   while ((m = specRe.exec(src)) !== null) {
     if (m[1] === '@cleocode/core') continue; // never a dependency of itself
+    const ln = lineAt(m.index).trimStart();
+    // Skip if the match is inside a JSDoc/block-comment line (starts with *)
+    // or a single-line comment (starts with //).
+    if (ln.startsWith('*') || ln.startsWith('//')) continue;
     found.add(m[1]);
   }
   return found;
@@ -272,24 +305,89 @@ async function main() {
   }
 
   // --- AC1: no unresolvable bare @cleocode/* import survives -------------------
-  console.log('\nInlining check — surviving @cleocode/* imports must be declared deps:');
+  //
+  // Two-pass check (T12012):
+  //
+  //   Pass A (submodule entry points) — scans the EXPORTED submodule files
+  //   declared in package.json exports (the original check). These are the
+  //   public API surface consumers import directly.
+  //
+  //   Pass B (full dist tree) — scans EVERY .js file under dist/ for bare
+  //   @cleocode/* specifiers that are undeclared in package.json dependencies.
+  //   This catches deep-linked files that are NOT in the exports map but are
+  //   still reachable at runtime (e.g. dist/selfimprove/fix-gen.js, which the
+  //   playbooks tsc -b reference build emits directly from source without the
+  //   esbuild utils-alias pass). The original AC1 missed these files because it
+  //   only probed the declared exports. Pass B is the canonical fallback guard.
+  //
+  // Pass A gives per-submodule diagnostics; Pass B is the comprehensive sweep.
+  // Both must pass before the gate succeeds.
+
+  console.log('\nAC1 Pass A — submodule entry-point inlining check:');
   for (const subpath of ['.', ...PROBED_SUBMODULES]) {
     const file = distEntryFor(exportsMap, subpath);
     if (!existsSync(file)) {
-      failures.push(`AC1: ${subpath} -> ${file} does not exist (build did not emit it)`);
+      failures.push(`AC1-A: ${subpath} -> ${file} does not exist (build did not emit it)`);
       continue;
     }
     const bare = bareCleocodeImports(file);
     const undeclared = [...bare].filter((spec) => !deps.has(spec));
     if (undeclared.length > 0) {
       failures.push(
-        `AC1: '${subpath}' emits undeclared bare import(s) ${undeclared.join(', ')} — ` +
+        `AC1-A: '${subpath}' emits undeclared bare import(s) ${undeclared.join(', ')} — ` +
           'every surviving @cleocode/* specifier must be a declared @cleocode/core dependency',
       );
     }
     console.log(
       `  ${subpath.padEnd(14)} imports: ${bare.size === 0 ? '(none — fully inlined)' : [...bare].join(', ')}`,
     );
+  }
+
+  // AC1 Pass B: full dist tree sweep for undeclared @cleocode/* bare imports.
+  // This is the canonical guard for deep-linked files not covered by Pass A.
+  console.log('\nAC1 Pass B — full dist tree sweep for undeclared @cleocode/* imports:');
+  {
+    /** @type {Map<string, Set<string>>} file (relative to dist/) -> set of undeclared specs */
+    const distOffenders = new Map();
+    const stack = [DIST_DIR];
+    while (stack.length > 0) {
+      const cur = stack.pop();
+      let entries;
+      try {
+        entries = readdirSync(cur, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const full = join(cur, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(full);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith('.js')) continue;
+        const bare = bareCleocodeImports(full);
+        const undeclared = [...bare].filter((spec) => !deps.has(spec));
+        if (undeclared.length > 0) {
+          distOffenders.set(full.slice(DIST_DIR.length + 1), new Set(undeclared));
+        }
+      }
+    }
+    if (distOffenders.size > 0) {
+      console.error(`  FAIL — ${distOffenders.size} dist file(s) contain undeclared @cleocode/* import(s):`);
+      for (const [rel, specs] of [...distOffenders.entries()].sort()) {
+        console.error(`    dist/${rel}: ${[...specs].join(', ')}`);
+        failures.push(
+          `AC1-B: dist/${rel} emits undeclared bare import(s) ${[...specs].join(', ')} — ` +
+            'not a declared @cleocode/core dependency; will break npm install',
+        );
+      }
+    } else {
+      console.log(
+        `  OK — no undeclared @cleocode/* bare imports found in any of the ${
+          [...readdirSync(DIST_DIR, { withFileTypes: true })].length
+        } top-level dist entries`,
+      );
+    }
   }
 
   // --- AC3: per-submodule tree-shake probe ------------------------------------

--- a/scripts/packed-install-smoke.mjs
+++ b/scripts/packed-install-smoke.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Packed-install smoke test (T12012 — systemic fix for third packaged-only
+ * failure in 24h: DHQ-096 / DHQ-098 / DHQ-099).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The monorepo workspace resolves `@cleocode/*` imports via symlinks in
+ * `node_modules/.pnpm`. A source file can import `@cleocode/utils` (or any
+ * other workspace-private package) and every CI gate will pass because the
+ * workspace graph satisfies the import at test/build time. The breakage only
+ * surfaces when a CONSUMER installs the tarball from npm — the private package
+ * is not published and the bare import is unresolvable.
+ *
+ * This script simulates a real npm install:
+ *
+ *   1. `npm pack` every published @cleocode package into a temp directory.
+ *   2. Build a minimal app manifest that `npm install`s the @cleocode/cleo
+ *      tarball with all peer @cleocode/* deps resolved from the LOCAL tarballs
+ *      (via package.json `overrides`) rather than from the npm registry. This
+ *      replicates the exact import graph a fresh `npm install @cleocode/cleo`
+ *      would produce, without hitting the network.
+ *   3. Run `cleo --version` via the installed binary and assert exit 0 +
+ *      a non-empty version string.
+ *
+ * Any `ERR_MODULE_NOT_FOUND` for an undeclared workspace-private package will
+ * surface here as a non-zero exit, failing the smoke test before publish.
+ *
+ * Usage (local):
+ *   node scripts/packed-install-smoke.mjs
+ *
+ * Exit code 0 = smoke passed.
+ * Exit code 1 = smoke failed (offending error printed to stderr).
+ *
+ * @task T12012
+ * @epic T11679
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Published package list (must stay in sync with .github/workflows/release.yml
+// `publish_pkg` invocations — see scripts/lint-publish-surface.mjs for the
+// canonical enforcement).
+// ---------------------------------------------------------------------------
+const PUBLISHED_PKGS = [
+  'adapters',
+  'agents',
+  'animations',
+  'brain',
+  'caamp',
+  'cant',
+  'cleo',
+  'cleo-os',
+  'contracts',
+  'core',
+  'git-shim',
+  'lafs',
+  'nexus',
+  'paths',
+  'playbooks',
+  'runtime',
+  'skills',
+  'worktree',
+];
+
+/** Human-readable byte formatter. */
+function fmtBytes(n) {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${n} B`;
+}
+
+/**
+ * Run a command synchronously, streaming stdout/stderr to the parent unless
+ * `capture` is true (returns stdout as string).
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {{ cwd?: string; capture?: boolean; env?: NodeJS.ProcessEnv }} [opts]
+ * @returns {string | undefined}
+ */
+function run(cmd, args, opts = {}) {
+  const { cwd = REPO_ROOT, capture = false, env } = opts;
+  try {
+    const out = execFileSync(cmd, args, {
+      cwd,
+      stdio: capture ? 'pipe' : 'inherit',
+      encoding: 'utf8',
+      env: env ?? process.env,
+    });
+    return capture ? out : undefined;
+  } catch (err) {
+    if (capture && err.stdout) return err.stdout;
+    throw err;
+  }
+}
+
+async function main() {
+  const tmpBase = mkdtempSync(join(tmpdir(), 'cleo-packed-smoke-'));
+  console.log(`\n[packed-smoke] Working in ${tmpBase}`);
+
+  const tarballs = join(tmpBase, 'tarballs');
+  const app = join(tmpBase, 'app');
+  mkdirSync(tarballs, { recursive: true });
+  mkdirSync(app, { recursive: true });
+
+  // ---------------------------------------------------------------------------
+  // Step 1: pnpm pack every published package into tarballs/
+  //
+  // IMPORTANT: must use `pnpm pack` (not `npm pack`) because this monorepo uses
+  // pnpm workspaces. `npm pack` leaves `workspace:*` specifiers intact in the
+  // packed package.json, which npm install cannot resolve. `pnpm pack` resolves
+  // `workspace:*` to actual version strings before packing, matching the real
+  // `pnpm publish` behaviour.
+  // ---------------------------------------------------------------------------
+  console.log('\n[packed-smoke] Step 1: packing all published packages (pnpm pack)...');
+  /** @type {Record<string, string>} pkgName -> tarball absolute path */
+  const tarballMap = {};
+
+  for (const pkgDir of PUBLISHED_PKGS) {
+    const pkgPath = join(REPO_ROOT, 'packages', pkgDir);
+    if (!existsSync(pkgPath)) {
+      console.warn(`  SKIP packages/${pkgDir} — directory not found`);
+      continue;
+    }
+    const pkgJson = JSON.parse(readFileSync(join(pkgPath, 'package.json'), 'utf8'));
+    const pkgName = pkgJson.name;
+    if (!pkgName) {
+      console.warn(`  SKIP packages/${pkgDir} — no name in package.json`);
+      continue;
+    }
+    try {
+      // pnpm pack outputs a multi-line summary ending with the tarball path.
+      // We scan the output for the last line that ends with .tgz.
+      const out = run('pnpm', ['pack', '--pack-destination', tarballs], {
+        cwd: pkgPath,
+        capture: true,
+      });
+      const lines = (out ?? '').trim().split('\n').filter(Boolean);
+      // pnpm pack prints the tarball path as the last line; earlier lines are
+      // a human-readable "Tarball Details" table. The tarball filename itself
+      // may appear as a full path or a bare name depending on pnpm version.
+      const tarLine = lines[lines.length - 1].trim();
+      // If pnpm printed the full path, use it directly; otherwise join with tarballs dir.
+      const tarPath = tarLine.startsWith('/') ? tarLine : join(tarballs, tarLine);
+      if (!existsSync(tarPath)) {
+        // Fallback: scan the tarballs dir for a file matching this package's name
+        // (handles pnpm versions that print just the filename, not the full path).
+        const tarName = lines
+          .map((l) => l.trim())
+          .find((l) => l.endsWith('.tgz') && l.includes(pkgDir.replace('/', '-')));
+        const fallback = tarName ? join(tarballs, tarName) : null;
+        if (!fallback || !existsSync(fallback)) {
+          console.error(
+            `  FAIL packages/${pkgDir}: pnpm pack reported '${tarLine}' but no matching tarball found in ${tarballs}`,
+          );
+          process.exit(1);
+        }
+        tarballMap[pkgName] = fallback;
+        const size = readFileSync(fallback).length;
+        console.log(`  packed ${pkgName} -> ${tarName} (${fmtBytes(size)})`);
+        continue;
+      }
+      const size = readFileSync(tarPath).length;
+      tarballMap[pkgName] = tarPath;
+      console.log(`  packed ${pkgName} -> ${tarPath.split('/').pop()} (${fmtBytes(size)})`);
+    } catch (err) {
+      console.error(`  FAIL packages/${pkgDir}: pnpm pack failed — ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  const cleoTarball = tarballMap['@cleocode/cleo'];
+  if (!cleoTarball) {
+    console.error('  FATAL: @cleocode/cleo tarball not produced — check packages/cleo/');
+    process.exit(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 2: build a minimal app package.json with overrides so npm resolves
+  //         every @cleocode/* dependency to the local tarballs rather than the
+  //         registry.
+  // ---------------------------------------------------------------------------
+  console.log('\n[packed-smoke] Step 2: building isolated app manifest...');
+
+  // Build the overrides map: every @cleocode/* with a local tarball gets
+  // overridden to `file:<path>` so npm does not fetch from the registry.
+  /** @type {Record<string, string>} */
+  const overrides = {};
+  for (const [pkgName, tarPath] of Object.entries(tarballMap)) {
+    overrides[pkgName] = `file:${tarPath}`;
+  }
+
+  const appPkgJson = {
+    name: 'packed-smoke-app',
+    version: '0.0.1',
+    private: true,
+    dependencies: {
+      '@cleocode/cleo': `file:${cleoTarball}`,
+    },
+    overrides,
+  };
+
+  writeFileSync(join(app, 'package.json'), JSON.stringify(appPkgJson, null, 2) + '\n', 'utf8');
+  console.log('  app/package.json written');
+
+  // ---------------------------------------------------------------------------
+  // Step 3: npm install into the app directory (no registry traffic — all
+  //         @cleocode/* deps are served from local tarballs via overrides).
+  // ---------------------------------------------------------------------------
+  console.log('\n[packed-smoke] Step 3: npm install from local tarballs...');
+  try {
+    run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=warn'], { cwd: app });
+  } catch (err) {
+    console.error(`\n[packed-smoke] FAIL: npm install failed — ${err.message}`);
+    console.error(
+      'This means a published @cleocode/* package imports a workspace-private package ' +
+        'that is not declared in its dependencies (ERR_MODULE_NOT_FOUND class of bug).',
+    );
+    process.exit(1);
+  }
+  console.log('  npm install succeeded');
+
+  // ---------------------------------------------------------------------------
+  // Step 4: smoke the installed binary.
+  // ---------------------------------------------------------------------------
+  console.log('\n[packed-smoke] Step 4: running installed cleo --version...');
+  const cleoBin = join(app, 'node_modules', '.bin', 'cleo');
+  if (!existsSync(cleoBin)) {
+    console.error(`  FAIL: cleo binary not found at ${cleoBin} after install`);
+    process.exit(1);
+  }
+
+  let versionOut;
+  try {
+    versionOut = run('node', [cleoBin, '--version'], {
+      cwd: app,
+      capture: true,
+      env: {
+        ...process.env,
+        // Prevent cleo from trying to connect to a daemon or read live DBs;
+        // we only need the version string to prove the module graph loads.
+        CLEO_OFFLINE: '1',
+        NO_COLOR: '1',
+      },
+    });
+  } catch (err) {
+    console.error(`\n[packed-smoke] FAIL: cleo --version exited non-zero — ${err.message}`);
+    if (err.stderr) console.error(err.stderr);
+    process.exit(1);
+  }
+
+  const version = (versionOut ?? '').trim();
+  if (!version) {
+    console.error('  FAIL: cleo --version printed nothing — binary may be broken');
+    process.exit(1);
+  }
+  console.log(`  cleo --version => ${version}`);
+
+  // ---------------------------------------------------------------------------
+  // Cleanup and final verdict
+  // ---------------------------------------------------------------------------
+  try {
+    rmSync(tmpBase, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+
+  console.log('\n[packed-smoke] PASS — packed install smoke test succeeded.');
+  console.log(
+    `  Verified: npm pack + install + cleo --version exit 0 with ${Object.keys(tarballMap).length} @cleocode/* tarballs`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`\n[packed-smoke] FATAL: ${err?.stack ?? err}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Root Cause

`build.mjs` Wave 7.5 surgically re-emits `@cleocode/utils`-consuming core source files via esbuild (inlining utils) to repair the bare import left by the playbooks `tsc -b` reference build. The list was **hardcoded**. T11989 (#1093) added a fourth consumer — `packages/core/src/selfimprove/fix-gen.ts` — and the hardcoded list was not updated.

Result: every cleo invocation on installed v2026.6.17 died with `ERR_MODULE_NOT_FOUND: Cannot find package '@cleocode/utils' imported from @cleocode/core/dist/selfimprove/fix-gen.js`. This is DHQ-099, the **third packaged-install-only failure in 24h** (DHQ-096 entry path, DHQ-098 studio-dist, now this).

The workspace resolves `@cleocode/utils` via symlinks so all CI gates passed. Only a packed `npm install` exposed the bare import. Two structural gates also failed to catch it: (1) bundle-budget AC1 only probed exported submodule entry points in `package.json` exports — `selfimprove/fix-gen.js` is a deep-linked file not in the exports map; (2) no packed-install smoke test existed in the release pipeline.

## Changes

### 1. Derived list — kill the rot class (build.mjs Wave 7.5)

Replace the hardcoded 3-entry list with a build-time scan of `packages/core/src/**/*.ts` (excluding `__tests__/` and `*.test.ts`) for files whose import specifiers reference `@cleocode/utils`. The derived list is logged at build time.

Before fix (hardcoded):
```
{ in: 'packages/core/src/memory/redaction.ts', out: 'memory/redaction' },
{ in: 'packages/core/src/llm/plugin-facade.ts', out: 'llm/plugin-facade' },
{ in: 'packages/core/src/docs/export-document.ts', out: 'docs/export-document' },
// selfimprove/fix-gen.ts was MISSING
```

After fix (scan output):
```
[build] Wave 7.5: re-inline @cleocode/utils into core leaf files (T11654, T12012)
  Derived 4 utils-consuming source file(s):
    packages/core/src/docs/export-document.ts -> packages/core/dist/docs/export-document.js
    packages/core/src/llm/plugin-facade.ts -> packages/core/dist/llm/plugin-facade.js
    packages/core/src/memory/redaction.ts -> packages/core/dist/memory/redaction.js
    packages/core/src/selfimprove/fix-gen.ts -> packages/core/dist/selfimprove/fix-gen.js  ← NOW INCLUDED
  Wave 7.5 complete — @cleocode/utils inlined into all consumers above.
[build] Wave 7.5 assertion passed — no bare @cleocode/utils import survives in packages/core/dist/
```

### 2. Build-time post-assertion (build.mjs, Wave 7.5)

After Wave 7.5 re-emit, scan ALL `packages/core/dist/**/*.js` for surviving bare `@cleocode/utils` import specifiers (skipping JSDoc comment lines). Hard-fails the build with the offending file list. Converts this class of latent failure into a build error.

### 3. Bundle-budget AC1 gate extended (packages/core/scripts/check-core-bundle-budget.mjs)

AC1 now runs two passes:
- **Pass A** (original): scans exported submodule entry points from `package.json` exports
- **Pass B** (new): full dist tree sweep — scans ALL `.js` files under `dist/`

Why the old AC1 missed it: Pass A only probes files declared in the `exports` map. `selfimprove/fix-gen.js` is a deep-linked file (not exported), invisible to Pass A. Pass B is the canonical fallback guard.

Comment-line false-positives (JSDoc examples with `* import { ... } from '...'`) are filtered by checking the trimmed line prefix before matching.

### 4. Packed-install smoke script (scripts/packed-install-smoke.mjs)

New `scripts/packed-install-smoke.mjs`:
1. `pnpm pack` all 18 published `@cleocode/*` packages to a temp dir (uses pnpm, not npm, to resolve `workspace:*` to actual version strings)
2. `npm install @cleocode/cleo` into an isolated app with `package.json` `overrides` mapping every `@cleocode/*` to its local tarball (zero registry traffic)
3. Run `cleo --version` and assert exit 0 + non-empty version string

Locally runnable: `node scripts/packed-install-smoke.mjs`

### 5. Release pipeline gate (.github/workflows/release.yml)

New step "Packed-install smoke test (T12012)" runs `scripts/packed-install-smoke.mjs` after the existing tarball verification steps, before `pnpm publish`. This is the systemic fix.

### 6. DHQ ledger

- Appended DHQ-099 (this regression — root cause, structural gate gaps, and answer vehicle)
- Flipped DHQ-097 to `FIXED #1096` (T12010 merged)

## Before/After Smoke Proof

**BEFORE fix** (analytical — build.mjs Wave 7.5 hardcoded list missing fix-gen.ts):
```
grep -rl "@cleocode/utils" packages/core/src/ --include="*.ts" | grep -v "__tests__"
# Output:
packages/core/src/docs/export-document.ts
packages/core/src/llm/plugin-facade.ts
packages/core/src/memory/redaction.ts
packages/core/src/selfimprove/fix-gen.ts  <-- NOT in old hardcoded list
```

**AFTER fix** (packed-install smoke output):
```
[packed-smoke] Step 4: running installed cleo --version...
  cleo --version => {"success":true,"data":{"version":"2026.5.126"},...}
[packed-smoke] PASS — packed install smoke test succeeded.
  Verified: npm pack + install + cleo --version exit 0 with 18 @cleocode/* tarballs
```

## Dist grep proof

```
grep "@cleocode/utils" packages/core/dist/selfimprove/fix-gen.js
# → (no output) PASS: no @cleocode/utils import in dist/selfimprove/fix-gen.js

node -e "import('file:///...worktree.../packages/core/dist/selfimprove/fix-gen.js').then(()=>console.log('loads'))"
# → PASS: fix-gen.js loads
```

## Sweep results (AC1 Pass B)

```
AC1 Pass B — full dist tree sweep for undeclared @cleocode/* imports:
  OK — no undeclared @cleocode/* bare imports found in any of the 247 top-level dist entries
```

## Test results

All 104 selfimprove tests pass (`src/selfimprove/__tests__/fix-gen.test.ts` + `run-loop.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)