### PR TITLE
chore: gitignore studio-dist and land stranded .cleo/rcasd drafts

### DIFF
--- a/.cleo/rcasd/T11676-adr-reconcile-plan-2026-06-05.md
+++ b/.cleo/rcasd/T11676-adr-reconcile-plan-2026-06-05.md
@@ -1,0 +1,112 @@
+# T11676 — ADR Cross-Store Reconciliation Plan
+
+**Generated:** 2026-06-05 · READ-ONLY analysis · NOTHING IN THIS PLAN HAS BEEN EXECUTED.
+**Grounded in:** `adr-cross-store-identity-map` (T11191) + ratified `docs-ssot-vault-reconciliation` policy.
+**Scope:** the 11 divergent ADR numbers — 051(×3), 052, 053, 054, 068(×3), 070, 072, 078, 079, 086, 088.
+
+## Locked policy (NOT re-litigated)
+
+1. **SLUG-PRIMARY** — the kebab slug is the canonical handle. ADR numbers are display aliases only. NEVER renumber a slug to resolve a collision; resolve collisions by content-review + (for true dups) supersession. New display aliases come from next-free numbers, no reuse.
+2. **cleo.db `docs_*` is the SOLE authority.** `.cleo/adrs/*.md` and `docs/adr/*.md` on disk are DERIVED projections; cleo.db wins on drift.
+
+## Decisive finding that reframes the task
+
+The collisions are **NOT drifted copies of one ADR.** Every shared number maps to **distinct decisions with distinct titles** (see table). And critically:
+
+**21 of the 25 divergent files are NOT in cleo.db (the SSoT) at all** — they live only on disk in `.cleo/adrs/` (legacy authoritative store) and `docs/adr/`. Only 4 distinct contents are in the SSoT today: `ADR-078-docs-provenance` (sha `28fcc3e4`), `adr-boundary-registry` (sha `0866e1c7`, = docs/adr ADR-078-boundary-registry — present TWICE as duplicate rows), `adr-086-cli-output-contract-e9` (sha `31398d1e`), plus the already-renamed `adr-080`/`adr-081`/`adr-082`.
+
+Therefore the reconciliation is mostly **INGEST disk-only distinct decisions into the SSoT and assign each a unique display alias** — not supersede-the-loser dedup. The only true dedup is the duplicate `adr-boundary-registry` rows; the only sanctioned deletes are the two `adr-079-r1/r2` forwarding stubs.
+
+## Next-free display-alias pool
+
+Confirmed ground truth across both stores + db: only gaps are **040, 060**; max occupied = **089** (083–089 all distinct live ADRs). So next-free pool, in order: **040, 060, 090, 091, 092, 093, …**.
+
+> ⚠️ **ADR-090 is RESERVED** by policy for the slug-primary ADR (T11193, per reconciliation doc §5). Do NOT consume 090 for an alias without owner confirmation — see OPEN QUESTIONS.
+
+## (a) Disposition TABLE
+
+Legend: store `A`=`.cleo/adrs/`, `D`=`docs/adr/`, `DB`=cleo.db SSoT. sha = first 12.
+
+| # | distinct docs + store | same/different | action | canonical slug (handle) | stale copies to drop |
+|---|---|---|---|---|
+| **051** | `ADR-051-override-patterns` (A, cca796c2) · `ADR-051-programmatic-gate-integrity` (A, 88fef39a) · `ADR-051-worktree-extension` (A, 6a63832c) | **3 DIFFERENT decisions** (override patterns ≠ gate integrity ≠ worktree evidence ext) | KEEP ALL 3; ingest each to SSoT; assign distinct display aliases | `adr-051-programmatic-gate-integrity` keeps 051; `adr-051-override-patterns`→**040**; `adr-051-worktree-extension`→**060** *(provisional, owner-confirm which keeps 051 — see OQ-1)* | none (no dup content) |
+| **052** | `ADR-052-caamp-keeps-commander` (A, 87e6300f) · `ADR-052-sdk-consolidation` (A, 8572746e) | **2 DIFFERENT** | KEEP BOTH; ingest both | `adr-052-sdk-consolidation` keeps 052; `adr-052-caamp-keeps-commander`→**090** *(provisional, OQ-2)* | none |
+| **053** | `ADR-053-playbook-runtime` (A, 5fde3e69) · `ADR-053-project-agnostic-release-pipeline` (A, 1a4f4c4c) | **2 DIFFERENT** | KEEP BOTH; ingest both | `adr-053-playbook-runtime` keeps 053; `adr-053-project-agnostic-release-pipeline`→next-free | none |
+| **054** | `ADR-054-manifest-unification` (A, a0580cef) · `ADR-054-migration-system-hybrid-path-a-plus` (A, 9865ec17) | **2 DIFFERENT** | KEEP BOTH; ingest both | `adr-054-migration-system-hybrid-path-a-plus` keeps 054; `adr-054-manifest-unification`→next-free | none |
+| **068** | `ADR-068-canonical-agent-system` (A, 90c07fc9) · `ADR-068-cleo-database-charter` (A, 0b57a475) · `ADR-068-per-worktree-handoff` (D, 71e12a3e) | **3 DIFFERENT** | KEEP ALL 3; ingest all 3 | `adr-068-cleo-database-charter` keeps 068 *(it is the canon cited in AGENTS.md)*; other two→next-free | none |
+| **070** | `ADR-070-three-tier-orchestration` (A, 0e43735c) · `ADR-070-verifier-backed-ac-auditor-loop` (A, 1a995876) | **2 DIFFERENT** | KEEP BOTH; ingest both | `adr-070-three-tier-orchestration` keeps 070; other→next-free | none |
+| **072** | `ADR-072-unified-llm-provider-architecture` (A, c28ec017, frontmatter id=ADR-072) · `ADR-072-nexus-db-split` (D, c8cc2b60) | **2 DIFFERENT** | KEEP BOTH; ingest both | `adr-072-unified-llm-provider-architecture` keeps 072 (declares id ADR-072); `adr-072-nexus-db-split`→next-free | none |
+| **078** | `ADR-078-docs-provenance` (A+**DB** 28fcc3e4) · `ADR-078-boundary-registry` (D, 0866e1c7 = **DB** slug `adr-boundary-registry`, **2 dup rows**) | **2 DIFFERENT** | KEEP BOTH (both already in SSoT); assign aliases; **dedup the 2 boundary-registry rows** | `adr-078-docs-provenance` keeps 078; `adr-boundary-registry`→next-free | **1 duplicate cleo.db row** of `adr-boundary-registry` (same sha 0866e1c7, owners T10176 & T10223) |
+| **079** | `ADR-079-docs-sdk-boundary-contract` (A, 0113f7f7) · `adr-079-r1-ac-stable-ids` (A, 1a545ec6 — STUB) · `adr-079-r2-satisfies-binding` (A, 0fa5e68f — STUB) · `adr-079-r2-satisfies-binding` (**DB**, 81ef246e — pre-rename FULL body, status Proposed) | r1/r2 = **TOMBSTONE forwarding stubs**; the `-079-docs-sdk-boundary-contract` is a real ADR; the DB r2 blob = stale pre-rename content of the now-canonical `adr-081` | ingest `adr-079-docs-sdk-boundary-contract`; **DELETE r1/r2 disk stubs**; **supersede the stale DB r2 blob → `adr-081-satisfies-binding`** | `adr-079-docs-sdk-boundary-contract` keeps 079 | **DELETE** disk `adr-079-r1-ac-stable-ids.md` + `adr-079-r2-satisfies-binding.md`; **retire** stale DB blob `81ef246e` (superseded by adr-081 65→44c9f737/44c9f737) |
+| **086** | `ADR-086-cli-output-contract-e9` (A+**DB** 31398d1e) · `ADR-086-nested-nexus-disposition` (D, 55d8ab46) | **2 DIFFERENT** | KEEP BOTH; ingest the disk-only one | `adr-086-cli-output-contract-e9` keeps 086 (canon cited in AGENTS.md, already SSoT); `adr-086-nested-nexus-disposition`→next-free | none |
+| **088** | `ADR-088-pm-core-v2-workgraph-relations-completion-criteria` (D, 28495951) · `ADR-088-release-pipeline-coherence` (D, 741bca80 — **content titles itself "ADR-087"**) | **2 DIFFERENT** + **MISLABEL** | KEEP BOTH; ingest both. `…-pm-core-v2…` keeps 088. `…-release-pipeline-coherence` content claims 087 but **087 is already taken** by `ADR-087-worktree-ffi-topology` → CANNOT reclaim 087 → assign next-free | `adr-pm-core-v2-workgraph-relations-completion` (= db slug, already SSoT) keeps 088; `adr-088-release-pipeline-coherence`→next-free *(OQ-3)* | none |
+
+Totals: **MERGE/supersede = 2** (1 dup `adr-boundary-registry` row + 1 stale DB `adr-079-r2` blob→adr-081) · **KEEP-BOTH + alias = 19 distinct decisions** across 9 numbers · **DELETE = 2** (079-r1/r2 disk stubs).
+
+## (b) Proposed ORDERED `cleo docs` operations — ⛔ NOT-EXECUTED (proposal only)
+
+> These are the operations the IMPLEMENTATION step (a separate, gated task) WOULD run. None were run in this analysis. Exact slugs/aliases for the "→next-free" rows are pending the OPEN QUESTIONS owner decisions; placeholders below use the provisional pool 040/060/090/091/… in number-then-file order.
+
+**Phase 1 — INGEST disk-only distinct decisions into the SSoT** (`cleo docs add`, type=adr). Each keeps its slug; display-alias number set via the slug-aware numbering surface (T10159 `numbering.ts`) at ingest:
+
+```
+# (slug-primary; number = display alias only)
+cleo docs add T<owner> .cleo/adrs/ADR-051-override-patterns.md            --type adr --slug adr-051-override-patterns
+cleo docs add T<owner> .cleo/adrs/ADR-051-programmatic-gate-integrity.md  --type adr --slug adr-051-programmatic-gate-integrity
+cleo docs add T<owner> .cleo/adrs/ADR-051-worktree-extension.md           --type adr --slug adr-051-worktree-extension
+cleo docs add T<owner> .cleo/adrs/ADR-052-caamp-keeps-commander.md        --type adr --slug adr-052-caamp-keeps-commander
+cleo docs add T<owner> .cleo/adrs/ADR-052-sdk-consolidation.md            --type adr --slug adr-052-sdk-consolidation
+cleo docs add T<owner> .cleo/adrs/ADR-053-playbook-runtime.md             --type adr --slug adr-053-playbook-runtime
+cleo docs add T<owner> .cleo/adrs/ADR-053-project-agnostic-release-pipeline.md --type adr --slug adr-053-project-agnostic-release-pipeline
+cleo docs add T<owner> .cleo/adrs/ADR-054-manifest-unification.md         --type adr --slug adr-054-manifest-unification
+cleo docs add T<owner> .cleo/adrs/ADR-054-migration-system-hybrid-path-a-plus.md --type adr --slug adr-054-migration-system-hybrid-path-a-plus
+cleo docs add T<owner> .cleo/adrs/ADR-068-canonical-agent-system.md       --type adr --slug adr-068-canonical-agent-system
+cleo docs add T<owner> .cleo/adrs/ADR-068-cleo-database-charter.md        --type adr --slug adr-068-cleo-database-charter
+cleo docs add T<owner> docs/adr/ADR-068-per-worktree-handoff.md           --type adr --slug adr-068-per-worktree-handoff
+cleo docs add T<owner> .cleo/adrs/ADR-070-three-tier-orchestration.md     --type adr --slug adr-070-three-tier-orchestration
+cleo docs add T<owner> .cleo/adrs/ADR-070-verifier-backed-ac-auditor-loop.md --type adr --slug adr-070-verifier-backed-ac-auditor-loop
+cleo docs add T<owner> .cleo/adrs/ADR-072-unified-llm-provider-architecture.md --type adr --slug adr-072-unified-llm-provider-architecture
+cleo docs add T<owner> docs/adr/ADR-072-nexus-db-split.md                 --type adr --slug adr-072-nexus-db-split
+cleo docs add T<owner> .cleo/adrs/ADR-079-docs-sdk-boundary-contract.md   --type adr --slug adr-079-docs-sdk-boundary-contract
+cleo docs add T<owner> docs/adr/ADR-086-nested-nexus-disposition.md       --type adr --slug adr-086-nested-nexus-disposition
+cleo docs add T<owner> docs/adr/ADR-088-pm-core-v2-workgraph-relations-completion-criteria.md --type adr --slug adr-088-pm-core-v2-workgraph-relations-completion-criteria
+cleo docs add T<owner> docs/adr/ADR-088-release-pipeline-coherence.md     --type adr --slug adr-088-release-pipeline-coherence
+```
+*(078-docs-provenance + 086-cli-output-contract-e9 + boundary-registry already in SSoT — NOT re-added.)*
+
+**Phase 2 — Assign display aliases** to the loser-of-collision slugs from the next-free pool (one alias-set op per slug; mechanism = the slug-aware numbering allocator). 13 slugs need a fresh alias (the 13 "→next-free" rows). Owner-confirm the pool ordering first (OQ-1/2/3).
+
+**Phase 3 — Dedup the duplicate SSoT row** (`adr-boundary-registry`, 2 rows same sha 0866e1c7, owners T10176/T10223): drop ONE attachment row (keep the canonical owner), content blob is shared so no data loss.
+
+**Phase 4 — Supersede the stale DB tombstone blob** for the pre-rename r2:
+```
+# logical supersede: DB blob 81ef246e (slug adr-079-r2-satisfies-binding, status Proposed)
+#   → canonical adr-081-satisfies-binding (sha 44c9f737, already SSoT)
+cleo docs ... supersede adr-079-r2-satisfies-binding -> adr-081-satisfies-binding   # exact verb TBD by impl
+```
+
+**Phase 5 — DELETE the two disk forwarding stubs** (079-r1/r2) — see DESTRUCTIVE section.
+
+**Phase 6 — Regenerate `docs/adr/` + `.cleo/adrs/` projections from the SSoT** once `cleo docs publish` is idempotent + `cleo check canon publish` gate exists (per reconciliation §5 PHASE 1d/5). This is the only step that rewrites on-disk files, and only DB→disk.
+
+## DESTRUCTIVE STEPS — REQUIRE OWNER GATE
+
+Every operation below mutates authoritative state and must NOT run without explicit owner approval. None executed.
+
+1. **DELETE disk file** `.cleo/adrs/adr-079-r1-ac-stable-ids.md` — sanctioned tombstone; content is a forwarding stub → `adr-080-ac-stable-ids` (which exists in SSoT, sha 65b41618). Git-tracked: removal is a tracked-file delete.
+2. **DELETE disk file** `.cleo/adrs/adr-079-r2-satisfies-binding.md` — sanctioned tombstone; forwarding stub → `adr-081-satisfies-binding` (SSoT sha 44c9f737). Git-tracked.
+3. **DROP one duplicate SSoT attachment row** of `adr-boundary-registry` (sha 0866e1c7 appears twice, owners T10176 & T10223). Shared blob → no content loss; verify which owner row is canonical before dropping.
+4. **SUPERSEDE/retire the stale DB blob** `81ef246e` (slug `adr-079-r2-satisfies-binding`, the pre-rename FULL Proposed body) in favor of `adr-081-satisfies-binding`. This changes SSoT provenance edges.
+5. **(Phase 6) OVERWRITE on-disk projections** `.cleo/adrs/*.md` + `docs/adr/*.md` when regenerating from the SSoT. DB→disk only; gated on idempotent publish.
+
+**No `git commit`/`push`, no `cleo exodus migrate`, no DB schema change is implied by this plan.**
+
+## OPEN QUESTIONS FOR OWNER
+
+- **OQ-1 (051 — which keeps display 051):** three distinct decisions share 051. Provisional: `programmatic-gate-integrity` keeps 051 (it is the override/evidence ADR most-cited by CLEO-INJECTION's evidence ritual). Confirm, or pick a different anchor; the other two take 040/060.
+- **OQ-2 (alias-pool ordering & 040/060 reuse):** is it acceptable to assign the historical gaps **040** and **060** as fresh display aliases? Policy says "next-free, no reuse" — 040/060 were never assigned, so they are free, but they are low/out-of-sequence visually. Alternative: assign everything sequentially from **091+** and leave 040/060 documented as permanent historical gaps (T11192). Owner to choose.
+- **OQ-3 (088/087 mislabel):** `ADR-088-release-pipeline-coherence.md` content titles itself **"ADR-087"**, but **087 is already taken** by `ADR-087-worktree-ffi-topology`. It cannot reclaim 087. Confirm it should take a fresh next-free alias and its body's "ADR-087" header be corrected to its new alias on next regeneration (Phase 6).
+- **OQ-4 (ADR-090 reservation):** the reconciliation doc reserves **ADR-090** for the slug-primary policy ADR (T11193). Should the alias pool SKIP 090 (use 091+), or is 090 already consumed by T11193? Affects every "→next-free" assignment.
+- **OQ-5 (canonical owner of duplicate boundary-registry row):** two SSoT rows for `adr-boundary-registry` exist under owners T10176 and T10223 — which owner is canonical to keep when dropping the duplicate?
+- **OQ-6 (ingest owner / authorship):** `cleo docs add` requires an owner task id. Should all 20 re-ingested ADRs be owned by T11676 (this reconciliation), or should each retain its original authoring task (recoverable from git history)? Original-author preserves provenance but is more work.
+- **OQ-7 (disk projection authority during transition):** until Phase 6 idempotent publish lands, `.cleo/adrs/` remains the de-facto authoritative copy for the 21 not-yet-ingested ADRs. Confirm the SSoT-wins rule is suspended for these until ingest completes, to avoid the DB (which lacks them) "winning" with emptiness.

--- a/.cleo/rcasd/cleo-docs-as-obsidian-buildplan-2026-06-06.md
+++ b/.cleo/rcasd/cleo-docs-as-obsidian-buildplan-2026-06-06.md
@@ -1,0 +1,38 @@
+# Cleo Docs IS Obsidian — build plan (research synthesis 2026-06-06)
+
+Source: research workflow `cleo-docs-as-obsidian-research` (5 agents). Full findings:
+`~/.temp/claude-1000/-mnt-projects-cleocode/cfafb395-*/tasks/w3b1zy55o.output`.
+Complements the ratified `.cleo/rcasd/obsidian-view-design-2026-06-05.md`.
+
+## Verdict
+~70–75% to BIDIRECTIONAL Obsidian integration; ~30–40% to STANDALONE ("don't NEED Obsidian").
+Dominant gap is NOT transport (gateway HTTP+SSE primitives exist) — it's that the **docs SSoT's own read/write core is unreliable**, and the **docs domain is another half-migrated exodus domain** (same class as the provenance cutover): `display_alias` is split-brain (on live 43-row `attachments`, absent on the 2765-row `docs_attachments`), `docs_wikilinks` has 0 rows, slug-fetch is broken.
+
+## The reframe vs the ratified plan
+- Ratified plan = a thin EXTERNAL Obsidian plugin as a live **read-only derived view** of cleo.db.
+- User reframe ("Cleo Docs IS Obsidian, don't NEED Obsidian") = CLEO must host its OWN editor + backlinks + graph (Studio) AND accept writes back. That's 2–3 phases beyond the ratified view (net-new Studio editor app + vault→cleo.db inbound sync). Re-scope accordingly — "thin plugin" ≠ "standalone Obsidian".
+
+## Smallest shippable proof (CORE-first, no UI/daemon)
+1. Run `rebuildDocsWikilinks()` once against the 2765-row corpus → `docs_wikilinks` 0 → real edge graph (idempotent). **Cheapest high-leverage unblock.**
+2. Fix `docs.fetch` to accept a **slug** (wire to already-shipped `readDoc(slug)`; today it only takes attachmentRef/SHA — T11877/DHQ-054).
+→ `cleo docs view <slug>` (already shipped) becomes a faithful, slug-addressable, backlink-aware Obsidian reader from ONE store. Proves the reframe at the data layer before any gateway/Studio/plugin.
+⚠️ Footgun: confirm WHICH physical table the runtime reads before any one-shot derivation/backfill (the docs_ split-brain).
+
+## Build sequence
+- **E0 CORE-first (BLOCKING):** T11877 fetch-by-slug · T11876 slug-uniqueness/dedup on add · T11878 reliable remove/dedup · T11879 supersede writes the wikilink edge. (Fix the SSoT before any view.)
+- **E0b display-alias (T11875):** add `display_alias` to the consolidated `docs_attachments` shape, backfill 2765 rows, stop deriving numbering from slug, then commit T11676 ADR reconciliation (resolve 3×ADR-051 / 3×ADR-068 collisions).
+- **E1 derive graph:** run `rebuildDocsWikilinks()` (idempotent); verify non-zero edges.
+- **E2 register gateway ops:** add `docs.read`/`docs.graph`/`docs.list` to the OperationName union + registry (wrap existing SDK fns; no new logic).
+- **E3 wire gateway daemon:** register `defineGatewaySubsystem` in daemon boot (currently never imported) + bind `startHttpServer` on loopback **with origin+bearer-token guard from day one**. Deliverable: `curl POST 127.0.0.1:PORT/query/docs/read {slug}`. (Also the T11769 prerequisite.)
+- **E4 docs-changed SSE:** `GET /query/docs/events`, start with a 2s poll of `docs_attachments`/`docs_wikilinks` version/sha256 (mirror Studio tasks/events).
+- **E5 Studio /docs (proof-of-life, read-only):** consume docs.read+graph+SSE; reuse BrainGraph/Cosmograph renderers.
+- **E6 thin Obsidian plugin (~200–300 LOC, ratified Phase 3):** fetch docs.read, render markdown+base64 blobs, EventSource on docs/events, backlinks pane from docs.graph. Bridge, not logic. Build artifact, not a workspace package.
+- **E7 TRUE bidirectional edit:** vault→cleo.db inbound sync (file-change observer → docs.update); gate behind E0 write-reliability. Needs a conflict/merge design (none exists — naive LWW risks SSoT loss).
+- **E8 STANDALONE "IS Obsidian":** net-new Studio markdown editor (codemirror/milkdown) + `[[wikilink]]` autocomplete against docs.list + live preview + backlinks pane + full CRUD via gateway. Obsidian becomes optional.
+- **E9 standardization swap (post-T11769):** repoint plugin+Studio at the generated `/v1` OpenAPI client. Pure transport swap.
+
+## Hard dependencies / risks
+- **Blocked on the reconciler heal:** every step needs a working cleo + the live DB. Cannot run/validate `rebuildDocsWikilinks`, backfill, or any docs op until v2026.6.10 heals the DB + the fixed binary is installed.
+- Markdown body `[[wikilink]]` parsing is OUT of scope today (edges are structured-only) — a user editing in Obsidian/Studio writes body `[[links]]` the graph ignores → silent divergence unless body-link parsing is added.
+- Daemon HTTP listener widens attack surface — origin+token guard MANDATORY before E6.
+- docs versions/audit/search (T11880) unimplemented — early deliverables are read+link+graph only; manage expectations.

--- a/.cleo/rcasd/obsidian-view-design-2026-06-05.md
+++ b/.cleo/rcasd/obsidian-view-design-2026-06-05.md
@@ -1,0 +1,103 @@
+# Design Recommendation: CLEO Docs SSoT as a Live, Obsidian-Grade View
+
+Status: DESIGN (no code). Author: system-architect. Date: 2026-06-05.
+Scope: how CLEO exposes `cleo.db` `docs_*` (the SOLE doc authority) as a live, Obsidian-grade view.
+Read-only investigation grounded in files/commits/tasks below.
+
+---
+
+## 1. Ground Truth (what EXISTS vs what is DESIGNED)
+
+### 1.1 T11769 REST API-standard — DESIGNED, not built
+- `cleo show T11769` → **pending** epic `E-API-STANDARD-FOUNDATION`, parent saga **T10400** `SG-CLEO-SDK-API` (also pending). It is the contracts op-registry → OpenAPI → one generated client over core's gateway, config-as-domain, REST `/v1`, Studio-via-SDK. None of that code-generation / OpenAPI surface exists yet.
+
+### 1.2 A REAL transport-neutral gateway already exists (and is tested) — but is NOT started by any live daemon
+This is the single most important finding and it changes the recommendation.
+- `packages/runtime/src/gateway/` is a framework-agnostic CQRS gateway with **four transport adapters**: CLI (in-process), MCP (stdio), **RPC (unix-socket NDJSON)**, **HTTP (`node:http`)**, plus shared **SSE** primitives.
+  - HTTP embedder: `packages/runtime/src/gateway/http/listen.ts` — `startHttpServer(handler, {port,host})`, routes `POST /<gateway>/<domain>/<operation>` (`<gateway>` ∈ `query|mutate`) through `routeUnary`, LAFS-shaped errors, 1 MiB body cap, loopback-default bind.
+  - SSE: `packages/runtime/src/gateway/http/sse.ts` — `createSseStream` / `SSE_HEADERS` / `encodeSseFrame`. Abort-safe, run-once teardown. **Studio's live task feed already consumes this** (`packages/studio/src/routes/api/tasks/events/+server.ts`).
+  - RPC: `packages/runtime/src/gateway/rpc/server.ts` — unix-socket NDJSON, the canonical local-client wire (CLI, Studio server, tests).
+  - Subsystem wrapper: `packages/runtime/src/gateway/daemon-subsystem.ts` — `defineGatewaySubsystem({scope, handler, rpc?, http?})` exposes RPC+HTTP as a supervised daemon subsystem with `start/healthProbe/shutdown`.
+- **CRITICAL GAP:** `defineGatewaySubsystem` is only referenced in its own definition + the runtime barrel. **No daemon boot path in `packages/cleo` or `packages/core` registers it.** So the HTTP `/<gateway>/<domain>/<op>` surface is *built and tested but never listening*. Wiring it into daemon boot is the missing ~1 task, not a from-scratch REST-server epic.
+- Note: the routing vocabulary today is `POST /query/<domain>/<op>` and `POST /mutate/<domain>/<op>` — **not** `/v1/...`. T11769 is what later standardizes the path + generates an OpenAPI client. The live-view does NOT need the OpenAPI generator; it needs the listener turned on.
+
+### 1.3 Studio (`packages/studio`) — server-side SSR, reads core SDK directly
+- `svelte.config.js` uses `@sveltejs/adapter-node` → **server-side (SSR) Node process**, not static.
+- Server routes call **`@cleocode/core` narrow subpaths in-process** (e.g. `@cleocode/core/tasks/list`, `/lifecycle/rollup`, `/store/data-accessor`) — see `routes/api/tasks/+server.ts`. ZERO raw SQL in-route; opens a `DataAccessor` bound to the project DB.
+- Live updates already work: `routes/api/tasks/events/+server.ts` is an SSE endpoint built on the shared `createSseStream` (2 s poll on `tasks.db`).
+- Studio depends on `@cleocode/core` AND `@cleocode/runtime` (`package.json`). It already has a `routes/api/v1/graph/+server.ts`. It only shells out to the `cleo` CLI for heavy nexus ops (`lib/server/spawn-cli.ts`) — never for hot reads.
+- **Implication:** Studio is already the proven "in-process core-SDK reader + SSE live feed over HTTP" pattern. A docs view fits it natively.
+
+### 1.4 The docs.read foundation (T11825 / T11826) — built on a branch, NOT yet on `main` HEAD
+- Commit `26f6a1f63` `feat(docs): docs.read core-SDK API + docs_wikilinks derived edge graph` adds: `packages/contracts/src/docs/read.ts` (`DocReadResponse`, `DocFrontmatter`, `DocBody`, zod schemas, `isDocReadResponse`), `packages/core/src/docs/read-doc.ts` (`readDoc(slug)`), `packages/core/src/docs/wikilinks.ts`, `build-provenance-graph.ts`, and `attachments` schema cols.
+- **`git merge-base --is-ancestor 26f6a1f63 HEAD` → NO.** On this checkout it is a feature branch, not merged into `main` (`265b7b5ca`). Treat as "implemented, pending merge."
+- What it exposes (sufficient for a *read* view):
+  - `DocReadResponse = { frontmatter, body }`. `frontmatter` carries slug, kind, title, summary, lifecycleStatus, docVersion, ownerVersion, **supersedes/supersededBy**, **topics**, **relatedTasks**, sha256, createdAt.
+  - `body` is `{encoding: 'utf-8'|'base64', text?|base64?, sizeBytes, mimeType}` — **blob rendering (images/PDF) already handled** via base64 (T11825 AC2).
+  - `docs_wikilinks` derived edge graph + `cleo docs graph` provenance verb.
+- What a *live* view still needs on top of `readDoc`:
+  1. A **transport** to call `readDoc`/graph from outside the Node process (Obsidian runs in its own Electron/Node, cannot import `@cleocode/core`).
+  2. A **change signal** (the wikilink graph + a doc's `docVersion`/`sha256` change when a doc is rewritten) → push or poll so the view re-renders live. `readDoc` itself is pull-only.
+  3. A **list/graph endpoint** (enumerate slugs, fetch backlinks) so the view builds a navigable vault, not just single-doc fetches.
+
+### 1.5 Obsidian plugin reality
+- An Obsidian plugin runs inside Obsidian's Electron renderer/Node. It can: `fetch()` an HTTP(S) endpoint on localhost; open an `EventSource`/SSE or WebSocket; read/write vault files. It **cannot** cleanly own a long-lived child subprocess, and a subprocess-per-call (`cleo docs ... --json`) pays cold-start cost on every keystroke/hover — wrong for a "live view."
+- Therefore the right transport for a live Obsidian view is **a persistent localhost HTTP connection with SSE for push** — exactly what the gateway HTTP adapter + `createSseStream` already provide.
+
+---
+
+## 2. Evaluation Matrix — PLACEMENT × TRANSPORT
+
+PLACEMENT ∈ {separate `cleo-obsidian` repo · in-monorepo package · Studio docs-view + thin Obsidian bridge · pure gateway HTTP endpoint Obsidian fetches}
+TRANSPORT ∈ {REST/HTTP gateway (`POST /query|mutate/docs/...` today; `/v1` later) · NDJSON unix socket · CLI-JSON subprocess}
+
+| Option | Placement | Transport | Consolidation | Live-ness | Aligns ratified REST dir. | Effort | Built today? |
+|---|---|---|---|---|---|---|---|
+| **A (PRIMARY)** | Gateway HTTP `docs` ops in `core`/`runtime`, hosted by daemon; Obsidian = thin fetch+SSE client | REST/HTTP gateway + SSE | ✅ in-monorepo, no new pkg | ✅ persistent conn + SSE push | ✅ IS the gateway T11769 standardizes | **Low–Med** (wire daemon subsystem + add `docs` query ops + thin plugin) | ✅ gateway+SSE+readDoc all exist; only daemon-wiring missing |
+| **B (runner-up)** | Studio docs-view page + Studio `/api/docs` SSE; Obsidian = thin iframe/fetch bridge to Studio | REST/HTTP (Studio SSR routes) | ✅ in Studio, no new pkg | ✅ Studio already does SSR+SSE | ⚠️ Studio routes, not the canonical gateway | **Low** (Studio already imports core + has SSE pattern) | ✅ pattern proven; needs docs routes |
+| **C (runner-up)** | In-monorepo `@cleocode/obsidian` plugin package | REST/HTTP gateway | ⚠️ adds a package (mild tension w/ collapse-to-fewer) | ✅ | ✅ | Med | plugin code is net-new |
+| D (reject) | Separate `cleo-obsidian` repo | any | ❌ contradicts consolidation philosophy | ✅ | ✅ | High (release/version skew) | ❌ |
+| E (reject) | Obsidian plugin shells `cleo docs ... --json` | CLI-JSON subprocess | ✅ | ❌ cold spawn per call ≠ live | ❌ conflicts ratified REST direction | Low but wrong | ✅ CLI exists |
+| F (reject) | NDJSON unix socket from plugin | NDJSON | ✅ | ✅ | ⚠️ local-only; not the public REST dir; harder for Electron fetch | Med | RPC server exists, unwired |
+
+---
+
+## 3. PRIMARY RECOMMENDATION
+
+**Placement:** in-monorepo — add `docs` **query operations** to the existing operation registry (`core`), host the existing **gateway HTTP + SSE adapter** via the daemon (`defineGatewaySubsystem`), and ship a **thin Obsidian plugin** (fetch + EventSource client; ~few hundred LOC) as the only net-new surface. The plugin is a *bridge*, not a place where logic lives.
+
+**Transport:** the existing **HTTP gateway over loopback** (`POST /query/docs/read`, `/query/docs/graph`, `/query/docs/list`) for pull, plus **SSE** (`GET` stream of `docs-changed` frames) for push. This is the same wire the daemon already exposes for every other domain and the exact surface T11769 later standardizes to `/v1` — so we ride the ratified REST direction instead of inventing a parallel path.
+
+**Rationale:**
+- Honors consolidation: **no new runtime package** for the data path; `core` IS the SDK (owner's own framing), `runtime` already owns the HTTP/SSE transport, the daemon already owns subsystem supervision. The only new artifact is the thin plugin client (unavoidable — it lives in Obsidian's process).
+- Honors the ratified REST/NDJSON/gRPC direction: the live view talks to the **gateway**, the canonical API surface. When T11769 standardizes paths to `/v1` and generates an OpenAPI client, the plugin swaps its base path / adopts the generated client with no architectural change.
+- Honors live-ness: persistent HTTP keep-alive + SSE push (`createSseStream`) — no subprocess spawns, no polling from the plugin. Blob/PDF/image render is already solved by `DocReadResponse.body.base64` (T11825 AC2).
+- Lowest *true* effort because ~80% is already built and tested: gateway HTTP, SSE plumbing, `readDoc`, wikilinks graph. The missing pieces are small and additive.
+
+### Top 2 trade-offs
+1. **Requires turning the daemon gateway ON (and accepting a localhost listener).** The HTTP subsystem is built but unwired; we must register `defineGatewaySubsystem` in daemon boot and accept a loopback port as part of CLEO's running surface (auth/origin policy needed before any non-loopback bind). This is a deliberate widening of the daemon's responsibility — but it is the same listener T11769/Studio-via-SDK need anyway, so the cost is paid once for the whole API standard, not just for Obsidian.
+2. **A change-notification (`docs-changed`) signal must be produced.** `readDoc` is pull-only; the docs SSoT has no event today. We need a cheap change source — either a `docs_*` version/sha poll inside the SSE source (mirrors Studio's 2 s `tasks.db` poll — already the proven pattern) or, better, emit a domain event on `cleo docs add/supersede`. Poll-first keeps effort low; event-driven is the clean follow-up.
+
+### Why the 2 runner-ups lose
+- **B (Studio docs-view + Obsidian bridge):** genuinely attractive and *lowest* effort (Studio already SSRs core + has the SSE pattern, and a docs page in Studio is independently valuable). It loses as the *primary docs API* only because Studio routes are an **app surface, not the canonical gateway** — making Studio the API would re-create the "Studio-specific routes drift from the SSoT" problem that T11769 exists to kill (Studio-via-SDK). **Strong recommendation: still build the Studio docs page, but have it consume the same gateway `docs` ops** — Studio becomes the first proof-of-life consumer, Obsidian the second. So B is not discarded; it is *folded under A* as a parallel consumer.
+- **C (in-monorepo `@cleocode/obsidian` package):** correct placement-philosophy-wise but adds a package while the owner is collapsing ~21 → fewer. A plugin is a *distribution artifact* (it ships into a user's vault), not a library other packages import — so it does not need to be a first-class workspace package. Ship the thin plugin as build output / a `templates/`-style asset or a single non-published dir, not a numbered package. (If a package proves necessary for build tooling, it is a minor variation of A, not a different architecture.)
+
+---
+
+## 4. Phased Build Plan
+
+- **Phase 0 — Land the foundation on `main` (prerequisite).** Merge T11825/T11826 (`docs.read` + `docs_wikilinks`, commit `26f6a1f63`) into `main`. Until then `readDoc`/wikilinks are branch-only.
+- **Phase 1 — Add `docs` query ops + host the gateway (the real keystone).** Register `docs.read` (wrap `readDoc`), `docs.graph`/`docs.list` (wrap wikilinks + slug enumeration) as **query** operations in the registry so they route through the gateway automatically. Wire `defineGatewaySubsystem` (HTTP transport) into daemon boot on a loopback port; add an origin/token guard. Deliverable: `curl POST 127.0.0.1:<port>/query/docs/read {slug}` returns a `DocReadResponse`.
+- **Phase 2 — Live signal + Studio proof-of-life.** Add a `GET /query/docs/events` SSE source emitting `docs-changed` (poll `docs_*` max(version)/sha like the tasks-events route, or emit on `docs add/supersede`). Build a Studio docs-view page consuming `docs/read` + `docs/graph` + the SSE feed — proves the gateway docs API end-to-end inside an existing consumer.
+- **Phase 3 — Thin Obsidian plugin (the bridge).** Plugin: on note open/hover, `fetch` `docs/read` (render markdown + base64 blobs), `docs/graph` for backlinks pane, `EventSource` on `docs/events` to live-refresh. No CLI spawns, no business logic in the plugin. Distribute as build output, not a published package.
+- **Phase 4 (optional, post-T11769) — adopt `/v1` + generated client.** When T11769 ships the op-registry→OpenAPI→generated client and `/v1` path standard, repoint the plugin (and Studio) at the generated SDK. Pure swap; no redesign.
+
+---
+
+## 5. Dependency on T11769 — and the honest "defer?" call
+
+**Not blocked on T11769.** T11769 is the *standardization + codegen* of the API surface; the live Obsidian view needs only the *transport that already exists* (gateway HTTP + SSE) plus `docs` ops + daemon wiring. Building Obsidian on the current gateway vocabulary (`/query/docs/...`) and migrating to `/v1` in Phase 4 is a clean, low-cost path — and it *de-risks* T11769 by giving it a real second consumer beyond Studio.
+
+**Do NOT defer the whole effort until REST `/v1` lands.** Deferring would idle a gateway that is already 80% built and tested, and would leave the docs SSoT with no live view for the duration of a large standardization epic. The one thing that *should* gate is Phase 1's daemon-gateway wiring: it is a genuine widening of CLEO's running surface (a listening socket) and must land with an origin/auth guard — but that wiring is needed for T11769 / Studio-via-SDK regardless, so doing it now is not wasted.
+
+**Net:** proceed now, on the existing gateway, in-monorepo, with a thin plugin. Treat T11769 as the later path-standardization that the plugin painlessly adopts — not a blocker.

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,9 @@ packages/worktree-napi-*/worktree-napi.*.node
 /audit/
 /tmp-doc-source/
 /editors/
+
+# Studio SPA bundle copied into the CLI package by `postbuild`
+# (packages/cleo/scripts/copy-studio-dist.mjs). It ships in the npm tarball via
+# package.json `files`, but it is generated output and must never be committed —
+# it was accidentally staged once (191 files / 5.7k lines) during T12037.
+packages/cleo/studio-dist/


### PR DESCRIPTION
Working-tree hygiene after the T12051 merge — no runtime code changes.

- **`packages/cleo/studio-dist/` gitignored.** Generated by `postbuild` and shipped in the npm tarball via `package.json` `files`, but it is build output. It was accidentally staged once (191 files / 5,764 lines) during T12037 and caught only by a manual diff review.
- **Three stranded `.cleo/rcasd/` drafts committed.** They had sat untracked in a *tracked* docs directory since early June. Five others were verified **byte-identical** to objects already in the content-addressed blob store (`.cleo/blobs/blobs/<sha256>`) and removed — the docs SSoT retains that content. These three had no blob counterpart, so they are landed rather than dropped. `cleo check canon docs` passes with them staged.
- **One archived changeset** committed to match its siblings under `.changeset/shipped/`.

Task: T12051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjR8YmPtQZ3JyQs2VMUxUU