### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # CLEO
 
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.kryptobaseddev%2Fcleo-mcp-server.svg)](https://mcptoplist.com/server/io.github.kryptobaseddev%2Fcleo-mcp-server)
+
 [![npm version](https://img.shields.io/npm/v/@cleocode/cleo.svg)](https://www.npmjs.com/package/@cleocode/cleo)
 [![CI](https://github.com/kryptobaseddev/cleo/actions/workflows/ci.yml/badge.svg)](https://github.com/kryptobaseddev/cleo/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **Cleo MCP Server** is currently ranked **#542**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/io.github.kryptobaseddev%2Fcleo-mcp-server.svg)](https://mcptoplist.com/server/io.github.kryptobaseddev%2Fcleo-mcp-server)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Cleo MCP Server!
