### PR TITLE
chore: add release plan for v2026.8.1

### DIFF
--- a/.cleo/release/v2026.8.1.plan.json
+++ b/.cleo/release/v2026.8.1.plan.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.8.1",
+  "resolvedVersion": "v2026.8.1",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T11249",
+  "releaseKind": "regular",
+  "createdAt": "2026-08-04T23:13:10.154Z",
+  "createdBy": "keatonhoskins",
+  "previousVersion": "v2026.7.2",
+  "previousTag": "v2026.7.2",
+  "previousShippedAt": "2026-07-01T21:21:14.681Z",
+  "tasks": [
+    {
+      "id": "T12035",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L11: Upgrade Drizzle rc.4 and align Node 24 SQLite types",
+      "evidenceAtoms": [
+        "pr:1140"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12036",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L12: Add path-keyed CleoRuntime store registry",
+      "evidenceAtoms": [
+        "pr:1141"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12042",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L12b: Key writer leases by runtime entry identity",
+      "evidenceAtoms": [
+        "pr:1142"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12043",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L12c: Adapt exodus abort fixture to explicit DB identity",
+      "evidenceAtoms": [
+        "pr:1142"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12044",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L12d: Pass explicit lease identity in conduit, memory graph, and task backfill",
+      "evidenceAtoms": [
+        "pr:1143"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12045",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L12e: Pass explicit lease identity in self-improve, Pi, and telemetry",
+      "evidenceAtoms": [
+        "pr:1144"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12046",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "E6-L12f: Pass explicit lease identity in nexus, sessions, and claude-memory migration",
+      "evidenceAtoms": [
+        "pr:1145"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12047",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "Fix release-prepare workflow: add build step before cleo CLI invocation",
+      "evidenceAtoms": [
+        "pr:1146"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    }
+  ],
+  "changelog": {
+    "features": [
+      "T12035",
+      "T12036",
+      "T12042",
+      "T12043",
+      "T12044",
+      "T12045",
+      "T12046",
+      "T12047"
+    ],
+    "fixes": [],
+    "chores": [],
+    "breaking": []
+  },
+  "gates": [
+    {
+      "name": "test",
+      "atom": "tool:test",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-04T23:13:10.154Z",
+      "resolvedCommand": "pnpm run test",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "build",
+      "atom": "tool:build",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-04T23:13:10.154Z",
+      "resolvedCommand": "pnpm run build",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "lint",
+      "atom": "tool:lint",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-04T23:13:10.154Z",
+      "resolvedCommand": "npx biome check .",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "typecheck",
+      "atom": "tool:typecheck",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-04T23:13:10.154Z",
+      "resolvedCommand": "npx tsc --noEmit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "audit",
+      "atom": "tool:audit",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-04T23:13:10.154Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "security-scan",
+      "atom": "tool:security-scan",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-04T23:13:10.154Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    }
+  ],
+  "platformMatrix": [
+    {
+      "platform": "any",
+      "publisher": "npm",
+      "package": "@cleocode/cleo"
+    }
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true,
+    "preflightWarnings": [
+      "Skipped 264 out-of-scope changeset entries whose task anchors are not part of this release plan"
+    ]
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned",
+  "meta": {
+    "firstEverRelease": false,
+    "archetype": "node",
+    "releaseNotes": "",
+    "changesetEntryCount": 0,
+    "changesetIds": [],
+    "taskIds": [
+      "T12035",
+      "T12036",
+      "T12042",
+      "T12043",
+      "T12044",
+      "T12045",
+      "T12046",
+      "T12047"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- commit pre-computed release plan for v2026.8.1 so the release-prepare workflow can verify it via sha256

## Why
The release-prepare workflow needs the plan file in the repo to verify its sha256 hash. Without it, the workflow tries to generate a fresh plan without task scope, which fails.

Task: release-v2026.8.1
