### PR TITLE
feat: db-heavy admission for exodus-on-open (never-OOM P2 — exodus can't co-schedule)

### DIFF
--- a/packages/core/src/store/__tests__/dual-scope-db.test.ts
+++ b/packages/core/src/store/__tests__/dual-scope-db.test.ts
@@ -17,7 +17,8 @@
 import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as governorModule from '../../resources/governor.js';
 import {
   _resetDualScopeDbCache,
   insertIdempotent,
@@ -233,4 +234,44 @@ describe('WAL coexistence (E3 AC8 preview)', () => {
     expect(projJournal?.journal_mode).toBe('wal');
     expect(globJournal?.journal_mode).toBe('wal');
   }, 30_000);
+});
+
+describe('exodus-on-open db-heavy admission (T12001 / Epic T11992)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips the exodus auto-migrate but still returns a usable handle when db-heavy is deferred', async () => {
+    // Force the governor to DENY db-heavy admission on the exodus-on-open path.
+    const spy = vi.spyOn(governorModule.governor, 'tryAcquire').mockResolvedValue({
+      deferred: true,
+      class: 'db-heavy',
+      retryAfterMs: 2000,
+      reason: 'forced deferral (test)',
+    });
+
+    // skip-not-block: the interactive open must NEVER fail or block under pressure
+    // — it returns a valid, live handle (migration is simply deferred to a calmer
+    // open). The legacy fleet is empty here, so the un-migrated handle is correct.
+    const handle = await openDualScopeDb('project', projectDir);
+    expect(handle).toBeDefined();
+    expect(handle.scope).toBe('project');
+
+    // The governor was consulted for db-heavy admission on the exodus path.
+    expect(spy).toHaveBeenCalledWith('db-heavy');
+  });
+
+  it('proceeds with exodus-on-open when db-heavy is granted (full-budget byte-compatible)', async () => {
+    const spy = vi.spyOn(governorModule.governor, 'tryAcquire').mockResolvedValue({
+      deferred: false,
+      class: 'db-heavy',
+      slot: 0,
+      acquiredAtMs: Date.now(),
+      release: async () => {},
+    });
+
+    const handle = await openDualScopeDb('project', projectDir);
+    expect(handle).toBeDefined();
+    expect(spy).toHaveBeenCalledWith('db-heavy');
+  });
 });

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -738,6 +738,36 @@ export async function openDualScopeDbAtPath(
     // `openDualScopeDb` AND `dbPath` is the canonical path for that scope+cwd —
     // never for explicit-path opens (test fixtures / legacy-path domains).
     if (exodusCwd !== undefined && dbPath === resolveDualScopeDbPath(scope, exodusCwd)) {
+      // ── T12001 (Epic T11992) — db-heavy admission for the exodus auto-migrate ──
+      // The on-open exodus (reconcile + parity verify + migrate) is a heavy DB op;
+      // letting it co-schedule with builds/tests/agents is a historical OOM vector.
+      // Admit it through the governor's `db-heavy` class (machine-wide serialized;
+      // deferred under memory backoff). On a denial we SKIP the migration THIS open
+      // (kill-switch precedent CLEO_DISABLE_EXODUS_ON_OPEN) — NEVER block or defer
+      // the interactive command (interactive-cli is never gated) — and it re-runs
+      // idempotently on a calmer open. Fail-open: ANY governor error proceeds
+      // un-gated, byte-identical to pre-T12001 behaviour.
+      let releaseDbHeavy: (() => Promise<void>) | null = null;
+      let dbHeavyDeferred = false;
+      try {
+        const { governor } = await import('../resources/governor.js');
+        const admit = await governor.tryAcquire('db-heavy');
+        if (admit.deferred) {
+          dbHeavyDeferred = true;
+        } else {
+          releaseDbHeavy = admit.release;
+        }
+      } catch {
+        // Governor unavailable — fail open (proceed un-gated).
+      }
+      if (dbHeavyDeferred) {
+        log.debug(
+          { scope, dbPath },
+          'exodus-on-open skipped this open — db-heavy deferred under memory pressure ' +
+            '(re-runs idempotently on a calmer open)',
+        );
+        return handle;
+      }
       try {
         const { maybeRunExodusOnOpen } = await import('./exodus/on-open.js');
         const result = await maybeRunExodusOnOpen(scope, dbPath, nativeDb, exodusCwd);
@@ -787,6 +817,10 @@ export async function openDualScopeDbAtPath(
         return scope === 'project'
           ? openDualScopeDbAtPath('project', dbPath)
           : openDualScopeDbAtPath('global', dbPath);
+      } finally {
+        // Release the db-heavy slot on EVERY exit path (early returns above run
+        // `finally` first). Idempotent; release errors are swallowed.
+        if (releaseDbHeavy) await releaseDbHeavy().catch(() => {});
       }
     }
 


### PR DESCRIPTION
Gates the **exodus auto-migration** (the on-open `reconcile + parity-verify + migrate`) through the `ResourceGovernor` `db-heavy` class (landed in #1110), so it can't co-schedule with builds/tests/agents into an OOM. This is the **"exodus" half** of the never-OOM P2 goal; #1110 delivered the builds/tests half.

## Change

At the `openDualScopeDb` exodus-on-open hook (`packages/core/src/store/dual-scope-db.ts`):

- `governor.tryAcquire('db-heavy')` before running the heavy migration.
- **Skip-not-block** (binding data-safety amendment): on a denial, **skip the migration THIS open** (kill-switch precedent `CLEO_DISABLE_EXODUS_ON_OPEN`) — the un-migrated handle is fully valid (legacy data stays in the bare tables) and the migration re-runs idempotently on a calmer open. The interactive command is **never blocked or deferred** (`interactive-cli` is never gated).
- **Fail-open:** any governor error proceeds un-gated, byte-identical to pre-T12001 behaviour.
- The `db-heavy` slot is released on **every** exit path via `finally`.

`db-heavy` is machine-wide serialized (budget 1, → 0 under memory `backoff`), so exodus, nexus, consolidation, and a sentient tick can't pile on together under pressure.

## Tests

- **Skip path** (forced governor deferral via spy): the open still returns a usable handle (never fails the interactive command) and consults the governor for `db-heavy`.
- **Grant path:** byte-compatible — exodus proceeds.
- The **25 existing** exodus/dual-scope-db tests pass unchanged (full-budget no-regression).

Local: capped full `node build.mjs` BUILD_EXIT=0, scoped vitest green, `biome ci .` clean, `cleo check arch` 6/6. (All cgroup-capped.)

## Remaining T12001 follow-ups (out of scope here)

Supervisor `resource_admit` Rust verb (degrades to local mode); sentient-tick `db-heavy` gating; the stall-escalator (memcg full-stall > budget → contained SIGKILL). **T12000** agent-spawn admission is a separate increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)