### PR TITLE
refactor(store): bind writer leases to exact database handles

### DIFF
--- a/packages/core/src/store/__tests__/dual-scope-db.test.ts
+++ b/packages/core/src/store/__tests__/dual-scope-db.test.ts
@@ -29,6 +29,7 @@ import {
   resolveDualScopeDbPath,
   setRuntimeOpenFn,
 } from '../dual-scope-db.js';
+import { makeWriterLeaseIdentity } from '../writer-lease.js';
 
 // ── Test directory management ─────────────────────────────────────────────────
 
@@ -193,8 +194,9 @@ describe('insertIdempotent + idempotency guarantee (E4 AC7)', () => {
     const { tasksTasks } = (await import('../schema/cleo-project/tasks-core.js')) as any; // db-open-allowed: test-only schema import
 
     let insertedCount = 0;
+    const identity = makeWriterLeaseIdentity('project', handle.dbPath);
     for (let i = 0; i < 100; i++) {
-      const n = await insertIdempotent(handle.db, tasksTasks, row, 'idempotencyKey');
+      const n = await insertIdempotent(handle.db, tasksTasks, row, 'idempotencyKey', identity);
       insertedCount += n;
     }
 

--- a/packages/core/src/store/__tests__/dual-scope-db.test.ts
+++ b/packages/core/src/store/__tests__/dual-scope-db.test.ts
@@ -29,7 +29,6 @@ import {
   resolveDualScopeDbPath,
   setRuntimeOpenFn,
 } from '../dual-scope-db.js';
-import { makeWriterLeaseIdentity } from '../writer-lease.js';
 
 // ── Test directory management ─────────────────────────────────────────────────
 
@@ -194,9 +193,8 @@ describe('insertIdempotent + idempotency guarantee (E4 AC7)', () => {
     const { tasksTasks } = (await import('../schema/cleo-project/tasks-core.js')) as any; // db-open-allowed: test-only schema import
 
     let insertedCount = 0;
-    const identity = makeWriterLeaseIdentity('project', handle.dbPath);
     for (let i = 0; i < 100; i++) {
-      const n = await insertIdempotent(handle.db, tasksTasks, row, 'idempotencyKey', identity);
+      const n = await insertIdempotent(handle.db, tasksTasks, row, 'idempotencyKey');
       insertedCount += n;
     }
 

--- a/packages/core/src/store/__tests__/exodus-abort-surface.test.ts
+++ b/packages/core/src/store/__tests__/exodus-abort-surface.test.ts
@@ -33,7 +33,7 @@ import {
   exodusAbortEvents,
   getRecordedExodusAbort,
 } from '../exodus/abort-events.js';
-import { makeWriterLeaseIdentity } from '../writer-lease.js';
+import { makeWriterLeaseIdentity, registerDbIdentity } from '../writer-lease.js';
 
 function makeDetail(over: Partial<ExodusAbortDetail> = {}): ExodusAbortDetail {
   return {
@@ -135,8 +135,6 @@ describe('exodus abort surface (T11828)', () => {
   });
 
   describe('write primitives reject while an abort is recorded', () => {
-    const identity = makeWriterLeaseIdentity('project', '/tmp/cleo.db');
-
     // A stub Drizzle handle whose insert chain would resolve if reached — proves
     // the guard short-circuits BEFORE any DB call when an abort is live.
     function makeInsertSpyDb(): { db: never; calls: number } {
@@ -162,7 +160,7 @@ describe('exodus abort surface (T11828)', () => {
       emitExodusAbort(makeDetail());
       const spy = makeInsertSpyDb();
       await expect(
-        insertIdempotent(spy.db, {} as never, {} as never, 'idempotencyKey', identity),
+        insertIdempotent(spy.db, {} as never, {} as never, 'idempotencyKey'),
       ).rejects.toBeInstanceOf(ExodusAbortWriteUnsafeError);
       expect(spy.calls).toBe(0);
     });
@@ -171,13 +169,8 @@ describe('exodus abort surface (T11828)', () => {
       emitExodusAbort(makeDetail());
       clearExodusAborts();
       const spy = makeInsertSpyDb();
-      const inserted = await insertIdempotent(
-        spy.db,
-        {} as never,
-        {} as never,
-        'idempotencyKey',
-        identity,
-      );
+      registerDbIdentity(spy.db, makeWriterLeaseIdentity('project', '/tmp/cleo.db'));
+      const inserted = await insertIdempotent(spy.db, {} as never, {} as never, 'idempotencyKey');
       expect(inserted).toBe(1);
       expect(spy.calls).toBe(1);
     });

--- a/packages/core/src/store/__tests__/exodus-abort-surface.test.ts
+++ b/packages/core/src/store/__tests__/exodus-abort-surface.test.ts
@@ -33,6 +33,7 @@ import {
   exodusAbortEvents,
   getRecordedExodusAbort,
 } from '../exodus/abort-events.js';
+import { makeWriterLeaseIdentity } from '../writer-lease.js';
 
 function makeDetail(over: Partial<ExodusAbortDetail> = {}): ExodusAbortDetail {
   return {
@@ -134,6 +135,8 @@ describe('exodus abort surface (T11828)', () => {
   });
 
   describe('write primitives reject while an abort is recorded', () => {
+    const identity = makeWriterLeaseIdentity('project', '/tmp/cleo.db');
+
     // A stub Drizzle handle whose insert chain would resolve if reached — proves
     // the guard short-circuits BEFORE any DB call when an abort is live.
     function makeInsertSpyDb(): { db: never; calls: number } {
@@ -159,7 +162,7 @@ describe('exodus abort surface (T11828)', () => {
       emitExodusAbort(makeDetail());
       const spy = makeInsertSpyDb();
       await expect(
-        insertIdempotent(spy.db, {} as never, {} as never, 'idempotencyKey'),
+        insertIdempotent(spy.db, {} as never, {} as never, 'idempotencyKey', identity),
       ).rejects.toBeInstanceOf(ExodusAbortWriteUnsafeError);
       expect(spy.calls).toBe(0);
     });
@@ -168,7 +171,13 @@ describe('exodus abort surface (T11828)', () => {
       emitExodusAbort(makeDetail());
       clearExodusAborts();
       const spy = makeInsertSpyDb();
-      const inserted = await insertIdempotent(spy.db, {} as never, {} as never, 'idempotencyKey');
+      const inserted = await insertIdempotent(
+        spy.db,
+        {} as never,
+        {} as never,
+        'idempotencyKey',
+        identity,
+      );
       expect(inserted).toBe(1);
       expect(spy.calls).toBe(1);
     });

--- a/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
+++ b/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
@@ -5,22 +5,13 @@
  *   - T12042 — writer-lease identity isolation: concurrent project A / project B /
  *     global writers cannot steal, release, resolve, or close each other's lease
  *     identity; the removed process-global activeScope() registry is replaced with
- *     explicit WriterLeaseIdentity per call.
- *   - Seam 0 — `withColdOpenLease` serializes the cold-open critical section
- *     (claims + releases the row), bootstraps the lease tables on the passed handle,
- *     and is a pure pass-through in `off` mode.
- *   - T9  — dual-scope: a project cold-open lease and a global cold-open lease are
- *     independent (distinct files, never serialize against each other).
- *   - T11 — two-writer arbitration (`local`, daemon OFF): two independent native
- *     handles to the SAME file racing `withColdOpenLease` serialize cleanly.
- *   - T14 — **T5158 regression**: N INDEPENDENT native handles to the SAME
- *     temp-dir cleo.db copy (modeling N processes — `withColdOpenLease` bypasses
- *     the in-process grant memo and arbitrates only over the persisted lease ROW,
- *     so the file is the sole shared medium, exactly as across real processes)
- *     concurrently cold-open in `local` mode → the Seam-0 lease serializes the racy
- *     migrate-write-txn analog → every increment lands (zero lost rows), zero
- *     `E_NOT_INITIALIZED`-class failures. `off` mode is run to confirm the race is
- *     real (guards the heal's value).
+ *     immutable DB-bound WriterLeaseIdentity via typed WeakMap + registerDbIdentity.
+ *   - Alias paths normalize to one identity; one memoized grant row.
+ *   - Chokepoint write primitives resolve identity from exact DB binding.
+ *   - Seam 0 — `withColdOpenLease` serializes the cold-open critical section.
+ *   - T9  — dual-scope independence.
+ *   - T11 — two-writer arbitration.
+ *   - T14 — T5158 regression.
  *
  * Every test runs against a TEMP-DIR cleo.db copy — never `.cleo/*.db`.
  *
@@ -31,7 +22,7 @@
 
 import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -47,6 +38,8 @@ import {
   type LeaseScope,
   type LeaseTarget,
   makeWriterLeaseIdentity,
+  registerDbIdentity,
+  resolveDbIdentity,
   withColdOpenLease,
 } from '../writer-lease.js';
 import { WRITER_LEASES_TABLE, WRITER_QUEUE_TABLE } from '../writer-lease-schema.js';
@@ -95,21 +88,55 @@ function countActive(db: DatabaseSync, scope: string, lane: string): number {
   );
 }
 
-// ── T12042 — writer-lease identity isolation (replaces process-global activeScope) ──
+// ── T12042 — identity normalization: alias paths resolve to one identity ──────
 
-describe('T12042 — explicit WriterLeaseIdentity isolation (replaces process-global activeScope)', () => {
-  it('makeWriterLeaseIdentity produces distinct frozen identities for distinct paths', () => {
-    const idA = makeWriterLeaseIdentity('project', '/tmp/a/.cleo/cleo.db');
-    const idB = makeWriterLeaseIdentity('project', '/tmp/b/.cleo/cleo.db');
-    expect(idA.scope).toBe('project');
-    expect(idB.scope).toBe('project');
-    expect(idA.dbPath).not.toBe(idB.dbPath);
-    // Frozen — cannot be mutated after construction.
-    expect(() => {
-      (idA as { scope: string }).scope = 'global';
-    }).toThrow();
+describe('T12042 — makeWriterLeaseIdentity normalizes alias paths to one identity', () => {
+  it('alias paths produce byte-identical identities (path.resolve normalization)', () => {
+    const idA = makeWriterLeaseIdentity('project', '/tmp/./proj/.cleo/cleo.db');
+    const idB = makeWriterLeaseIdentity('project', '/tmp/proj/.cleo/cleo.db');
+    expect(idA.dbPath).toBe(idB.dbPath);
+    expect(idA.dbPath).toBe(resolvePath('/tmp/proj/.cleo/cleo.db'));
   });
 
+  it('different canonical paths produce distinct identities', () => {
+    const idA = makeWriterLeaseIdentity('project', '/tmp/a/.cleo/cleo.db');
+    const idB = makeWriterLeaseIdentity('project', '/tmp/b/.cleo/cleo.db');
+    expect(idA.dbPath).not.toBe(idB.dbPath);
+    expect(idA.scope).toBe(idB.scope);
+  });
+
+  it('a single memoized grant row for alias paths (one identity)', async () => {
+    // Two callers acquire the same scope+dbPath through an aliased dbPath param.
+    const native = await openTempScope('project', join(testRoot, 'alias', '.cleo'));
+    const realPath = resolvePath(join(testRoot, 'alias', '.cleo', 'cleo.db'));
+    const aliasPath = join(testRoot, 'alias', '.cleo', '.', 'cleo.db'); // aliased via redundant .
+
+    _setNativeDbResolverForTest(
+      async (): Promise<LeaseTarget> => ({
+        native,
+        dbPath: realPath,
+      }),
+    );
+
+    // The identity created by makeWriterLeaseIdentity normalizes alias → canonical.
+    const id = makeWriterLeaseIdentity('project', aliasPath);
+    expect(id.dbPath).toBe(realPath);
+
+    const h1 = await acquireWriterLease(id.scope, 'tasks', { dbPath: id.dbPath });
+    const h2 = await acquireWriterLease(id.scope, 'tasks', { dbPath: id.dbPath });
+    // Same identity → same memo key → shared grant (re-entrant).
+    expect(h2).toBe(h1);
+    expect(countActive(native, 'project', 'tasks')).toBe(1);
+
+    await h1.release();
+    await h2.release();
+    expect(countActive(native, 'project', 'tasks')).toBe(0);
+  }, 20_000);
+});
+
+// ── T12042 — identity isolation: release/renew/assert cannot cross projects ────
+
+describe('T12042 — writer-lease identity isolation (project A / B / global)', () => {
   it('a project identity release cannot free a different project identity row', async () => {
     const dirA = join(testRoot, 'isoA', '.cleo');
     const dirB = join(testRoot, 'isoB', '.cleo');
@@ -131,18 +158,16 @@ describe('T12042 — explicit WriterLeaseIdentity isolation (replaces process-gl
     expect(countActive(nativeA, 'project', 'tasks')).toBe(1);
     expect(countActive(nativeB, 'project', 'tasks')).toBe(1);
 
-    // Release A must NOT free B.
     await hA.release();
     expect(countActive(nativeA, 'project', 'tasks')).toBe(0);
     expect(countActive(nativeB, 'project', 'tasks')).toBe(1);
 
-    // Release B must NOT resurrect A.
     await hB.release();
     expect(countActive(nativeB, 'project', 'tasks')).toBe(0);
     expect(countActive(nativeA, 'project', 'tasks')).toBe(0);
   }, 20_000);
 
-  it("a project identity assertion must not gate a global identity's release", async () => {
+  it("a project identity release must not gate a global identity's release", async () => {
     const projNative = await openTempScope('project', join(testRoot, 'iso-p', '.cleo'));
     const globNative = await openTempScope('global', join(testRoot, 'iso-g'));
 
@@ -160,21 +185,19 @@ describe('T12042 — explicit WriterLeaseIdentity isolation (replaces process-gl
     expect(countActive(projNative, 'project', 'tasks')).toBe(1);
     expect(countActive(globNative, 'global', 'tasks')).toBe(1);
 
-    // Release project — global row MUST remain active.
     await hP.release();
     expect(countActive(projNative, 'project', 'tasks')).toBe(0);
     expect(countActive(globNative, 'global', 'tasks')).toBe(1);
 
-    // Release global.
     await hG.release();
     expect(countActive(globNative, 'global', 'tasks')).toBe(0);
   }, 20_000);
 });
 
-// ── Chokepoint write primitives with explicit identity ───────────────────────
+// ── T12042 — insertIdempotent resolves identity from exact DB binding ─────────
 
-describe('chokepoint write primitives with explicit WriterLeaseIdentity', () => {
-  it('insertIdempotent leases with the passed identity, not a process-global', async () => {
+describe('T12042 — write primitive resolves identity from exact DB binding (WeakMap)', () => {
+  it('insertIdempotent resolves identity from registered DB handle', async () => {
     const projectNative = await openTempScope('project', join(testRoot, 'choke', '.cleo'));
     const dbPath = join(testRoot, 'choke', '.cleo', 'cleo.db');
     const identity = makeWriterLeaseIdentity('project', dbPath);
@@ -206,12 +229,35 @@ describe('chokepoint write primitives with explicit WriterLeaseIdentity', () => 
           },
         };
       },
-    } as any;
+    } as Record<string, unknown>;
 
-    const inserted = await insertIdempotent(stubDb, {} as any, {} as any, 'k', identity);
+    // Register the stub DB so insertIdempotent can resolve its identity.
+    registerDbIdentity(stubDb, identity);
+
+    // The primitive call shape is UNCHANGED — no identity parameter.
+    const inserted = await insertIdempotent(stubDb as any, {} as any, {} as any, 'k');
     expect(inserted).toBe(1);
     expect(activeDuringWrite).toBe(1);
     expect(countActive(projectNative, 'project', 'tasks')).toBe(0);
+  }, 20_000);
+
+  it('resolveDbIdentity throws for unregistered DB handle', () => {
+    const unregistered = {};
+    expect(() => resolveDbIdentity(unregistered)).toThrow(/E_WRITER_LEASE_IDENTITY_UNREGISTERED/);
+  });
+
+  it('a real DualScopeDbHandle carries identity bound at construction', async () => {
+    // openDualScopeDbAtPath constructs the identity internally via
+    // makeWriterLeaseIdentity + registerDbIdentity.
+    const handle = await openDualScopeDbAtPath('project', join(testRoot, 'ds', '.cleo', 'cleo.db'));
+    expect(handle.identity.scope).toBe('project');
+    expect(handle.identity.dbPath).toBe(handle.dbPath);
+    // The identity is registered on the drizzle DB handle.
+    expect(() => resolveDbIdentity(handle.db)).not.toThrow();
+    const resolved = resolveDbIdentity(handle.db);
+    expect(resolved.scope).toBe('project');
+    expect(resolved.dbPath).toBe(handle.dbPath);
+    handle.close();
   }, 20_000);
 });
 
@@ -226,14 +272,12 @@ describe('Seam 0 — withColdOpenLease (cold-open critical section)', () => {
 
     let activeDuring = -1;
     const out = await withColdOpenLease('project', nativeDb, async () => {
-      // Tables were bootstrapped before the section runs.
       activeDuring = countActive(nativeDb, 'project', 'tasks');
       return 'ready';
     });
     expect(out).toBe('ready');
-    expect(activeDuring).toBe(1); // lease held during the section
-    expect(countActive(nativeDb, 'project', 'tasks')).toBe(0); // released after
-    // The lease infra tables now exist on the handle.
+    expect(activeDuring).toBe(1);
+    expect(countActive(nativeDb, 'project', 'tasks')).toBe(0);
     const tbl = nativeDb
       .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
       .get(WRITER_QUEUE_TABLE) as { name: string } | undefined;
@@ -254,7 +298,6 @@ describe('Seam 0 — withColdOpenLease (cold-open critical section)', () => {
       ran = true;
     });
     expect(ran).toBe(true);
-    // off mode never bootstraps lease tables — the table must not exist.
     const tbl = nativeDb
       .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
       .get(WRITER_LEASES_TABLE) as { name: string } | undefined;
@@ -276,7 +319,6 @@ describe('T9 — dual-scope cold-open leases are independent', () => {
     applyPerfPragmas(proj, { mmapSizeBytes: 0, cacheSizeKb: 8000 });
     applyPerfPragmas(glob, { mmapSizeBytes: 0, cacheSizeKb: 8000 });
 
-    // Hold the project cold-open lease while concurrently taking the global one.
     let globalRan = false;
     await withColdOpenLease('project', proj, async () => {
       expect(countActive(proj, 'project', 'tasks')).toBe(1);
@@ -315,7 +357,6 @@ describe('T11 — two independent handles to one file serialize cleanly (local)'
       });
 
     await Promise.all([section(a), section(b)]);
-    // The lease serialized them — they never overlapped in the section.
     expect(maxConcurrent).toBe(1);
     expect(countActive(a, 'project', 'tasks')).toBe(0);
     a.close();
@@ -325,22 +366,6 @@ describe('T11 — two independent handles to one file serialize cleanly (local)'
 
 // ── T14 — T5158 regression (concurrent cold-open writers serialize) ─────────────
 
-/**
- * Model N concurrent processes by opening N INDEPENDENT native handles to the
- * SAME db file (WAL allows it). `withColdOpenLease` bypasses the in-process grant
- * memo and arbitrates DIRECTLY over the persisted `_writer_leases` row with a fresh
- * `holderId` per call — so the ONLY shared state across these N handles is the
- * SQLite file itself, exactly as it is across real processes. Each "writer" runs
- * the lost-update race (read counter → async yield → write counter+1) that is
- * consistent ONLY under serialization — the cold-open migrate/reconcile write-txn
- * analog at the heart of T5158.
- *
- * @param dbPath - The shared db file.
- * @param count - Number of concurrent independent-handle writers.
- * @param mode - `'local'` (lease serializes) or `'off'` (pass-through, race).
- * @param raceWindowMs - Read→write yield window (widens interleaving).
- * @returns Per-writer `{ id, error }`; `error` is non-null on any open/lease failure.
- */
 async function runConcurrentColdOpens(
   dbPath: string,
   count: number,
@@ -364,8 +389,6 @@ async function runConcurrentColdOpens(
         'project',
         h,
         async () => {
-          // The shared counter + provenance tables (idempotent — any writer may be
-          // the one that creates them; the lease makes these safe).
           h.exec(
             'CREATE TABLE IF NOT EXISTS _t14_counter (id INTEGER PRIMARY KEY, n INTEGER NOT NULL)',
           );
@@ -373,15 +396,13 @@ async function runConcurrentColdOpens(
             'CREATE TABLE IF NOT EXISTS _t14_provenance (writer_id INTEGER PRIMARY KEY, observed INTEGER NOT NULL)',
           );
           h.exec('INSERT OR IGNORE INTO _t14_counter (id, n) VALUES (1, 0)');
-
-          // ── The racy read-modify-write (lost-update if not serialized) ────────
           const before =
             (
               h.prepare('SELECT n FROM _t14_counter WHERE id = 1').get() as
                 | { n: number }
                 | undefined
             )?.n ?? 0;
-          await new Promise((r) => setTimeout(r, raceWindowMs)); // widen read→write gap
+          await new Promise((r) => setTimeout(r, raceWindowMs));
           h.prepare('UPDATE _t14_counter SET n = ? WHERE id = 1').run(before + 1);
           h.prepare('INSERT INTO _t14_provenance (writer_id, observed) VALUES (?, ?)').run(
             id,
@@ -433,16 +454,13 @@ describe('T14 — T5158 regression: concurrent cold-open writers serialize (loca
 
     const results = await runConcurrentColdOpens(dbPath, WRITERS, 'local', RACE_WINDOW_MS);
 
-    // Zero open/arbitration failures (no E_NOT_INITIALIZED / E_INTERNAL class error).
     const errors = results.filter((r) => r.error !== null);
     expect(errors, JSON.stringify(errors)).toHaveLength(0);
 
     const verify = new DatabaseSync(dbPath, { allowExtension: true });
     applyPerfPragmas(verify, { mmapSizeBytes: 0, cacheSizeKb: 8000 });
-    // Serialized → every writer's increment landed (zero lost updates / lost rows).
     expect(counterValue(verify)).toBe(WRITERS);
     expect(provenanceCount(verify)).toBe(WRITERS);
-    // No active lease row leaks past the end (all released).
     expect(countActive(verify, 'project', 'tasks')).toBe(0);
     verify.close();
   }, 60_000);
@@ -452,11 +470,6 @@ describe('T14 — T5158 regression: concurrent cold-open writers serialize (loca
     mkdirSync(dirname(dbPath), { recursive: true });
 
     const results = await runConcurrentColdOpens(dbPath, WRITERS, 'off', RACE_WINDOW_MS);
-    // off mode does not arbitrate: opens still succeed (no error), but the racy
-    // read-modify-write across the concurrent handles loses updates → the final
-    // counter is LESS than the writer count. This proves the race is real and that
-    // local-mode serialization (above) is what heals it. (`< WRITERS` keeps the
-    // assertion deterministic regardless of interleaving.)
     expect(results.filter((r) => r.error !== null)).toHaveLength(0);
     const verify = new DatabaseSync(dbPath, { allowExtension: true });
     applyPerfPragmas(verify, { mmapSizeBytes: 0, cacheSizeKb: 8000 });

--- a/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
+++ b/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
@@ -1,15 +1,14 @@
 /**
- * T11627 ST-3 — T5158 heal wiring tests (Seams 0 & 1).
+ * T11627 ST-3 — T5158 heal wiring tests (Seams 0 & 1) + T12042 identity binding.
  *
- * Covers the spec test-plan rows assigned to ST-3:
- *   - T12042 — writer-lease identity isolation: concurrent project A / project B /
- *     global writers cannot steal, release, resolve, or close each other's lease
- *     identity; the removed process-global activeScope() registry is replaced with
- *     immutable DB-bound WriterLeaseIdentity via typed WeakMap + registerDbIdentity.
- *   - Alias paths normalize to one identity; one memoized grant row.
- *   - Chokepoint write primitives resolve identity from exact DB binding.
- *   - Seam 0 — `withColdOpenLease` serializes the cold-open critical section.
- *   - T9  — dual-scope independence.
+ * Covers:
+ *   - T12042 — exact DB-bound writer-lease identity (WeakMap).
+ *   - T12042 Finding 4 — alias path normalization in acquireWriterLease.
+ *   - T12042 — registerDbIdentity hardening (idempotent same, throw mismatch).
+ *   - T12042 — primitive-level row isolation: insertIdempotent + upsertIdempotent
+ *     across project A / project B / global handles.
+ *   - Seam 0 — withColdOpenLease serializes the cold-open critical section.
+ *   - T9  — dual-scope cold-open lease independence.
  *   - T11 — two-writer arbitration.
  *   - T14 — T5158 regression.
  *
@@ -29,6 +28,7 @@ import {
   _resetDualScopeDbCache,
   insertIdempotent,
   openDualScopeDbAtPath,
+  upsertIdempotent,
 } from '../dual-scope-db.js';
 import { applyPerfPragmas } from '../sqlite-pragmas.js';
 import {
@@ -65,7 +65,6 @@ afterEach(() => {
   }
 });
 
-/** Open + migrate an isolated temp cleo.db for a scope; return its native handle. */
 async function openTempScope(scope: LeaseScope, dir: string): Promise<DatabaseSync> {
   mkdirSync(dir, { recursive: true });
   const dbPath = join(dir, 'cleo.db');
@@ -88,28 +87,18 @@ function countActive(db: DatabaseSync, scope: string, lane: string): number {
   );
 }
 
-// ── T12042 — identity normalization: alias paths resolve to one identity ──────
+function countRows(db: DatabaseSync, table: string): number {
+  return (
+    (db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number } | undefined)?.c ?? 0
+  );
+}
 
-describe('T12042 — makeWriterLeaseIdentity normalizes alias paths to one identity', () => {
-  it('alias paths produce byte-identical identities (path.resolve normalization)', () => {
-    const idA = makeWriterLeaseIdentity('project', '/tmp/./proj/.cleo/cleo.db');
-    const idB = makeWriterLeaseIdentity('project', '/tmp/proj/.cleo/cleo.db');
-    expect(idA.dbPath).toBe(idB.dbPath);
-    expect(idA.dbPath).toBe(resolvePath('/tmp/proj/.cleo/cleo.db'));
-  });
+// ── T12042 Finding 4 — alias path normalization in acquireWriterLease ───────
 
-  it('different canonical paths produce distinct identities', () => {
-    const idA = makeWriterLeaseIdentity('project', '/tmp/a/.cleo/cleo.db');
-    const idB = makeWriterLeaseIdentity('project', '/tmp/b/.cleo/cleo.db');
-    expect(idA.dbPath).not.toBe(idB.dbPath);
-    expect(idA.scope).toBe(idB.scope);
-  });
-
-  it('a single memoized grant row for alias paths (one identity)', async () => {
-    // Two callers acquire the same scope+dbPath through an aliased dbPath param.
+describe('T12042 Finding 4 — acquireWriterLease normalizes alias dbPath', () => {
+  it('alias path resolves to one memoized grant + one active row', async () => {
     const native = await openTempScope('project', join(testRoot, 'alias', '.cleo'));
     const realPath = resolvePath(join(testRoot, 'alias', '.cleo', 'cleo.db'));
-    const aliasPath = join(testRoot, 'alias', '.cleo', '.', 'cleo.db'); // aliased via redundant .
 
     _setNativeDbResolverForTest(
       async (): Promise<LeaseTarget> => ({
@@ -118,19 +107,172 @@ describe('T12042 — makeWriterLeaseIdentity normalizes alias paths to one ident
       }),
     );
 
-    // The identity created by makeWriterLeaseIdentity normalizes alias → canonical.
-    const id = makeWriterLeaseIdentity('project', aliasPath);
-    expect(id.dbPath).toBe(realPath);
+    // Pass an aliased path (with redundant segments) directly to acquireWriterLease.
+    const aliasPath = join(testRoot, 'alias', '.cleo', '.', 'cleo.db');
+    const h1 = await acquireWriterLease('project', 'tasks', { dbPath: aliasPath });
+    // Same canonical path, different spelling — must share the grant.
+    const h2 = await acquireWriterLease('project', 'tasks', { dbPath: realPath });
 
-    const h1 = await acquireWriterLease(id.scope, 'tasks', { dbPath: id.dbPath });
-    const h2 = await acquireWriterLease(id.scope, 'tasks', { dbPath: id.dbPath });
-    // Same identity → same memo key → shared grant (re-entrant).
-    expect(h2).toBe(h1);
-    expect(countActive(native, 'project', 'tasks')).toBe(1);
+    expect(h2).toBe(h1); // same memoized grant (re-entrant)
+    expect(h1.epoch).toBeGreaterThan(0);
+    expect(countActive(native, 'project', 'tasks')).toBe(1); // one active row
 
     await h1.release();
     await h2.release();
     expect(countActive(native, 'project', 'tasks')).toBe(0);
+  }, 20_000);
+});
+
+// ── T12042 — registerDbIdentity hardening ────────────────────────────────────
+
+describe('T12042 — registerDbIdentity hardening', () => {
+  it('same DB + same canonical identity is idempotent', () => {
+    const db = {};
+    const id = makeWriterLeaseIdentity('project', '/tmp/cleo.db');
+    registerDbIdentity(db, id);
+    expect(() => registerDbIdentity(db, id)).not.toThrow();
+    expect(resolveDbIdentity(db)).toBe(id);
+  });
+
+  it('same DB with different scope must throw', () => {
+    const db = {};
+    registerDbIdentity(db, makeWriterLeaseIdentity('project', '/tmp/cleo.db'));
+    expect(() => registerDbIdentity(db, makeWriterLeaseIdentity('global', '/tmp/cleo.db'))).toThrow(
+      /E_WRITER_LEASE_IDENTITY_MISMATCH/,
+    );
+  });
+
+  it('same DB with different dbPath must throw', () => {
+    const db = {};
+    registerDbIdentity(db, makeWriterLeaseIdentity('project', '/tmp/a/cleo.db'));
+    expect(() =>
+      registerDbIdentity(db, makeWriterLeaseIdentity('project', '/tmp/b/cleo.db')),
+    ).toThrow(/E_WRITER_LEASE_IDENTITY_MISMATCH/);
+  });
+});
+
+// ── T12042 — primitive row isolation across project A / B / global ────────────
+
+/**
+ * Build a stub drizzle DB that writes rows to the given native handle's test
+ * table via raw SQL. The stub is registered with the correct identity so
+ * insertIdempotent/upsertIdempotent can resolve scope+dbPath from it.
+ */
+function makeStubDb(
+  native: DatabaseSync,
+  identity: WriterLeaseIdentity,
+): { db: Record<string, unknown>; calls: () => number } {
+  let callCount = 0;
+  const db = {
+    insert() {
+      return {
+        values(_row: unknown) {
+          return {
+            onConflictDoNothing() {
+              return {
+                async returning() {
+                  callCount += 1;
+                  native.prepare('INSERT OR IGNORE INTO _t_iso (k, v) VALUES (?, ?)').run('x', 1);
+                  return [{ k: 'x' }];
+                },
+              };
+            },
+            onConflictDoUpdate(opts: { target: unknown; set: unknown }) {
+              void opts;
+              return {
+                async returning() {
+                  callCount += 1;
+                  native
+                    .prepare(
+                      'INSERT INTO _t_iso (k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v',
+                    )
+                    .run('x', 99);
+                  return [{ k: 'x' }];
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+  registerDbIdentity(db, identity);
+  return { db, calls: () => callCount };
+}
+
+describe('T12042 — primitive row isolation: insertIdempotent + upsertIdempotent', () => {
+  /** Open a real dual-scope handle, capture identity + native for inspection. */
+  async function openIsolated(
+    scope: LeaseScope,
+    dir: string,
+  ): Promise<{ native: DatabaseSync; dbPath: string; identity: WriterLeaseIdentity }> {
+    mkdirSync(dir, { recursive: true });
+    const dbPath = join(dir, 'cleo.db');
+    const handle =
+      scope === 'project'
+        ? await openDualScopeDbAtPath('project', dbPath)
+        : await openDualScopeDbAtPath('global', dbPath);
+    const native = (handle.db as unknown as { $client: DatabaseSync }).$client;
+    native.exec('CREATE TABLE IF NOT EXISTS _t_iso (k TEXT PRIMARY KEY, v INTEGER NOT NULL)');
+    return { native, dbPath, identity: handle.identity };
+  }
+
+  it('insertIdempotent lands rows ONLY in the correct project-A DB, not B', async () => {
+    const a = await openIsolated('project', join(testRoot, 'projA', '.cleo'));
+    const b = await openIsolated('project', join(testRoot, 'projB', '.cleo'));
+
+    _setNativeDbResolverForTest(async (_scope, dbPath): Promise<LeaseTarget> => {
+      if (dbPath === a.dbPath) return { native: a.native, dbPath: a.dbPath };
+      return { native: b.native, dbPath: b.dbPath };
+    });
+
+    const stubA = makeStubDb(a.native, a.identity);
+    await insertIdempotent(stubA.db as any, {} as any, {} as any, 'k');
+
+    expect(countRows(a.native, '_t_iso')).toBe(1);
+    expect(countRows(b.native, '_t_iso')).toBe(0);
+    expect(countActive(a.native, 'project', 'tasks')).toBe(0);
+    expect(countActive(b.native, 'project', 'tasks')).toBe(0);
+  }, 20_000);
+
+  it('insertIdempotent across project-A and global lands in each exact DB', async () => {
+    const p = await openIsolated('project', join(testRoot, 'p', '.cleo'));
+    const g = await openIsolated('global', join(testRoot, 'g'));
+
+    _setNativeDbResolverForTest(async (scope, dbPath): Promise<LeaseTarget> => {
+      if (scope === 'global') return { native: g.native, dbPath: g.dbPath };
+      return { native: p.native, dbPath: p.dbPath };
+    });
+
+    const stubP = makeStubDb(p.native, p.identity);
+    const stubG = makeStubDb(g.native, g.identity);
+
+    await insertIdempotent(stubP.db as any, {} as any, {} as any, 'k');
+    await insertIdempotent(stubG.db as any, {} as any, {} as any, 'k');
+
+    expect(countRows(p.native, '_t_iso')).toBe(1);
+    expect(countRows(g.native, '_t_iso')).toBe(1);
+    expect(countActive(p.native, 'project', 'tasks')).toBe(0);
+    expect(countActive(g.native, 'global', 'tasks')).toBe(0);
+  }, 20_000);
+
+  it('upsertIdempotent conflict-update lands in the correct DB only', async () => {
+    const a = await openIsolated('project', join(testRoot, 'upA', '.cleo'));
+    const b = await openIsolated('project', join(testRoot, 'upB', '.cleo'));
+
+    _setNativeDbResolverForTest(
+      async (): Promise<LeaseTarget> => ({
+        native: a.native,
+        dbPath: a.dbPath,
+      }),
+    );
+
+    const { db: dbA, calls } = makeStubDb(a.native, a.identity);
+    const result = await upsertIdempotent(dbA as any, {} as any, {} as any, 'k', {} as any);
+    expect(result).toBe(1);
+    expect(calls()).toBe(1); // upsert chain was reached
+    expect(countActive(a.native, 'project', 'tasks')).toBe(0);
+    expect(countRows(b.native, '_t_iso')).toBe(0);
   }, 20_000);
 });
 
@@ -194,7 +336,7 @@ describe('T12042 — writer-lease identity isolation (project A / B / global)', 
   }, 20_000);
 });
 
-// ── T12042 — insertIdempotent resolves identity from exact DB binding ─────────
+// ── T12042 — insertIdempotent + resolveDbIdentity ────────────────────────────
 
 describe('T12042 — write primitive resolves identity from exact DB binding (WeakMap)', () => {
   it('insertIdempotent resolves identity from registered DB handle', async () => {
@@ -231,10 +373,7 @@ describe('T12042 — write primitive resolves identity from exact DB binding (We
       },
     } as Record<string, unknown>;
 
-    // Register the stub DB so insertIdempotent can resolve its identity.
     registerDbIdentity(stubDb, identity);
-
-    // The primitive call shape is UNCHANGED — no identity parameter.
     const inserted = await insertIdempotent(stubDb as any, {} as any, {} as any, 'k');
     expect(inserted).toBe(1);
     expect(activeDuringWrite).toBe(1);
@@ -242,17 +381,13 @@ describe('T12042 — write primitive resolves identity from exact DB binding (We
   }, 20_000);
 
   it('resolveDbIdentity throws for unregistered DB handle', () => {
-    const unregistered = {};
-    expect(() => resolveDbIdentity(unregistered)).toThrow(/E_WRITER_LEASE_IDENTITY_UNREGISTERED/);
+    expect(() => resolveDbIdentity({})).toThrow(/E_WRITER_LEASE_IDENTITY_UNREGISTERED/);
   });
 
   it('a real DualScopeDbHandle carries identity bound at construction', async () => {
-    // openDualScopeDbAtPath constructs the identity internally via
-    // makeWriterLeaseIdentity + registerDbIdentity.
     const handle = await openDualScopeDbAtPath('project', join(testRoot, 'ds', '.cleo', 'cleo.db'));
     expect(handle.identity.scope).toBe('project');
     expect(handle.identity.dbPath).toBe(handle.dbPath);
-    // The identity is registered on the drizzle DB handle.
     expect(() => resolveDbIdentity(handle.db)).not.toThrow();
     const resolved = resolveDbIdentity(handle.db);
     expect(resolved.scope).toBe('project');

--- a/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
+++ b/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
@@ -2,9 +2,10 @@
  * T11627 ST-3 — T5158 heal wiring tests (Seams 0 & 1).
  *
  * Covers the spec test-plan rows assigned to ST-3:
- *   - AC3 — cross-scope leakage: the process-local `activeScope()` registry is
- *     set at cold-open and read back by the chokepoint write primitives WITHOUT a
- *     signature change; a project open after a global open targets the right scope.
+ *   - T12042 — writer-lease identity isolation: concurrent project A / project B /
+ *     global writers cannot steal, release, resolve, or close each other's lease
+ *     identity; the removed process-global activeScope() registry is replaced with
+ *     explicit WriterLeaseIdentity per call.
  *   - Seam 0 — `withColdOpenLease` serializes the cold-open critical section
  *     (claims + releases the row), bootstraps the lease tables on the passed handle,
  *     and is a pure pass-through in `off` mode.
@@ -24,6 +25,7 @@
  * Every test runs against a TEMP-DIR cleo.db copy — never `.cleo/*.db`.
  *
  * @task T11627
+ * @task T12042 (E6-L12b — explicit writer-lease identity)
  * @epic T11625
  */
 
@@ -36,16 +38,15 @@ import {
   _resetDualScopeDbCache,
   insertIdempotent,
   openDualScopeDbAtPath,
-  upsertIdempotent,
 } from '../dual-scope-db.js';
 import { applyPerfPragmas } from '../sqlite-pragmas.js';
 import {
-  _clearActiveScopeForTest,
   _resetWriterLeaseStateForTest,
   _setNativeDbResolverForTest,
-  activeScope,
+  acquireWriterLease,
   type LeaseScope,
-  setActiveScope,
+  type LeaseTarget,
+  makeWriterLeaseIdentity,
   withColdOpenLease,
 } from '../writer-lease.js';
 import { WRITER_LEASES_TABLE, WRITER_QUEUE_TABLE } from '../writer-lease-schema.js';
@@ -94,51 +95,96 @@ function countActive(db: DatabaseSync, scope: string, lane: string): number {
   );
 }
 
-// ── AC3 — cross-scope leakage: the activeScope() registry ──────────────────────
+// ── T12042 — writer-lease identity isolation (replaces process-global activeScope) ──
 
-describe('AC3 — activeScope() registry (Seam 1 wiring, no signature change)', () => {
-  it("defaults to 'project' before any cold-open records a scope", () => {
-    _clearActiveScopeForTest();
-    expect(activeScope()).toBe('project');
+describe('T12042 — explicit WriterLeaseIdentity isolation (replaces process-global activeScope)', () => {
+  it('makeWriterLeaseIdentity produces distinct frozen identities for distinct paths', () => {
+    const idA = makeWriterLeaseIdentity('project', '/tmp/a/.cleo/cleo.db');
+    const idB = makeWriterLeaseIdentity('project', '/tmp/b/.cleo/cleo.db');
+    expect(idA.scope).toBe('project');
+    expect(idB.scope).toBe('project');
+    expect(idA.dbPath).not.toBe(idB.dbPath);
+    // Frozen — cannot be mutated after construction.
+    expect(() => {
+      (idA as { scope: string }).scope = 'global';
+    }).toThrow();
   });
 
-  it('records the scope of the most-recent cold-open; project-after-global is project', () => {
-    setActiveScope('global');
-    expect(activeScope()).toBe('global');
-    setActiveScope('project');
-    expect(activeScope()).toBe('project');
-  });
+  it('a project identity release cannot free a different project identity row', async () => {
+    const dirA = join(testRoot, 'isoA', '.cleo');
+    const dirB = join(testRoot, 'isoB', '.cleo');
 
-  it('a real cold-open through openDualScopeDbAtPath records the scope', async () => {
-    _clearActiveScopeForTest();
-    await openTempScope('global', join(testRoot, 'g1'));
-    // The cold-open Seam-0 wrap called setActiveScope('global').
-    expect(activeScope()).toBe('global');
+    const nativeA = await openTempScope('project', dirA);
+    const nativeB = await openTempScope('project', dirB);
 
-    await openTempScope('project', join(testRoot, 'p1', '.cleo'));
-    // A subsequent project cold-open moves the active scope (chokepoint writes are
-    // project-tier tasks_* mutations — 'project' is the only correct lease scope).
-    expect(activeScope()).toBe('project');
-  });
+    const idA = makeWriterLeaseIdentity('project', join(dirA, 'cleo.db'));
+    const idB = makeWriterLeaseIdentity('project', join(dirB, 'cleo.db'));
 
-  it('insertIdempotent / upsertIdempotent lease against activeScope() without a signature change', async () => {
-    // Route the engine's resolver at an isolated temp project DB so the Seam-1
-    // withWriterLease(activeScope(),'tasks',…) inside the primitives can claim a row.
+    _setNativeDbResolverForTest(async (_scope, dbPath): Promise<LeaseTarget> => {
+      if (dbPath === idB.dbPath) return { native: nativeB, dbPath: idB.dbPath };
+      return { native: nativeA, dbPath: idA.dbPath };
+    });
+
+    const hA = await acquireWriterLease(idA.scope, 'tasks', { dbPath: idA.dbPath });
+    const hB = await acquireWriterLease(idB.scope, 'tasks', { dbPath: idB.dbPath });
+
+    expect(countActive(nativeA, 'project', 'tasks')).toBe(1);
+    expect(countActive(nativeB, 'project', 'tasks')).toBe(1);
+
+    // Release A must NOT free B.
+    await hA.release();
+    expect(countActive(nativeA, 'project', 'tasks')).toBe(0);
+    expect(countActive(nativeB, 'project', 'tasks')).toBe(1);
+
+    // Release B must NOT resurrect A.
+    await hB.release();
+    expect(countActive(nativeB, 'project', 'tasks')).toBe(0);
+    expect(countActive(nativeA, 'project', 'tasks')).toBe(0);
+  }, 20_000);
+
+  it("a project identity assertion must not gate a global identity's release", async () => {
+    const projNative = await openTempScope('project', join(testRoot, 'iso-p', '.cleo'));
+    const globNative = await openTempScope('global', join(testRoot, 'iso-g'));
+
+    const projId = makeWriterLeaseIdentity('project', join(testRoot, 'iso-p', '.cleo', 'cleo.db'));
+    const globId = makeWriterLeaseIdentity('global', join(testRoot, 'iso-g', 'cleo.db'));
+
+    _setNativeDbResolverForTest(async (scope, dbPath): Promise<LeaseTarget> => {
+      if (scope === 'global') return { native: globNative, dbPath: globId.dbPath };
+      return { native: projNative, dbPath: projId.dbPath };
+    });
+
+    const hP = await acquireWriterLease(projId.scope, 'tasks', { dbPath: projId.dbPath });
+    const hG = await acquireWriterLease(globId.scope, 'tasks', { dbPath: globId.dbPath });
+
+    expect(countActive(projNative, 'project', 'tasks')).toBe(1);
+    expect(countActive(globNative, 'global', 'tasks')).toBe(1);
+
+    // Release project — global row MUST remain active.
+    await hP.release();
+    expect(countActive(projNative, 'project', 'tasks')).toBe(0);
+    expect(countActive(globNative, 'global', 'tasks')).toBe(1);
+
+    // Release global.
+    await hG.release();
+    expect(countActive(globNative, 'global', 'tasks')).toBe(0);
+  }, 20_000);
+});
+
+// ── Chokepoint write primitives with explicit identity ───────────────────────
+
+describe('chokepoint write primitives with explicit WriterLeaseIdentity', () => {
+  it('insertIdempotent leases with the passed identity, not a process-global', async () => {
     const projectNative = await openTempScope('project', join(testRoot, 'choke', '.cleo'));
-    _setNativeDbResolverForTest(async () => projectNative);
-    setActiveScope('project');
+    const dbPath = join(testRoot, 'choke', '.cleo', 'cleo.db');
+    const identity = makeWriterLeaseIdentity('project', dbPath);
 
-    // Create a tiny target table on the SAME handle the resolver hands back, plus a
-    // matching drizzle-less raw insert path: we assert the lease is taken/released
-    // around the write (one active row during, zero after) rather than re-deriving
-    // the full tasks_tasks schema — the primitive's lease wrapping is what ST-3 adds.
+    _setNativeDbResolverForTest(async () => ({ native: projectNative, dbPath }));
+
     projectNative.exec(
       'CREATE TABLE IF NOT EXISTS _t_choke (k TEXT PRIMARY KEY, v INTEGER NOT NULL)',
     );
 
-    // A minimal drizzle-shaped stub: insertIdempotent/upsertIdempotent only touch
-    // `db.insert(...)`, so we pass a thin object whose insert() chain performs the
-    // raw write and lets us observe the lease was held during it.
     let activeDuringWrite = -1;
     const stubDb = {
       insert() {
@@ -156,32 +202,14 @@ describe('AC3 — activeScope() registry (Seam 1 wiring, no signature change)', 
                   },
                 };
               },
-              onConflictDoUpdate() {
-                return {
-                  async returning() {
-                    activeDuringWrite = countActive(projectNative, 'project', 'tasks');
-                    projectNative
-                      .prepare(
-                        'INSERT INTO _t_choke (k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v',
-                      )
-                      .run('a', 2);
-                    return [{ k: 'a' }];
-                  },
-                };
-              },
             };
           },
         };
       },
     } as any;
 
-    const inserted = await insertIdempotent(stubDb, {} as any, {} as any, 'k');
+    const inserted = await insertIdempotent(stubDb, {} as any, {} as any, 'k', identity);
     expect(inserted).toBe(1);
-    expect(activeDuringWrite).toBe(1); // the tasks lease was HELD during the write
-    expect(countActive(projectNative, 'project', 'tasks')).toBe(0); // released after
-
-    const upserted = await upsertIdempotent(stubDb, {} as any, {} as any, 'k', {} as any);
-    expect(upserted).toBe(1);
     expect(activeDuringWrite).toBe(1);
     expect(countActive(projectNative, 'project', 'tasks')).toBe(0);
   }, 20_000);
@@ -231,17 +259,6 @@ describe('Seam 0 — withColdOpenLease (cold-open critical section)', () => {
       .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
       .get(WRITER_LEASES_TABLE) as { name: string } | undefined;
     expect(tbl).toBeUndefined();
-    nativeDb.close();
-  });
-
-  it('records the active scope as a side effect (Seam 1 wiring)', async () => {
-    _clearActiveScopeForTest();
-    const dbPath = join(testRoot, 'seam0-scope', 'cleo.db');
-    mkdirSync(dirname(dbPath), { recursive: true });
-    const nativeDb = new DatabaseSync(dbPath, { allowExtension: true });
-    applyPerfPragmas(nativeDb, { mmapSizeBytes: 0, cacheSizeKb: 8000 });
-    await withColdOpenLease('global', nativeDb, async () => {});
-    expect(activeScope()).toBe('global');
     nativeDb.close();
   });
 });

--- a/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
+++ b/packages/core/src/store/__tests__/writer-lease-coldopen.test.ts
@@ -35,11 +35,14 @@ import {
   _resetWriterLeaseStateForTest,
   _setNativeDbResolverForTest,
   acquireWriterLease,
+  assertWriterLeaseHeld,
+  hasActiveGrant,
   type LeaseScope,
   type LeaseTarget,
   makeWriterLeaseIdentity,
   registerDbIdentity,
   resolveDbIdentity,
+  WriterLeaseRequiredError,
   withColdOpenLease,
 } from '../writer-lease.js';
 import { WRITER_LEASES_TABLE, WRITER_QUEUE_TABLE } from '../writer-lease-schema.js';
@@ -120,6 +123,42 @@ describe('T12042 Finding 4 — acquireWriterLease normalizes alias dbPath', () =
     await h1.release();
     await h2.release();
     expect(countActive(native, 'project', 'tasks')).toBe(0);
+  }, 20_000);
+
+  it('acquire → hasActiveGrant → assertWriterLeaseHeld → release with aliased filesystem path', async () => {
+    const native = await openTempScope('project', join(testRoot, 'alias2', '.cleo'));
+    const realPath = resolvePath(join(testRoot, 'alias2', '.cleo', 'cleo.db'));
+    const aliasPath = join(testRoot, 'alias2', '.cleo', '.', 'cleo.db');
+
+    _setNativeDbResolverForTest(
+      async (): Promise<LeaseTarget> => ({
+        native,
+        dbPath: realPath,
+      }),
+    );
+
+    // Acquire with alias → memo key uses canonicalized (real) path.
+    const h = await acquireWriterLease('project', 'brain', { dbPath: aliasPath });
+    expect(h.epoch).toBeGreaterThan(0);
+
+    // hasActiveGrant with the canonical path must find the grant.
+    expect(hasActiveGrant('project', 'brain', realPath)).toBe(true);
+    // hasActiveGrant with the alias path must also find it (both normalize to real).
+    expect(hasActiveGrant('project', 'brain', aliasPath)).toBe(true);
+    // assert must pass with either spelling.
+    expect(() => assertWriterLeaseHeld('project', 'brain', realPath)).not.toThrow();
+    expect(() => assertWriterLeaseHeld('project', 'brain', aliasPath)).not.toThrow();
+    // Unrelated path must NOT find the grant.
+    expect(hasActiveGrant('project', 'brain', join(testRoot, 'other', '.cleo', 'cleo.db'))).toBe(
+      false,
+    );
+    expect(() =>
+      assertWriterLeaseHeld('project', 'brain', join(testRoot, 'other', '.cleo', 'cleo.db')),
+    ).toThrow(WriterLeaseRequiredError);
+
+    await h.release();
+    expect(hasActiveGrant('project', 'brain', realPath)).toBe(false);
+    expect(hasActiveGrant('project', 'brain', aliasPath)).toBe(false);
   }, 20_000);
 });
 

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -707,8 +707,10 @@ export async function openDualScopeDbAtPath(
       // `__drizzle_migrations` journal) WITH the supervisor daemon disabled (`local`
       // mode default). `off` mode is a pass-through → byte-identical to pre-lease
       // behaviour (busy_timeout=30000 still serializes the write-txn).
-      // `withColdOpenLease` also records the scope in the Seam-1 active-scope registry
-      // so chokepoint write primitives lease correctly.
+      // The identity is bound to the drizzle DB handle via
+      // registerDbIdentity during construction — the chokepoint write
+      // primitives resolve it from the exact handle binding (T12042), no
+      // longer from a process-global active-scope registry.
       //
       // The lease wraps ONLY reconcileJournal + migrateWithRetry — the precise write-
       // txn that races in T5158. The exodus-on-open hook runs AFTER the lease releases

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -64,12 +64,7 @@ import {
   resolveCorePackageMigrationsFolder,
 } from './resolve-migrations-folder.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
-import {
-  activeScope,
-  activeScopeDbPath,
-  withColdOpenLease,
-  withWriterLease,
-} from './writer-lease.js';
+import { type WriterLeaseIdentity, withColdOpenLease, withWriterLease } from './writer-lease.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -1573,14 +1568,22 @@ import type { SQLiteTableWithColumns, TableConfig } from 'drizzle-orm/sqlite-cor
  * the consolidated-schema MUTATION primitives, so the guard is write-only and
  * never affects read paths.
  *
+ * @param identity - The explicit writer-lease identity (scope + canonical dbPath)
+ *   owning this write. Replaces the removed process-global last-writer scope
+ *   (T12042) so concurrent project A, B, and global writers cannot steal or
+ *   release each other's lease.
+ *
  * @example
  * ```ts
  * import { tasksTasksTable } from '@cleocode/core/store/schema/cleo-project';
- * const inserted = await insertIdempotent(db, tasksTasksTable, newTask, 'idempotencyKey');
+ * import { makeWriterLeaseIdentity } from '@cleocode/core/store/writer-lease';
+ * const identity = makeWriterLeaseIdentity('project', handle.dbPath);
+ * const inserted = await insertIdempotent(db, tasksTasksTable, newTask, 'idempotencyKey', identity);
  * ```
  *
  * @task T11513 (E4-T2)
  * @task T11828 (write-side exodus-abort guard)
+ * @task T12042 (E6-L12b — explicit writer-lease identity)
  * @epic T11247 (E4)
  * @saga T11242
  */
@@ -1591,23 +1594,17 @@ export async function insertIdempotent<TTable extends SQLiteTableWithColumns<Tab
   row: InferInsertModel<TTable>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _keyColumn: string,
+  identity: WriterLeaseIdentity,
 ): Promise<number> {
   assertNoRecordedExodusAbort();
-  // Seam 1 (T11627 ST-3): gate the chokepoint write through the writer lease so
-  // it serializes with the leased cold-open (Seam 0) and every other chokepoint
-  // write in the process. The scope AND dbPath come from the process-local
-  // active-scope registry recorded at cold-open ({@link activeScope} /
-  // {@link activeScopeDbPath}) — no signature change. Pinning the dbPath keeps the
-  // lease row in the SAME file this write targets when multiple projects are open
-  // (T11627 Finding 1). `off` mode is a pass-through (busy_timeout serializes).
   return withWriterLease(
-    activeScope(),
+    identity.scope,
     'tasks',
     async () => {
       const result = await db.insert(table).values(row).onConflictDoNothing().returning();
       return result.length;
     },
-    { dbPath: activeScopeDbPath() },
+    { dbPath: identity.dbPath },
   );
 }
 
@@ -1632,14 +1629,20 @@ export async function insertIdempotent<TTable extends SQLiteTableWithColumns<Tab
  * Refuses the write (throws {@link ExodusAbortWriteUnsafeError}) when a prior
  * exodus-on-open aborted in this process (T11828 · DHQ-059) — write-only guard.
  *
+ * @param identity - The explicit writer-lease identity (scope + canonical dbPath)
+ *   owning this write. Replaces the removed process-global last-writer scope
+ *   (T12042) so concurrent project A, B, and global writers cannot steal or
+ *   release each other's lease.
+ *
  * @example
  * ```ts
  * await upsertIdempotent(db, tasksTasksTable, updatedTask, 'idempotencyKey',
- *   tasksTasksTable.idempotencyKey);
+ *   tasksTasksTable.idempotencyKey, identity);
  * ```
  *
  * @task T11513 (E4-T2)
  * @task T11828 (write-side exodus-abort guard)
+ * @task T12042 (E6-L12b — explicit writer-lease identity)
  * @epic T11247 (E4)
  * @saga T11242
  */
@@ -1653,13 +1656,11 @@ export async function upsertIdempotent<TTable extends SQLiteTableWithColumns<Tab
   // biome-ignore lint/suspicious/noExplicitAny: column reference type varies by table
   conflictTarget: any,
   set?: Partial<InferInsertModel<TTable>>,
+  identity?: WriterLeaseIdentity,
 ): Promise<number> {
   assertNoRecordedExodusAbort();
-  // Seam 1 (T11627 ST-3): gate the chokepoint upsert through the writer lease —
-  // same active-scope-registry path as insertIdempotent (scope + pinned dbPath),
-  // no signature change.
   return withWriterLease(
-    activeScope(),
+    identity?.scope ?? 'project',
     'tasks',
     async () => {
       const updateSet = set ?? row;
@@ -1674,6 +1675,6 @@ export async function upsertIdempotent<TTable extends SQLiteTableWithColumns<Tab
         .returning();
       return result.length;
     },
-    { dbPath: activeScopeDbPath() },
+    identity ? { dbPath: identity.dbPath } : undefined,
   );
 }

--- a/packages/core/src/store/dual-scope-db.ts
+++ b/packages/core/src/store/dual-scope-db.ts
@@ -64,7 +64,14 @@ import {
   resolveCorePackageMigrationsFolder,
 } from './resolve-migrations-folder.js';
 import { applyPerfPragmas } from './sqlite-pragmas.js';
-import { type WriterLeaseIdentity, withColdOpenLease, withWriterLease } from './writer-lease.js';
+import {
+  makeWriterLeaseIdentity,
+  registerDbIdentity,
+  resolveDbIdentity,
+  type WriterLeaseIdentity,
+  withColdOpenLease,
+  withWriterLease,
+} from './writer-lease.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -96,6 +103,13 @@ export interface DualScopeDbHandle<TScope extends DualScope = DualScope> {
   readonly scope: TScope;
   /** Absolute path to the underlying SQLite file. */
   readonly dbPath: string;
+  /**
+   * Immutable writer-lease identity bound to this exact handle at construction
+   * (T12042). The chokepoint write primitives derive scope + dbPath from this
+   * identity via {@link resolveDbIdentity} — a caller cannot pair file-A
+   * identity with file-B DB. Frozen and normalized.
+   */
+  readonly identity: WriterLeaseIdentity;
   /**
    * Whether the underlying native `DatabaseSync` connection is still
    * open. Reflects `nativeDb.isOpen` and is `false` after `close()`.
@@ -489,10 +503,14 @@ async function openDedicatedDualScopeDb(
 
         log.debug({ scope, dbPath }, 'DEDICATED dual-scope cleo.db ready (T11782 FIX D)');
 
+        const identity = makeWriterLeaseIdentity(scope, dbPath);
+        registerDbIdentity(db, identity);
+
         return {
           db,
           scope,
           dbPath,
+          identity,
           get isOpen() {
             return nativeDb.isOpen;
           },
@@ -506,7 +524,6 @@ async function openDedicatedDualScopeDb(
           },
         };
       },
-      { dbPath },
     );
 
     return handle;
@@ -728,10 +745,14 @@ export async function openDualScopeDbAtPath(
 
           log.debug({ scope, dbPath: normalizedPath }, 'dual-scope cleo.db ready');
 
+          const identity = makeWriterLeaseIdentity(scope, normalizedPath);
+          registerDbIdentity(db, identity);
+
           const built: DualScopeDbHandle = {
             db,
             scope,
             dbPath: normalizedPath,
+            identity,
             get isOpen() {
               return nativeDb.isOpen;
             },
@@ -762,10 +783,6 @@ export async function openDualScopeDbAtPath(
 
           return built;
         },
-        // Record this open's resolved dbPath in the Seam-1 registry so the chokepoint
-        // write primitives lease their row in THIS file — not the cwd-default — when
-        // more than one project's cleo.db is open in this process (T11627 Finding 1).
-        { dbPath: normalizedPath },
       );
 
       // ── Exodus-on-open (E6 · T11553) — runs AFTER the cold-open lease releases ──
@@ -950,6 +967,11 @@ export interface ProjectStore {
   readonly scope: 'project';
   /** Absolute on-disk path to this project's `cleo.db`. */
   readonly dbPath: string;
+  /**
+   * Immutable writer-lease identity bound to this store's underlying
+   * {@link DualScopeDbHandle} at construction (T12042).
+   */
+  readonly identity: WriterLeaseIdentity;
   /** The typed Drizzle ORM handle for the project-scope consolidated schema. */
   readonly db: CleoProjectDb;
   /**
@@ -993,6 +1015,11 @@ export interface GlobalStore {
   readonly scope: 'global';
   /** Absolute on-disk path to the global `cleo.db`. */
   readonly dbPath: string;
+  /**
+   * Immutable writer-lease identity bound to this store's underlying
+   * {@link DualScopeDbHandle} at construction (T12042).
+   */
+  readonly identity: WriterLeaseIdentity;
   /** The typed Drizzle ORM handle for the global-scope consolidated schema. */
   readonly db: CleoGlobalDb;
   /**
@@ -1395,6 +1422,7 @@ class CleoRuntimeImpl implements CleoRuntime {
     entryId: EntryId,
   ): ProjectStore | GlobalStore {
     const dbPath = dualHandle.dbPath;
+    const identity = dualHandle.identity;
     const exodusAbort = dualHandle.exodusAbort;
     const key = cacheKey(scope, dbPath);
 
@@ -1402,6 +1430,7 @@ class CleoRuntimeImpl implements CleoRuntime {
       const store: ProjectStore = {
         scope: 'project',
         dbPath,
+        identity,
         db: dualHandle.db as CleoProjectDb,
         get isOpen() {
           return dualHandle.isOpen;
@@ -1418,6 +1447,7 @@ class CleoRuntimeImpl implements CleoRuntime {
     const store: GlobalStore = {
       scope: 'global',
       dbPath,
+      identity,
       db: dualHandle.db as CleoGlobalDb,
       get isOpen() {
         return dualHandle.isOpen;
@@ -1568,22 +1598,20 @@ import type { SQLiteTableWithColumns, TableConfig } from 'drizzle-orm/sqlite-cor
  * the consolidated-schema MUTATION primitives, so the guard is write-only and
  * never affects read paths.
  *
- * @param identity - The explicit writer-lease identity (scope + canonical dbPath)
- *   owning this write. Replaces the removed process-global last-writer scope
- *   (T12042) so concurrent project A, B, and global writers cannot steal or
- *   release each other's lease.
+ * Derives the writer-lease identity from the DB handle itself via
+ * {@link resolveDbIdentity} — the identity was registered at
+ * {@link DualScopeDbHandle} construction, so a caller cannot pair file-A
+ * identity with file-B DB (T12042).
  *
  * @example
  * ```ts
  * import { tasksTasksTable } from '@cleocode/core/store/schema/cleo-project';
- * import { makeWriterLeaseIdentity } from '@cleocode/core/store/writer-lease';
- * const identity = makeWriterLeaseIdentity('project', handle.dbPath);
- * const inserted = await insertIdempotent(db, tasksTasksTable, newTask, 'idempotencyKey', identity);
+ * const inserted = await insertIdempotent(db, tasksTasksTable, newTask, 'idempotencyKey');
  * ```
  *
  * @task T11513 (E4-T2)
  * @task T11828 (write-side exodus-abort guard)
- * @task T12042 (E6-L12b — explicit writer-lease identity)
+ * @task T12042 (E6-L12b — exact DB-bound identity)
  * @epic T11247 (E4)
  * @saga T11242
  */
@@ -1594,9 +1622,9 @@ export async function insertIdempotent<TTable extends SQLiteTableWithColumns<Tab
   row: InferInsertModel<TTable>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _keyColumn: string,
-  identity: WriterLeaseIdentity,
 ): Promise<number> {
   assertNoRecordedExodusAbort();
+  const identity = resolveDbIdentity(db);
   return withWriterLease(
     identity.scope,
     'tasks',
@@ -1629,20 +1657,18 @@ export async function insertIdempotent<TTable extends SQLiteTableWithColumns<Tab
  * Refuses the write (throws {@link ExodusAbortWriteUnsafeError}) when a prior
  * exodus-on-open aborted in this process (T11828 · DHQ-059) — write-only guard.
  *
- * @param identity - The explicit writer-lease identity (scope + canonical dbPath)
- *   owning this write. Replaces the removed process-global last-writer scope
- *   (T12042) so concurrent project A, B, and global writers cannot steal or
- *   release each other's lease.
+ * Derives the writer-lease identity from the DB handle itself via
+ * {@link resolveDbIdentity} (T12042 — exact DB-bound identity, no fallback).
  *
  * @example
  * ```ts
  * await upsertIdempotent(db, tasksTasksTable, updatedTask, 'idempotencyKey',
- *   tasksTasksTable.idempotencyKey, identity);
+ *   tasksTasksTable.idempotencyKey);
  * ```
  *
  * @task T11513 (E4-T2)
  * @task T11828 (write-side exodus-abort guard)
- * @task T12042 (E6-L12b — explicit writer-lease identity)
+ * @task T12042 (E6-L12b — exact DB-bound identity)
  * @epic T11247 (E4)
  * @saga T11242
  */
@@ -1656,11 +1682,11 @@ export async function upsertIdempotent<TTable extends SQLiteTableWithColumns<Tab
   // biome-ignore lint/suspicious/noExplicitAny: column reference type varies by table
   conflictTarget: any,
   set?: Partial<InferInsertModel<TTable>>,
-  identity?: WriterLeaseIdentity,
 ): Promise<number> {
   assertNoRecordedExodusAbort();
+  const identity = resolveDbIdentity(db);
   return withWriterLease(
-    identity?.scope ?? 'project',
+    identity.scope,
     'tasks',
     async () => {
       const updateSet = set ?? row;
@@ -1675,6 +1701,6 @@ export async function upsertIdempotent<TTable extends SQLiteTableWithColumns<Tab
         .returning();
       return result.length;
     },
-    identity ? { dbPath: identity.dbPath } : undefined,
+    { dbPath: identity.dbPath },
   );
 }

--- a/packages/core/src/store/writer-lease.ts
+++ b/packages/core/src/store/writer-lease.ts
@@ -64,6 +64,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { resolve as resolvePath } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import type { LeaseLane, LeaseScope } from '@cleocode/contracts';
 import { getLogger } from '../logger.js';
@@ -391,32 +392,104 @@ function memoKey(scope: LeaseScope, dbPath: string, lane: LeaseLane): string {
  * acquire/release/renew/assert and cold-open path uses this same explicit
  * identity — a release for A must never affect B/global even when concurrent.
  *
+ * Identity is IMMUTABLE after construction: it is frozen and bound to the
+ * exact drizzle DB handle at {@link DualScopeDbHandle} construction time via
+ * {@link registerDbIdentity}. Callers resolve it through
+ * {@link resolveDbIdentity} — never construct one by hand.
+ *
  * @task T12042 (E6-L12b)
  * @task T11627
  */
 export interface WriterLeaseIdentity {
   /** The cleo.db scope this lease arbitrates within. */
   readonly scope: LeaseScope;
-  /** Absolute canonical on-disk path to this scope's cleo.db. */
+  /** Absolute canonical on-disk path to this scope's cleo.db (normalized). */
   readonly dbPath: string;
 }
 
 /**
- * Build a {@link WriterLeaseIdentity} from explicit scope and dbPath. Extracts
- * the canonical identity key used by the grant memo, the native handle resolver,
- * and the lease row claims. Two different project files opened in one process
- * produce DISTINCT identities (distinct `dbPath` values), so their grants never
- * cross — a release for one file cannot free the other's row, and a cold-open
- * at one path cannot overwrite identity for the other.
+ * Build a frozen {@link WriterLeaseIdentity} from scope + dbPath.
+ *
+ * The dbPath is normalized via `path.resolve()` before freezing — so alias paths
+ * (`/a/../a/cleo.db`, `/a/cleo.db`) produce byte-identical identities and a
+ * single memoized grant row. Callers MUST pass the identity through
+ * {@link registerDbIdentity} to bind it to a concrete drizzle DB handle; the
+ * chokepoint write primitives resolve identity from the handle itself.
  *
  * @param scope - The cleo.db scope.
- * @param dbPath - The absolute canonical on-disk path.
- * @returns A frozen identity object.
+ * @param dbPath - An absolute or relative path to the scope's cleo.db. Normalized
+ *   via `path.resolve()` before freezing.
+ * @returns A frozen, normalized identity.
  *
  * @task T12042 (E6-L12b)
  */
 export function makeWriterLeaseIdentity(scope: LeaseScope, dbPath: string): WriterLeaseIdentity {
-  return Object.freeze({ scope, dbPath });
+  return Object.freeze({ scope, dbPath: resolvePath(dbPath) });
+}
+
+// ── DB-identity registry (typed WeakMap — immutable, concurrency-safe) ──────
+
+/**
+ * Maps a drizzle DB object to its immutable writer-lease identity. Keyed on the
+ * EXACT drizzle DB object reference so two different projects' drizzle handles
+ * are distinct keys — a caller cannot pair file-A identity with file-B DB.
+ *
+ * Typed `WeakMap<object, …>` because WeakMap keys must be non-primitive; the DB
+ * handles are always objects. Unregistered lookups throw a descriptive error —
+ * there is NO fallback, ambient cwd lookup, or compatibility shim.
+ *
+ * @task T12042 (E6-L12b)
+ */
+const _dbIdentityRegistry = new WeakMap<object, WriterLeaseIdentity>();
+
+/**
+ * Register a drizzle DB handle's immutable writer-lease identity.
+ *
+ * Called at {@link DualScopeDbHandle} construction time (both cached and
+ * dedicated opens). Subsequent calls for the SAME handle object silently
+ * overwrite (last registration wins), but the identity is immutable — a
+ * replacement identity for the same handle is a bug.
+ *
+ * @param db - The drizzle DB handle (or any non-primitive key). Must be the
+ *   exact same object reference that {@link resolveDbIdentity} will look up.
+ * @param identity - The frozen identity built by {@link makeWriterLeaseIdentity}.
+ *
+ * @task T12042 (E6-L12b)
+ */
+export function registerDbIdentity(db: object, identity: WriterLeaseIdentity): void {
+  _dbIdentityRegistry.set(db, identity);
+}
+
+/**
+ * Resolve the immutable writer-lease identity bound to a drizzle DB handle.
+ *
+ * The chokepoint write primitives ({@link insertIdempotent} /
+ * {@link upsertIdempotent}) call this with their `db` parameter to derive the
+ * correct scope + dbPath for the writer lease. A handle opened through the
+ * dual-scope chokepoint is always registered; a stub or synthetic handle
+ * passed in tests must be registered via {@link registerDbIdentity} before a
+ * write primitive reaches the identity-resolve point.
+ *
+ * @param db - The drizzle DB handle whose identity to look up.
+ * @returns The frozen identity registered at construction time.
+ * @throws {Error} `E_WRITER_LEASE_IDENTITY_UNREGISTERED` when the handle was
+ *   not registered — the caller MUST open the DB through the dual-scope
+ *   chokepoint or call {@link registerDbIdentity} explicitly.
+ *
+ * @task T12042 (E6-L12b)
+ */
+export function resolveDbIdentity(db: object): WriterLeaseIdentity {
+  const identity = _dbIdentityRegistry.get(db);
+  if (!identity) {
+    throw new Error(
+      'E_WRITER_LEASE_IDENTITY_UNREGISTERED: the drizzle DB handle has no ' +
+        'registered writer-lease identity. Open the DB through the dual-scope ' +
+        'chokepoint (openDualScopeDb/openDualScopeDbAtPath) or call ' +
+        'registerDbIdentity(handle, identity) explicitly in tests. ' +
+        '(T12042 — no ambient fallback)',
+    );
+  }
+  return identity;
 }
 
 // ── Small helpers ─────────────────────────────────────────────────────────────
@@ -1158,10 +1231,9 @@ function ensureColdOpenLeaseTables(nativeDb: DatabaseSync): void {
  * Unlike {@link withWriterLease} it operates DIRECTLY on the already-opened native
  * handle — it never routes through the default resolver (which would re-enter
  * `openDualScopeDb` and recurse) and it bootstraps the lease tables first (the full
- * migration that creates them runs inside `fn`). The caller is responsible for
- * threading the correct explicit {@link WriterLeaseIdentity} into downstream
- * chokepoint write primitives — the removed process-global active-scope registry
- * (T12042) is no longer set as a side effect.
+ * migration that creates them runs inside `fn`). The identity is bound to the
+ * drizzle DB handle at construction via {@link registerDbIdentity} — this function
+ * no longer records a process-global side effect (T12042).
  *
  * Mode semantics mirror {@link withWriterLease}:
  * - `off` → pass-through: runs `fn` under today's `busy_timeout=30000`, byte-
@@ -1174,21 +1246,19 @@ function ensureColdOpenLeaseTables(nativeDb: DatabaseSync): void {
  * @param scope - The cleo.db scope being cold-opened.
  * @param nativeDb - The native handle the cold-open just created (pragmas applied).
  * @param fn - The cold-open body to run while holding the lease.
- * @param opts - Priority / TTL options + the resolved `dbPath` of this cold-open.
- *   The caller must thread `dbPath` into the explicit {@link WriterLeaseIdentity}
- *   passed to downstream chokepoint write primitives (T12042) — the removed
- *   process-global registry no longer propagates it as a side effect. Cold-open
- *   defaults to highest priority ({@link SCHEMA_BOOTSTRAP_PRIORITY}) and a 60s TTL
- *   (schema bootstrap can be slow).
+ * @param opts - Priority / TTL options. Cold-open defaults to highest priority
+ *   ({@link SCHEMA_BOOTSTRAP_PRIORITY}) and a 60s TTL (schema bootstrap can be
+ *   slow).
  * @returns The resolved value of `fn`.
  *
  * @task T11627
+ * @task T12042 (E6-L12b — no process-global side effect)
  */
 export async function withColdOpenLease<T>(
   scope: LeaseScope,
   nativeDb: DatabaseSync,
   fn: () => Promise<T>,
-  opts?: { priority?: number; ttlMs?: number; dbPath?: string },
+  opts?: { priority?: number; ttlMs?: number },
 ): Promise<T> {
   const mode = effectiveMode();
 

--- a/packages/core/src/store/writer-lease.ts
+++ b/packages/core/src/store/writer-lease.ts
@@ -129,12 +129,12 @@ export interface LeaseAcquireOptions {
    */
   reentrant?: boolean;
   /**
-   * Pin the lease to a SPECIFIC cleo.db file (its resolved on-disk path) instead
-   * of the cwd-default canonical path the scope→path resolver returns. The
-   * chokepoint write primitives pass the dbPath recorded at cold-open
-   * ({@link activeScopeDbPath}) so the lease row lands in the SAME file the write
-   * targets — correct when more than one project's cleo.db is open in one process
-   * (Finding 1). When omitted, the canonical scope→path resolution is used.
+   * Pin the lease to a SPECIFIC cleo.db file path. When omitted the
+   * canonical scope→path resolver is used. The path is normalized via
+   * `path.resolve()` before memo-keying so alias paths share one grant
+   * row (T12042 Finding 4). The chokepoint write primitives resolve
+   * identity from their exact DB handle via {@link resolveDbIdentity},
+   * not from a process-global registry.
    */
   dbPath?: string;
 }
@@ -446,17 +446,33 @@ const _dbIdentityRegistry = new WeakMap<object, WriterLeaseIdentity>();
  * Register a drizzle DB handle's immutable writer-lease identity.
  *
  * Called at {@link DualScopeDbHandle} construction time (both cached and
- * dedicated opens). Subsequent calls for the SAME handle object silently
- * overwrite (last registration wins), but the identity is immutable — a
- * replacement identity for the same handle is a bug.
+ * dedicated opens). Idempotent when the same DB handle is re-registered with
+ * the SAME canonical identity (same scope AND same `dbPath`). Throws
+ * `E_WRITER_LEASE_IDENTITY_MISMATCH` when the same DB handle is registered
+ * with a DIFFERENT identity — a scope/path mismatch for the same handle is a
+ * programming error.
  *
  * @param db - The drizzle DB handle (or any non-primitive key). Must be the
  *   exact same object reference that {@link resolveDbIdentity} will look up.
  * @param identity - The frozen identity built by {@link makeWriterLeaseIdentity}.
+ * @throws {Error} When the handle was previously registered with a different
+ *   scope or dbPath.
  *
  * @task T12042 (E6-L12b)
  */
 export function registerDbIdentity(db: object, identity: WriterLeaseIdentity): void {
+  const existing = _dbIdentityRegistry.get(db);
+  if (existing) {
+    if (existing.scope === identity.scope && existing.dbPath === identity.dbPath) {
+      return; // idempotent — same canonical identity
+    }
+    throw new Error(
+      'E_WRITER_LEASE_IDENTITY_MISMATCH: the same drizzle DB handle was ' +
+        `previously registered as ${existing.scope}::${existing.dbPath} ` +
+        `but is being re-registered as ${identity.scope}::${identity.dbPath}. ` +
+        'A DB handle must carry exactly one immutable identity (T12042).',
+    );
+  }
   _dbIdentityRegistry.set(db, identity);
 }
 
@@ -889,13 +905,11 @@ export async function acquireWriterLease(
     return makeNoopHandle(scope, lane);
   }
 
-  // Build the lease-scope key up front from the explicit pinned dbPath (when the
-  // chokepoint pins a non-cwd-default file) or the I/O-free path resolver, so the
-  // re-entrant fast path AND the single-flight guard are decided SYNCHRONOUSLY,
-  // before any `await` yields the event loop. Keying on `${scope}::${dbPath}::
-  // ${lane}` means two different project files in one process are distinct lease
-  // scopes (Finding 1) and that the same (scope,dbPath,lane) never double-claims.
-  const dbPath = opts?.dbPath ?? _dbPathResolver(scope);
+  // Build the lease-scope key up front from the normalized dbPath. Normalizing
+  // BEFORE keying and resolver use means alias paths (/a/../a/cleo.db) resolve
+  // to the same memo key + grant row as canonical (/a/cleo.db) — a single
+  // memoized grant, one active row (T12042 Finding 4).
+  const dbPath = opts?.dbPath ? resolvePath(opts.dbPath) : _dbPathResolver(scope);
   const key = memoKey(scope, dbPath, lane);
 
   // Re-entrant fast path: an existing same-(scope,dbPath,lane) grant is shared
@@ -904,14 +918,21 @@ export async function acquireWriterLease(
     const existing = _grantMemo.get(key);
     if (existing) {
       existing.refcount += 1;
-      // Reflect the re-entry in the durable row depth (best-effort under epoch guard).
-      const { native } = await _nativeDbResolver(scope, dbPath);
-      native
-        .prepare(
-          `UPDATE ${WRITER_LEASES_TABLE} SET reentrancy_depth = reentrancy_depth + 1 ` +
-            `WHERE scope = ? AND lane = ? AND holder_id = ? AND epoch = ? AND active = 1`,
-        )
-        .run(scope, lane, existing.handle.holderId, existing.handle.epoch);
+      try {
+        const { native } = await _nativeDbResolver(scope, dbPath);
+        native
+          .prepare(
+            `UPDATE ${WRITER_LEASES_TABLE} SET reentrancy_depth = reentrancy_depth + 1 ` +
+              `WHERE scope = ? AND lane = ? AND holder_id = ? AND epoch = ? AND active = 1`,
+          )
+          .run(scope, lane, existing.handle.holderId, existing.handle.epoch);
+      } catch (err) {
+        // Native resolver or depth-update failed — roll back the refcount
+        // increment so the grant is not leaked. The caller receives the
+        // original error; the held grant is intact (single refcount tick).
+        existing.refcount -= 1;
+        throw err;
+      }
       return existing.handle;
     }
 
@@ -928,14 +949,18 @@ export async function acquireWriterLease(
       const entry = _grantMemo.get(key);
       if (entry && entry.handle === shared) {
         entry.refcount += 1;
-        // `entry.handle` is the concrete InternalLeaseHandle (holderId/epoch).
-        const { native } = await _nativeDbResolver(scope, dbPath);
-        native
-          .prepare(
-            `UPDATE ${WRITER_LEASES_TABLE} SET reentrancy_depth = reentrancy_depth + 1 ` +
-              `WHERE scope = ? AND lane = ? AND holder_id = ? AND epoch = ? AND active = 1`,
-          )
-          .run(scope, lane, entry.handle.holderId, entry.handle.epoch);
+        try {
+          const { native } = await _nativeDbResolver(scope, dbPath);
+          native
+            .prepare(
+              `UPDATE ${WRITER_LEASES_TABLE} SET reentrancy_depth = reentrancy_depth + 1 ` +
+                `WHERE scope = ? AND lane = ? AND holder_id = ? AND epoch = ? AND active = 1`,
+            )
+            .run(scope, lane, entry.handle.holderId, entry.handle.epoch);
+        } catch (err) {
+          entry.refcount -= 1;
+          throw err;
+        }
         return entry.handle;
       }
       // The shared acquire is no longer active — fall through to a fresh acquire.

--- a/packages/core/src/store/writer-lease.ts
+++ b/packages/core/src/store/writer-lease.ts
@@ -378,9 +378,39 @@ const _inflightAcquire = new Map<string, Promise<LeaseHandle>>();
  * Build the lease-scope memo key. Keyed on `${scope}::${dbPath}::${lane}` — the
  * `${scope}::${dbPath}` prefix is byte-equal to `cacheKey(scope, dbPath)` in
  * `dual-scope-db.ts` so the lease scope and the handle cache agree on identity.
+ *
+ * Every call site MUST pass a canonicalized dbPath — {@link canonicalizeDbPath}
+ * is the single normalization boundary.
  */
 function memoKey(scope: LeaseScope, dbPath: string, lane: LeaseLane): string {
   return `${scope}::${dbPath}::${lane}`;
+}
+
+/**
+ * Normalize a dbPath for memo-key and resolver use before every lease operation.
+ *
+ * This is the SINGLE normalization boundary. Every public API that accepts or
+ * constructs a dbPath (acquire, release, hasActiveGrant, assertWriterLeaseHeld)
+ * runs the path through this function before constructing a memo key, so alias
+ * filesystem paths produce byte-identical keys and test:// sentinels are
+ * preserved as opaque virtual keys.
+ *
+ * Canonicalization rules:
+ * - `test://*` / `sentinel://*` — URI-like test sentinels pass through
+ *   unchanged (they are never filesystem paths).
+ * - Everything else — normalized via `path.resolve()` so `/a/../a/cleo.db`
+ *   and `/a/cleo.db` are byte-identical.
+ *
+ * @param dbPath - A raw dbPath from opts or an explicit parameter.
+ * @returns A canonicalized path ready for memo-key construction.
+ *
+ * @task T12042 (E6-L12b · Finding 4 — alias normalization)
+ */
+function canonicalizeDbPath(dbPath: string): string {
+  if (dbPath.startsWith('test://') || dbPath.startsWith('sentinel://')) {
+    return dbPath;
+  }
+  return resolvePath(dbPath);
 }
 
 /**
@@ -722,7 +752,8 @@ export class WriterLeaseRequiredError extends Error {
  * @task T11627
  */
 export function hasActiveGrant(scope: LeaseScope, lane: LeaseLane, dbPath?: string): boolean {
-  const entry = _grantMemo.get(memoKey(scope, dbPath ?? _dbPathResolver(scope), lane));
+  const normalized = dbPath ? canonicalizeDbPath(dbPath) : _dbPathResolver(scope);
+  const entry = _grantMemo.get(memoKey(scope, normalized, lane));
   return entry !== undefined && entry.refcount > 0;
 }
 
@@ -909,7 +940,7 @@ export async function acquireWriterLease(
   // BEFORE keying and resolver use means alias paths (/a/../a/cleo.db) resolve
   // to the same memo key + grant row as canonical (/a/cleo.db) — a single
   // memoized grant, one active row (T12042 Finding 4).
-  const dbPath = opts?.dbPath ? resolvePath(opts.dbPath) : _dbPathResolver(scope);
+  const dbPath = opts?.dbPath ? canonicalizeDbPath(opts.dbPath) : _dbPathResolver(scope);
   const key = memoKey(scope, dbPath, lane);
 
   // Re-entrant fast path: an existing same-(scope,dbPath,lane) grant is shared

--- a/packages/core/src/store/writer-lease.ts
+++ b/packages/core/src/store/writer-lease.ts
@@ -239,7 +239,6 @@ export function _resetWriterLeaseStateForTest(): void {
   _inflightAcquire.clear();
   _nativeDbResolver = defaultNativeDbResolver;
   _dbPathResolver = resolveDualScopeDbPath;
-  _activeScope = null;
 }
 
 // ── Native handle resolution (test-injectable) ────────────────────────────────
@@ -383,87 +382,41 @@ function memoKey(scope: LeaseScope, dbPath: string, lane: LeaseLane): string {
   return `${scope}::${dbPath}::${lane}`;
 }
 
-// ── Active-scope registry (ST-3 · Seam 1 — process-local, no signature change) ──
-
 /**
- * The scope + resolved dbPath of the most-recent canonical cold-open in this
- * process.
+ * Writer-lease identity: explicit scope and canonical dbPath.
  *
- * The chokepoint write primitives ({@link insertIdempotent} /
- * {@link upsertIdempotent} in `dual-scope-db.ts`) receive only a drizzle handle —
- * NOT the scope or a {@link LeaseHandle}. To gate them through the writer lease
- * (Seam 1) WITHOUT a signature change, the cold-open path records its scope AND
- * dbPath here (mirroring the `getRecordedExodusAbort` registry pattern already
- * used by those primitives) and the primitive reads them back via
- * {@link activeScope} / {@link activeScopeDbPath}.
+ * Replaces the removed process-global last-writer scope with explicit per-call
+ * identity so concurrent project A, project B, and global writers cannot steal,
+ * release, resolve, or close each other's lease identity. Every lease
+ * acquire/release/renew/assert and cold-open path uses this same explicit
+ * identity — a release for A must never affect B/global even when concurrent.
  *
- * Recording the dbPath (not just the abstract scope LABEL) means the chokepoint
- * leases against the lease ROW in the SAME file the open targeted — so two
- * different projects opened in one process lease in their OWN cleo.db, never the
- * cwd-default file (Finding 1).
- *
- * `null` until the first canonical cold-open records a scope.
- */
-let _activeScope: LeaseScope | null = null;
-let _activeScopeDbPath: string | null = null;
-
-/**
- * Record the scope (and optionally the resolved dbPath) of the cold-open
- * currently in progress / most recently opened. Called by `dual-scope-db.ts` at
- * the head of its cold-open critical section (Seam 0). Idempotent — last writer
- * wins; a project open after a global open makes `'project'` the active scope,
- * which is correct because the chokepoint write primitives only ever write the
- * project-tier `tasks_*` tables.
- *
- * @param scope - The scope of the in-progress cold-open.
- * @param dbPath - The resolved on-disk path of that scope's cleo.db. When
- *   omitted, the active dbPath is cleared so {@link activeScopeDbPath} falls back
- *   to the canonical scope→path resolver.
- * @internal
+ * @task T12042 (E6-L12b)
  * @task T11627
  */
-export function setActiveScope(scope: LeaseScope, dbPath?: string): void {
-  _activeScope = scope;
-  _activeScopeDbPath = dbPath ?? null;
+export interface WriterLeaseIdentity {
+  /** The cleo.db scope this lease arbitrates within. */
+  readonly scope: LeaseScope;
+  /** Absolute canonical on-disk path to this scope's cleo.db. */
+  readonly dbPath: string;
 }
 
 /**
- * The scope the chokepoint write primitives should lease against. Defaults to
- * `'project'` (the tasks chokepoint is project-tier) when no cold-open has
- * recorded a scope yet — a write before any open is degenerate, but `'project'`
- * is the only correct lease scope for `tasks_*` mutations.
+ * Build a {@link WriterLeaseIdentity} from explicit scope and dbPath. Extracts
+ * the canonical identity key used by the grant memo, the native handle resolver,
+ * and the lease row claims. Two different project files opened in one process
+ * produce DISTINCT identities (distinct `dbPath` values), so their grants never
+ * cross — a release for one file cannot free the other's row, and a cold-open
+ * at one path cannot overwrite identity for the other.
  *
- * @returns The active {@link LeaseScope}.
- * @internal
- * @task T11627
- */
-export function activeScope(): LeaseScope {
-  return _activeScope ?? 'project';
-}
-
-/**
- * The dbPath the chokepoint write primitives should lease their row in. Returns
- * the path recorded by the most-recent cold-open, or — defensively — the
- * canonical scope→path resolution for {@link activeScope} when none was recorded.
+ * @param scope - The cleo.db scope.
+ * @param dbPath - The absolute canonical on-disk path.
+ * @returns A frozen identity object.
  *
- * @returns The active cleo.db on-disk path.
- * @internal
- * @task T11627
+ * @task T12042 (E6-L12b)
  */
-export function activeScopeDbPath(): string {
-  return _activeScopeDbPath ?? _dbPathResolver(activeScope());
-}
-
-/**
- * Clear the recorded active scope + dbPath. Tests only — production records once
- * per cold-open and never clears (the scope of the last canonical open remains
- * the lease target for subsequent writes).
- *
- * @internal
- */
-export function _clearActiveScopeForTest(): void {
-  _activeScope = null;
-  _activeScopeDbPath = null;
+export function makeWriterLeaseIdentity(scope: LeaseScope, dbPath: string): WriterLeaseIdentity {
+  return Object.freeze({ scope, dbPath });
 }
 
 // ── Small helpers ─────────────────────────────────────────────────────────────
@@ -1205,9 +1158,10 @@ function ensureColdOpenLeaseTables(nativeDb: DatabaseSync): void {
  * Unlike {@link withWriterLease} it operates DIRECTLY on the already-opened native
  * handle — it never routes through the default resolver (which would re-enter
  * `openDualScopeDb` and recurse) and it bootstraps the lease tables first (the full
- * migration that creates them runs inside `fn`). It also records the scope in the
- * Seam-1 active-scope registry ({@link setActiveScope}) so chokepoint write
- * primitives lease against the right scope.
+ * migration that creates them runs inside `fn`). The caller is responsible for
+ * threading the correct explicit {@link WriterLeaseIdentity} into downstream
+ * chokepoint write primitives — the removed process-global active-scope registry
+ * (T12042) is no longer set as a side effect.
  *
  * Mode semantics mirror {@link withWriterLease}:
  * - `off` → pass-through: runs `fn` under today's `busy_timeout=30000`, byte-
@@ -1221,9 +1175,9 @@ function ensureColdOpenLeaseTables(nativeDb: DatabaseSync): void {
  * @param nativeDb - The native handle the cold-open just created (pragmas applied).
  * @param fn - The cold-open body to run while holding the lease.
  * @param opts - Priority / TTL options + the resolved `dbPath` of this cold-open.
- *   `dbPath` is recorded in the Seam-1 active-scope registry so the chokepoint
- *   write primitives lease their row in the SAME file this open targeted (correct
- *   when more than one project is open in one process — Finding 1). Cold-open
+ *   The caller must thread `dbPath` into the explicit {@link WriterLeaseIdentity}
+ *   passed to downstream chokepoint write primitives (T12042) — the removed
+ *   process-global registry no longer propagates it as a side effect. Cold-open
  *   defaults to highest priority ({@link SCHEMA_BOOTSTRAP_PRIORITY}) and a 60s TTL
  *   (schema bootstrap can be slow).
  * @returns The resolved value of `fn`.
@@ -1236,11 +1190,6 @@ export async function withColdOpenLease<T>(
   fn: () => Promise<T>,
   opts?: { priority?: number; ttlMs?: number; dbPath?: string },
 ): Promise<T> {
-  // Seam 1 wiring: record the scope + resolved dbPath of this cold-open so
-  // chokepoint write primitives (insertIdempotent/upsertIdempotent) lease against
-  // the right scope AND the right file.
-  setActiveScope(scope, opts?.dbPath);
-
   const mode = effectiveMode();
 
   // `off` mode — pure pass-through. busy_timeout=30000 on the connection still


### PR DESCRIPTION
## Summary
- replace process-global writer lease scope/path state with immutable `WriterLeaseIdentity` values
- bind each cached and dedicated Drizzle database handle to its exact identity through a `WeakMap`
- canonicalize filesystem aliases consistently while preserving virtual test/sentinel paths
- adapt the exodus abort fixture to provide explicit identity (T12043)

## Verification
- `pnpm biome check --write .` (3,832 files, no fixes)
- `pnpm run build` (pass)
- focused store tests (105/105 pass in worker verification; 89/89 pass in independent final rerun)
- full suite: 18,294/18,309 pass; 15 known host/history-specific failures remain in native worktree and audit reconstruction tests
- `cleo check arch` (6/6 pass)
- `node scripts/lint-changesets.mjs` (264 entries valid)

Tasks: T12042, T12043