### PR TITLE
Release v2026.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2026.8.1] (2026-08-04)
+
+_No changeset entries parsed for this release._
+
+_Add entries under `.changeset/*.md` and re-run `cleo release plan` to populate this section._
+
 ## [2026.7.2] (2026-07-01)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.5.105"
+version = "2026.8.1"
 rust-version = "1.94"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "2026.8.1"
+version = "2026.5.105"
 rust-version = "1.94"
 
 [workspace.dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/monorepo",
-  "version": "2026.5.126",
+  "version": "2026.8.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/adapters",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "description": "Unified provider adapters for CLEO (Claude Code, OpenCode, Cursor)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/agents",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "description": "CLEO agent protocols and templates",
   "type": "module",
   "license": "MIT",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cleocode/animations",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "type": "module",
-  "description": "CLEO terminal animations \u2014 braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
+  "description": "CLEO terminal animations — braille spinners, progress bars, and sparks for the cleo CLI and CleoOS. Forked from gunnargray-dev/unicode-animations (MIT).",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@cleocode/brain",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": false,
   "type": "module",
-  "description": "CLEO unified-graph Brain substrate \u2014 BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",
+  "description": "CLEO unified-graph Brain substrate — BRAIN + NEXUS + TASKS + CONDUIT + SIGNALDOCK projection",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {

--- a/packages/caamp/package.json
+++ b/packages/caamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {

--- a/packages/cant/package.json
+++ b/packages/cant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/cant",
-  "version": "2026.5.122",
-  "description": "CANT DSL \u2014 cant-core (SSoT) parser, validator, and pipeline executor via napi-rs; agent identity, message parsing, and migration utilities",
+  "version": "2026.8.1",
+  "description": "CANT DSL — cant-core (SSoT) parser, validator, and pipeline executor via napi-rs; agent identity, message parsing, and migration utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/cleo-os/package.json
+++ b/packages/cleo-os/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/cleo-os",
-  "version": "2026.5.126",
-  "description": "CleoOS \u2014 the batteries-included agentic development environment wrapping Pi",
+  "version": "2026.8.1",
+  "description": "CleoOS — the batteries-included agentic development environment wrapping Pi",
   "type": "module",
   "main": "./dist/cli.js",
   "bin": {
@@ -13,7 +13,7 @@
     "build:extensions": "tsc -p tsconfig.extensions.json",
     "build:postinstall": "tsc -p tsconfig.postinstall.json",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.extensions.json --noEmit && tsc -p tsconfig.postinstall.json --noEmit",
-    "prepublishOnly": "pnpm run build && test -f extensions/tui-theme.js && test -f extensions/cleo-cant-bridge.js && test -f extensions/cleo-startup.js && test -f extensions/cleo-chatroom.js && test -f extensions/cleo-agent-monitor.js && test -f extensions/cleo-hooks-bridge.js && test -f bin/postinstall.js || (echo 'ERROR: extensions or postinstall not built \u2014 run pnpm run build first' && exit 1)",
+    "prepublishOnly": "pnpm run build && test -f extensions/tui-theme.js && test -f extensions/cleo-cant-bridge.js && test -f extensions/cleo-startup.js && test -f extensions/cleo-chatroom.js && test -f extensions/cleo-agent-monitor.js && test -f extensions/cleo-hooks-bridge.js && test -f bin/postinstall.js || (echo 'ERROR: extensions or postinstall not built — run pnpm run build first' && exit 1)",
     "test": "vitest run",
     "postinstall": "node bin/postinstall.js"
   },

--- a/packages/cleo/package.json
+++ b/packages/cleo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/cleo",
-  "version": "2026.5.126",
+  "version": "2026.8.1",
   "description": "CLEO CLI — the assembled product consuming @cleocode/core",
   "type": "module",
   "main": "./dist/cli/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/contracts",
-  "version": "2026.5.126",
+  "version": "2026.8.1",
   "description": "Domain types, interfaces, and contracts for the CLEO ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/core",
-  "version": "2026.5.126",
-  "description": "CLEO core business logic kernel \u2014 tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
+  "version": "2026.8.1",
+  "description": "CLEO core business logic kernel — tasks, sessions, memory, orchestration, lifecycle, with bundled SQLite store",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/git-shim/package.json
+++ b/packages/git-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/git-shim",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": false,
   "type": "module",
   "description": "Harness-agnostic git shim for CLEO agent branch-protection (T1118)",

--- a/packages/lafs/package.json
+++ b/packages/lafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/lafs",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": false,
   "type": "module",
   "description": "LLM-Agent-First Specification schemas and conformance tooling",

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@cleocode/nexus",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": false,
   "type": "module",
-  "description": "CLEO project registry and code intelligence \u2014 unified nexus package",
+  "description": "CLEO project registry and code intelligence — unified nexus package",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@cleocode/paths",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": false,
   "type": "module",
-  "description": "CLEO XDG/env-paths SSoT \u2014 createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",
+  "description": "CLEO XDG/env-paths SSoT — createPlatformPathsResolver factory, cleo-bound platform paths, project hash + worktree root primitives, isAbsolutePath. Zero-dep leaf package consumed by core, worktree, brain, adapters, and caamp.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/playbooks/package.json
+++ b/packages/playbooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/playbooks",
-  "version": "2026.5.122",
-  "description": "Playbook DSL + runtime for CLEO \u2014 T889 Orchestration Coherence v3",
+  "version": "2026.8.1",
+  "description": "Playbook DSL + runtime for CLEO — T889 Orchestration Coherence v3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/runtime",
-  "version": "2026.5.122",
-  "description": "Long-running process layer for CLEO \u2014 agent polling, SSE connections, heartbeat, key rotation",
+  "version": "2026.8.1",
+  "description": "Long-running process layer for CLEO — agent polling, SSE connections, heartbeat, key rotation",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/skills",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "description": "CLEO skill definitions - bundled with CLEO monorepo",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleocode/studio",
-  "version": "2026.5.122",
-  "description": "CLEO Studio \u2014 unified web portal for Nexus, Brain, and Tasks visualization",
+  "version": "2026.8.1",
+  "description": "CLEO Studio — unified web portal for Nexus, Brain, and Tasks visualization",
   "type": "module",
   "private": false,
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/utils",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": true,
   "type": "module",
   "description": "CLEO shared pure-utility leaf — zero-dependency, stateless helpers (formatBytes, …) collapsed from duplicated inline copies across packages. Bundled into @cleocode/cleo, never published (owner decision: single published artifact).",

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/worktree",
-  "version": "2026.5.122",
+  "version": "2026.8.1",
   "private": false,
   "type": "module",
   "description": "Native CLEO worktree backend SDK",


### PR DESCRIPTION
## Release v2026.8.1

Version bump across 23 files from 2026.5.x to 2026.8.1.

### Shipped in this release

| Task | Description | PR |
|------|-------------|-----|
| T12035 | Drizzle rc.4 cache initialization fix | #1140 |
| T12036 | Path-keyed CleoRuntime store registry | #1141 |
| T12042/T12043 | Exact-handle writer-lease identity + exodus fixture | #1142 |
| T12044 | Conduit, graph-memory, backfill lease migration | #1143 |
| T12045 | DHQ, Pi, telemetry lease migration | #1144 |
| T12046 | Nexus, claude-mem lease migration | #1145 |
| T12047 | Release-prepare workflow build fix | #1146 |

### Architectural changes

- **Drizzle rc.4**: Fixed cache initialization ordering; typed DB session access without any/unknown shortcuts
- **CleoRuntime**: Path-keyed store registry with scoped ProjectStore/GlobalStore, single-flight acquisition, identity-guarded close
- **Writer leases**: All withWriterLease/acquireWriterLease callers now pass explicit canonical dbPath identity. Process-global/cwd-default lease routing eliminated. Exact-handle WeakMap binding prevents cross-project lease theft.

### GitHub issues closed

- #1116: Implemented gate commit-reachability for integration branches (fixed via T12028)
