### PR TITLE
refactor(store): pin nexus and claude-mem leases to canonical paths

### DIFF
--- a/packages/core/src/memory/claude-mem-migration.ts
+++ b/packages/core/src/memory/claude-mem-migration.ts
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module';
 // underscore-import: node:sqlite type alias is required for createRequire interop.
 import type { DatabaseSync as _DatabaseSyncType } from 'node:sqlite';
 import { getClaudeMemDbPath } from '../paths.js';
+import { resolveDualScopeDbPath } from '../store/dual-scope-db.js';
 import { getBrainDb, getBrainNativeDb } from '../store/memory-sqlite.js';
 import type { BRAIN_OBSERVATION_TYPES } from '../store/schema/memory-schema.js';
 import { applyPerfPragmas } from '../store/sqlite-pragmas.js';
@@ -193,7 +194,12 @@ export async function migrateClaudeMem(
     // lease (acquire-once / write-all-phases / release) so it serializes against
     // other writers. `dryRun` writes nothing; the lease is still held for the
     // read-side BEGIN IMMEDIATE batches' consistency. `off` mode → no-op handle.
-    brainBulkLease = await acquireWriterLease('project', 'bulk', { priority: 50 });
+    // T12046 (E6-L12f): pin the lease to the canonical project cleo.db path so
+    // the lease row lands in THIS project's arbitration file.
+    brainBulkLease = await acquireWriterLease('project', 'bulk', {
+      priority: 50,
+      dbPath: resolveDualScopeDbPath('project', projectRoot),
+    });
 
     // Ensure FTS5 tables exist for the rebuild at the end
     ensureFts5Tables(nativeDb);

--- a/packages/core/src/nexus/migrations/M-split-graph.ts
+++ b/packages/core/src/nexus/migrations/M-split-graph.ts
@@ -19,6 +19,7 @@ import { copyFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { getCleoHome } from '../../paths.js';
+import { resolveDualScopeDbPath } from '../../store/dual-scope-db.js';
 import { withWriterLease } from '../../store/writer-lease.js';
 
 // ---------------------------------------------------------------------------
@@ -123,68 +124,75 @@ export async function migrateToSplit(
   // registry + per-project graph DBs (global-infra, outside the consolidated
   // cleo.db). Hold the global `bulk` lease for the whole write phase so it
   // serializes against other writers. `off` mode → pass-through.
-  await withWriterLease('global', 'bulk', async () => {
-    // Step 2: Create nexus-registry.db
-    await mkdir(graphDir, { recursive: true });
-    const registryDb = new DatabaseSync(registryDbPath, { open: true }); // db-open-allowed: one-shot migration creates nexus-registry.db (not a CLEO metadata DB)
-    registryDb.exec(`ATTACH DATABASE '${legacyDbPath}' AS legacy`);
-    // Copy registry tables
-    for (const table of [
-      'project_registry',
-      'project_id_aliases',
-      'nexus_audit_log',
-      'nexus_schema_meta',
-      'user_profile',
-      'sigils',
-    ]) {
-      const tableExists =
-        (registryDb
-          .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
-          .get(table) as { name: string } | null) !== null;
-      if (!tableExists) {
-        // Create from legacy schema
-        const schemaRow = legacyDb
-          .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
-          .get(table) as { sql: string } | null;
-        if (schemaRow?.sql) {
-          registryDb.exec(schemaRow.sql);
-        }
-      }
-      try {
-        registryDb.exec(`INSERT OR IGNORE INTO main.${table} SELECT * FROM legacy.${table}`);
-      } catch {
-        // table may not exist in legacy — skip
-      }
-    }
-    registryDb.exec(`DETACH DATABASE legacy`);
-    registryDb.close();
-
-    // Step 3: Per-project graph DBs
-    for (const { project_id: projectId } of projects) {
-      const graphDbPath = join(graphDir, `${projectId}.db`);
-      const graphDb = new DatabaseSync(graphDbPath, { open: true }); // db-open-allowed: one-shot migration creates per-project graph DB (not a CLEO metadata DB)
-      graphDb.exec(`ATTACH DATABASE '${legacyDbPath}' AS legacy`);
-      for (const table of ['nexus_nodes', 'nexus_relations', 'nexus_contracts']) {
-        const schemaRow = legacyDb
-          .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
-          .get(table) as { sql: string } | null;
-        if (schemaRow?.sql) {
-          try {
-            graphDb.exec(schemaRow.sql);
-            graphDb
-              .prepare(
-                `INSERT OR IGNORE INTO main.${table} SELECT * FROM legacy.${table} WHERE project_id=?`,
-              )
-              .run(projectId);
-          } catch {
-            // skip tables that don't have project_id or don't exist
+  // T12046 (E6-L12f): pin the lease to the canonical global cleo.db path so
+  // the lease row lands in the global arbitration file.
+  await withWriterLease(
+    'global',
+    'bulk',
+    async () => {
+      // Step 2: Create nexus-registry.db
+      await mkdir(graphDir, { recursive: true });
+      const registryDb = new DatabaseSync(registryDbPath, { open: true }); // db-open-allowed: one-shot migration creates nexus-registry.db (not a CLEO metadata DB)
+      registryDb.exec(`ATTACH DATABASE '${legacyDbPath}' AS legacy`);
+      // Copy registry tables
+      for (const table of [
+        'project_registry',
+        'project_id_aliases',
+        'nexus_audit_log',
+        'nexus_schema_meta',
+        'user_profile',
+        'sigils',
+      ]) {
+        const tableExists =
+          (registryDb
+            .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+            .get(table) as { name: string } | null) !== null;
+        if (!tableExists) {
+          // Create from legacy schema
+          const schemaRow = legacyDb
+            .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
+            .get(table) as { sql: string } | null;
+          if (schemaRow?.sql) {
+            registryDb.exec(schemaRow.sql);
           }
         }
+        try {
+          registryDb.exec(`INSERT OR IGNORE INTO main.${table} SELECT * FROM legacy.${table}`);
+        } catch {
+          // table may not exist in legacy — skip
+        }
       }
-      graphDb.exec(`DETACH DATABASE legacy`);
-      graphDb.close();
-    }
-  });
+      registryDb.exec(`DETACH DATABASE legacy`);
+      registryDb.close();
+
+      // Step 3: Per-project graph DBs
+      for (const { project_id: projectId } of projects) {
+        const graphDbPath = join(graphDir, `${projectId}.db`);
+        const graphDb = new DatabaseSync(graphDbPath, { open: true }); // db-open-allowed: one-shot migration creates per-project graph DB (not a CLEO metadata DB)
+        graphDb.exec(`ATTACH DATABASE '${legacyDbPath}' AS legacy`);
+        for (const table of ['nexus_nodes', 'nexus_relations', 'nexus_contracts']) {
+          const schemaRow = legacyDb
+            .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
+            .get(table) as { sql: string } | null;
+          if (schemaRow?.sql) {
+            try {
+              graphDb.exec(schemaRow.sql);
+              graphDb
+                .prepare(
+                  `INSERT OR IGNORE INTO main.${table} SELECT * FROM legacy.${table} WHERE project_id=?`,
+                )
+                .run(projectId);
+            } catch {
+              // skip tables that don't have project_id or don't exist
+            }
+          }
+        }
+        graphDb.exec(`DETACH DATABASE legacy`);
+        graphDb.close();
+      }
+    },
+    { dbPath: resolveDualScopeDbPath('global') },
+  );
 
   legacyDb.close();
 


### PR DESCRIPTION
## Summary
- pin the nexus split-graph migration lease to resolveDualScopeDbPath('global') so the lease row lands in the canonical global arbitration file
- pin the claude-mem migration lease to resolveDualScopeDbPath('project', projectRoot) so the lease row lands in THIS project's arbitration file
- the session-manifest-mirror callsite was already migrated in a prior cycle

## Verification
- pnpm biome check --write . (3,833 files, no fixes)
- pnpm run build (pass)
- focused writer-lease tests (22/22 pass)
- cleo check arch (6/6 pass)
- node scripts/lint-changesets.mjs (264 entries valid)

Task: T12046
