### PR TITLE
Task: T12031 fix grade-mode query auditing across fresh CLI processes

### DIFF
--- a/packages/cleo/src/dispatch/middleware/__tests__/audit.test.ts
+++ b/packages/cleo/src/dispatch/middleware/__tests__/audit.test.ts
@@ -6,26 +6,36 @@
  *   2. SQLite audit_log table
  *
  * @task T4844
+ * @task T12031 — cross-process durable gradeMode tests
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DispatchRequest, DispatchResponse } from '../../types.js';
 
 // Hoist mock functions so vi.mock factories can reference them
-const { mockLogInfo, mockLogWarn, mockLogError, mockInsertRun, mockInsertValues, mockInsert } =
-  vi.hoisted(() => {
-    const mockInsertRun = vi.fn().mockResolvedValue(undefined);
-    const mockInsertValues = vi.fn(() => ({ run: mockInsertRun }));
-    const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
-    return {
-      mockLogInfo: vi.fn(),
-      mockLogWarn: vi.fn(),
-      mockLogError: vi.fn(),
-      mockInsertRun,
-      mockInsertValues,
-      mockInsert,
-    };
-  });
+const {
+  mockLogInfo,
+  mockLogWarn,
+  mockLogError,
+  mockInsertRun,
+  mockInsertValues,
+  mockInsert,
+  mockResolveCurrentSession,
+} = vi.hoisted(() => {
+  const mockInsertRun = vi.fn().mockResolvedValue(undefined);
+  const mockInsertValues = vi.fn(() => ({ run: mockInsertRun }));
+  const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
+  const mockResolveCurrentSession = vi.fn().mockResolvedValue(null);
+  return {
+    mockLogInfo: vi.fn(),
+    mockLogWarn: vi.fn(),
+    mockLogError: vi.fn(),
+    mockInsertRun,
+    mockInsertValues,
+    mockInsert,
+    mockResolveCurrentSession,
+  };
+});
 
 // Mock Pino logger
 vi.mock('../../../../../core/src/logger.js', () => ({
@@ -64,6 +74,14 @@ vi.mock('../../../../../core/src/store/sqlite.js', () => ({
 // audit test does not have to spin up a real brain.db handle.
 vi.mock('../../../../../core/src/store/memory-sqlite.js', () => ({
   getBrainNativeDb: vi.fn().mockReturnValue(null),
+}));
+
+// Mock session-store for T12031 cross-process gradeMode resolution
+vi.mock('../../../../../core/src/store/session-store.js', () => ({
+  createSession: vi.fn(),
+  getActiveSession: vi.fn().mockResolvedValue(null),
+  resolveCurrentSession: (...args: unknown[]) => mockResolveCurrentSession(...args),
+  resolveCurrentSessionId: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../../../../../core/src/store/tasks-schema.js', async (importOriginal) => {
@@ -250,5 +268,104 @@ describe('createAudit middleware', () => {
     const insertedValues = (mockInsertValues.mock.calls as any)[0]![0];
     expect(insertedValues.errorMessage).toBe('Task not found');
     expect(insertedValues.success).toBe(0);
+  });
+
+  // ── T12031: cross-process durable gradeMode ──
+
+  describe('grade-mode query auditing (T12031)', () => {
+    it('should audit queries when env CLEO_SESSION_GRADE is set', async () => {
+      process.env.CLEO_SESSION_GRADE = 'true';
+      const middleware = createAudit();
+      const response = makeResponse({ meta: { ...makeResponse().meta, gateway: 'query' } });
+      const next = vi.fn(() => Promise.resolve(response));
+      const request = makeRequest({ gateway: 'query' });
+
+      await middleware(request, next);
+
+      // Wait for fire-and-forget promises
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockLogInfo).toHaveBeenCalledOnce();
+      expect(mockInsert).toHaveBeenCalled();
+    });
+
+    it('should audit queries from durable gradeMode when env is NOT set', async () => {
+      // Simulate a fresh subprocess: no CLEO_SESSION_GRADE env, but
+      // the session row has gradeMode = true from a prior session-start.
+      delete process.env.CLEO_SESSION_GRADE;
+      mockResolveCurrentSession.mockResolvedValue({ id: 'sess-grade', gradeMode: true });
+
+      const middleware = createAudit();
+      const response = makeResponse({ meta: { ...makeResponse().meta, gateway: 'query' } });
+      const next = vi.fn(() => Promise.resolve(response));
+      const request = makeRequest({ gateway: 'query' });
+
+      await middleware(request, next);
+
+      // Wait for fire-and-forget promises
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockLogInfo).toHaveBeenCalledOnce();
+      expect(mockInsert).toHaveBeenCalled();
+    });
+
+    it('should NOT audit queries when durable gradeMode is false', async () => {
+      delete process.env.CLEO_SESSION_GRADE;
+      mockResolveCurrentSession.mockResolvedValue({ id: 'sess-normal', gradeMode: false });
+
+      const middleware = createAudit();
+      const response = makeResponse({ meta: { ...makeResponse().meta, gateway: 'query' } });
+      const next = vi.fn(() => Promise.resolve(response));
+      const request = makeRequest({ gateway: 'query' });
+
+      await middleware(request, next);
+
+      // Wait for fire-and-forget promises
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockLogInfo).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it('should fail-open: DB lookup failure does not crash pipeline', async () => {
+      delete process.env.CLEO_SESSION_GRADE;
+      mockResolveCurrentSession.mockRejectedValueOnce(new Error('DB unavailable'));
+
+      const middleware = createAudit();
+      const response = makeResponse();
+      const next = vi.fn(() => Promise.resolve(response));
+      const request = makeRequest();
+
+      // Must not throw
+      const result = await middleware(request, next);
+
+      // Wait for fire-and-forget promises
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(result).toBe(response);
+      // Mutations still logged even after failed grade-mode lookup
+      expect(mockLogInfo).toHaveBeenCalled();
+    });
+
+    it('should fail-open for query: DB failure → no audit (not a crash)', async () => {
+      delete process.env.CLEO_SESSION_GRADE;
+      mockResolveCurrentSession.mockRejectedValueOnce(new Error('DB unavailable'));
+
+      const middleware = createAudit();
+      const response = makeResponse({ meta: { ...makeResponse().meta, gateway: 'query' } });
+      const next = vi.fn(() => Promise.resolve(response));
+      const request = makeRequest({ gateway: 'query' });
+
+      // Must not throw
+      const result = await middleware(request, next);
+
+      // Wait for fire-and-forget promises
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(result).toBe(response);
+      // Queries not audited when grade-mode lookup fails open
+      expect(mockLogInfo).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cleo/src/dispatch/middleware/audit.ts
+++ b/packages/cleo/src/dispatch/middleware/audit.ts
@@ -13,7 +13,12 @@
  * @task T4844
  */
 
-import { getLogger, getProjectInfoSync, resolveSessionIdFromEnv } from '@cleocode/core/internal';
+import {
+  getLogger,
+  getProjectInfoSync,
+  resolveCurrentSession,
+  resolveSessionIdFromEnv,
+} from '@cleocode/core/internal';
 import { getConfig } from '../lib/config.js';
 import type { DispatchNext, DispatchRequest, DispatchResponse, Middleware } from '../types.js';
 
@@ -40,11 +45,28 @@ import type { AuditEntry } from '@cleocode/core/internal';
 /**
  * Check if the current context is a grade session.
  *
- * Now simplified: session-resolver middleware (T4959) populates request.sessionId
- * before audit runs, so we only need to check grade mode flags.
+ * Consults the durable session `gradeMode` state in addition to the env var,
+ * so fresh CLI subprocesses that lack `CLEO_SESSION_GRADE` still audit queries.
+ *
+ * Precedence:
+ *   1. `CLEO_SESSION_GRADE` env (set by session-start, inherited by children).
+ *   2. Durable `gradeMode` column on the caller's session row (cross-process).
+ *
+ * Fail-open: a DB lookup failure defaults to `false` so audit lookup never
+ * blocks the pipeline and normal sessions never accidentally log queries.
+ *
+ * @task T12031
  */
-function isGradeMode(): boolean {
-  return process.env.CLEO_SESSION_GRADE === 'true';
+async function isGradeMode(): Promise<boolean> {
+  if (process.env.CLEO_SESSION_GRADE === 'true') return true;
+
+  try {
+    const session = await resolveCurrentSession();
+    if (session?.gradeMode) return true;
+  } catch {
+    // fail-open — DB unreachable defaults to no grade mode
+  }
+  return false;
 }
 
 /**
@@ -148,7 +170,7 @@ export function createAudit(): Middleware {
     // audit runs. Fall back to legacy lookup only if resolver missed it.
     const currentSessionId: string | null =
       req.sessionId ?? (await getActiveSessionInfo())?.id ?? null;
-    const isGradeSession = isGradeMode();
+    const isGradeSession = await isGradeMode();
 
     const response = await next();
 


### PR DESCRIPTION
## Summary

Fixes #814: grade-mode query auditing silently dropped across fresh CLI subprocesses.

### Root cause
The `isGradeMode()` helper in the audit middleware only consulted `CLEO_SESSION_GRADE` (set at session-start time). Fresh subprocesses that lacked this env var silently skipped query audit logging because the durable `grade_mode` column on the persisted session row was never read.

### Fix
- Made `isGradeMode()` async; it now falls back to `resolveCurrentSession()` (the canonical identity-resolving store accessor chokepoint) when the env var is absent.
- Fail-open: a DB lookup failure defaults to `false` so audit never blocks the pipeline and normal sessions never accidentally log queries.
- Reuses the existing store accessor chokepoint — no direct DB open.

### Tests
Extended audit middleware tests with 5 new cases:
1. **Env-first precedence** — `CLEO_SESSION_GRADE=true` audits queries
2. **Durable fallback** — env unset, session `gradeMode: true` → queries audited (cross-process scenario)
3. **Normal session silence** — env unset, session `gradeMode: false` → queries NOT audited
4. **Fail-open (mutation)** — DB lookup failure doesn't crash the pipeline
5. **Fail-open (query)** — DB lookup failure defaults to no audit (not a crash)

### Files changed
- `packages/cleo/src/dispatch/middleware/audit.ts` — `isGradeMode()` now async with durable fallback
- `packages/cleo/src/dispatch/middleware/__tests__/audit.test.ts` — +5 test cases

Closes #814