### PR TITLE
feat(T12001 AC3): gate sentient tick through db-heavy admission (never-OOM P2)

### DIFF
--- a/packages/core/src/sentient/__tests__/tick-admission.test.ts
+++ b/packages/core/src/sentient/__tests__/tick-admission.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Sentient-tick admission tests (T12001 AC3, Epic T11992) — Never-OOM.
+ *
+ * The whole tick (pick + spawn + the background dream/deriver/hygiene/drift/
+ * prune scans) is db-heavy. `safeRunTick` gates it through the governor's
+ * `db-heavy` class: under memory pressure it skips the interval cleanly (a
+ * `backoff` outcome carrying `tickSkipped:pressure`, no user-visible error) and
+ * never runs the heavy work; otherwise it proceeds and releases the slot.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Task } from '@cleocode/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as governorModule from '../../resources/governor.js';
+import { SENTIENT_STATE_FILE } from '../daemon.js';
+import { DEFAULT_SENTIENT_STATE, writeSentientState } from '../state.js';
+import { safeRunTick, type TickOptions } from '../tick.js';
+
+function makeTask(id: string): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    status: 'pending',
+    priority: 'medium',
+    createdAt: new Date().toISOString(),
+  } as Task;
+}
+
+function mkTickOpts(projectRoot: string, overrides: Partial<TickOptions> = {}): TickOptions {
+  return {
+    projectRoot,
+    statePath: join(projectRoot, SENTIENT_STATE_FILE),
+    pickTask: async () => null,
+    spawn: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    skipReVerify: true,
+    runDeriverBatch: false,
+    ...overrides,
+  };
+}
+
+describe('safeRunTick — db-heavy admission (T12001 AC3)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'cleo-tick-admission-'));
+    await writeSentientState(join(root, SENTIENT_STATE_FILE), { ...DEFAULT_SENTIENT_STATE });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 500 });
+  });
+
+  it('skips the tick under pressure without running the heavy work', async () => {
+    vi.spyOn(governorModule.governor, 'tryAcquire').mockResolvedValue({
+      deferred: true,
+      class: 'db-heavy',
+      retryAfterMs: 2000,
+      reason: 'db-heavy budget is 0 under current pressure',
+    });
+    const pickTask = vi.fn(async () => makeTask('T001'));
+    const checkAndDream = vi.fn(async () => ({
+      triggered: false,
+      tier: null,
+      skippedReason: 'test',
+    }));
+
+    const outcome = await safeRunTick(mkTickOpts(root, { pickTask, checkAndDream }));
+
+    expect(outcome.kind).toBe('backoff');
+    expect(outcome.detail).toContain('tickSkipped:pressure');
+    // The heavy tick body never ran: neither the task picker nor the dream scan.
+    expect(pickTask).not.toHaveBeenCalled();
+    expect(checkAndDream).not.toHaveBeenCalled();
+  });
+
+  it('proceeds and releases the slot when admitted', async () => {
+    const release = vi.fn(async () => {});
+    vi.spyOn(governorModule.governor, 'tryAcquire').mockResolvedValue({
+      deferred: false,
+      class: 'db-heavy',
+      slot: 0,
+      acquiredAtMs: 1,
+      release,
+    });
+    const pickTask = vi.fn(async () => null);
+    // Inject a no-op dream scan so the tick opens no DB — otherwise a real
+    // brain.db open would itself acquire/release db-heavy (exodus gate, #1111)
+    // and double-count the shared release spy.
+    const checkAndDream = vi.fn(async () => ({
+      triggered: false,
+      tier: null,
+      skippedReason: 'test',
+    }));
+
+    const outcome = await safeRunTick(mkTickOpts(root, { pickTask, checkAndDream }));
+
+    // No task available → normal no-task outcome (NOT a pressure skip).
+    expect(outcome.kind).toBe('no-task');
+    expect(pickTask).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/sentient/tick.ts
+++ b/packages/core/src/sentient/tick.ts
@@ -1146,6 +1146,27 @@ async function maybeTriggerDreamCycleScan(
  * @returns The tick outcome (or an `error` outcome if the tick itself threw).
  */
 export async function safeRunTick(options: TickOptions): Promise<TickOutcome> {
+  // T12001 (Never-OOM AC3): the whole tick — pick + spawn + the background
+  // dream / deriver / hygiene / drift / worktree-prune scans — is db-heavy.
+  // Gate the interval through the governor's `db-heavy` class; under memory
+  // pressure skip this tick cleanly (recorded skip reason, NO user-visible
+  // error) and let the next cron interval retry. `off` mode is pass-through.
+  // Lazy-imported to keep the test surface small (matches this file's pattern).
+  const { governor } = await import('../resources/governor.js');
+  const dbHeavy = await governor.tryAcquire('db-heavy');
+  if (dbHeavy.deferred) {
+    try {
+      await incrementStats(options.statePath, { ticksExecuted: 1 });
+    } catch {
+      // ignore — stats increment is best-effort
+    }
+    return {
+      kind: 'backoff',
+      taskId: null,
+      detail: `tickSkipped:pressure (db-heavy deferred, retryAfterMs=${dbHeavy.retryAfterMs})`,
+    };
+  }
+
   let outcome: TickOutcome;
   try {
     outcome = await runTick(options);
@@ -1248,6 +1269,15 @@ export async function safeRunTick(options: TickOptions): Promise<TickOutcome> {
         // Ignore.
       });
   }
+
+  // Release the db-heavy slot now the tick + scan dispatch has returned. The
+  // body above is exception-safe (runTick is caught into an outcome; every
+  // background scan is fire-and-forget with its own .catch), so a
+  // release-before-return is sufficient — and a leaked slot self-heals via the
+  // governor's stale-lock recovery regardless.
+  await dbHeavy.release().catch(() => {
+    /* idempotent — slot already reaped */
+  });
 
   return outcome;
 }


### PR DESCRIPTION
Part of **T12001** under Epic **T11992** (Never-OOM). Completes **AC3** (background ticks / migration-class work defer cleanly under pressure). AC1 (pressure-dynamic tool slots) and AC4 (full-build pinned to 1) already merged in #1110; AC2 (supervisor `resource_admit` verb) follows in a separate PR.

## Change
The whole sentient tick — task pick + spawn + the background **dream / deriver / hygiene / drift / worktree-prune** scans — is db-heavy. `safeRunTick` now acquires the governor's `db-heavy` class at the top of the interval:
- **Under pressure** → skip the tick cleanly: a `backoff` outcome carrying `tickSkipped:pressure (db-heavy deferred, retryAfterMs=…)`. No user-visible error; the next cron interval retries.
- **Admitted** → proceed as today, release the slot after the tick + scan dispatch returns.
- `off` mode → pass-through.

`db-heavy` is machine-wide serialized (1 slot, → 0 under backoff), so the tick can't co-schedule with exodus/nexus/consolidation under pressure — closing the background-tick contribution to the OOM.

## Tests
- forced deferral → tick skipped, `pickTask`/`checkAndDream` never run, `backoff`+`tickSkipped:pressure`
- granted → proceeds (`no-task`), slot released once
- existing `dream-tick`/`propose-tick` suites **16/17 green** (1 todo); `biome ci .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)