### PR TITLE
feat: ResourceGovernor core + pressure-dynamic tool slots (never-OOM P2 keystone)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2057,6 +2057,21 @@ export type {
 } from './release/version-bump.js';
 // === Human Render Contract (Epic T10114, ADR-077) ===
 export * from './render/index.js';
+export type {
+  AdmissionResult,
+  GovernorMode,
+  ResourceClass,
+  ResourceDeferral,
+  ResourceGrant,
+} from './resource-governor.js';
+// === Resource Governor — Never-OOM admission layer (T11999 / Epic T11992) ===
+export {
+  DEFAULT_RESOURCE_RETRY_AFTER_MS,
+  isResourceGrant,
+  RESOURCE_BACKPRESSURE_CODE,
+  RESOURCE_CLASSES,
+  RESOURCE_DEFERRED_CODE,
+} from './resource-governor.js';
 // === Result Types (Dashboard, Stats, Log, Context, Sequence, Analysis, Deps) ===
 export type {
   BottleneckTask,

--- a/packages/contracts/src/resource-governor.ts
+++ b/packages/contracts/src/resource-governor.ts
@@ -1,0 +1,123 @@
+/**
+ * Resource Governor — shared types for the Never-OOM admission layer.
+ *
+ * The {@link ResourceGovernor} (in `@cleocode/core`) admits resource-intensive
+ * work through priority classes whose budgets are computed from host memory and
+ * memory-pressure (PSI). A denial returns a structured, retryable
+ * {@link ResourceDeferral} (code {@link RESOURCE_DEFERRED_CODE}) rather than a
+ * silent drop or a crash — orchestrators treat it like a lifecycle gate: wait
+ * and retry, never fail the task.
+ *
+ * Mirrors the llm-queue deferral contract (`retry_after_ms`, degrade-to-direct)
+ * so the two admission surfaces share one shape.
+ *
+ * @task T11999
+ * @epic T11992
+ * @adr resource-governor-never-oom-architecture §3.4
+ */
+
+/**
+ * Governor arbitration mode. Mirrors the writer-lease mode shape
+ * (`writer-lease.ts` {@link LeaseMode}).
+ *
+ * - `supervisor` — defer to the Rust `cleo-supervisor` `resource_admit` verb
+ *   (continuous PSI, priority wakeups). Demotes to `local` when the supervisor
+ *   IPC client is not wired/reachable (never deadlocks).
+ * - `local` — DEFAULT. Daemon-off arbitration through shared per-class slot
+ *   directories (proper-lockfile crash-stale auto-release) + a point-sample of
+ *   {@link ResourceSample} taken inside `acquire`. Genuinely cross-process
+ *   without a daemon, mirroring the tool-semaphore engine.
+ * - `off` — pure pass-through; every acquire is granted immediately.
+ */
+export type GovernorMode = 'supervisor' | 'local' | 'off';
+
+/**
+ * Priority classes (highest priority first). `interactive-cli` is NEVER gated;
+ * `full-build` is pinned to one machine-wide slot regardless of pressure.
+ *
+ * @adr resource-governor-never-oom-architecture §3.4 (classes)
+ */
+export type ResourceClass =
+  | 'interactive-cli'
+  | 'agent-session'
+  | 'llm-call'
+  | 'test-run'
+  | 'scoped-build'
+  | 'full-build'
+  | 'db-heavy'
+  | 'background-autonomous';
+
+/**
+ * All resource classes in descending priority order. Single source of truth for
+ * iteration + validation.
+ */
+export const RESOURCE_CLASSES: readonly ResourceClass[] = Object.freeze([
+  'interactive-cli',
+  'agent-session',
+  'llm-call',
+  'test-run',
+  'scoped-build',
+  'full-build',
+  'db-heavy',
+  'background-autonomous',
+]);
+
+/** Error code emitted when an acquire is denied because no slot is available. */
+export const RESOURCE_DEFERRED_CODE = 'E_RESOURCE_DEFERRED' as const;
+
+/**
+ * Soft-signal code raised on the next admit when the host enters `backoff` —
+ * asks granted work to checkpoint. Existing grants are NEVER revoked.
+ */
+export const RESOURCE_BACKPRESSURE_CODE = 'E_RESOURCE_BACKPRESSURE' as const;
+
+/**
+ * Structured, retryable deferral returned when admission is denied. Never a
+ * silent drop; callers back off `retryAfterMs` and re-request, or annotate the
+ * unit as deferred and let a pull-based retry pick it up.
+ */
+export interface ResourceDeferral {
+  /** Discriminant for narrowing against the success grant. */
+  readonly deferred: true;
+  /** The class whose budget was exhausted. */
+  readonly class: ResourceClass;
+  /** Suggested back-off before re-requesting, in milliseconds. */
+  readonly retryAfterMs: number;
+  /** Human-readable reason (pressure state, budget, held count). */
+  readonly reason: string;
+}
+
+/**
+ * A granted admission slot. Hold it for the lifetime of the work, then
+ * {@link ResourceGrant.release}. Releasing reaps the slot so the next acquirer
+ * can proceed; releasing twice is a no-op.
+ */
+export interface ResourceGrant {
+  /** Discriminant for narrowing against {@link ResourceDeferral}. */
+  readonly deferred: false;
+  /** The class this grant belongs to. */
+  readonly class: ResourceClass;
+  /**
+   * Slot index held (local mode), or `-1` for an ungated pass-through grant
+   * (`interactive-cli`, `off` mode, or an unbounded budget).
+   */
+  readonly slot: number;
+  /** Monotonic timestamp (ms) when the grant was acquired. */
+  readonly acquiredAtMs: number;
+  /** Release the slot. Idempotent. */
+  release(): Promise<void>;
+}
+
+/** Discriminated union returned by a non-blocking `tryAcquire`. */
+export type AdmissionResult = ResourceGrant | ResourceDeferral;
+
+/**
+ * Default back-off hint when a class is saturated, in milliseconds. Aligned
+ * with the llm-queue `DEFAULT_ADMIT_DEADLINE_MS` so the two surfaces agree.
+ */
+export const DEFAULT_RESOURCE_RETRY_AFTER_MS = 2_000;
+
+/** Type guard: did an admission attempt produce a usable grant? */
+export function isResourceGrant(r: AdmissionResult): r is ResourceGrant {
+  return r.deferred === false;
+}

--- a/packages/core/src/resources/__tests__/governor.test.ts
+++ b/packages/core/src/resources/__tests__/governor.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the ResourceGovernor admission core (T11999, Epic T11992).
+ *
+ * Samples are injected synthetically — no `/proc` reads — so budget math and
+ * admission are deterministic and fast. Slot directories are isolated per fork
+ * by the vitest harness (CLEO_HOME pinned to a per-fork tmpdir).
+ *
+ * @task T11999
+ */
+
+import { isResourceGrant, RESOURCE_DEFERRED_CODE } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ResourceSample } from '../backend.js';
+import {
+  _resetGovernorStateForTest,
+  computeClassBudget,
+  ResourceGovernor,
+  resolveGovernorMode,
+} from '../governor.js';
+
+const GB = 1024 * 1024 * 1024;
+
+/** Build a synthetic sample with a given MemAvailable and `some avg10`. */
+function makeSample(
+  opts: { memAvailableGb?: number; someAvg10?: number; fullAvg10?: number } = {},
+): ResourceSample {
+  const some = opts.someAvg10 ?? 0;
+  const full = opts.fullAvg10 ?? 0;
+  return {
+    sampledAtMs: 1,
+    pressureAvailable: true,
+    memAvailableBytes: (opts.memAvailableGb ?? 32) * GB,
+    globalPressure: {
+      some: { avg10: some, avg60: some, avg300: some, totalUs: 0 },
+      full: { avg10: full, avg60: full, avg300: full, totalUs: 0 },
+    },
+    slicePressure: null,
+    walObservations: [],
+  };
+}
+
+const BUDGET_OPTS = { cpuCount: 16, totalMemBytes: 64 * GB } as const;
+
+describe('computeClassBudget (T11999)', () => {
+  it('interactive-cli is never gated (Infinity)', () => {
+    expect(computeClassBudget('interactive-cli', makeSample({ someAvg10: 99 }), BUDGET_OPTS)).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it('full-build is pinned to 1 machine-wide regardless of pressure', () => {
+    expect(computeClassBudget('full-build', makeSample({ someAvg10: 0 }), BUDGET_OPTS)).toBe(1);
+    expect(computeClassBudget('full-build', makeSample({ someAvg10: 90 }), BUDGET_OPTS)).toBe(1);
+  });
+
+  it('test-run scales down under pressure: base → half (some>10) → 1 (some>25)', () => {
+    const base = computeClassBudget('test-run', makeSample({ someAvg10: 0 }), BUDGET_OPTS);
+    expect(base).toBe(4); // max(1, 16/4)
+    expect(computeClassBudget('test-run', makeSample({ someAvg10: 15 }), BUDGET_OPTS)).toBe(2); // halved
+    expect(computeClassBudget('test-run', makeSample({ someAvg10: 30 }), BUDGET_OPTS)).toBe(1); // floor
+  });
+
+  it('agent-session clamps by MemAvailable and cpus-2', () => {
+    // 60 GB avail, 2 GB headroom, 4 GB/agent → ⌊58/4⌋=14, clamped to cpus-2=14
+    expect(
+      computeClassBudget('agent-session', makeSample({ memAvailableGb: 60 }), BUDGET_OPTS),
+    ).toBe(14);
+    // 6 GB avail → ⌊4/4⌋=1
+    expect(
+      computeClassBudget('agent-session', makeSample({ memAvailableGb: 6 }), BUDGET_OPTS),
+    ).toBe(1);
+  });
+
+  it('db-heavy defers (0) under backoff-level pressure, else 1', () => {
+    expect(computeClassBudget('db-heavy', makeSample({ someAvg10: 0 }), BUDGET_OPTS)).toBe(1);
+    expect(computeClassBudget('db-heavy', makeSample({ someAvg10: 30 }), BUDGET_OPTS)).toBe(0);
+  });
+
+  it('background-autonomous defers (0) under any hold-level pressure', () => {
+    expect(
+      computeClassBudget('background-autonomous', makeSample({ someAvg10: 0 }), BUDGET_OPTS),
+    ).toBe(1);
+    expect(
+      computeClassBudget('background-autonomous', makeSample({ someAvg10: 15 }), BUDGET_OPTS),
+    ).toBe(0);
+  });
+});
+
+describe('ResourceGovernor.acquire (T11999)', () => {
+  let gov: ResourceGovernor;
+
+  beforeEach(() => {
+    _resetGovernorStateForTest();
+    delete process.env.CLEO_RESOURCES_MODE;
+    gov = new ResourceGovernor();
+  });
+  afterEach(() => {
+    _resetGovernorStateForTest();
+    delete process.env.CLEO_RESOURCES_MODE;
+  });
+
+  it('off mode is a pure pass-through (ungated grant, slot -1)', async () => {
+    process.env.CLEO_RESOURCES_MODE = 'off';
+    _resetGovernorStateForTest();
+    const r = await gov.acquire('db-heavy', { sample: makeSample({ someAvg10: 99 }) });
+    expect(isResourceGrant(r)).toBe(true);
+    if (isResourceGrant(r)) {
+      expect(r.slot).toBe(-1);
+      await r.release();
+    }
+  });
+
+  it('interactive-cli is never gated even at extreme pressure', async () => {
+    const r = await gov.acquire('interactive-cli', { sample: makeSample({ someAvg10: 99 }) });
+    expect(isResourceGrant(r)).toBe(true);
+  });
+
+  it('grants a real slot when budget is available', async () => {
+    const r = await gov.acquire('db-heavy', {
+      sample: makeSample({ someAvg10: 0 }),
+      blocking: false,
+    });
+    expect(isResourceGrant(r)).toBe(true);
+    if (isResourceGrant(r)) {
+      expect(r.slot).toBeGreaterThanOrEqual(0);
+      expect(r.class).toBe('db-heavy');
+      await r.release();
+    }
+  });
+
+  it('zero-budget returns a structured E_RESOURCE_DEFERRED envelope', async () => {
+    const r = await gov.acquire('db-heavy', {
+      sample: makeSample({ someAvg10: 30 }),
+      blocking: false,
+    });
+    expect(isResourceGrant(r)).toBe(false);
+    if (!isResourceGrant(r)) {
+      expect(r.deferred).toBe(true);
+      expect(r.class).toBe('db-heavy');
+      expect(r.retryAfterMs).toBeGreaterThan(0);
+      expect(typeof r.reason).toBe('string');
+    }
+    // The contract code is exported for callers that surface it as an error.
+    expect(RESOURCE_DEFERRED_CODE).toBe('E_RESOURCE_DEFERRED');
+  });
+
+  it('a saturated single-slot class defers the second non-blocking acquire, then recovers on release', async () => {
+    const s = makeSample({ someAvg10: 0 }); // db-heavy budget = 1
+    const first = await gov.acquire('db-heavy', { sample: s, blocking: false });
+    expect(isResourceGrant(first)).toBe(true);
+
+    const second = await gov.acquire('db-heavy', { sample: s, blocking: false });
+    expect(isResourceGrant(second)).toBe(false); // no slot free
+
+    if (isResourceGrant(first)) await first.release();
+
+    const third = await gov.acquire('db-heavy', { sample: s, blocking: false });
+    expect(isResourceGrant(third)).toBe(true); // slot freed
+    if (isResourceGrant(third)) await third.release();
+  });
+
+  it('available() reports budget minus held slots', async () => {
+    // Pin cpuCount so the agent-session budget (clamped at cpus-2) is
+    // deterministic across CI runners with varying core counts.
+    const s = makeSample({ someAvg10: 0, memAvailableGb: 60 }); // budget = clamp(1, 14, 14) = 14
+    const before = await gov.available('agent-session', { ...BUDGET_OPTS, sample: s });
+    expect(before).toBe(14);
+    const g = await gov.acquire('agent-session', { ...BUDGET_OPTS, sample: s, blocking: false });
+    const after = await gov.available('agent-session', { ...BUDGET_OPTS, sample: s });
+    expect(after).toBe(13);
+    if (isResourceGrant(g)) await g.release();
+  });
+});
+
+describe('resolveGovernorMode (T11999)', () => {
+  afterEach(() => {
+    _resetGovernorStateForTest();
+    delete process.env.CLEO_RESOURCES_MODE;
+  });
+
+  it('defaults to local when unset', () => {
+    _resetGovernorStateForTest();
+    delete process.env.CLEO_RESOURCES_MODE;
+    expect(resolveGovernorMode()).toBe('local');
+  });
+
+  it('honours off and supervisor; unknown → local', () => {
+    _resetGovernorStateForTest();
+    process.env.CLEO_RESOURCES_MODE = 'off';
+    expect(resolveGovernorMode()).toBe('off');
+    _resetGovernorStateForTest();
+    process.env.CLEO_RESOURCES_MODE = 'bogus';
+    expect(resolveGovernorMode()).toBe('local');
+  });
+
+  it('supervisor mode demotes to local for admission (off-by-default arbiter)', async () => {
+    _resetGovernorStateForTest();
+    process.env.CLEO_RESOURCES_MODE = 'supervisor';
+    const gov = new ResourceGovernor();
+    // demotes to local arbitration → still grants a real local slot
+    const r = await gov.acquire('db-heavy', {
+      sample: makeSample({ someAvg10: 0 }),
+      blocking: false,
+    });
+    expect(isResourceGrant(r)).toBe(true);
+    if (isResourceGrant(r)) {
+      expect(r.slot).toBeGreaterThanOrEqual(0);
+      await r.release();
+    }
+  });
+});

--- a/packages/core/src/resources/governor.ts
+++ b/packages/core/src/resources/governor.ts
@@ -1,0 +1,400 @@
+/**
+ * ResourceGovernor — Never-OOM class-based admission (T11999, Epic T11992).
+ *
+ * Admits resource-intensive work through priority classes whose slot budgets
+ * are computed at acquire time from host memory + memory-pressure (PSI). A
+ * denial returns a structured, retryable {@link ResourceDeferral} — never a
+ * silent drop, never a crash. Existing grants are NEVER revoked.
+ *
+ * Three modes (verbatim writer-lease shape, `writer-lease.ts` `resolveLeaseMode`):
+ * - `supervisor` — defer to the Rust `cleo-supervisor` `resource_admit` verb.
+ *   Demotes to `local` (log-once) until the IPC client is wired — a
+ *   dead/absent arbiter must never deadlock work.
+ * - `local` — DEFAULT, daemon-off. Per-class slot directories under
+ *   `getCleoHome()/locks/resource-<class>/` arbitrated by `proper-lockfile`
+ *   (crash-stale auto-release ⇒ genuinely cross-process without a daemon),
+ *   plus a point-sample of the {@link ResourceMonitor} taken INSIDE acquire.
+ *   Generalizes the tool-semaphore engine (`tool-semaphore.ts`).
+ * - `off` — pure pass-through.
+ *
+ * `interactive-cli` is NEVER gated; `full-build` is pinned to one machine-wide
+ * slot regardless of pressure.
+ *
+ * @task T11999
+ * @epic T11992
+ * @adr resource-governor-never-oom-architecture §3.4
+ */
+
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { availableParallelism, totalmem } from 'node:os';
+import { join } from 'node:path';
+import {
+  type AdmissionResult,
+  DEFAULT_RESOURCE_RETRY_AFTER_MS,
+  type GovernorMode,
+  type ResourceClass,
+  type ResourceDeferral,
+  type ResourceGrant,
+} from '@cleocode/contracts';
+import lockfile from 'proper-lockfile';
+import { getLogger } from '../logger.js';
+import { getCleoHome } from '../paths.js';
+import type { ResourceSample } from './backend.js';
+import { ResourceMonitor } from './monitor.js';
+
+let _log: ReturnType<typeof getLogger> | null = null;
+function log(): ReturnType<typeof getLogger> {
+  if (_log === null) _log = getLogger('resource-governor');
+  return _log;
+}
+
+// ---------------------------------------------------------------------------
+// Mode resolution (mirrors writer-lease.ts:192)
+// ---------------------------------------------------------------------------
+
+let _cachedMode: GovernorMode | null = null;
+let _supervisorDemotionLogged = false;
+
+/**
+ * Resolve the governor mode from `CLEO_RESOURCES_MODE`, once per process.
+ * Unknown / unset values resolve to `'local'` — the production-safe default
+ * while the supervisor daemon is disabled.
+ *
+ * @task T11999
+ */
+export function resolveGovernorMode(): GovernorMode {
+  if (_cachedMode !== null) return _cachedMode;
+  const raw = process.env.CLEO_RESOURCES_MODE;
+  _cachedMode = raw === 'supervisor' || raw === 'local' || raw === 'off' ? raw : 'local';
+  return _cachedMode;
+}
+
+/**
+ * The mode actually used for arbitration. `supervisor` demotes to `local`
+ * because the IPC client is not wired yet — a dead/absent arbiter must never
+ * deadlock work. Logged once. Mirrors writer-lease `effectiveMode`.
+ */
+function effectiveMode(): Exclude<GovernorMode, 'supervisor'> {
+  const mode = resolveGovernorMode();
+  if (mode === 'supervisor') {
+    if (!_supervisorDemotionLogged) {
+      _supervisorDemotionLogged = true;
+      log().info(
+        'CLEO_RESOURCES_MODE=supervisor but no IPC client is wired; ' +
+          'demoting to local-mode admission for the process lifetime.',
+      );
+    }
+    return 'local';
+  }
+  return mode;
+}
+
+/**
+ * Reset cached process-global state (mode + demotion flag). Tests only.
+ * @internal
+ */
+export function _resetGovernorStateForTest(): void {
+  _cachedMode = null;
+  _supervisorDemotionLogged = false;
+}
+
+// ---------------------------------------------------------------------------
+// Budget computation — f(totalRAM, MemAvailable, PSI)
+// ---------------------------------------------------------------------------
+
+/** Tunables for budget computation. All optional; sane defaults applied. */
+export interface BudgetOptions {
+  /** RAM reserved for the OS + interactive use, in MiB. Default 2048. */
+  readonly headroomMb?: number;
+  /** Estimated RAM per agent session (incl. ~300 MB MCP suite), MiB. Default 4096. */
+  readonly agentEstRamMb?: number;
+  /** `some avg10` (pp) at/above which test/build budgets halve. Default 10. */
+  readonly holdSomeAvg10?: number;
+  /** `some avg10` (pp) at/above which test/build budgets floor to 1. Default 25. */
+  readonly floorSomeAvg10?: number;
+  /** Override CPU count (tests). Default {@link availableParallelism}. */
+  readonly cpuCount?: number;
+  /** Override total RAM bytes (tests). Default {@link totalmem}. */
+  readonly totalMemBytes?: number;
+}
+
+const MB = 1024 * 1024;
+
+/** Extract `some avg10` (0–100) from a sample; 0 when unavailable. */
+function someAvg10(sample: ResourceSample): number {
+  const some = sample.globalPressure?.some ?? sample.slicePressure?.some;
+  return some?.avg10 ?? 0;
+}
+
+/**
+ * Compute the slot budget for a class given a point-sample.
+ *
+ * - `interactive-cli` → `Infinity` (never gated).
+ * - `full-build` → `1` machine-wide, pressure-independent.
+ * - `agent-session` → `clamp(1, ⌊(MemAvailable − headroom)/estRamMb⌋, cpus−2)`.
+ * - `test-run` / `scoped-build` → `max(1, ⌊cpus/4⌋)`, ×0.5 when `some>hold`,
+ *   floored to 1 when `some>floor`.
+ * - `llm-call` → `max(1, cpus−2)` (primarily gated by the llm-queue elsewhere).
+ * - `db-heavy` → `1`, deferred (→0) under `backoff`-level pressure.
+ * - `background-autonomous` → `1` only when pressure is `ok`, else `0`.
+ *
+ * @adr resource-governor-never-oom-architecture §3.4 (budgets)
+ */
+export function computeClassBudget(
+  cls: ResourceClass,
+  sample: ResourceSample,
+  opts: BudgetOptions = {},
+): number {
+  if (cls === 'interactive-cli') return Number.POSITIVE_INFINITY;
+
+  const cpus = Math.max(1, opts.cpuCount ?? availableParallelism());
+  const totalBytes = opts.totalMemBytes ?? totalmem();
+  const headroomBytes = (opts.headroomMb ?? 2048) * MB;
+  const hold = opts.holdSomeAvg10 ?? 10;
+  const floor = opts.floorSomeAvg10 ?? 25;
+  const some = someAvg10(sample);
+  // MemAvailable can be null on non-Linux / read error — fall back to total.
+  const availBytes = sample.memAvailableBytes ?? totalBytes;
+  const fullStall = sample.globalPressure?.full?.avg10 ?? sample.slicePressure?.full?.avg10 ?? 0;
+  const backoff = some > floor || fullStall > 10;
+
+  switch (cls) {
+    case 'full-build':
+      return 1;
+    case 'agent-session': {
+      const estRamBytes = (opts.agentEstRamMb ?? 4096) * MB;
+      const byMem = Math.floor((availBytes - headroomBytes) / estRamBytes);
+      return clamp(1, byMem, Math.max(1, cpus - 2));
+    }
+    case 'llm-call':
+      return Math.max(1, cpus - 2);
+    case 'test-run':
+    case 'scoped-build': {
+      const base = Math.max(1, Math.floor(cpus / 4));
+      if (some > floor) return 1;
+      if (some > hold) return Math.max(1, Math.floor(base / 2));
+      return base;
+    }
+    case 'db-heavy':
+      return backoff ? 0 : 1;
+    case 'background-autonomous':
+      return some > hold || fullStall > 5 ? 0 : 1;
+    default:
+      return 1;
+  }
+}
+
+function clamp(lo: number, v: number, hi: number): number {
+  return Math.max(lo, Math.min(v, hi));
+}
+
+// ---------------------------------------------------------------------------
+// Local-mode slot engine (generalizes tool-semaphore.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Machine-wide slot directory for a class, under
+ * `getCleoHome()/locks/resource-<class>/`. Shared across projects, worktrees,
+ * and PIDs — exactly like the tool semaphore.
+ */
+export function governorSlotDir(cls: ResourceClass): string {
+  return join(getCleoHome(), 'locks', `resource-${cls}`);
+}
+
+function ensureSlotFiles(dir: string, count: number): string[] {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const paths: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const p = join(dir, `slot-${i}.lock`);
+    if (!existsSync(p)) writeFileSync(p, '', { flag: 'a' });
+    paths.push(p);
+  }
+  return paths;
+}
+
+const STALE_MS = 600_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function passThroughGrant(cls: ResourceClass): ResourceGrant {
+  return {
+    deferred: false,
+    class: cls,
+    slot: -1,
+    acquiredAtMs: Date.now(),
+    release: async () => {},
+  };
+}
+
+function deferral(cls: ResourceClass, reason: string, retryAfterMs: number): ResourceDeferral {
+  return { deferred: true, class: cls, retryAfterMs, reason };
+}
+
+/** Options for {@link ResourceGovernor.acquire}. */
+export interface AcquireOptions extends BudgetOptions {
+  /**
+   * When `false`, a single non-blocking pass — returns a {@link ResourceDeferral}
+   * immediately if no slot is free (admission semantics; spawn/wave clamp).
+   * When `true` (default), polls until a slot frees or `timeoutMs` elapses
+   * (queue semantics; heavy ops). On timeout, returns a deferral.
+   */
+  readonly blocking?: boolean;
+  /** Max wall-clock to wait in blocking mode (ms). Default 3_600_000. */
+  readonly timeoutMs?: number;
+  /** Poll interval in blocking mode (ms). Default 200. */
+  readonly pollMs?: number;
+  /**
+   * Inject a pre-taken sample (tests, or to avoid re-sampling). When omitted,
+   * a fresh point-sample is taken inside acquire.
+   */
+  readonly sample?: ResourceSample;
+  /** Inject a monitor (tests). Default a fresh {@link ResourceMonitor}. */
+  readonly monitor?: ResourceMonitor;
+}
+
+/**
+ * The Never-OOM admission gate. Stateless wrapper over the mode-resolved
+ * backend (local slot dirs today; supervisor IPC when wired). Construct once
+ * and share, or use the module-level {@link governor} singleton.
+ */
+export class ResourceGovernor {
+  /**
+   * Acquire one slot of `cls`. Returns a {@link ResourceGrant} on success or a
+   * {@link ResourceDeferral} on denial. Never throws for admission control;
+   * only genuinely unexpected I/O errors propagate.
+   */
+  async acquire(cls: ResourceClass, opts: AcquireOptions = {}): Promise<AdmissionResult> {
+    // Ungated fast paths: off mode + interactive-cli are pure pass-through.
+    if (effectiveMode() === 'off' || cls === 'interactive-cli') {
+      return passThroughGrant(cls);
+    }
+
+    const sample = opts.sample ?? (await (opts.monitor ?? new ResourceMonitor()).sample());
+    const budget = computeClassBudget(cls, sample, opts);
+
+    if (!Number.isFinite(budget)) return passThroughGrant(cls);
+    if (budget <= 0) {
+      return deferral(
+        cls,
+        `class '${cls}' budget is 0 under current pressure (some avg10=${someAvg10(sample).toFixed(1)})`,
+        DEFAULT_RESOURCE_RETRY_AFTER_MS,
+      );
+    }
+
+    const dir = governorSlotDir(cls);
+    const slots = ensureSlotFiles(dir, budget);
+    const blocking = opts.blocking ?? true;
+    const timeoutMs = opts.timeoutMs ?? 3_600_000;
+    const pollMs = opts.pollMs ?? 200;
+    const startedAt = Date.now();
+
+    do {
+      // Re-shuffle each pass so concurrent acquirers don't collide on slot 0.
+      const order = shuffledIndices(slots.length);
+      for (const idx of order) {
+        const path = slots[idx];
+        if (!path) continue;
+        try {
+          const release = await lockfile.lock(path, {
+            retries: 0,
+            stale: STALE_MS,
+            realpath: false,
+          });
+          let released = false;
+          return {
+            deferred: false,
+            class: cls,
+            slot: idx,
+            acquiredAtMs: Date.now(),
+            release: async () => {
+              if (released) return;
+              released = true;
+              try {
+                await release();
+              } catch {
+                // Already released (e.g. stale recovery) — post-condition holds.
+              }
+            },
+          };
+        } catch {
+          // slot busy — try next
+        }
+      }
+      if (!blocking) break;
+      await sleep(pollMs);
+    } while (Date.now() - startedAt < timeoutMs);
+
+    return deferral(
+      cls,
+      `class '${cls}' is at capacity (${budget} slot(s)); ` +
+        (blocking ? `timed out after ${timeoutMs}ms` : 'no slot free'),
+      Math.min(pollMs * 4, DEFAULT_RESOURCE_RETRY_AFTER_MS),
+    );
+  }
+
+  /** Non-blocking single-pass acquire (admission semantics). */
+  async tryAcquire(cls: ResourceClass, opts: AcquireOptions = {}): Promise<AdmissionResult> {
+    return this.acquire(cls, { ...opts, blocking: false });
+  }
+
+  /**
+   * Currently-grantable slot count for `cls` = budget − held. Held is the count
+   * of slot files currently locked. `Infinity` for ungated classes.
+   */
+  async available(cls: ResourceClass, opts: AcquireOptions = {}): Promise<number> {
+    if (effectiveMode() === 'off' || cls === 'interactive-cli') return Number.POSITIVE_INFINITY;
+    const sample = opts.sample ?? (await (opts.monitor ?? new ResourceMonitor()).sample());
+    const budget = computeClassBudget(cls, sample, opts);
+    if (!Number.isFinite(budget)) return Number.POSITIVE_INFINITY;
+    if (budget <= 0) return 0;
+    const held = await countHeldSlots(cls, budget);
+    return Math.max(0, budget - held);
+  }
+}
+
+function shuffledIndices(n: number): number[] {
+  const order = Array.from({ length: n }, (_, i) => i);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const a = order[i];
+    const b = order[j];
+    if (a !== undefined && b !== undefined) {
+      order[i] = b;
+      order[j] = a;
+    }
+  }
+  return order;
+}
+
+/**
+ * Count how many of `budget` slots are currently held, by probing each with a
+ * non-blocking lock. A successful probe-lock is released immediately — it never
+ * holds the slot, so it cannot starve a real acquirer.
+ */
+async function countHeldSlots(cls: ResourceClass, budget: number): Promise<number> {
+  const dir = governorSlotDir(cls);
+  if (!existsSync(dir)) return 0;
+  const slots = ensureSlotFiles(dir, budget);
+  let held = 0;
+  for (const path of slots) {
+    try {
+      const release = await lockfile.lock(path, { retries: 0, stale: STALE_MS, realpath: false });
+      await release();
+    } catch {
+      held++;
+    }
+  }
+  return held;
+}
+
+/** Count of slot files for a class (debug/introspection). */
+export function slotFileCount(cls: ResourceClass): number {
+  const dir = governorSlotDir(cls);
+  if (!existsSync(dir)) return 0;
+  return readdirSync(dir).filter((f) => f.startsWith('slot-') && f.endsWith('.lock')).length;
+}
+
+/** Process-wide governor singleton. */
+export const governor = new ResourceGovernor();

--- a/packages/core/src/tasks/__tests__/tool-semaphore.test.ts
+++ b/packages/core/src/tasks/__tests__/tool-semaphore.test.ts
@@ -23,12 +23,29 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import type { ResourceSample } from '../../resources/backend.js';
 import {
   acquireGlobalSlot,
   defaultMaxConcurrent,
+  pressureScaleSlots,
   resolveMaxConcurrent,
   semaphoreDir,
 } from '../tool-semaphore.js';
+
+/** Synthetic pressure sample for deterministic, /proc-free slot-scaling tests. */
+function makeSample(someAvg10: number): ResourceSample {
+  return {
+    sampledAtMs: 1,
+    pressureAvailable: true,
+    memAvailableBytes: 32 * 1024 * 1024 * 1024,
+    globalPressure: {
+      some: { avg10: someAvg10, avg60: someAvg10, avg300: someAvg10, totalUs: 0 },
+      full: { avg10: 0, avg60: 0, avg300: 0, totalUs: 0 },
+    },
+    slicePressure: null,
+    walObservations: [],
+  };
+}
 
 let originalCleoHome: string | undefined;
 
@@ -215,6 +232,77 @@ describe('acquireGlobalSlot — blocking', () => {
       );
     } finally {
       await blocking();
+    }
+  });
+});
+
+describe('pressureScaleSlots (T12001 — pressure-dynamic slots)', () => {
+  it('halves test/build slots at hold pressure (some>10) and floors to 1 at backoff (some>25)', () => {
+    expect(pressureScaleSlots('test', 4, makeSample(0))).toBe(4);
+    expect(pressureScaleSlots('test', 4, makeSample(15))).toBe(2);
+    expect(pressureScaleSlots('test', 4, makeSample(30))).toBe(1);
+    expect(pressureScaleSlots('build', 4, makeSample(30))).toBe(1);
+  });
+
+  it('leaves light tools (lint/typecheck) unscaled under pressure', () => {
+    expect(pressureScaleSlots('lint', 8, makeSample(30))).toBe(8);
+    expect(pressureScaleSlots('typecheck', 8, makeSample(30))).toBe(8);
+  });
+});
+
+describe('acquireGlobalSlot pressure scaling (T12001)', () => {
+  it('shrinks the acquirable window to 1 under backoff pressure, recovers on release', async () => {
+    isolateCleoHome();
+    const high = makeSample(30); // some>25 → effectiveMax = 1 for 'test'
+    const first = await acquireGlobalSlot('test', { pressureSample: high, cpuCount: 16 });
+    try {
+      // Only one slot is eligible under high pressure → second acquire times out.
+      await expect(
+        acquireGlobalSlot('test', {
+          pressureSample: high,
+          cpuCount: 16,
+          pollMs: 10,
+          timeoutMs: 100,
+        }),
+      ).rejects.toThrow(/Timed out/);
+    } finally {
+      await first();
+    }
+    // After release, a fresh acquire under high pressure succeeds (slot freed).
+    const again = await acquireGlobalSlot('test', {
+      pressureSample: high,
+      cpuCount: 16,
+      timeoutMs: 200,
+    });
+    await again();
+  });
+
+  it('allows full static concurrency when pressure is low (no scaling)', async () => {
+    isolateCleoHome();
+    const low = makeSample(0); // effectiveMax = static = max(1, 16/4) = 4
+    const a = await acquireGlobalSlot('test', {
+      pressureSample: low,
+      cpuCount: 16,
+      timeoutMs: 500,
+    });
+    const b = await acquireGlobalSlot('test', {
+      pressureSample: low,
+      cpuCount: 16,
+      timeoutMs: 500,
+    });
+    // Two concurrent grants coexist under low pressure.
+    await a();
+    await b();
+  });
+
+  it('honors an explicit CLEO_TOOL_CONCURRENCY override (no scaling)', () => {
+    process.env.CLEO_TOOL_CONCURRENCY_TEST = '7';
+    try {
+      // Override is read by resolveMaxConcurrent; pressureScaleSlots is bypassed
+      // in acquire when an override is present (asserted via resolveMaxConcurrent).
+      expect(resolveMaxConcurrent('test', 16)).toBe(7);
+    } finally {
+      delete process.env.CLEO_TOOL_CONCURRENCY_TEST;
     }
   });
 });

--- a/packages/core/src/tasks/tool-semaphore.ts
+++ b/packages/core/src/tasks/tool-semaphore.ts
@@ -40,6 +40,8 @@ import { join } from 'node:path';
 import lockfile from 'proper-lockfile';
 
 import { getCleoHome } from '../paths.js';
+import type { ResourceSample } from '../resources/backend.js';
+import { ResourceMonitor } from '../resources/monitor.js';
 import type { CanonicalTool } from './tool-resolver.js';
 
 // ---------------------------------------------------------------------------
@@ -89,6 +91,16 @@ export interface AcquireSlotOptions {
    * @internal
    */
   cpuCount?: number;
+  /**
+   * Memory-pressure sample used to scale the effective slot count for the
+   * pressure-sensitive `test`/`build` tools (T12001, Epic T11992). When
+   * omitted, a best-effort live sample is taken (fail-open to the static slot
+   * count on any error). Pass `null` to disable pressure scaling explicitly.
+   * Tests inject a synthetic sample for determinism.
+   *
+   * @internal
+   */
+  pressureSample?: ResourceSample | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +150,62 @@ export function resolveMaxConcurrent(canonical: CanonicalTool, cpuCount?: number
     }
   }
   return defaultMaxConcurrent(canonical, cpuCount ?? availableParallelism());
+}
+
+/**
+ * Whether a canonical tool's slot budget shrinks under memory pressure.
+ * Only the heavy `test`/`build` classes scale; lint/typecheck/audit are light
+ * and single-threaded, so they keep their static budget.
+ */
+function isPressureSensitive(canonical: CanonicalTool): boolean {
+  return canonical === 'test' || canonical === 'build';
+}
+
+/**
+ * Scale a static slot budget down under memory pressure (T12001 · choke-point
+ * #6). Mirrors the governor's `test-run` budget: halve when `some avg10` exceeds
+ * the hold threshold, floor to 1 when it exceeds the backoff/floor threshold.
+ * Recovers automatically as pressure clears. `full-build` is not represented as
+ * a canonical tool here; the dedicated `full-build` governor class (T11999)
+ * pins that to one machine-wide slot.
+ *
+ * @task T12001
+ */
+export function pressureScaleSlots(
+  canonical: CanonicalTool,
+  staticMax: number,
+  sample: ResourceSample,
+  thresholds: { holdSomeAvg10?: number; floorSomeAvg10?: number } = {},
+): number {
+  if (!Number.isFinite(staticMax) || !isPressureSensitive(canonical)) return staticMax;
+  const hold = thresholds.holdSomeAvg10 ?? 10;
+  const floor = thresholds.floorSomeAvg10 ?? 25;
+  const some = sample.globalPressure?.some?.avg10 ?? sample.slicePressure?.some?.avg10 ?? 0;
+  if (some > floor) return 1;
+  if (some > hold) return Math.max(1, Math.floor(staticMax / 2));
+  return staticMax;
+}
+
+/**
+ * Best-effort point-sample for slot scaling. NEVER throws — on any error (no
+ * `/proc`, non-Linux, read failure) returns `null` so the caller fails open to
+ * the static slot count. The PSI + meminfo reads are sub-5ms.
+ */
+async function samplePressureSafe(): Promise<ResourceSample | null> {
+  try {
+    return await new ResourceMonitor().sample();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether an explicit `CLEO_TOOL_CONCURRENCY_<TOOL>` override is set — when so,
+ * the operator's intent is authoritative and pressure scaling is bypassed.
+ */
+function hasConcurrencyOverride(canonical: CanonicalTool): boolean {
+  const raw = process.env[`CLEO_TOOL_CONCURRENCY_${canonical.toUpperCase().replace(/-/g, '_')}`];
+  return raw !== undefined && raw !== '';
 }
 
 // ---------------------------------------------------------------------------
@@ -214,8 +282,24 @@ export async function acquireGlobalSlot(
     return NOOP_RELEASE;
   }
 
+  // T12001 / choke-point #6: shrink the EFFECTIVE slot count for the heavy
+  // test/build classes under memory pressure so builds/tests can't co-schedule
+  // into an OOM. The static slot FILES are still created (stable dir across
+  // pressure swings) — only the acquirable window shrinks, and it recovers as
+  // pressure clears. An explicit CLEO_TOOL_CONCURRENCY_* override is honored
+  // verbatim, and any sampling failure fails OPEN to the static count.
+  let effectiveMax = max;
+  if (isPressureSensitive(canonical) && !hasConcurrencyOverride(canonical)) {
+    const sample =
+      opts.pressureSample !== undefined ? opts.pressureSample : await samplePressureSafe();
+    if (sample) effectiveMax = pressureScaleSlots(canonical, max, sample);
+  }
+
   const dir = semaphoreDir(canonical);
+  // Create the full static slot set so the directory is stable; only the first
+  // `effectiveMax` are eligible this acquire.
   const slots = ensureSlotFiles(dir, max);
+  const usableSlots = slots.slice(0, Math.max(1, effectiveMax));
 
   const timeoutMs = opts.timeoutMs ?? 3_600_000;
   const pollMs = opts.pollMs ?? 100;
@@ -224,7 +308,7 @@ export async function acquireGlobalSlot(
 
   // Randomise slot order so concurrent acquirers don't collide on slot 0.
   // The Fisher–Yates shuffle is fine for small N.
-  const order = [...slots.keys()];
+  const order = [...usableSlots.keys()];
   for (let i = order.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     const a = order[i];


### PR DESCRIPTION
Lands the **keystone of the Never-OOM P2 admission wave** (Epic T11992) — the heavy-op admission layer so builds/tests can't co-schedule into an OOM. Implements the binding architecture spec `resource-governor-never-oom-architecture` §3.4.

## T11999 — ResourceGovernor core (`packages/core/src/resources/governor.ts`)

Class-based admission. Slot **budgets are computed at acquire time** from `totalRAM`, `MemAvailable`, and PSI (via the existing P1 `ResourceMonitor`).

- **3 modes** mirroring the writer-lease shape: `supervisor` → `local` demotion (log-once, never deadlocks while the arbiter is off); `local` (DEFAULT, daemon-off) via per-class `proper-lockfile` slot dirs under `getCleoHome()/locks/resource-<class>/` (crash-stale auto-release ⇒ genuinely cross-process without a daemon); `off` pass-through.
- **Classes** (priority desc): `interactive-cli` (NEVER gated) → `agent-session` → `llm-call` → `test-run`/`scoped-build` → `full-build` (=1 machine-wide) → `db-heavy` → `background-autonomous`.
- **Denials** return a structured, retryable `E_RESOURCE_DEFERRED { class, retryAfterMs, reason }` (typed in `@cleocode/contracts`) — never a silent drop or a crash; **existing grants are never revoked**.
- API: `acquire` (blocking/queue) / `tryAcquire` (non-blocking/admission) / `available` per class.

## T12001 (choke-point #6) — pressure-dynamic tool-semaphore slots

The heavy `test`/`build` evidence-tool classes now shrink their **effective** slot count under memory pressure (halve at `some>10`, floor to 1 at `some>25`) and recover as pressure clears — so builds/tests can't co-schedule into an OOM.

- **Fail-open:** any sampling error falls back to the static count.
- An explicit `CLEO_TOOL_CONCURRENCY_*` override is honored verbatim (pressure scaling bypassed).
- The full static slot-file set is still created so the directory is stable across pressure swings; only the acquirable window shrinks.

## Tests

34 regression tests (governor admission + budget math + tool-semaphore scaling), all with **injected synthetic samples** — no `/proc` reads, deterministic and fast.

Local: capped full `node build.mjs` BUILD_EXIT=0, scoped vitest 34/34, `biome ci .` clean, `cleo check arch` 6/6, contracts-purity Gate 10 clean. (All builds/tests cgroup-capped per the never-OOM discipline.)

## Follow-ups (remaining P2 — intentionally out of scope here, to ship a correct increment)

- **T12000** — agent-spawn admission (`spawn-ops.ts`) + ready/wave clamp.
- **T12001 remainder** — `db-heavy`/exodus-on-open gating (skip-not-block on the never-gated interactive path, per the binding data-safety amendment), supervisor `resource_admit` Rust verb (degrades to local mode), and the stall-escalator (memcg full-stall > budget → contained SIGKILL).
- The tier-0 `ct-orchestrator` skill update for `E_RESOURCE_DEFERRED` lands with **T12000** (the surface orchestrators actually consume the deferral on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)