### PR TITLE
fix(T12019): flaky agent_registry_skills 'no such table' — dual-scope path divergence

### DIFF
--- a/packages/core/src/orchestration/__tests__/spawn.test.ts
+++ b/packages/core/src/orchestration/__tests__/spawn.test.ts
@@ -97,6 +97,27 @@ async function makeTmpEnv(suffix: string): Promise<TmpEnv> {
 
   const dbPath = join(cleoHome, 'cleo.db'); // E6-L5 (T11525): signaldock consolidated into GLOBAL cleo.db
 
+  // Regression assertion (flaky `no such table: agent_registry_skills`, fixed by
+  // routing ensureGlobalAgentRegistryDb through openDualScopeDbAtPath('global',
+  // dbPath) so the migration always lands at THIS resolved path — not a stale
+  // mock generation of getCleoHome). If the consolidated migration ran against a
+  // divergent path, the table is absent here and we fail with a clear message
+  // instead of a cryptic seed error 100 lines later.
+  {
+    const verify = new DatabaseSync(dbPath);
+    const skillsTable = verify
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agent_registry_skills'")
+      .get() as { name: string } | undefined;
+    verify.close();
+    if (!skillsTable) {
+      throw new Error(
+        `makeTmpEnv: ensureGlobalAgentRegistryDb() did not create agent_registry_skills at ` +
+          `${dbPath} — the consolidated global migration resolved to a divergent path ` +
+          `(regression: dual-scope path divergence under vi.doMock churn).`,
+      );
+    }
+  }
+
   // Seed the skills catalog so junction writes succeed.
   const seedDb = new DatabaseSync(dbPath);
   seedDb.exec('PRAGMA foreign_keys = ON');

--- a/packages/core/src/store/agent-registry-store.ts
+++ b/packages/core/src/store/agent-registry-store.ts
@@ -62,7 +62,7 @@ import { getCleoHome } from '../paths.js';
 // the prefixed `agent_registry_*` tables). T11622 routes the runtime read/write
 // path onto those prefixed tables; this module only reconciles the legacy
 // health-probe ledger via the drizzle-agent-registry forward migration.
-import { _resetDualScopeDbCache, openDualScopeDb } from './dual-scope-db.js';
+import { _resetDualScopeDbCache, openDualScopeDbAtPath } from './dual-scope-db.js';
 import { migrateSanitized, reconcileJournal } from './migration-manager.js';
 import {
   resolveConsolidatedJournalSiblings,
@@ -329,7 +329,22 @@ export async function ensureGlobalAgentRegistryDb(): Promise<{
   // and runs the consolidated cleo-global migrations (which create the prefixed
   // `agent_registry_*` tables + apply the 20260602000001_t11622 rename). We
   // extract its native handle so we can reconcile the legacy health-probe ledger.
-  const dualHandle = await openDualScopeDb('global');
+  // Open the consolidated GLOBAL handle at the EXACT path this module resolved
+  // (`dbPath`), rather than letting `openDualScopeDb('global')` re-resolve it from
+  // its OWN `getCleoHome()` binding. Both bindings normally agree — they build the
+  // identical `join(getCleoHome(), 'cleo.db')` — but under per-test `vi.doMock`
+  // churn the two module graphs can resolve `getCleoHome()` to DIFFERENT generations
+  // of the mock, so `openDualScopeDb('global')` would migrate (and cache) a STALE
+  // path while this module seeds/reads `dbPath`. That divergence created an empty,
+  // un-migrated `cleo.db` at `dbPath` (root cause of the flaky `no such table:
+  // agent_registry_skills`). Passing the resolved `dbPath` to the explicit-path
+  // opener makes `getGlobalAgentRegistryDbPath()` the SINGLE source of truth for the
+  // path. The explicit-path form passes no `exodusCwd`, so it never arms the
+  // exodus-on-open hook (correct: this is the canonical global identity DB) and it
+  // caches per (scope, dbPath) exactly like `openDualScopeDb`. Behaviour is
+  // byte-identical in production, where `getCleoHome()` is stable and both bindings
+  // already agree.
+  const dualHandle = await openDualScopeDbAtPath('global', dbPath);
 
   // Extract the underlying DatabaseSync. Drizzle exposes it via `$client`.
   const nativeDb = (dualHandle.db as { $client?: DatabaseSync }).$client ?? null;


### PR DESCRIPTION
## Problem
Intermittent CI failure: `SqliteError: no such table: agent_registry_skills` in `spawn.test.ts` (passes on re-run). Surfaced repeatedly while landing the never-OOM governor PRs (#1110/#1111) — proven **unrelated** to that work.

## Root cause (production, not test-only trigger)
`ensureGlobalAgentRegistryDb` resolved the global `cleo.db` path **twice**:
- `getGlobalAgentRegistryDbPath()` → correct (current-test mock generation)
- `openDualScopeDb('global')` → re-resolves via its **own** `getCleoHome()` binding

Under per-test `vi.doMock` + `vi.resetModules()` churn the two module graphs bind to **different mock generations**, so the consolidated global migration ran against a **stale path** while the caller seeded/read the resolved `dbPath`. Result: an empty, un-migrated `cleo.db` at `dbPath` → the missing table. Intermittency = random module-graph resolution timing.

## Fix
Route through `openDualScopeDbAtPath('global', dbPath)` so `getGlobalAgentRegistryDbPath()` is the **single source of truth** for the path. Strictly more robust (a function that resolves a path then asks a collaborator to re-resolve the same path is a latent footgun), **byte-identical in production** (`getCleoHome()` is env-stable), arms no exodus-on-open hook, caches per `(scope, dbPath)` identically.

`spawn.test.ts` `makeTmpEnv` now asserts `agent_registry_skills` exists at the resolved path — fails loudly at setup instead of cryptically 100 lines later.

## Verification
Memory-capped (`systemd-run MemoryMax=8G`, `--maxWorkers=2`):
- `spawn.test.ts`: **5/5 green** (was ~80–100% fail)
- `spawn.test.ts` + `spawn-retrieval-parity.test.ts`: **5/5 green**
- full `orchestration/__tests__/`: 470/470 · agent-registry suite: 79/79
- biome clean on both files

Task: T12019 (under Epic T11992)

🤖 Generated with [Claude Code](https://claude.com/claude-code)