### PR TITLE
feat(T12000): govern agent admission — wave/ready annotation + spawn gate (never-OOM P2)

### DIFF
--- a/packages/core/src/orchestrate/__tests__/agent-admission.test.ts
+++ b/packages/core/src/orchestrate/__tests__/agent-admission.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Agent admission tests (T12000, Epic T11992) — Never-OOM wave/spawn gating.
+ *
+ * Covers:
+ *  - {@link computeAgentAdmission}: ungated (off / unbounded) admits everything;
+ *    a finite budget splits admitted vs deferred preserving order; budget 0
+ *    defers everything; empty input is empty.
+ *  - `orchestrateReady` / `orchestrateWaves`: the additive `admission` annotation
+ *    under a forced zero-budget governor (everything deferred) and a full-budget
+ *    governor (today's `readyTasks`/`total` output is unchanged — AC3).
+ *  - `orchestrateSpawnExecute`: a denied `agent-session` grant short-circuits to
+ *    a retryable `E_RESOURCE_DEFERRED` BEFORE any worktree/process is provisioned
+ *    (AC1 — no partial artifacts).
+ *
+ * The governor singleton is spied so budgets are deterministic and host-/CI-
+ * core-count independent.
+ */
+
+import { mkdirSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as governorModule from '../../resources/governor.js';
+import { computeAgentAdmission } from '../admission.js';
+import { orchestrateReady, orchestrateWaves } from '../query-ops.js';
+import { orchestrateSpawnExecute } from '../spawn-ops.js';
+
+let TEST_ROOT: string;
+
+/** Epic T900 with three ready, no-dependency children (T901/T902/T903). */
+async function seedTasks(testRoot: string): Promise<void> {
+  const cleoDir = join(testRoot, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+  const { getDb, createTask } = await import('@cleocode/core/internal');
+  await getDb(testRoot);
+
+  const tasks = [
+    {
+      id: 'T900',
+      title: 'Admission Test Epic',
+      description: 'Parent epic',
+      type: 'epic',
+      status: 'active',
+      priority: 'high',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: null,
+    },
+    ...['T901', 'T902', 'T903'].map((id, i) => ({
+      id,
+      title: `Ready task ${id}`,
+      description: 'No dependencies, pending',
+      type: 'task',
+      status: 'pending',
+      priority: 'medium',
+      parentId: 'T900',
+      files: [`packages/core/src/${id.toLowerCase()}-placeholder.ts`],
+      createdAt: `2026-01-01T00:0${i}:00Z`,
+      updatedAt: null,
+    })),
+  ];
+
+  for (const task of tasks) {
+    await createTask(task as Parameters<typeof createTask>[0], testRoot);
+  }
+}
+
+beforeEach(async () => {
+  TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-admission-'));
+  mkdirSync(join(TEST_ROOT, '.git'), { recursive: true });
+  await seedTasks(TEST_ROOT);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  try {
+    const { closeAllDatabases } = await import('@cleocode/core/internal');
+    await closeAllDatabases();
+  } catch {
+    // ignore cleanup errors
+  }
+  await rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// computeAgentAdmission — unit
+// ---------------------------------------------------------------------------
+
+describe('computeAgentAdmission', () => {
+  it('admits everything when the governor is ungated (Infinity budget)', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(Number.POSITIVE_INFINITY);
+    const a = await computeAgentAdmission(['T1', 'T2', 'T3']);
+    expect(a.admitted).toEqual(['T1', 'T2', 'T3']);
+    expect(a.deferred).toEqual([]);
+    expect(a.agentBudget).toBe(3);
+  });
+
+  it('splits admitted vs deferred at a finite budget, preserving order', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(2);
+    const a = await computeAgentAdmission(['T1', 'T2', 'T3', 'T4']);
+    expect(a.admitted).toEqual(['T1', 'T2']);
+    expect(a.deferred).toEqual(['T3', 'T4']);
+    expect(a.agentBudget).toBe(2);
+  });
+
+  it('defers everything at budget 0', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(0);
+    const a = await computeAgentAdmission(['T1', 'T2']);
+    expect(a.admitted).toEqual([]);
+    expect(a.deferred).toEqual(['T1', 'T2']);
+    expect(a.agentBudget).toBe(0);
+  });
+
+  it('is empty for an empty candidate set', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(5);
+    const a = await computeAgentAdmission([]);
+    expect(a.admitted).toEqual([]);
+    expect(a.deferred).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orchestrateReady / orchestrateWaves — admission annotation
+// ---------------------------------------------------------------------------
+
+type ReadyData = {
+  readyTasks: Array<{ id: string }>;
+  total: number;
+  admission: { agentBudget: number; admitted: string[]; deferred: string[] };
+};
+
+describe('orchestrateReady — admission annotation', () => {
+  it('full-budget governor reproduces today’s ready output unchanged (AC3)', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(Number.POSITIVE_INFINITY);
+    const result = await orchestrateReady('T900', TEST_ROOT);
+    expect(result.success).toBe(true);
+    const data = result.data as ReadyData;
+
+    const ids = data.readyTasks.map((t) => t.id).sort();
+    expect(ids).toEqual(['T901', 'T902', 'T903']);
+    expect(data.total).toBe(3);
+    // Annotation is additive: everything admitted, nothing deferred.
+    expect(data.admission.admitted.sort()).toEqual(['T901', 'T902', 'T903']);
+    expect(data.admission.deferred).toEqual([]);
+  });
+
+  it('zero-budget governor defers every ready task while preserving readyTasks/total', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(0);
+    const result = await orchestrateReady('T900', TEST_ROOT);
+    expect(result.success).toBe(true);
+    const data = result.data as ReadyData;
+
+    // The full ready set is still reported (non-destructive)...
+    expect(data.readyTasks).toHaveLength(3);
+    expect(data.total).toBe(3);
+    // ...but every task is annotated as deferred for the orchestrator to retry.
+    expect(data.admission.admitted).toEqual([]);
+    expect(data.admission.deferred).toHaveLength(3);
+    expect(data.admission.agentBudget).toBe(0);
+  });
+
+  it('clamps the admitted set to a finite budget', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(1);
+    const result = await orchestrateReady('T900', TEST_ROOT);
+    const data = result.data as ReadyData;
+    expect(data.admission.admitted).toHaveLength(1);
+    expect(data.admission.deferred).toHaveLength(2);
+  });
+});
+
+describe('orchestrateWaves — admission annotation', () => {
+  it('annotates the first actionable wave under a finite budget', async () => {
+    vi.spyOn(governorModule.governor, 'available').mockResolvedValue(2);
+    const result = await orchestrateWaves('T900', TEST_ROOT);
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      waves: Array<{ taskIds: string[] }>;
+      admission: { admitted: string[]; deferred: string[] };
+    };
+    // Wave 1 holds all three no-dep tasks; admission clamps to 2.
+    expect(data.admission.admitted).toHaveLength(2);
+    expect(data.admission.deferred).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orchestrateSpawnExecute — hard admission gate (AC1)
+// ---------------------------------------------------------------------------
+
+describe('orchestrateSpawnExecute — agent-session admission gate', () => {
+  it('short-circuits to a retryable E_RESOURCE_DEFERRED when no slot is grantable', async () => {
+    vi.spyOn(governorModule.governor, 'tryAcquire').mockResolvedValue({
+      deferred: true,
+      class: 'agent-session',
+      retryAfterMs: 2000,
+      reason: 'agent-session at capacity under pressure',
+    });
+
+    const result = await orchestrateSpawnExecute('T901', undefined, undefined, TEST_ROOT);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected deferral');
+    expect(result.error.code).toBe('E_RESOURCE_DEFERRED');
+    const details = result.error.details as { class: string; retryAfterMs: number };
+    expect(details.class).toBe('agent-session');
+    expect(details.retryAfterMs).toBe(2000);
+  });
+});

--- a/packages/core/src/orchestrate/admission.ts
+++ b/packages/core/src/orchestrate/admission.ts
@@ -1,0 +1,89 @@
+/**
+ * Agent admission — Never-OOM wave/spawn gating (T12000, Epic T11992).
+ *
+ * Two surfaces share the {@link ResourceGovernor} `agent-session` class:
+ *
+ * 1. **Advisory annotation** ({@link computeAgentAdmission}) — `orchestrate ready`
+ *    and `orchestrate waves` annotate which ready tasks are admittable NOW
+ *    versus deferred, so an orchestrator sizes its parallel fan-out to host
+ *    capacity and retries the remainder on a later pull instead of spawning a
+ *    swarm that OOMs the box. Non-destructive: the full ready set is preserved;
+ *    only an additive `admission` breakdown is attached.
+ * 2. **Hard enforcement** (the spawn-execute gate in `spawn-ops.ts`) — acquires
+ *    an `agent-session` grant BEFORE any worktree or process is provisioned, so
+ *    a denial returns a retryable {@link RESOURCE_DEFERRED_CODE} with no partial
+ *    artifacts left behind.
+ *
+ * The annotation guides; the gate enforces. In `off` mode (and on idle hosts
+ * with ample memory) both are pass-through and today's behaviour is unchanged.
+ *
+ * @task T12000
+ * @epic T11992
+ * @adr resource-governor-never-oom-architecture §3.4 (admission #1/#2)
+ */
+
+import type { ResourceSample } from '../resources/backend.js';
+import { governor } from '../resources/governor.js';
+
+/**
+ * Additive admission breakdown attached to `ready`/`waves` envelopes. Legacy
+ * consumers ignore it; admission-aware orchestrators spawn only {@link admitted}
+ * and re-query for {@link deferred} as slots free.
+ */
+export interface AgentAdmission {
+  /**
+   * Currently-grantable `agent-session` slots (budget − held). A finite count
+   * in `local`/`supervisor` mode; equals the candidate count when ungated
+   * (`off` mode / unbounded budget) so the field always serializes as a number.
+   */
+  readonly agentBudget: number;
+  /** Candidate task IDs admitted to spawn now (the first {@link agentBudget}). */
+  readonly admitted: string[];
+  /** Candidate task IDs deferred — retry on a later query as slots free. */
+  readonly deferred: string[];
+}
+
+/** Options for {@link computeAgentAdmission}. */
+export interface AgentAdmissionOptions {
+  /** Inject a pre-taken pressure sample (tests). */
+  readonly sample?: ResourceSample;
+  /** Override CPU count (tests). */
+  readonly cpuCount?: number;
+  /** Override total RAM bytes (tests). */
+  readonly totalMemBytes?: number;
+}
+
+/**
+ * Split an ordered list of candidate (ready) task IDs into the set admittable
+ * under the current `agent-session` budget and the deferred remainder.
+ *
+ * Ordering is preserved, so priority-sorted ready sets admit highest-priority
+ * tasks first. When the governor is ungated (`off` mode / unbounded), every
+ * candidate is admitted and `agentBudget` reflects the full count. A budget of
+ * `0` (all slots held) defers everything — the caller re-queries; the spawn
+ * gate is the hard backstop, so an over-eager retry is bounded there too.
+ *
+ * @param taskIds - Ready task IDs in the order they should be admitted.
+ * @param opts - Optional pressure/host overrides (tests).
+ */
+export async function computeAgentAdmission(
+  taskIds: readonly string[],
+  opts: AgentAdmissionOptions = {},
+): Promise<AgentAdmission> {
+  const budget = await governor.available('agent-session', {
+    ...(opts.sample !== undefined ? { sample: opts.sample } : {}),
+    ...(opts.cpuCount !== undefined ? { cpuCount: opts.cpuCount } : {}),
+    ...(opts.totalMemBytes !== undefined ? { totalMemBytes: opts.totalMemBytes } : {}),
+  });
+
+  if (!Number.isFinite(budget)) {
+    return { agentBudget: taskIds.length, admitted: [...taskIds], deferred: [] };
+  }
+
+  const cap = Math.max(0, Math.floor(budget));
+  return {
+    agentBudget: cap,
+    admitted: taskIds.slice(0, cap),
+    deferred: taskIds.slice(cap),
+  };
+}

--- a/packages/core/src/orchestrate/query-ops.ts
+++ b/packages/core/src/orchestrate/query-ops.ts
@@ -34,6 +34,7 @@ import { resolveSagaMemberIds } from '../sagas/storage.js';
 import { type DataAccessor, getTaskAccessor } from '../store/data-accessor.js';
 import type { DepGraphIssue } from '../tasks/dep-graph-validator.js';
 import { runValidation } from '../tasks/dep-graph-validator.js';
+import { computeAgentAdmission } from './admission.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -473,6 +474,10 @@ export async function orchestrateReady(
         }
       }
 
+      // T12000: annotate which ready tasks are admittable now vs deferred so
+      // orchestrators size their fan-out to host capacity (Never-OOM).
+      const admission = await computeAgentAdmission(aggregated.map((t) => t.id));
+
       return {
         success: true,
         data: {
@@ -481,6 +486,7 @@ export async function orchestrateReady(
           total: aggregated.length,
           via: 'saga' as const,
           sagaMembers: members,
+          admission,
           ...(skippedNested.length > 0 && { sagaNestedSkipped: skippedNested }),
           ...(reason !== undefined && { reason }),
           ...(depsWarning !== undefined && { depsWarning }),
@@ -507,18 +513,24 @@ export async function orchestrateReady(
       }
     }
 
+    const readyOut = ready.map((t) => ({
+      id: t.taskId,
+      title: t.title,
+      priority: t.priority,
+      depends: t.depends,
+    }));
+    // T12000: annotate which ready tasks are admittable now vs deferred so
+    // orchestrators size their fan-out to host capacity (Never-OOM).
+    const admission = await computeAgentAdmission(readyOut.map((t) => t.id));
+
     return {
       success: true,
       data: {
         epicId,
-        readyTasks: ready.map((t) => ({
-          id: t.taskId,
-          title: t.title,
-          priority: t.priority,
-          depends: t.depends,
-        })),
-        total: ready.length,
+        readyTasks: readyOut,
+        total: readyOut.length,
         via: 'parent' as const,
+        admission,
         ...(reason !== undefined && { reason }),
         ...(depsWarning !== undefined && { depsWarning }),
       },
@@ -651,9 +663,13 @@ export async function orchestrateWaves(
 
     if (!sagaShaped) {
       const result = await getEnrichedWaves(epicId, root, accessor);
+      // T12000: admission over the first actionable (non-completed) wave —
+      // the tasks an orchestrator would spawn next — so the fan-out is sized
+      // to host capacity (Never-OOM).
+      const admission = await computeAgentAdmission(firstActionableWaveTaskIds(result.waves));
       return {
         success: true,
-        data: { ...result, via: 'parent' as const },
+        data: { ...result, via: 'parent' as const, admission },
       };
     }
 
@@ -719,6 +735,9 @@ export async function orchestrateWaves(
       mergedWaves.push(merged);
     }
 
+    // T12000: admission over the first actionable merged wave (Never-OOM).
+    const admission = await computeAgentAdmission(firstActionableWaveTaskIds(mergedWaves));
+
     return {
       success: true,
       data: {
@@ -728,6 +747,7 @@ export async function orchestrateWaves(
         totalTasks: totalChildren,
         via: 'saga' as const,
         sagaMembers: members,
+        admission,
         ...(skippedNested.length > 0 && { sagaNestedSkipped: skippedNested }),
       },
     };
@@ -735,6 +755,19 @@ export async function orchestrateWaves(
     const code = (err as { code?: string }).code ?? 'E_GENERAL';
     return engineError(code, (err as Error).message);
   }
+}
+
+/**
+ * Task IDs of the first actionable (non-completed) wave — the set an
+ * orchestrator would spawn next. Empty when every wave is complete. Used to
+ * scope the {@link AgentAdmission} annotation to the immediately-relevant fan-out
+ * rather than the entire (largely future) wave plan.
+ *
+ * @task T12000
+ */
+function firstActionableWaveTaskIds(waves: readonly EnrichedWave[]): string[] {
+  const actionable = waves.find((w) => w.status !== 'completed');
+  return actionable ? [...actionable.taskIds] : [];
 }
 
 /**

--- a/packages/core/src/orchestrate/spawn-ops.ts
+++ b/packages/core/src/orchestrate/spawn-ops.ts
@@ -67,6 +67,7 @@ import type {
   CLEOSpawnContext,
   WorktreeHook,
 } from '@cleocode/contracts';
+import { RESOURCE_DEFERRED_CODE } from '@cleocode/contracts';
 import { destroyWorktree, runWorktreeHooks } from '@cleocode/worktree';
 import { findLeastLoadedAgent } from '../agents/capacity.js';
 import { substituteCantAgentBody } from '../agents/variable-substitution.js';
@@ -81,6 +82,7 @@ import type { ConduitSubscriptionConfig } from '../orchestration/spawn-prompt.js
 import { resolveEffectiveTier } from '../orchestration/tier-selector.js';
 import { validateSpawnReadiness } from '../orchestration/validate-spawn.js';
 import { getProjectRoot } from '../paths.js';
+import { governor } from '../resources/governor.js';
 import { provisionIsolatedShell } from '../sdk/isolation.js';
 import { spawnWorktree } from '../sentient/worktree-dispatch.js';
 import { initializeDefaultAdapters, spawnRegistry } from '../spawn/adapter-registry.js';
@@ -740,6 +742,23 @@ export async function orchestrateSpawnExecute(
   const cwd = getProjectRoot(projectRoot);
   const autoComplete = opts.autoComplete ?? true;
 
+  // T12000 (Never-OOM): acquire an `agent-session` grant BEFORE any worktree or
+  // process is provisioned, so a denial under memory pressure leaves NO partial
+  // artifacts behind — the orchestrator gets a structured, retryable deferral
+  // (treat like a lifecycle gate: wait `retryAfterMs`, re-spawn). Pass-through
+  // in `off` mode and on idle hosts, so single spawns are never spuriously
+  // blocked; under pressure it serialises the provisioning bursts that drive
+  // the OOM. The grant is held for the provisioning + dispatch window and
+  // released in the `finally` (point-in-time admission; lifetime process-group
+  // ownership is the supervisor-mode backend's job, T11998).
+  const admit = await governor.tryAcquire('agent-session');
+  if (admit.deferred) {
+    return engineError(RESOURCE_DEFERRED_CODE, admit.reason, {
+      exitCode: 75,
+      details: { class: admit.class, retryAfterMs: admit.retryAfterMs, taskId },
+    });
+  }
+
   try {
     // Get spawn registry
     await initializeDefaultAdapters();
@@ -1092,6 +1111,11 @@ export async function orchestrateSpawnExecute(
         exitCode: 60,
       },
     };
+  } finally {
+    // Release the agent-session slot once provisioning + dispatch returns.
+    await admit.release().catch(() => {
+      /* Idempotent release — slot already reaped (e.g. stale recovery). */
+    });
   }
 }
 

--- a/packages/skills/skills/ct-orchestrator/SKILL.md
+++ b/packages/skills/skills/ct-orchestrator/SKILL.md
@@ -183,6 +183,26 @@ cleo orchestrate start --epic T1575  # Full state: session, pipeline, next task
 7. Final validation with Lead across the full epic
 ```
 
+#### Never-OOM admission (T11992 · T12000)
+
+`cleo orchestrate ready` / `waves` now carry an additive `admission` block:
+
+```
+"admission": { "agentBudget": 2, "admitted": ["T1","T2"], "deferred": ["T3"] }
+```
+
+- Spawn **only** `admission.admitted` this pass — that is the fan-out the host can
+  take without OOM. Do **not** spawn `admission.deferred`.
+- After a worker completes (a slot frees), **re-query** `orchestrate ready` — the
+  previously-deferred tasks promote into `admitted`. This is pull-based; never
+  fail or skip a deferred task, just retry it on the next pull.
+- If a `cleo orchestrate spawn` returns `E_RESOURCE_DEFERRED` (the hard gate
+  denied an `agent-session` slot under pressure), treat it like a lifecycle gate:
+  wait `details.retryAfterMs` and re-spawn. No worktree/process was provisioned,
+  so there is nothing to clean up.
+
+On an idle host every ready task is `admitted` and behaviour is unchanged.
+
 ### 4. Report to Human
 
 After each wave or on request: what completed, blockers needing HITL, next actions.


### PR DESCRIPTION
Completes **T12000** under Epic **T11992** (Never-OOM). Two surfaces share the `ResourceGovernor` `agent-session` class:

## 1. Advisory annotation (`computeAgentAdmission`)
`cleo orchestrate ready` / `waves` attach an **additive** block:
```json
"admission": { "agentBudget": 2, "admitted": ["T1","T2"], "deferred": ["T3"] }
```
so an orchestrator sizes its parallel fan-out to host capacity and **retries the remainder on a later pull** instead of spawning a swarm that OOMs the box. **Non-destructive** — `readyTasks`/`total` are byte-identical to today; on idle hosts everything is admitted. `ct-orchestrator` skill updated to spawn only `admission.admitted` and re-query for `deferred`.

## 2. Hard enforcement (`orchestrateSpawnExecute`)
Acquires an `agent-session` grant **BEFORE any worktree or process is provisioned**, so a denial under pressure returns a retryable **`E_RESOURCE_DEFERRED`** (`details.retryAfterMs`, `class`) with **no partial artifacts** (AC1). Grant released in `finally` after the provisioning + dispatch window (point-in-time admission; lifetime process-group ownership is the supervisor-mode backend's job, T11998).

## Why both
The annotation sizes Claude-orchestrated wave fan-out; the spawn gate hard-enforces cleo-native adapter spawns (Pi harness etc.). Together they prevent the simultaneous worktree+node provisioning bursts that drive the OOM. `off` mode and idle hosts are pure pass-through → today's behaviour unchanged.

## Tests
- `computeAgentAdmission`: ungated→all admitted · finite budget→ordered split · budget 0→all deferred · empty→empty
- `orchestrateReady`/`waves`: forced **zero-budget** defers all (AC3) · **full-budget** reproduces today's `readyTasks`/`total` unchanged (AC3) · finite budget clamps admitted
- `orchestrateSpawnExecute`: denied grant → `E_RESOURCE_DEFERRED` short-circuit (AC1)
- **9/9 new green**; existing orchestrate/spawn-execute/saga tests **20/20**; `cleo check arch` 6/6; `biome ci .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)