### PR TITLE
fix(ci): add build step to release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -291,6 +291,16 @@ jobs:
         run: pnpm install --frozen-lockfile
         timeout-minutes: 5
 
+      - name: Build CLI
+        run: pnpm run build
+        timeout-minutes: 15
+
+      - name: Link cleo CLI
+        run: |
+          chmod +x packages/cleo/bin/cleo.js
+          ln -sf "$PWD/packages/cleo/bin/cleo.js" /usr/local/bin/cleo
+        timeout-minutes: 1
+
       # R-205(a)/(b): resolve plan — call `cleo release plan` if sha is empty,
       # otherwise verify the existing plan blob via sha256.
       - name: Resolve release plan

--- a/packages/core/templates/workflows/release-prepare.yml.tmpl
+++ b/packages/core/templates/workflows/release-prepare.yml.tmpl
@@ -291,6 +291,16 @@ jobs:
         run: {{INSTALL_CMD}}
         timeout-minutes: 5
 
+      - name: Build CLI
+        run: pnpm run build
+        timeout-minutes: 15
+
+      - name: Link cleo CLI
+        run: |
+          chmod +x packages/cleo/bin/cleo.js
+          ln -sf "$PWD/packages/cleo/bin/cleo.js" /usr/local/bin/cleo
+        timeout-minutes: 1
+
       # R-205(a)/(b): resolve plan — call `cleo release plan` if sha is empty,
       # otherwise verify the existing plan blob via sha256.
       - name: Resolve release plan


### PR DESCRIPTION
## Summary
- add `pnpm run build` step to the bump-pr job in release-prepare workflow
- symlink `cleo` to `/usr/local/bin/cleo` after build so all subsequent steps can invoke it
- fix applies to both the template and the rendered workflow

## Root Cause
The bump-pr job ran `cleo release plan`, `cleo version-bump`, and `cleo release changelog` without ever building the CLI binary, causing exit 127 (`cleo: command not found`).

## Verification
- `node scripts/lint-deployed-template-parity.mjs` — PASS (deployed matches template)

Task: T12047
