### PR TITLE
refactor(store): pin bulk leases to project database paths

### DIFF
--- a/packages/core/src/conduit/local-transport.ts
+++ b/packages/core/src/conduit/local-transport.ts
@@ -685,21 +685,12 @@ export class LocalTransport implements Transport {
   }
 
   /**
-   * Seam 3 (T11627): conduit.db is a raw bypass writer (project-tier, sidesteps
-   * the tasks chokepoint via its own `openFreshConduitDb` handle). Hold the
-   * project `bulk` lease around a synchronous write block so conduit writes
-   * serialize against other writers on the same scope. `off` mode → pass-through
-   * (busy_timeout serializes as before). The wrapped `fn` is synchronous because
-   * every conduit write is a synchronous `db.prepare(...).run(...)`.
+   * Run a synchronous conduit write under the project `bulk` lease. Conduit uses
+   * the consolidated project cleo.db, so the connection state's exact path pins
+   * the lease to this project rather than the process cwd.
    *
    * @param fn - The synchronous write block to run under the lease.
    * @returns The value returned by `fn`.
-   */
-  /**
-   * Seam 3 (T11627): conduit.db is now the same file as the project cleo.db
-   * (E6-L3). Pass the exact canonical dbPath from the state so the lease row
-   * lands in THIS project's cleo.db — never in the cwd-default file — ensuring
-   * concurrent projects route to their own rows (T12044 · E6-L12d).
    */
   private runWrite<T>(fn: () => T): Promise<T> {
     return withWriterLease('project', 'bulk', async () => fn(), {

--- a/packages/core/src/conduit/local-transport.ts
+++ b/packages/core/src/conduit/local-transport.ts
@@ -695,7 +695,15 @@ export class LocalTransport implements Transport {
    * @param fn - The synchronous write block to run under the lease.
    * @returns The value returned by `fn`.
    */
+  /**
+   * Seam 3 (T11627): conduit.db is now the same file as the project cleo.db
+   * (E6-L3). Pass the exact canonical dbPath from the state so the lease row
+   * lands in THIS project's cleo.db — never in the cwd-default file — ensuring
+   * concurrent projects route to their own rows (T12044 · E6-L12d).
+   */
   private runWrite<T>(fn: () => T): Promise<T> {
-    return withWriterLease('project', 'bulk', async () => fn());
+    return withWriterLease('project', 'bulk', async () => fn(), {
+      dbPath: this.state!.dbPath,
+    });
   }
 }

--- a/packages/core/src/memory/graph-memory-bridge.ts
+++ b/packages/core/src/memory/graph-memory-bridge.ts
@@ -1411,64 +1411,71 @@ export async function linkConduitMessagesToSymbols(
       // writer-thread chokepoint with a direct `brainNative` handle (project-tier
       // consolidated cleo.db). Hold the project `bulk` lease for the whole write
       // batch so they serialize against other writers. `off` → pass-through.
-      await withWriterLease('project', 'bulk', async () => {
-        // For each message, scan content and attachments for symbol mentions
-        for (const msg of messages) {
-          const corpus = `${msg.content}`;
+      // T12044 (E6-L12d): pin the lease to the exact project cleo.db path resolved
+      // from the projectRoot parameter so concurrent projects route to their own rows.
+      await withWriterLease(
+        'project',
+        'bulk',
+        async () => {
+          // For each message, scan content and attachments for symbol mentions
+          for (const msg of messages) {
+            const corpus = `${msg.content}`;
 
-          for (const [symbolName, nexusNode] of symbolMap.entries()) {
-            // Case-insensitive check: does the symbol name appear in the message?
-            const corpusLower = corpus.toLowerCase();
-            const nameLower = symbolName.toLowerCase();
+            for (const [symbolName, nexusNode] of symbolMap.entries()) {
+              // Case-insensitive check: does the symbol name appear in the message?
+              const corpusLower = corpus.toLowerCase();
+              const nameLower = symbolName.toLowerCase();
 
-            if (corpusLower.includes(nameLower)) {
-              const messageNodeId = `conduit:${msg.id}`;
+              if (corpusLower.includes(nameLower)) {
+                const messageNodeId = `conduit:${msg.id}`;
 
-              try {
-                // Upsert a stub node for the message in brain_page_nodes (idempotent)
-                brainNative
-                  .prepare(`
+                try {
+                  // Upsert a stub node for the message in brain_page_nodes (idempotent)
+                  brainNative
+                    .prepare(`
                   INSERT OR IGNORE INTO brain_page_nodes
                     (id, node_type, label, quality_score, content_hash, metadata_json, last_activity_at, created_at, updated_at)
                   VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, ?)
                 `)
-                  .run(
-                    messageNodeId,
-                    'observation',
-                    `Conduit message: ${msg.id}`,
-                    0.5,
-                    now,
-                    now,
-                    now,
-                  );
+                    .run(
+                      messageNodeId,
+                      'observation',
+                      `Conduit message: ${msg.id}`,
+                      0.5,
+                      now,
+                      now,
+                      now,
+                    );
 
-                // Write the conduit_mentions_symbol edge (idempotent via INSERT OR IGNORE)
-                brainNative
-                  .prepare(`
+                  // Write the conduit_mentions_symbol edge (idempotent via INSERT OR IGNORE)
+                  brainNative
+                    .prepare(`
                   INSERT OR IGNORE INTO brain_page_edges
                     (from_id, to_id, edge_type, weight, provenance, created_at)
                   VALUES (?, ?, ?, ?, ?, ?)
                 `)
-                  .run(
-                    messageNodeId,
-                    nexusNode.id,
-                    'conduit_mentions_symbol',
-                    1.0,
-                    'auto:conduit-fts',
-                    now,
-                  );
+                    .run(
+                      messageNodeId,
+                      nexusNode.id,
+                      'conduit_mentions_symbol',
+                      1.0,
+                      'auto:conduit-fts',
+                      now,
+                    );
 
-                edgesCreated++;
-              } catch (edgeErr) {
-                console.warn('[graph-memory-bridge] conduit edge insert failed:', edgeErr);
+                  edgesCreated++;
+                } catch (edgeErr) {
+                  console.warn('[graph-memory-bridge] conduit edge insert failed:', edgeErr);
+                }
+
+                // Only link once per message per symbol (continue to next symbol)
+                break;
               }
-
-              // Only link once per message per symbol (continue to next symbol)
-              break;
             }
           }
-        }
-      });
+        },
+        { dbPath: conduitDbPath },
+      );
 
       result.linked = edgesCreated;
     } finally {

--- a/packages/core/src/store/__tests__/writer-lease.test.ts
+++ b/packages/core/src/store/__tests__/writer-lease.test.ts
@@ -521,6 +521,34 @@ describe('Finding 1 — two project files in one process are distinct lease scop
     expect(countActive(projB, 'project', 'tasks')).toBe(0);
   }, 20_000);
 
+  it('concurrent withWriterLease across two projects writes independent rows (T12044)', async () => {
+    // AC2: two concurrent withWriterLease calls for project-A and project-B
+    // must each claim an independent active row and neither row leaks across.
+    await Promise.all([
+      withWriterLease('project', 'bulk', async () => {}, { dbPath: pathA }),
+      withWriterLease('project', 'bulk', async () => {}, { dbPath: pathB }),
+    ]);
+
+    // After both leases complete, neither file should have a lingering active row.
+    expect(countActive(projA, 'project', 'bulk')).toBe(0);
+    expect(countActive(projB, 'project', 'bulk')).toBe(0);
+  }, 20_000);
+
+  it('release of project-A withWriterLease does NOT free project-B row (T12044)', async () => {
+    // Hold project-A then release it while project-B is still active.
+    const hB = await acquireWriterLease('project', 'bulk', { dbPath: pathB });
+    expect(countActive(projB, 'project', 'bulk')).toBe(1);
+
+    await withWriterLease('project', 'bulk', async () => {}, { dbPath: pathA });
+    // A's lease completed → A's DB should be clean.
+    expect(countActive(projA, 'project', 'bulk')).toBe(0);
+    // B's lease must NOT be freed — independent scope.
+    expect(countActive(projB, 'project', 'bulk')).toBe(1);
+
+    await hB.release();
+    expect(countActive(projB, 'project', 'bulk')).toBe(0);
+  }, 20_000);
+
   it('a nested re-entrant acquire shares the grant ONLY within the same dbPath', async () => {
     const a1 = await acquireWriterLease('project', 'tasks', { dbPath: pathA });
     const a2 = await acquireWriterLease('project', 'tasks', { dbPath: pathA });

--- a/packages/core/src/store/__tests__/writer-lease.test.ts
+++ b/packages/core/src/store/__tests__/writer-lease.test.ts
@@ -522,12 +522,26 @@ describe('Finding 1 — two project files in one process are distinct lease scop
   }, 20_000);
 
   it('concurrent withWriterLease across two projects writes independent rows (T12044)', async () => {
-    // AC2: two concurrent withWriterLease calls for project-A and project-B
-    // must each claim an independent active row and neither row leaks across.
-    await Promise.all([
-      withWriterLease('project', 'bulk', async () => {}, { dbPath: pathA }),
-      withWriterLease('project', 'bulk', async () => {}, { dbPath: pathB }),
+    const bothEntered = Promise.withResolvers<void>();
+    const releaseBoth = Promise.withResolvers<void>();
+    let enteredCount = 0;
+    const holdLease = async (): Promise<void> => {
+      enteredCount += 1;
+      if (enteredCount === 2) bothEntered.resolve();
+      await releaseBoth.promise;
+    };
+
+    const leases = Promise.all([
+      withWriterLease('project', 'bulk', holdLease, { dbPath: pathA }),
+      withWriterLease('project', 'bulk', holdLease, { dbPath: pathB }),
     ]);
+
+    await bothEntered.promise;
+    expect(countActive(projA, 'project', 'bulk')).toBe(1);
+    expect(countActive(projB, 'project', 'bulk')).toBe(1);
+
+    releaseBoth.resolve();
+    await leases;
 
     // After both leases complete, neither file should have a lingering active row.
     expect(countActive(projA, 'project', 'bulk')).toBe(0);

--- a/packages/core/src/tasks/backfill-child-projections.ts
+++ b/packages/core/src/tasks/backfill-child-projections.ts
@@ -182,16 +182,23 @@ export async function backfillChildProjections(
       // insertAcRows, deleteAcRowsForTask, appendAcHistory, updateTaskFields).
       // Seam 3 (T11627): this raw tasks.db writer sidesteps the chokepoint, so
       // hold the project `bulk` lease around the write txn. `off` → pass-through.
-      await withWriterLease('project', 'bulk', async () => {
-        db.exec('BEGIN');
-        try {
-          await rebuildChildProjectionAc(tx as any, parentId, children, now);
-          db.exec('COMMIT');
-        } catch (e) {
-          db.exec('ROLLBACK');
-          throw e;
-        }
-      });
+      // T12044 (E6-L12d): pin the lease to the exact project cleo.db path resolved
+      // from the projectRoot parameter so concurrent projects route to their own rows.
+      await withWriterLease(
+        'project',
+        'bulk',
+        async () => {
+          db.exec('BEGIN');
+          try {
+            await rebuildChildProjectionAc(tx as any, parentId, children, now);
+            db.exec('COMMIT');
+          } catch (e) {
+            db.exec('ROLLBACK');
+            throw e;
+          }
+        },
+        { dbPath: resolve(projectRoot, '.cleo', 'cleo.db') },
+      );
 
       // Re-audit
       const rebuiltDbRows = acRowsStmt.all(parentId) as AcDbRow[];


### PR DESCRIPTION
## Summary
- pin conduit writes to the exact consolidated `cleo.db` path held by `LocalTransport`
- pin graph-memory bridge and child-projection backfill bulk leases to their explicit project databases
- prove two project bulk leases hold simultaneous independent rows and release without cross-project interference

## Verification
- `pnpm biome check --write .` (3,832 files, no fixes)
- `pnpm run build` (pass)
- focused conduit, backfill, and writer-lease tests (53/53 pass)
- `cleo check arch` (6/6 pass)
- `node scripts/lint-changesets.mjs` (264 entries valid)
- full suite: 18,304 passed; 16 known local worktree/history failures in six files; no changed-domain failures

Task: T12044