### PR TITLE
fix(T12007): isolate selfimprove draft-PR packaging in an ephemeral worktree (P1 data-safety)

### DIFF
--- a/packages/core/src/selfimprove/__tests__/draft-pr.test.ts
+++ b/packages/core/src/selfimprove/__tests__/draft-pr.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the draft-PR egress (T11889-C · T11913).
+ * Tests for the draft-PR egress (T11889-C · T11913 · T12007).
  *
  * Proves the self-dogfooding egress contract:
  *  - dry-run is the DEFAULT (no git/gh invoked); the planned `gh pr create` step
@@ -7,17 +7,28 @@
  *  - no step pushes `main`;
  *  - the live path appends `--draft` to the real `gh pr create` argv (mocked
  *    runner) and NEVER auto-merges / publishes;
- *  - missing / empty patch ⇒ typed error.
+ *  - missing / empty patch ⇒ typed error;
+ *  - **workspace isolation (T12007):** every git mutation runs INSIDE the
+ *    ephemeral worktree (never the invoking checkout), only the patch's paths
+ *    are staged (never `git add -A`), and the orchestrator's untracked /
+ *    uncommitted files survive untouched and are absent from the PR.
  *
  * @epic T11889
  * @task T11913
+ * @task T12007
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type CommandRunner, draftPrBranchName, openDraftPr } from '../draft-pr.js';
+import {
+  type CommandRunner,
+  draftPrBranchName,
+  openDraftPr,
+  parseUnifiedDiffPaths,
+} from '../draft-pr.js';
 
 let dir: string;
 
@@ -37,6 +48,31 @@ describe('draftPrBranchName', () => {
   it('produces a sanitized feat/T11889 branch', () => {
     const b = draftPrBranchName('dhq-replay-find', '2026-06-08T00:00:00.000Z');
     expect(b).toBe('feat/T11889-selfimprove-dhq-replay-find-2026-06-08T00-00-00-000Z');
+  });
+});
+
+describe('parseUnifiedDiffPaths (T12007)', () => {
+  it('extracts modified paths from a diff --git header', () => {
+    const patch =
+      'diff --git a/packages/core/src/x.ts b/packages/core/src/x.ts\n' +
+      '--- a/packages/core/src/x.ts\n' +
+      '+++ b/packages/core/src/x.ts\n' +
+      '@@ -1 +1 @@\n-a\n+b\n';
+    expect(parseUnifiedDiffPaths(patch)).toEqual(['packages/core/src/x.ts']);
+  });
+
+  it('skips /dev/null on pure adds and captures the new path', () => {
+    const patch = 'diff --git a/new.ts b/new.ts\n--- /dev/null\n+++ b/new.ts\n@@ -0,0 +1 @@\n+x\n';
+    expect(parseUnifiedDiffPaths(patch)).toEqual(['new.ts']);
+  });
+
+  it('captures BOTH sides of a rename', () => {
+    const patch = 'diff --git a/old.ts b/new.ts\nrename from old.ts\nrename to new.ts\n';
+    expect(parseUnifiedDiffPaths(patch)).toEqual(['old.ts', 'new.ts']);
+  });
+
+  it('de-duplicates and returns empty for prose', () => {
+    expect(parseUnifiedDiffPaths('I could not find the bug, sorry.')).toEqual([]);
   });
 });
 
@@ -64,16 +100,23 @@ describe('openDraftPr — dry-run (default)', () => {
     expect(ghStep).toContain('--base main');
     expect(res.branchName).toBe('feat/T11889-selfimprove-scen-2026-06-08T00-00-00-000Z');
     expect(res.steps.some((s) => /push\s+-u\s+origin\s+main\b/.test(s))).toBe(false);
+    // T12007: the plan stages ONLY the patch's paths, never `git add -A`.
+    expect(res.patchPaths).toEqual(['x']);
+    expect(res.steps.some((s) => /git add -A/.test(s))).toBe(false);
+    expect(res.steps.some((s) => s.includes('add -- x'))).toBe(true);
   });
 });
 
-describe('openDraftPr — live (mocked runner)', () => {
-  it('passes --draft to gh pr create and returns the PR url; never auto-merges', async () => {
+describe('openDraftPr — live (mocked runner + injected worktree)', () => {
+  it('runs every git mutation inside the worktree, stages only patch paths, never touches main', async () => {
     const patch = join(dir, 'fix.patch');
-    writeFileSync(patch, 'diff --git a/x b/x\n');
+    writeFileSync(patch, 'diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-1\n+2\n');
+    const worktreeDir = join(dir, 'wt');
 
+    const calls: Array<{ file: string; args: readonly string[]; cwd?: string }> = [];
     const ghArgv: string[][] = [];
-    const run = vi.fn<CommandRunner>((file, args) => {
+    const run = vi.fn<CommandRunner>((file, args, cwd) => {
+      calls.push({ file, args, cwd });
       if (file === 'gh' && args[0] === 'pr') {
         ghArgv.push([...args]);
         return 'https://github.com/o/r/pull/42\n';
@@ -81,6 +124,9 @@ describe('openDraftPr — live (mocked runner)', () => {
       if (file === 'gh') return 'gh version 2.x';
       return '';
     });
+
+    const provisioned: string[] = [];
+    const removed: string[] = [];
 
     const res = await openDraftPr({
       scenario: 'scen',
@@ -90,17 +136,49 @@ describe('openDraftPr — live (mocked runner)', () => {
       cwd: dir,
       execute: true,
       run,
+      worktreeDir,
+      provisionWorktree: (o) => {
+        provisioned.push(o.worktreePath);
+        expect(o.baseRef).toBe('origin/main');
+        expect(o.projectRoot).toBe(dir);
+      },
+      removeWorktree: (_root, p) => {
+        removed.push(p);
+      },
       timestamp: () => 'TS',
     });
 
     expect(res.kind).toBe('ok');
     if (res.kind !== 'ok') throw new Error('expected ok');
     expect(res.prUrl).toBe('https://github.com/o/r/pull/42');
-    // The gh pr create argv includes --draft and --base main, never --merge/auto.
+    expect(res.patchPaths).toEqual(['a.ts']);
+
+    // The worktree was provisioned and torn down.
+    expect(provisioned).toEqual([worktreeDir]);
+    expect(removed).toEqual([worktreeDir]);
+
+    // gh pr create argv includes --draft/--base main, never --merge/auto.
     expect(ghArgv[0]).toContain('--draft');
     expect(ghArgv[0]).toContain('--base');
     expect(ghArgv[0]).toContain('main');
     expect(ghArgv[0]).not.toContain('--merge');
+
+    // T12007: apply/add/commit/push all run INSIDE the worktree, never cwd=dir.
+    const gitMutations = calls.filter(
+      (c) => c.file === 'git' && ['apply', 'add', 'commit', 'push'].includes(c.args[0]),
+    );
+    expect(gitMutations.length).toBe(4);
+    for (const c of gitMutations) expect(c.cwd).toBe(worktreeDir);
+
+    // T12007: staging is `git add -- a.ts`, NEVER `git add -A`.
+    const addCall = calls.find((c) => c.file === 'git' && c.args[0] === 'add');
+    expect(addCall?.args).toEqual(['add', '--', 'a.ts']);
+    expect(calls.some((c) => c.file === 'git' && c.args.includes('-A'))).toBe(false);
+
+    // The only `git` call against the invoking checkout is the read-only fetch.
+    const cwdDirGit = calls.filter((c) => c.file === 'git' && c.cwd === dir);
+    expect(cwdDirGit.every((c) => c.args[0] === 'fetch')).toBe(true);
+
     // No `git push … main` was ever run.
     const pushedMain = run.mock.calls.some(
       ([file, args]) => file === 'git' && args[0] === 'push' && args.includes('main'),
@@ -118,5 +196,117 @@ describe('openDraftPr — live (mocked runner)', () => {
     });
     expect(res.kind).toBe('error');
     if (res.kind === 'error') expect(res.code).toBe('E_NOT_FOUND');
+  });
+});
+
+/**
+ * The AC4 regression: a REAL git workspace with a bare `origin`, a seeded
+ * untracked owner file, and an uncommitted edit to a tracked file. Proves the
+ * egress isolates in a clean worktree — the untracked file survives on disk,
+ * stays untracked in the workspace, and is ABSENT from the pushed branch, which
+ * contains ONLY the patch's path off origin/main.
+ */
+describe('openDraftPr — isolation against a real dirty checkout (T12007 AC1-AC4)', () => {
+  const git = (cwd: string, ...args: string[]): string =>
+    execFileSync('git', args, { cwd, stdio: 'pipe' }).toString('utf8');
+
+  let origin: string;
+  let work: string;
+
+  beforeEach(() => {
+    origin = mkdtempSync(join(tmpdir(), 'sip-origin-'));
+    work = mkdtempSync(join(tmpdir(), 'sip-work-'));
+    git(origin, 'init', '--bare', '--initial-branch=main', '.');
+    git(work, 'init', '--initial-branch=main', '.');
+    git(work, 'config', 'user.email', 'test@example.com');
+    git(work, 'config', 'user.name', 'Test');
+    git(work, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(work, 'src.ts'), 'export const v = 1;\n');
+    git(work, 'add', 'src.ts');
+    git(work, 'commit', '-m', 'init');
+    git(work, 'remote', 'add', 'origin', origin);
+    git(work, 'push', '-u', 'origin', 'main');
+  });
+
+  afterEach(() => {
+    for (const d of [origin, work]) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('never sweeps the dirty workspace; PR carries only the patch path', async () => {
+    // Seed an UNTRACKED owner scratch file (the class of file that was swept).
+    mkdirSync(join(work, '.cleo', 'rcasd'), { recursive: true });
+    const scratch = join(work, '.cleo', 'rcasd', 'scratch.md');
+    const scratchBody = 'OWNER SCRATCH — must survive\n';
+    writeFileSync(scratch, scratchBody);
+    // And leave the tracked file dirty (uncommitted local edit).
+    writeFileSync(join(work, 'src.ts'), 'export const v = 1;\n// local uncommitted edit\n');
+
+    // The fix-gen patch: modifies src.ts, generated against origin/main state.
+    const patch =
+      'diff --git a/src.ts b/src.ts\n' +
+      '--- a/src.ts\n' +
+      '+++ b/src.ts\n' +
+      '@@ -1 +1 @@\n' +
+      '-export const v = 1;\n' +
+      '+export const v = 2;\n';
+    writeFileSync(join(work, 'fix.patch'), patch);
+
+    // Real git for everything; mock ONLY gh (no network / no real PR).
+    const run: CommandRunner = (file, args, cwd) => {
+      if (file === 'gh' && args[0] === 'pr') return 'https://github.com/o/r/pull/99\n';
+      if (file === 'gh') return 'gh version 2.x';
+      return git(cwd ?? work, ...args);
+    };
+
+    const res = await openDraftPr({
+      scenario: 'iso',
+      diffPath: 'fix.patch',
+      title: 'fix',
+      body: 'body',
+      cwd: work,
+      execute: true,
+      run,
+      timestamp: () => 'TS',
+    });
+
+    expect(res.kind).toBe('ok');
+    if (res.kind !== 'ok') throw new Error(`expected ok, got ${JSON.stringify(res)}`);
+    const branch = res.branchName;
+
+    // AC3/AC4: the untracked owner file survives on disk, byte-identical.
+    expect(existsSync(scratch)).toBe(true);
+    expect(readFileSync(scratch, 'utf8')).toBe(scratchBody);
+
+    // AC3: the workspace is still exactly as dirty as we left it — the scratch
+    // file is still untracked and src.ts still shows the uncommitted edit.
+    const status = git(work, 'status', '--porcelain', '-uall');
+    expect(status).toContain('?? .cleo/rcasd/scratch.md');
+    expect(status).toContain(' M src.ts');
+
+    // AC2: the invoking checkout is untouched — still on `main`, HEAD unmoved.
+    expect(git(work, 'rev-parse', '--abbrev-ref', 'HEAD').trim()).toBe('main');
+
+    // AC1/AC4: the pushed branch on origin contains ONLY src.ts, not scratch.
+    const tree = git(origin, 'ls-tree', '-r', '--name-only', branch)
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    expect(tree).toContain('src.ts');
+    expect(tree.some((f) => f.includes('scratch'))).toBe(false);
+
+    const changed = git(origin, 'diff', '--name-only', 'main', branch).trim();
+    expect(changed).toBe('src.ts');
+
+    // The branch's src.ts is the PATCH result (v=2 off origin/main), NOT the
+    // local uncommitted edit that lived in the invoking checkout.
+    const blob = git(origin, 'show', `${branch}:src.ts`);
+    expect(blob).toContain('export const v = 2;');
+    expect(blob).not.toContain('local uncommitted edit');
   });
 });

--- a/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
+++ b/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
@@ -397,6 +397,10 @@ describe('run-loop CAPSTONE — regression → fix-gen → DRAFT PR (determinist
       piRunnerEnabled: true, // arm fix-gen WITHOUT mutating process.env
       fixGenerator: generator,
       draftPrRun, // mock the egress shell-out
+      // T12007: the egress isolates in a transient worktree; mock the
+      // provisioner/remover so the capstone stays deterministic (no real git).
+      draftPrProvisionWorktree: () => {},
+      draftPrRemoveWorktree: () => {},
     });
 
     // 1. The pipeline closed: regression acted on + fix-gen wrote the patch.

--- a/packages/core/src/selfimprove/draft-pr.ts
+++ b/packages/core/src/selfimprove/draft-pr.ts
@@ -5,7 +5,7 @@
  * PR against the cleocode repo (ADR-065 — PRs target `main` via the Merge Queue;
  * NEVER a direct push to `main`, NEVER an auto-merge, NEVER a publish). This module
  * is the egress primitive, modeled on `propose-patch.ts` (the closest "agent
- * proposes a fix PR" exemplar) with three self-dogfooding hardenings:
+ * proposes a fix PR" exemplar) with four self-dogfooding hardenings:
  *
  *   1. **`--draft` is ALWAYS appended** to `gh pr create` — the PR is never
  *      ready-for-merge; a human reviews and undrafts it.
@@ -14,6 +14,13 @@
  *      side-effect-free at egress by default.
  *   3. **Branch `feat/T11889-selfimprove-<scenario>-<ts>`** — a feature branch
  *      (ADR-065); no main mutation path exists in this module.
+ *   4. **Workspace isolation (T12007).** The patch is applied inside an
+ *      *ephemeral transient worktree* cut fresh off `origin/main` — NEVER the
+ *      invoking checkout — and ONLY the paths the patch names are staged
+ *      (`git add -- <paths>`, never `git add -A`). This closes a P1 data-safety
+ *      defect where the egress swept the orchestrator's entire dirty working
+ *      tree (untracked owner scratch notes, uncommitted edits) into the public
+ *      branch and deleted them locally. The invoking repo is never mutated.
  *
  * The live path wraps the git/gh shell-out in
  * {@link "../sentient/skill-provenance.js".withProvenance}`('pr-generator', …)`
@@ -26,12 +33,16 @@
  * @module @cleocode/core/selfimprove/draft-pr
  * @epic T11889
  * @task T11913
+ * @task T12007
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve as resolvePath } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve as resolvePath } from 'node:path';
 import { cwd as processCwd } from 'node:process';
+import { addTransientWorktree, removeTransientWorktree } from '@cleocode/worktree';
 import { withProvenance } from '../sentient/skill-provenance.js';
 
 /**
@@ -44,22 +55,59 @@ const PR_BODY_TRAILER =
 /**
  * Pluggable command runner. Returns stdout as UTF-8 text or throws on non-zero
  * exit. Production default wraps `child_process.execFileSync` with piped stdio.
+ *
+ * The optional `cwd` is REQUIRED for workspace isolation (T12007): every git
+ * mutation runs inside the ephemeral worktree, never `process.cwd()` (which
+ * would be the invoking checkout). The default runner threads it into
+ * `execFileSync`; test doubles capture it to assert the isolation boundary.
  */
-export type CommandRunner = (file: string, args: readonly string[]) => string;
+export type CommandRunner = (file: string, args: readonly string[], cwd?: string) => string;
 
 /** Default command runner — wraps `execFileSync` with stdout-piped semantics. */
-const defaultRun: CommandRunner = (file, args) =>
-  execFileSync(file, [...args], { stdio: 'pipe' }).toString('utf8');
+const defaultRun: CommandRunner = (file, args, cwd) =>
+  execFileSync(file, [...args], { cwd, stdio: 'pipe' }).toString('utf8');
+
+/**
+ * Provision arguments for the isolated worktree hook (T12007).
+ *
+ * @see {@link WorktreeProvisioner}
+ */
+export interface ProvisionWorktreeArgs {
+  /** Absolute invoking project root the worktree is registered against. */
+  readonly projectRoot: string;
+  /** Absolute path where the ephemeral worktree directory is created (tmpdir). */
+  readonly worktreePath: string;
+  /** The feature branch created inside the worktree. */
+  readonly branch: string;
+  /** The base ref the worktree (and its branch) is cut from — `origin/main`. */
+  readonly baseRef: string;
+}
+
+/**
+ * Inject hook that provisions the ephemeral isolation worktree. Production
+ * leaves it undefined and the module routes through `@cleocode/worktree`'s
+ * `addTransientWorktree` (the sanctioned escape hatch for tmpdir worktrees —
+ * keeps the raw `git worktree` shell-out out of `packages/core/` per the
+ * T9984 lint gate). Tests inject a double to avoid a real git remote.
+ */
+export type WorktreeProvisioner = (args: ProvisionWorktreeArgs) => Promise<void> | void;
+
+/**
+ * Inject hook that removes the ephemeral isolation worktree. Production leaves
+ * it undefined and the module routes through `@cleocode/worktree`'s
+ * `removeTransientWorktree`.
+ */
+export type WorktreeRemover = (projectRoot: string, worktreePath: string) => Promise<void> | void;
 
 /** Failure codes from {@link openDraftPr}. */
 export type DraftPrErrorCode =
   /** Patch file does not exist on disk. */
   | 'E_NOT_FOUND'
-  /** Patch file exists but is empty. */
+  /** Patch file exists but is empty (or names no files). */
   | 'E_PATCH_EMPTY'
   /** `gh` CLI missing / not authenticated. */
   | 'E_GH_UNAVAILABLE'
-  /** Shell-out failure during the live PR cut. */
+  /** Shell-out failure during the live PR cut (incl. worktree provisioning). */
   | 'E_DRAFT_PR_FAILED';
 
 /** Args for {@link openDraftPr}. */
@@ -80,12 +128,25 @@ export interface OpenDraftPrArgs {
    * @defaultValue false
    */
   readonly execute?: boolean;
-  /** Working directory for path resolution + git ops. Defaults to {@link process.cwd}. */
+  /**
+   * The INVOKING checkout / project root. Used to (a) resolve {@link diffPath}
+   * and (b) register the ephemeral worktree against — it is NEVER mutated
+   * (T12007). Defaults to {@link process.cwd}.
+   */
   readonly cwd?: string;
   /** Injectable command runner (tests capture the shell-out). Defaults to {@link execFileSync}. */
   readonly run?: CommandRunner;
   /** Injectable timestamp source for the branch suffix (tests pin it). Defaults to now. */
   readonly timestamp?: () => string;
+  /**
+   * Explicit path for the ephemeral isolation worktree (T12007). Defaults to a
+   * unique `os.tmpdir()` directory. Overridable for deterministic tests.
+   */
+  readonly worktreeDir?: string;
+  /** Injectable worktree provisioner (tests avoid a real remote). Defaults to `addTransientWorktree`. */
+  readonly provisionWorktree?: WorktreeProvisioner;
+  /** Injectable worktree remover. Defaults to `removeTransientWorktree`. */
+  readonly removeWorktree?: WorktreeRemover;
 }
 
 /** Dry-run result — the planned steps, no side effects. */
@@ -95,6 +156,8 @@ export interface DraftPrDryRun {
   readonly branchName: string;
   /** The planned shell steps; the `gh pr create` step includes `--draft`. */
   readonly steps: readonly string[];
+  /** The repo-relative paths the patch touches — the ONLY paths that will be staged. */
+  readonly patchPaths: readonly string[];
 }
 
 /** Live result — the opened draft PR. */
@@ -104,6 +167,8 @@ export interface DraftPrOk {
   readonly branchName: string;
   /** The draft PR URL emitted by `gh pr create --draft`. */
   readonly prUrl: string;
+  /** The repo-relative paths the patch touched (the PR's complete file set). */
+  readonly patchPaths: readonly string[];
 }
 
 /** Failure result. */
@@ -117,6 +182,15 @@ export interface DraftPrFailure {
 export type DraftPrResult = DraftPrDryRun | DraftPrOk | DraftPrFailure;
 
 /**
+ * Sanitize a scenario name into a filesystem/ref-safe stem.
+ *
+ * @internal
+ */
+function safeStem(scenario: string): string {
+  return scenario.replace(/[^a-z0-9-]/gi, '-');
+}
+
+/**
  * Compute the feature branch name for a scenario's draft PR (ADR-065 feature
  * branch — `feat/T11889-selfimprove-<scenario>-<ts>`). The timestamp is
  * colon/dot-sanitized so it is a valid git ref.
@@ -126,9 +200,73 @@ export type DraftPrResult = DraftPrDryRun | DraftPrOk | DraftPrFailure;
  * @returns The branch name.
  */
 export function draftPrBranchName(scenario: string, ts: string): string {
-  const safeScenario = scenario.replace(/[^a-z0-9-]/gi, '-');
+  const safeScenario = safeStem(scenario);
   const safeTs = ts.replace(/[:.]/g, '-');
   return `feat/T11889-selfimprove-${safeScenario}-${safeTs}`;
+}
+
+/**
+ * Extract the set of repo-relative paths a unified diff touches — the SSoT for
+ * "which paths may be staged" (T12007).
+ *
+ * Parses the `diff --git a/<old> b/<new>` header (the authoritative per-file
+ * boundary in a git-format diff), collecting BOTH the pre-image (`a/`) and
+ * post-image (`b/`) paths so renames stage their old path too and deletions
+ * stage the removed path. `/dev/null` sentinels (pure add / pure delete) are
+ * skipped. Also parses bare `--- ` / `+++ ` headers as a fallback for
+ * non-`diff --git` unified diffs. The result is de-duplicated and stable
+ * ordered by first appearance.
+ *
+ * The egress stages ONLY these paths (`git add -- <paths>`), so the isolated
+ * worktree can never sweep anything the patch did not name.
+ *
+ * @param diffText - The unified-diff text.
+ * @returns The de-duplicated repo-relative paths the diff touches.
+ */
+export function parseUnifiedDiffPaths(diffText: string): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+
+  const push = (raw: string): void => {
+    // Strip surrounding double-quotes git adds for paths with special chars,
+    // then drop a leading `a/` or `b/` prefix and any trailing tab-timestamp.
+    let p = raw.trim();
+    if (p.startsWith('"') && p.endsWith('"') && p.length >= 2) p = p.slice(1, -1);
+    p = p.replace(/\t.*$/, '');
+    if (p === '/dev/null' || p.length === 0) return;
+    const rel = p.replace(/^[ab]\//, '');
+    if (rel.length === 0 || rel === '/dev/null' || seen.has(rel)) return;
+    seen.add(rel);
+    paths.push(rel);
+  };
+
+  for (const line of diffText.split('\n')) {
+    const trimmed = line.replace(/\r$/, '');
+    const gitHeader = /^diff --git (\S+) (\S+)\s*$/.exec(trimmed);
+    if (gitHeader) {
+      push(gitHeader[1]);
+      push(gitHeader[2]);
+      continue;
+    }
+    const minus = /^--- (.+)$/.exec(trimmed);
+    if (minus) {
+      push(minus[1]);
+      continue;
+    }
+    const plus = /^\+\+\+ (.+)$/.exec(trimmed);
+    if (plus) push(plus[1]);
+  }
+  return paths;
+}
+
+/**
+ * Build a unique ephemeral worktree path under `os.tmpdir()` for a scenario.
+ * The random suffix keeps concurrent self-improve runs from colliding.
+ *
+ * @internal
+ */
+function tempWorktreeDir(scenario: string): string {
+  return join(tmpdir(), `cleo-selfimprove-${safeStem(scenario)}-${randomBytes(4).toString('hex')}`);
 }
 
 /**
@@ -137,9 +275,15 @@ export function draftPrBranchName(scenario: string, ts: string): string {
  * DRY-RUN by default ({@link OpenDraftPrArgs.execute} falsey): returns the planned
  * `steps[]` (the `gh pr create` step ALWAYS carries `--draft`) WITHOUT touching
  * git/gh — so the loop is egress-side-effect-free unless `--execute` is threaded
- * through. The live path (`execute: true`) cuts the feature branch, applies the
- * diff, commits, pushes the FEATURE branch (NEVER `main`), and runs
- * `gh pr create --base main --head <branch> --draft`, returning the PR URL.
+ * through.
+ *
+ * The live path (`execute: true`) never mutates the invoking checkout (T12007).
+ * It cuts an EPHEMERAL transient worktree fresh off `origin/main`, applies the
+ * diff there, stages ONLY the paths the patch names (`git add -- <paths>` — NEVER
+ * `git add -A`), commits, pushes the FEATURE branch (NEVER `main`), runs
+ * `gh pr create --base main --head <branch> --draft`, and tears the worktree
+ * down in a `finally`. The orchestrator's untracked/uncommitted files are never
+ * staged, pushed, or deleted.
  *
  * NEVER pushes `main`, NEVER auto-merges, NEVER publishes — the only egress is a
  * draft PR against a feature branch.
@@ -151,7 +295,7 @@ export function draftPrBranchName(scenario: string, ts: string): string {
  * ```ts
  * // dry-run (default): no side effects, steps include `--draft`
  * const plan = await openDraftPr({ scenario: 'x', diffPath: 'fix.patch', title, body });
- * // live: cuts branch + opens draft PR
+ * // live: cuts an isolated worktree + opens draft PR (invoking repo untouched)
  * const res = await openDraftPr({ scenario: 'x', diffPath: 'fix.patch', title, body, execute: true });
  * ```
  */
@@ -180,6 +324,17 @@ export async function openDraftPr(args: OpenDraftPrArgs): Promise<DraftPrResult>
     };
   }
 
+  // The authoritative "what may be staged" set. A patch that names no files is
+  // treated as empty — staging nothing would produce an empty PR.
+  const patchPaths = parseUnifiedDiffPaths(diffBytes);
+  if (patchPaths.length === 0) {
+    return {
+      kind: 'error',
+      code: 'E_PATCH_EMPTY',
+      message: `Patch file '${resolvedDiff}' names no files (no unified-diff headers)`,
+    };
+  }
+
   if (execute) {
     try {
       run('gh', ['--version']);
@@ -193,46 +348,96 @@ export async function openDraftPr(args: OpenDraftPrArgs): Promise<DraftPrResult>
   }
 
   const branchName = draftPrBranchName(args.scenario, isoNow);
+  const worktreePath = args.worktreeDir ?? tempWorktreeDir(args.scenario);
+
+  // Planned steps reflect the ISOLATED flow: every git mutation runs inside the
+  // ephemeral worktree (`<worktree>`), and staging is scoped to the patch paths.
   const steps: readonly string[] = [
-    `git checkout -b ${branchName}`,
-    `git apply ${resolvedDiff}`,
-    'git add -A',
-    `git commit -m "fix(selfimprove): ${args.scenario} regression"`,
-    `git push -u origin ${branchName}`,
+    `git fetch origin ${base}`,
+    `# provision ephemeral worktree at ${worktreePath} off origin/${base} (via @cleocode/worktree)`,
+    `git -C <worktree> apply ${resolvedDiff}`,
+    `git -C <worktree> add -- ${patchPaths.join(' ')}`,
+    `git -C <worktree> commit -m "fix(selfimprove): ${args.scenario} regression"`,
+    `git -C <worktree> push -u origin ${branchName}`,
     `gh pr create --base ${base} --head ${branchName} --draft --title "${args.title}" --body <stdin>`,
+    '# remove ephemeral worktree (finally)',
   ];
 
   if (!execute) {
-    return { kind: 'dry-run', scenario: args.scenario, branchName, steps };
+    return { kind: 'dry-run', scenario: args.scenario, branchName, steps, patchPaths };
   }
 
+  const provision: WorktreeProvisioner =
+    args.provisionWorktree ??
+    ((o) =>
+      addTransientWorktree({
+        projectRoot: o.projectRoot,
+        worktreePath: o.worktreePath,
+        branch: o.branch,
+        baseRef: o.baseRef,
+        resetBranch: true,
+      }));
+  const teardown: WorktreeRemover =
+    args.removeWorktree ?? ((projectRoot, p) => removeTransientWorktree(projectRoot, p));
+
   try {
-    const prUrl = await withProvenance('pr-generator', () => {
-      run('git', ['checkout', '-b', branchName]);
-      run('git', ['apply', resolvedDiff]);
-      run('git', ['add', '-A']);
-      run('git', ['commit', '-m', `fix(selfimprove): ${args.scenario} regression`]);
-      run('git', ['push', '-u', 'origin', branchName]);
-      return run('gh', [
-        'pr',
-        'create',
-        '--base',
-        base,
-        '--head',
-        branchName,
-        '--draft',
-        '--title',
-        args.title,
-        '--body',
-        body,
-      ]).trim();
+    // Freshen origin/<base> so the isolated worktree branches off the true tip.
+    run('git', ['fetch', 'origin', base], cwd);
+
+    // Provision the ephemeral worktree OFF origin/<base> — NEVER the invoking
+    // tree. All subsequent git mutations target `worktreePath`.
+    await provision({
+      projectRoot: cwd,
+      worktreePath,
+      branch: branchName,
+      baseRef: `origin/${base}`,
     });
-    return { kind: 'ok', scenario: args.scenario, branchName, prUrl };
+
+    const prUrl = await withProvenance('pr-generator', async () => {
+      // Apply the patch INSIDE the isolated worktree (its working tree only).
+      run('git', ['apply', resolvedDiff], worktreePath);
+      // Stage ONLY the paths the patch names — never `git add -A`, never the
+      // invoking checkout. This is the crux of the T12007 fix.
+      run('git', ['add', '--', ...patchPaths], worktreePath);
+      run('git', ['commit', '-m', `fix(selfimprove): ${args.scenario} regression`], worktreePath);
+      run('git', ['push', '-u', 'origin', branchName], worktreePath);
+      return run(
+        'gh',
+        [
+          'pr',
+          'create',
+          '--base',
+          base,
+          '--head',
+          branchName,
+          '--draft',
+          '--title',
+          args.title,
+          '--body',
+          body,
+        ],
+        worktreePath,
+      ).trim();
+    });
+    return { kind: 'ok', scenario: args.scenario, branchName, prUrl, patchPaths };
   } catch (err) {
     return {
       kind: 'error',
       code: 'E_DRAFT_PR_FAILED',
       message: `draft-pr failed: ${err instanceof Error ? err.message : String(err)}`,
     };
+  } finally {
+    // Best-effort teardown — the invoking checkout is never touched, only the
+    // ephemeral worktree registration + its tmpdir directory.
+    try {
+      await teardown(cwd, worktreePath);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      rmSync(worktreePath, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
   }
 }

--- a/packages/core/src/selfimprove/run-loop.ts
+++ b/packages/core/src/selfimprove/run-loop.ts
@@ -67,7 +67,13 @@ import {
   type SelfImproveBudget,
 } from './budget.js';
 import { createDhqAdapter, type DhqAdapter } from './dhq-adapter.js';
-import { type CommandRunner, type DraftPrResult, openDraftPr } from './draft-pr.js';
+import {
+  type CommandRunner,
+  type DraftPrResult,
+  openDraftPr,
+  type WorktreeProvisioner,
+  type WorktreeRemover,
+} from './draft-pr.js';
 import { computeQuestionHash, type DiffEntry, diffEnvelopes } from './envelope-diff.js';
 import {
   createLlmFixGenerator,
@@ -139,6 +145,14 @@ export interface RunSelfImproveOptions {
    * tests so the capstone proves the egress WITHOUT a real `gh`/`git` invocation.
    */
   readonly draftPrRun?: CommandRunner;
+  /**
+   * Test seam: inject the draft-PR isolation-worktree provisioner (T12007).
+   * Defaults to `@cleocode/worktree`'s `addTransientWorktree`. Supplied by tests
+   * so the capstone proves the egress WITHOUT a real git repo / remote.
+   */
+  readonly draftPrProvisionWorktree?: WorktreeProvisioner;
+  /** Test seam: inject the draft-PR isolation-worktree remover (T12007). */
+  readonly draftPrRemoveWorktree?: WorktreeRemover;
   /** Test seam: inject the guard backing the in-process fallback env. */
   readonly guard?: ToolGuard;
   /** Test seam: inject the run id (defaults to a timestamped id). */
@@ -409,6 +423,12 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
         execute,
         ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
         ...(opts.draftPrRun !== undefined ? { run: opts.draftPrRun } : {}),
+        ...(opts.draftPrProvisionWorktree !== undefined
+          ? { provisionWorktree: opts.draftPrProvisionWorktree }
+          : {}),
+        ...(opts.draftPrRemoveWorktree !== undefined
+          ? { removeWorktree: opts.draftPrRemoveWorktree }
+          : {}),
       });
       if (draftPr.kind === 'ok') {
         await adapter.recordPrUrl(questionHash, draftPr.prUrl);


### PR DESCRIPTION
## Summary

Fixes **T12007** (DHQ-094) — a **P1 data-safety defect** found live during the first model-authored PR (#1090).

The self-improvement loop's draft-PR egress applied the fix patch in the **invoking checkout** and ran `git add -A`, sweeping the orchestrator's entire dirty working tree — untracked owner scratch notes (`.cleo/rcasd/*`), shipped changesets, the patch artifact — onto the public branch, pushing them to `origin` and **deleting them locally** (restored manually from `FETCH_HEAD`). An autonomous loop pushing owner-workspace data to a public branch is a data-safety class defect.

## Fix (CORE-first — `packages/core/src/selfimprove/draft-pr.ts`)

- **Isolation:** provision an ephemeral transient worktree **off `origin/main`** via `@cleocode/worktree` (the sanctioned tmpdir escape hatch — keeps the raw `git worktree` shell-out out of `core/` per the T9984 lint gate); apply the patch there, **never** the invoking checkout.
- **Scoped staging:** new `parseUnifiedDiffPaths()` SSoT + `git add -- <paths>` — stages **only** the paths the patch names, **never** `git add -A`.
- **Root cause:** thread a `cwd` through `CommandRunner` so every git mutation runs **inside the worktree** (was implicitly `process.cwd()` = the invoking checkout). Teardown in `finally`; the invoking repo is never mutated.
- `run-loop.ts`: additive worktree-provisioner test seams mirroring the existing `draftPrRun` seam.

## Acceptance (all proven by tests)

| AC | Proof |
|----|-------|
| AC1 draft PR contains ONLY patch files | real-git test asserts pushed branch tree = `src.ts` only |
| AC2 apply/branch in a clean worktree, never the invoking checkout | invoking `HEAD` stays on `main`; all git mutations run with `cwd = worktree` |
| AC3 untracked/uncommitted workspace files never staged/pushed/deleted | seeded untracked `.cleo/rcasd/scratch.md` survives byte-identical + stays untracked |
| AC4 regression test seeds an untracked file and asserts survival + absence from PR | dedicated real-git test (bare origin + dirty tree) |

## Gates

- ✅ 109/109 `selfimprove` tests pass (incl. new real-git isolation regression + `parseUnifiedDiffPaths` unit tests)
- ✅ biome, `tsc --noEmit` (core + cleo), `pnpm --filter @cleocode/core build`
- ✅ all 6 architectural boundary gates + `lint-no-raw-git-worktree` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)