### PR TITLE
refactor(store): pin self-improve Pi and telemetry leases

### DIFF
--- a/packages/core/src/llm/pi/__tests__/pi-session-storage.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-session-storage.test.ts
@@ -197,7 +197,7 @@ describe('AC4.1 — tree-structured persistence round-trip', () => {
 });
 
 describe('AC4.2 — lease-held write proof', () => {
-  it('appendEntry + setLeafId acquire the project/bulk writer lease', async () => {
+  it('appendEntry + setLeafId acquire the project/bulk writer lease with explicit dbPath identity', async () => {
     const spy = vi.spyOn(writerLease, 'withWriterLease');
     const s = durableStorage('sess-lease');
 
@@ -213,6 +213,10 @@ describe('AC4.2 — lease-held write proof', () => {
     for (const call of spy.mock.calls) {
       expect(call[0]).toBe('project');
       expect(call[1]).toBe('bulk');
+      // T12045 · E6-L12e: explicit canonical dbPath must be passed.
+      const opts = call[3] as { dbPath?: string } | undefined;
+      expect(opts).toBeDefined();
+      expect(opts!.dbPath).toEqual(expect.stringContaining('.cleo/cleo.db'));
     }
   });
 
@@ -234,7 +238,10 @@ describe('AC4.2 — lease-held write proof', () => {
         message: { role: 'user', content: 'x', timestamp: 1 },
       } as SessionTreeEntry),
     ).rejects.toThrow();
-    expect(spy).toHaveBeenCalledWith('project', 'bulk', expect.any(Function));
+    // T12045: explicit dbPath passed as 4th argument.
+    expect(spy).toHaveBeenCalledWith('project', 'bulk', expect.any(Function), {
+      dbPath: expect.stringContaining('.cleo/cleo.db'),
+    });
 
     // Nothing was written outside the (rejected) lease.
     const count = (

--- a/packages/core/src/llm/pi/__tests__/pi-session-storage.test.ts
+++ b/packages/core/src/llm/pi/__tests__/pi-session-storage.test.ts
@@ -213,10 +213,7 @@ describe('AC4.2 — lease-held write proof', () => {
     for (const call of spy.mock.calls) {
       expect(call[0]).toBe('project');
       expect(call[1]).toBe('bulk');
-      // T12045 · E6-L12e: explicit canonical dbPath must be passed.
-      const opts = call[3] as { dbPath?: string } | undefined;
-      expect(opts).toBeDefined();
-      expect(opts!.dbPath).toEqual(expect.stringContaining('.cleo/cleo.db'));
+      expect(call[3]?.dbPath).toBe(join(projectCwd, '.cleo', 'cleo.db'));
     }
   });
 
@@ -238,9 +235,8 @@ describe('AC4.2 — lease-held write proof', () => {
         message: { role: 'user', content: 'x', timestamp: 1 },
       } as SessionTreeEntry),
     ).rejects.toThrow();
-    // T12045: explicit dbPath passed as 4th argument.
     expect(spy).toHaveBeenCalledWith('project', 'bulk', expect.any(Function), {
-      dbPath: expect.stringContaining('.cleo/cleo.db'),
+      dbPath: join(projectCwd, '.cleo', 'cleo.db'),
     });
 
     // Nothing was written outside the (rejected) lease.

--- a/packages/core/src/llm/pi/pi-session-storage.ts
+++ b/packages/core/src/llm/pi/pi-session-storage.ts
@@ -41,6 +41,7 @@ import type {
 } from '@earendil-works/pi-agent-core';
 import { SessionError } from '@earendil-works/pi-agent-core';
 import { getLogger } from '../../logger.js';
+import { resolveDualScopeDbPath } from '../../store/dual-scope-db.js';
 import {
   getPiSessionNativeDb,
   insertPiSessionEntry,
@@ -156,6 +157,7 @@ export class CleoSessionStorage implements SessionStorage {
   readonly #sessionId: string;
   readonly #cwd: string | undefined;
   readonly #now: () => string;
+  readonly #dbPath: string;
 
   /**
    * @param options - The daemon-stamped session id + optional cwd / clock.
@@ -164,6 +166,7 @@ export class CleoSessionStorage implements SessionStorage {
     this.#sessionId = options.sessionId;
     this.#cwd = options.cwd;
     this.#now = options.now ?? (() => new Date().toISOString());
+    this.#dbPath = resolveDualScopeDbPath('project', options.cwd);
   }
 
   /**
@@ -367,9 +370,16 @@ export class CleoSessionStorage implements SessionStorage {
     fn: (native: Awaited<ReturnType<typeof getPiSessionNativeDb>>) => void,
   ): Promise<void> {
     const native = await getPiSessionNativeDb(this.#cwd);
-    await withWriterLease('project', 'bulk', async () => {
-      fn(native);
-    });
+    // Pinned to the exact project cleo.db path so lease rows for two concurrent
+    // projects remain isolated (T12045 · E6-L12e).
+    await withWriterLease(
+      'project',
+      'bulk',
+      async () => {
+        fn(native);
+      },
+      { dbPath: this.#dbPath },
+    );
     log().debug({ sessionId: this.#sessionId }, 'pi session leased write committed');
   }
 }

--- a/packages/core/src/selfimprove/__tests__/dhq-adapter.test.ts
+++ b/packages/core/src/selfimprove/__tests__/dhq-adapter.test.ts
@@ -19,12 +19,12 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-// ── Mock the lease: capture (scope, lane) and run fn() inline ──────────────────
-const leaseCalls: Array<{ scope: string; lane: string }> = [];
+// ── Mock the lease: capture (scope, lane, opts) and run fn() inline ──────────────
+const leaseCalls: Array<{ scope: string; lane: string; opts?: unknown }> = [];
 vi.mock('../../store/writer-lease.js', () => ({
   withWriterLease: vi.fn(
-    async (scope: string, lane: string, fn: (h: unknown) => Promise<unknown>) => {
-      leaseCalls.push({ scope, lane });
+    async (scope: string, lane: string, fn: (h: unknown) => Promise<unknown>, opts?: unknown) => {
+      leaseCalls.push({ scope, lane, opts });
       return fn({});
     },
   ),
@@ -58,7 +58,7 @@ vi.mock('../../store/selfimprove-dhq-store.js', async () => {
 import { createDhqAdapter } from '../dhq-adapter.js';
 
 describe('dhq-adapter — lease discipline', () => {
-  it('upsertOpenDhq acquires the (project, bulk) lease exactly once', async () => {
+  it('upsertOpenDhq acquires the (project, bulk) lease exactly once with explicit dbPath', async () => {
     leaseCalls.length = 0;
     const adapter = createDhqAdapter({ now: () => 42 });
     await adapter.upsertOpenDhq({
@@ -70,14 +70,28 @@ describe('dhq-adapter — lease discipline', () => {
       severity: null,
       runId: 'r',
     });
-    expect(leaseCalls).toEqual([{ scope: 'project', lane: 'bulk' }]);
+    expect(leaseCalls).toHaveLength(1);
+    expect(leaseCalls[0].scope).toBe('project');
+    expect(leaseCalls[0].lane).toBe('bulk');
+    // T12045 · E6-L12e: explicit canonical dbPath identity must be passed.
+    expect(leaseCalls[0].opts).toBeDefined();
+    expect((leaseCalls[0].opts as Record<string, unknown>).dbPath).toEqual(
+      expect.stringContaining('.cleo/cleo.db'),
+    );
   });
 
-  it('recordPrUrl acquires the (project, bulk) lease exactly once', async () => {
+  it('recordPrUrl acquires the (project, bulk) lease exactly once with explicit dbPath', async () => {
     leaseCalls.length = 0;
     const adapter = createDhqAdapter({ now: () => 42 });
     await adapter.recordPrUrl('h', 'https://x/pull/1');
-    expect(leaseCalls).toEqual([{ scope: 'project', lane: 'bulk' }]);
+    expect(leaseCalls).toHaveLength(1);
+    expect(leaseCalls[0].scope).toBe('project');
+    expect(leaseCalls[0].lane).toBe('bulk');
+    // T12045 · E6-L12e: explicit canonical dbPath identity must be passed.
+    expect(leaseCalls[0].opts).toBeDefined();
+    expect((leaseCalls[0].opts as Record<string, unknown>).dbPath).toEqual(
+      expect.stringContaining('.cleo/cleo.db'),
+    );
   });
 
   it('readOpen does NOT acquire a lease (reads are lease-free)', async () => {

--- a/packages/core/src/selfimprove/__tests__/dhq-adapter.test.ts
+++ b/packages/core/src/selfimprove/__tests__/dhq-adapter.test.ts
@@ -18,14 +18,21 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { resolveDualScopeDbPath } from '../../store/dual-scope-db.js';
+import type { LeaseAcquireOptions, LeaseLane, LeaseScope } from '../../store/writer-lease.js';
 
 // ── Mock the lease: capture (scope, lane, opts) and run fn() inline ──────────────
-const leaseCalls: Array<{ scope: string; lane: string; opts?: unknown }> = [];
+const leaseCalls: Array<{ scope: LeaseScope; lane: LeaseLane; opts?: LeaseAcquireOptions }> = [];
 vi.mock('../../store/writer-lease.js', () => ({
   withWriterLease: vi.fn(
-    async (scope: string, lane: string, fn: (h: unknown) => Promise<unknown>, opts?: unknown) => {
+    async <T>(
+      scope: LeaseScope,
+      lane: LeaseLane,
+      fn: () => Promise<T>,
+      opts?: LeaseAcquireOptions,
+    ): Promise<T> => {
       leaseCalls.push({ scope, lane, opts });
-      return fn({});
+      return fn();
     },
   ),
 }));
@@ -71,13 +78,9 @@ describe('dhq-adapter — lease discipline', () => {
       runId: 'r',
     });
     expect(leaseCalls).toHaveLength(1);
-    expect(leaseCalls[0].scope).toBe('project');
-    expect(leaseCalls[0].lane).toBe('bulk');
-    // T12045 · E6-L12e: explicit canonical dbPath identity must be passed.
-    expect(leaseCalls[0].opts).toBeDefined();
-    expect((leaseCalls[0].opts as Record<string, unknown>).dbPath).toEqual(
-      expect.stringContaining('.cleo/cleo.db'),
-    );
+    expect(leaseCalls[0]?.scope).toBe('project');
+    expect(leaseCalls[0]?.lane).toBe('bulk');
+    expect(leaseCalls[0]?.opts?.dbPath).toBe(resolveDualScopeDbPath('project'));
   });
 
   it('recordPrUrl acquires the (project, bulk) lease exactly once with explicit dbPath', async () => {
@@ -85,13 +88,9 @@ describe('dhq-adapter — lease discipline', () => {
     const adapter = createDhqAdapter({ now: () => 42 });
     await adapter.recordPrUrl('h', 'https://x/pull/1');
     expect(leaseCalls).toHaveLength(1);
-    expect(leaseCalls[0].scope).toBe('project');
-    expect(leaseCalls[0].lane).toBe('bulk');
-    // T12045 · E6-L12e: explicit canonical dbPath identity must be passed.
-    expect(leaseCalls[0].opts).toBeDefined();
-    expect((leaseCalls[0].opts as Record<string, unknown>).dbPath).toEqual(
-      expect.stringContaining('.cleo/cleo.db'),
-    );
+    expect(leaseCalls[0]?.scope).toBe('project');
+    expect(leaseCalls[0]?.lane).toBe('bulk');
+    expect(leaseCalls[0]?.opts?.dbPath).toBe(resolveDualScopeDbPath('project'));
   });
 
   it('readOpen does NOT acquire a lease (reads are lease-free)', async () => {

--- a/packages/core/src/selfimprove/dhq-adapter.ts
+++ b/packages/core/src/selfimprove/dhq-adapter.ts
@@ -36,6 +36,7 @@
  * @task T11913
  */
 
+import { resolveDualScopeDbPath } from '../store/dual-scope-db.js';
 import {
   getSelfimproveDhqNativeDb,
   readOpenSelfimproveDhq,
@@ -113,6 +114,7 @@ export interface DhqAdapter {
 export function createDhqAdapter(opts: { cwd?: string; now?: () => number } = {}): DhqAdapter {
   const cwd = opts.cwd;
   const now = opts.now ?? (() => Date.now());
+  const dbPath = resolveDualScopeDbPath('project', cwd);
 
   return {
     async readOpen(questionHash: string): Promise<SelfimproveDhqRow | null> {
@@ -123,27 +125,39 @@ export function createDhqAdapter(opts: { cwd?: string; now?: () => number } = {}
     async upsertOpenDhq(input: UpsertDhqInput): Promise<void> {
       // EVERY write is leased — never raw / unleased. The lease serializes against
       // other writers on (project, bulk); the table-confinement is the accessor's.
-      await withWriterLease('project', 'bulk', async () => {
-        const native = await getSelfimproveDhqNativeDb(cwd);
-        const row: SelfimproveDhqUpsert = {
-          dhqId: input.dhqId,
-          scenario: input.scenario,
-          questionHash: input.questionHash,
-          title: input.title,
-          regressionJson: input.regressionJson,
-          severity: input.severity,
-          runId: input.runId,
-          now: now(),
-        };
-        upsertOpenSelfimproveDhq(native, row);
-      });
+      // Pinned to the exact project cleo.db path so lease rows for two concurrent
+      // projects remain isolated (T12045 · E6-L12e).
+      await withWriterLease(
+        'project',
+        'bulk',
+        async () => {
+          const native = await getSelfimproveDhqNativeDb(cwd);
+          const row: SelfimproveDhqUpsert = {
+            dhqId: input.dhqId,
+            scenario: input.scenario,
+            questionHash: input.questionHash,
+            title: input.title,
+            regressionJson: input.regressionJson,
+            severity: input.severity,
+            runId: input.runId,
+            now: now(),
+          };
+          upsertOpenSelfimproveDhq(native, row);
+        },
+        { dbPath },
+      );
     },
 
     async recordPrUrl(questionHash: string, prUrl: string): Promise<number> {
-      return withWriterLease('project', 'bulk', async () => {
-        const native = await getSelfimproveDhqNativeDb(cwd);
-        return setSelfimproveDhqPrUrl(native, questionHash, prUrl, now());
-      });
+      return withWriterLease(
+        'project',
+        'bulk',
+        async () => {
+          const native = await getSelfimproveDhqNativeDb(cwd);
+          return setSelfimproveDhqPrUrl(native, questionHash, prUrl, now());
+        },
+        { dbPath },
+      );
     },
   };
 }

--- a/packages/core/src/telemetry/__tests__/telemetry-leases.test.ts
+++ b/packages/core/src/telemetry/__tests__/telemetry-leases.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Telemetry lease-identity tests (T12045 · E6-L12e).
+ *
+ * Proves that the telemetry flush path passes explicit canonical dbPath identity
+ * to `withWriterLease` so the lease row lands in the global cleo.db arbitration
+ * file, not in an ambient cwd-resolved one.
+ *
+ * @task T12045
+ * @epic T11625
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const leaseCalls: Array<{ scope: string; lane: string; opts?: unknown }> = [];
+vi.mock('../../store/writer-lease.js', () => ({
+  ...vi.importActual('../../store/writer-lease.js'),
+  withWriterLease: vi.fn(
+    async (scope: string, lane: string, fn: (h: unknown) => Promise<unknown>, opts?: unknown) => {
+      leaseCalls.push({ scope, lane, opts });
+      return fn({});
+    },
+  ),
+}));
+
+// Mock telemetry DB so flush doesn't try to open a real SQLite file.
+vi.mock('../sqlite.js', () => ({
+  getTelemetryDb: vi.fn(async () => ({
+    insert: vi.fn(() => ({ values: vi.fn(() => ({ run: vi.fn() })) })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({ where: vi.fn(() => ({ all: vi.fn(() => []) })) })),
+    })),
+    delete: vi.fn(() => ({ where: vi.fn(() => ({ run: vi.fn() })) })),
+  })),
+  getTelemetryDbPath: vi.fn(() => '/mock/cleo-home/telemetry.db'),
+  resetTelemetryDbState: vi.fn(),
+}));
+
+// Mock telemetry config: enabled with a valid anonymousId so recordTelemetryEvent
+// proceeds past the config gate and enqueues a row into the buffer.
+vi.mock('node:fs', () => {
+  const actual = vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+    readFileSync: vi.fn(() =>
+      JSON.stringify({ enabled: true, anonymousId: 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee' }),
+    ),
+    writeFileSync: vi.fn(),
+  };
+});
+
+import { flushTelemetryBuffer, recordTelemetryEvent, resetTelemetryBufferState } from '../index.js';
+
+describe('telemetry lease identity (T12045 · E6-L12e)', () => {
+  it('_flushTelemetryBuffer passes explicit global dbPath in opts', async () => {
+    leaseCalls.length = 0;
+    resetTelemetryBufferState();
+
+    await recordTelemetryEvent({
+      domain: 'test',
+      gateway: 'query',
+      operation: 'test-op',
+      durationMs: 1,
+      exitCode: 0,
+    });
+
+    await flushTelemetryBuffer();
+
+    expect(leaseCalls.length).toBeGreaterThanOrEqual(1);
+    expect(leaseCalls[0].scope).toBe('global');
+    expect(leaseCalls[0].lane).toBe('bulk');
+    // T12045: explicit dbPath MUST be passed. The global cleo.db path is
+    // resolved via resolveDualScopeDbPath('global') at call time.
+    const opts = leaseCalls[0].opts as Record<string, unknown> | undefined;
+    expect(opts).toBeDefined();
+    expect(typeof opts!.dbPath).toBe('string');
+    expect((opts!.dbPath as string).length).toBeGreaterThan(0);
+  });
+
+  it('global-leased telemetry writes do not share scope with project-leased writes', () => {
+    // Static proof: telemetry uses 'global' scope; dhq-adapter/Pi use 'project'.
+    // The lease scope discriminator is embedded in the memo key, so a release
+    // for a project lane never reaches a global lane, and vice versa.
+    expect(leaseCalls.length).toBeGreaterThanOrEqual(1);
+    for (const call of leaseCalls) {
+      expect(call.scope).toBe('global');
+    }
+  });
+});

--- a/packages/core/src/telemetry/__tests__/telemetry-leases.test.ts
+++ b/packages/core/src/telemetry/__tests__/telemetry-leases.test.ts
@@ -10,14 +10,20 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { resolveDualScopeDbPath } from '../../store/dual-scope-db.js';
+import type { LeaseAcquireOptions, LeaseLane, LeaseScope } from '../../store/writer-lease.js';
 
-const leaseCalls: Array<{ scope: string; lane: string; opts?: unknown }> = [];
+const leaseCalls: Array<{ scope: LeaseScope; lane: LeaseLane; opts?: LeaseAcquireOptions }> = [];
 vi.mock('../../store/writer-lease.js', () => ({
-  ...vi.importActual('../../store/writer-lease.js'),
   withWriterLease: vi.fn(
-    async (scope: string, lane: string, fn: (h: unknown) => Promise<unknown>, opts?: unknown) => {
+    async <T>(
+      scope: LeaseScope,
+      lane: LeaseLane,
+      fn: () => Promise<T>,
+      opts?: LeaseAcquireOptions,
+    ): Promise<T> => {
       leaseCalls.push({ scope, lane, opts });
-      return fn({});
+      return fn();
     },
   ),
 }));
@@ -37,8 +43,8 @@ vi.mock('../sqlite.js', () => ({
 
 // Mock telemetry config: enabled with a valid anonymousId so recordTelemetryEvent
 // proceeds past the config gate and enqueues a row into the buffer.
-vi.mock('node:fs', () => {
-  const actual = vi.importActual<typeof import('node:fs')>('node:fs');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
     existsSync: vi.fn(() => true),
@@ -68,23 +74,8 @@ describe('telemetry lease identity (T12045 · E6-L12e)', () => {
     await flushTelemetryBuffer();
 
     expect(leaseCalls.length).toBeGreaterThanOrEqual(1);
-    expect(leaseCalls[0].scope).toBe('global');
-    expect(leaseCalls[0].lane).toBe('bulk');
-    // T12045: explicit dbPath MUST be passed. The global cleo.db path is
-    // resolved via resolveDualScopeDbPath('global') at call time.
-    const opts = leaseCalls[0].opts as Record<string, unknown> | undefined;
-    expect(opts).toBeDefined();
-    expect(typeof opts!.dbPath).toBe('string');
-    expect((opts!.dbPath as string).length).toBeGreaterThan(0);
-  });
-
-  it('global-leased telemetry writes do not share scope with project-leased writes', () => {
-    // Static proof: telemetry uses 'global' scope; dhq-adapter/Pi use 'project'.
-    // The lease scope discriminator is embedded in the memo key, so a release
-    // for a project lane never reaches a global lane, and vice versa.
-    expect(leaseCalls.length).toBeGreaterThanOrEqual(1);
-    for (const call of leaseCalls) {
-      expect(call.scope).toBe('global');
-    }
+    expect(leaseCalls[0]?.scope).toBe('global');
+    expect(leaseCalls[0]?.lane).toBe('bulk');
+    expect(leaseCalls[0]?.opts?.dbPath).toBe(resolveDualScopeDbPath('global'));
   });
 });

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { and, count, desc, gt, lt, sql } from 'drizzle-orm';
 import { getCleoHome } from '../paths.js';
+import { resolveDualScopeDbPath } from '../store/dual-scope-db.js';
 import { telemetryEvents } from '../store/schema/telemetry-schema.js';
 import { withWriterLease } from '../store/writer-lease.js';
 import { getTelemetryDb } from './sqlite.js';
@@ -63,12 +64,19 @@ async function _flushTelemetryBuffer(): Promise<void> {
     // Seam 3 (T11627): telemetry.db is a raw bypass writer (global-tier, sidesteps
     // the tasks chokepoint). Hold the global `bulk` lease for the whole flush batch
     // so the writes serialize against other writers. `off` mode → pass-through.
-    await withWriterLease('global', 'bulk', async () => {
-      const db = await getTelemetryDb();
-      for (const row of batch) {
-        await db.insert(telemetryEvents).values(row).run();
-      }
-    });
+    // Pinned to the global cleo.db path so the lease row lives in the canonical
+    // global arbitration file (T12045 · E6-L12e).
+    await withWriterLease(
+      'global',
+      'bulk',
+      async () => {
+        const db = await getTelemetryDb();
+        for (const row of batch) {
+          await db.insert(telemetryEvents).values(row).run();
+        }
+      },
+      { dbPath: resolveDualScopeDbPath('global') },
+    );
   } catch {
     // Non-fatal — telemetry flush must never surface errors.
   } finally {


### PR DESCRIPTION
## Summary
- pin both DHQ write paths to their canonical project `cleo.db`
- retain the exact Pi project database path at storage construction and use it for every leased write
- pin telemetry flushes to the canonical global `cleo.db`
- add typed caller assertions for exact project/global paths without ambient fallback

## Verification
- `pnpm biome check --write .` (3,833 files, no fixes)
- `pnpm run build` (pass)
- focused DHQ, Pi, telemetry, and writer-lease tests (36/36 pass)
- `cleo check arch` (6/6 pass)
- `node scripts/lint-changesets.mjs` (264 entries valid)
- full suite: 18,305 passed; 16 known local worktree/history failures in six files; no changed-domain failures

Task: T12045