### PR TITLE
Task: T12026 — Extend ProjectContext contract and JSON schema for typed lint/typecheck/audit/security-scan command overrides

### DIFF
--- a/packages/contracts/src/project-context.ts
+++ b/packages/contracts/src/project-context.ts
@@ -91,16 +91,25 @@ export interface ProjectContext {
     commonPatterns?: string[];
     avoidPatterns?: string[];
   };
-  /** Override commands for developer workflow steps (lint, typecheck, audit, security scan). */
-  commands?: {
+  /** Lint command override (T12026). */
+  lint?: {
     /** Command to run static analysis / lint checks. */
-    lint?: string;
+    command?: string;
+  };
+  /** Type-check command override (T12026). */
+  typecheck?: {
     /** Command to run type checking. */
-    typecheck?: string;
+    command?: string;
+  };
+  /** Audit command override (T12026). */
+  audit?: {
     /** Command to run dependency/module audit checks. */
-    audit?: string;
+    command?: string;
+  };
+  /** Security-scan command override (T12026). JSON key is `security-scan`. */
+  'security-scan'?: {
     /** Command to run security vulnerability scanning. */
-    securityScan?: string;
+    command?: string;
   };
 }
 

--- a/packages/contracts/src/project-context.ts
+++ b/packages/contracts/src/project-context.ts
@@ -91,6 +91,17 @@ export interface ProjectContext {
     commonPatterns?: string[];
     avoidPatterns?: string[];
   };
+  /** Override commands for developer workflow steps (lint, typecheck, audit, security scan). */
+  commands?: {
+    /** Command to run static analysis / lint checks. */
+    lint?: string;
+    /** Command to run type checking. */
+    typecheck?: string;
+    /** Command to run dependency/module audit checks. */
+    audit?: string;
+    /** Command to run security vulnerability scanning. */
+    securityScan?: string;
+  };
 }
 
 /**

--- a/packages/core/schemas/project-context.schema.json
+++ b/packages/core/schemas/project-context.schema.json
@@ -159,6 +159,29 @@
           "description": "Deprecated APIs, incompatible syntax, style violations to avoid"
         }
       }
+    },
+    "commands": {
+      "type": "object",
+      "description": "Developer workflow command overrides for lint, typecheck, audit, and security scan.",
+      "additionalProperties": false,
+      "properties": {
+        "lint": {
+          "type": "string",
+          "description": "Command to run static analysis / lint checks"
+        },
+        "typecheck": {
+          "type": "string",
+          "description": "Command to run type checking"
+        },
+        "audit": {
+          "type": "string",
+          "description": "Command to run dependency/module audit checks"
+        },
+        "securityScan": {
+          "type": "string",
+          "description": "Command to run security vulnerability scanning"
+        }
+      }
     }
   }
 }

--- a/packages/core/schemas/project-context.schema.json
+++ b/packages/core/schemas/project-context.schema.json
@@ -160,24 +160,45 @@
         }
       }
     },
-    "commands": {
+    "lint": {
       "type": "object",
-      "description": "Developer workflow command overrides for lint, typecheck, audit, and security scan.",
+      "description": "Lint command override (T12026).",
       "additionalProperties": false,
       "properties": {
-        "lint": {
+        "command": {
           "type": "string",
           "description": "Command to run static analysis / lint checks"
-        },
-        "typecheck": {
+        }
+      }
+    },
+    "typecheck": {
+      "type": "object",
+      "description": "Type-check command override (T12026).",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
           "type": "string",
           "description": "Command to run type checking"
-        },
-        "audit": {
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "description": "Audit command override (T12026).",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
           "type": "string",
           "description": "Command to run dependency/module audit checks"
-        },
-        "securityScan": {
+        }
+      }
+    },
+    "security-scan": {
+      "type": "object",
+      "description": "Security-scan command override (T12026).",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
           "type": "string",
           "description": "Command to run security vulnerability scanning"
         }

--- a/packages/core/src/store/__tests__/project-detect.test.ts
+++ b/packages/core/src/store/__tests__/project-detect.test.ts
@@ -491,32 +491,32 @@ describe('Group 7: Schema compliance', () => {
     expect(result.projectTypes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('commands field with lint/typecheck/audit/securityScan is schema-valid (T12026 regression)', () => {
+  it('top-level lint/typecheck/audit/security-scan command objects are schema-valid (T12026 regression)', () => {
     dir = scaffold({ 'package.json': '{"name":"app"}' });
     const result = detectProjectType(dir);
-    result.commands = {
-      lint: 'pnpm biome check --write .',
-      typecheck: 'pnpm run typecheck',
-      audit: 'pnpm audit',
-      securityScan: 'pnpm run security-scan',
-    };
-    assertSchemaValid(result, 'commands overrides');
-    expect(result.commands.lint).toBe('pnpm biome check --write .');
-    expect(result.commands.typecheck).toBe('pnpm run typecheck');
-    expect(result.commands.audit).toBe('pnpm audit');
-    expect(result.commands.securityScan).toBe('pnpm run security-scan');
+    result.lint = { command: 'pnpm biome check --write .' };
+    result.typecheck = { command: 'pnpm run typecheck' };
+    result.audit = { command: 'pnpm audit' };
+    // eslint-disable-next-line dot-notation
+    result['security-scan'] = { command: 'pnpm run security-scan' };
+    assertSchemaValid(result, 'top-level command overrides');
+    expect(result.lint?.command).toBe('pnpm biome check --write .');
+    expect(result.typecheck?.command).toBe('pnpm run typecheck');
+    expect(result.audit?.command).toBe('pnpm audit');
+    // eslint-disable-next-line dot-notation
+    expect(result['security-scan']?.command).toBe('pnpm run security-scan');
   });
 
-  it('commands field survives JSON roundtrip (T12026 regression)', () => {
+  it('top-level command objects survive JSON roundtrip (T12026 regression)', () => {
     dir = scaffold({ 'package.json': '{"name":"app"}' });
     const result = detectProjectType(dir);
-    result.commands = {
-      lint: 'pnpm biome check --write .',
-      typecheck: 'pnpm run typecheck',
-    };
+    result.lint = { command: 'pnpm biome check --write .' };
+    result.typecheck = { command: 'pnpm run typecheck' };
     const roundtripped = JSON.parse(JSON.stringify(result));
-    assertSchemaValid(roundtripped, 'commands roundtrip');
-    expect(roundtripped.commands).toEqual(result.commands);
+    assertSchemaValid(roundtripped, 'top-level command roundtrip');
+    expect(roundtripped.lint).toEqual({ command: 'pnpm biome check --write .' });
+    expect(roundtripped.typecheck).toEqual({ command: 'pnpm run typecheck' });
+    expect(roundtripped['security-scan']).toBeUndefined();
   });
 });
 

--- a/packages/core/src/store/__tests__/project-detect.test.ts
+++ b/packages/core/src/store/__tests__/project-detect.test.ts
@@ -490,6 +490,34 @@ describe('Group 7: Schema compliance', () => {
     const result = detectProjectType(dir);
     expect(result.projectTypes.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('commands field with lint/typecheck/audit/securityScan is schema-valid (T12026 regression)', () => {
+    dir = scaffold({ 'package.json': '{"name":"app"}' });
+    const result = detectProjectType(dir);
+    result.commands = {
+      lint: 'pnpm biome check --write .',
+      typecheck: 'pnpm run typecheck',
+      audit: 'pnpm audit',
+      securityScan: 'pnpm run security-scan',
+    };
+    assertSchemaValid(result, 'commands overrides');
+    expect(result.commands.lint).toBe('pnpm biome check --write .');
+    expect(result.commands.typecheck).toBe('pnpm run typecheck');
+    expect(result.commands.audit).toBe('pnpm audit');
+    expect(result.commands.securityScan).toBe('pnpm run security-scan');
+  });
+
+  it('commands field survives JSON roundtrip (T12026 regression)', () => {
+    dir = scaffold({ 'package.json': '{"name":"app"}' });
+    const result = detectProjectType(dir);
+    result.commands = {
+      lint: 'pnpm biome check --write .',
+      typecheck: 'pnpm run typecheck',
+    };
+    const roundtripped = JSON.parse(JSON.stringify(result));
+    assertSchemaValid(roundtripped, 'commands roundtrip');
+    expect(roundtripped.commands).toEqual(result.commands);
+  });
 });
 
 // ─── Group 8: Build detection ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends the shared `ProjectContext` interface in `packages/contracts/src/project-context.ts` and the corresponding JSON schema (`packages/core/schemas/project-context.schema.json`) with four top-level optional command objects, consistent with the existing `testing.command` and `build.command` pattern:

| Field                    | Type                    | Purpose                                        |
|--------------------------|-------------------------|------------------------------------------------|
| `lint.command`           | `string` (optional)     | Static analysis / lint command override         |
| `typecheck.command`      | `string` (optional)     | Type checking command override                  |
| `audit.command`          | `string` (optional)     | Dependency/module audit command override        |
| `security-scan.command`  | `string` (optional)     | Security vulnerability scan command override    |

### Changes
- **3 files**, +64 / -34 lines
- `packages/contracts/src/project-context.ts` — added `lint`, `typecheck`, `audit`, `security-scan` top-level `{ command?: string }` objects to `ProjectContext`
- `packages/core/schemas/project-context.schema.json` — added 4 top-level object properties with typed `command` sub-property
- `packages/core/src/store/__tests__/project-detect.test.ts` — 2 regression tests (schema validation + JSON roundtrip for top-level command objects)

### Verification
- `pnpm --filter @cleocode/contracts run build` — passed
- `vitest run src/store/__tests__/project-detect.test.ts` — 79/79 passed (2 updated T12026 regression tests)
- `pnpm biome check` — no fixes needed

### What is NOT included
- **Resolver/runner behavior** for these command overrides — deferred to dependent task T12027.

### Package Boundary Check
Code placed in `packages/contracts/` and the existing `packages/core/` schema/tests per Package-Boundary Check, verified against AGENTS.md.

Part of #1122 and #1129; runtime resolver follows in T12027.