### PR TITLE
fix: make BRAIN recall actually work — prefix terms, conjunctive-first, interleaved fusion, FTS decisions, bidirectional supersession (T12073)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1223,7 +1223,14 @@ jobs:
     needs: [biome, changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
+    # T12073: raised from 35. T12070 restored 199 previously-undiscovered
+    # @cleocode/cleo test files to the run (they had never executed — the
+    # project's include globs matched nothing), which grew the suite enough
+    # that macOS started hitting the ceiling: Ubuntu finishes a shard in ~17
+    # minutes, macOS runners are roughly 2x slower, and both macOS shards were
+    # cancelled at 35m21s / 35m27s — a timeout, not a failure. 55 leaves real
+    # headroom above the ~34-minute macOS baseline instead of sitting on it.
+    timeout-minutes: 55
     strategy:
       matrix:
         # Windows shards temporarily disabled pending T9182/T9181 follow-up — pre-existing

--- a/packages/cleo/src/cli/commands/memory.ts
+++ b/packages/cleo/src/cli/commands/memory.ts
@@ -1167,6 +1167,43 @@ const reflectCommand = defineCommand({
 });
 
 /** cleo memory dedup-scan — scan brain.db for potential duplicate entries (T745) */
+/**
+ * `cleo memory prune-stubs` — remove content-free observation stubs (T12073).
+ *
+ * Dry-run by default; `--apply` is required to delete. See
+ * `packages/core/src/memory/brain-stub-prune.ts` for the rules and the
+ * measurements that motivate them.
+ */
+const pruneStubsCommand = defineCommand({
+  meta: {
+    name: 'prune-stubs',
+    description:
+      'Report (and with --apply, delete) content-free BRAIN observation stubs — ' +
+      'auto-hook task-start/complete records and the "status: undefined" artefact of T12071. ' +
+      'These are short enough that BM25 length-normalisation ranks them ABOVE substantive ' +
+      'memories, so they actively degrade recall. Dry-run by default.',
+  },
+  args: {
+    apply: {
+      type: 'boolean',
+      description: 'Actually delete the matched rows (default: report only)',
+    },
+  },
+  async run({ args }) {
+    const root = getProjectRoot();
+    await getBrainDb(root);
+    const { getBrainNativeDb } = await import('@cleocode/core/internal' as string);
+    const nativeDb = getBrainNativeDb();
+    if (!nativeDb) {
+      cliError('BRAIN database is not open');
+      return;
+    }
+    const { pruneObservationStubs } = await import('@cleocode/core/internal' as string);
+    const result = pruneObservationStubs(nativeDb, Boolean(args.apply));
+    cliOutput(result, { command: 'memory prune-stubs', operation: 'memory.prune-stubs' });
+  },
+});
+
 const dedupScanCommand = defineCommand({
   meta: {
     name: 'dedup-scan',
@@ -2191,6 +2228,7 @@ export const memoryCommand = defineCommand({
     dream: dreamCommand,
     reflect: reflectCommand,
     'dedup-scan': dedupScanCommand,
+    'prune-stubs': pruneStubsCommand,
     import: importCommand,
     doctor: doctorCommand,
     'llm-status': llmStatusCommand,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -688,6 +688,13 @@ export type {
   StdpPlasticityResult,
 } from './memory/brain-stdp.js';
 export { applyStdpPlasticity, getPlasticityStats } from './memory/brain-stdp.js';
+// T12073: targeted content-free observation prune (dry-run by default).
+export {
+  MAX_STUB_NARRATIVE,
+  pruneObservationStubs,
+  STUB_PRUNE_RULES,
+  type StubPruneResult,
+} from './memory/brain-stub-prune.js';
 export { migrateClaudeMem } from './memory/claude-mem-migration.js';
 // Memory — dream cycle (T628 auto-consolidation)
 export type {

--- a/packages/core/src/memory/__tests__/brain-search-recall.test.ts
+++ b/packages/core/src/memory/__tests__/brain-search-recall.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Recall-quality regressions for BRAIN search (T12073).
+ *
+ * These lock the two independent defects that made `cleo memory find` return
+ * plausible-but-wrong results for anything except an exact rare token:
+ *
+ *   1. exact-match terms, so morphological variants were invisible; and
+ *   2. a fixed table concatenation, so the largest store was structurally
+ *      unreachable regardless of relevance.
+ *
+ * @task T12073
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildFts5Queries,
+  escapeFts5Query,
+  interleaveRanked,
+  matchConjunctiveFirst,
+} from '../brain-search.js';
+
+describe('buildFts5Queries (T12073)', () => {
+  it('emits prefix-matching terms so morphological variants are reachable', () => {
+    // Measured on the live corpus: `orphan` matched 113 documents while
+    // `orphan*` matched 189. Seventy-six documents saying "orphaned" could not
+    // be found by searching for "orphan". FTS5's unicode61 tokenizer has no
+    // stemmer, so the prefix operator is the substitute.
+    const q = buildFts5Queries('orphan');
+    expect(q.and).toBe('"orphan"*');
+    expect(q.or).toBe('"orphan"*');
+  });
+
+  it('produces both a conjunctive and a disjunctive form', () => {
+    const q = buildFts5Queries('nexus orphan');
+    expect(q.and).toBe('"nexus"* AND "orphan"*');
+    expect(q.or).toBe('"nexus"* OR "orphan"*');
+    expect(q.termCount).toBe(2);
+  });
+
+  it('drops punctuation-only tokens rather than zeroing the query (T553)', () => {
+    // The original reason OR semantics were introduced: an em dash or a bare
+    // colon cannot be indexed, and under implicit AND that guaranteed zero
+    // matches for the whole query.
+    const q = buildFts5Queries('EPIC: — auth');
+    expect(q.and).toBe('"EPIC"* AND "auth"*');
+  });
+
+  it('deduplicates case-insensitively', () => {
+    expect(buildFts5Queries('Auth auth AUTH').termCount).toBe(1);
+  });
+
+  it('escapes embedded quotes so a query cannot break out of the term', () => {
+    const q = buildFts5Queries('say"hi');
+    expect(q.and).toBe('"say""hi"*');
+  });
+
+  it('returns a safe empty match for an all-punctuation query', () => {
+    expect(buildFts5Queries('— :: !').and).toBe('""');
+    expect(buildFts5Queries('').termCount).toBe(0);
+  });
+
+  it('keeps escapeFts5Query as the disjunctive form for existing callers', () => {
+    expect(escapeFts5Query('nexus orphan')).toBe('"nexus"* OR "orphan"*');
+  });
+});
+
+describe('matchConjunctiveFirst (T12073)', () => {
+  it('prefers the conjunctive result when it is non-empty', () => {
+    const seen: string[] = [];
+    const rows = matchConjunctiveFirst((expr) => {
+      seen.push(expr);
+      return expr.includes('AND') ? ['precise'] : ['noisy'];
+    }, buildFts5Queries('nexus orphan'));
+    expect(rows).toEqual(['precise']);
+    expect(seen).toHaveLength(1); // OR never ran
+  });
+
+  it('falls back to disjunctive only when the conjunction finds nothing', () => {
+    const seen: string[] = [];
+    const rows = matchConjunctiveFirst((expr) => {
+      seen.push(expr);
+      return expr.includes('AND') ? [] : ['fallback'];
+    }, buildFts5Queries('nexus orphan'));
+    expect(rows).toEqual(['fallback']);
+    expect(seen).toEqual(['"nexus"* AND "orphan"*', '"nexus"* OR "orphan"*']);
+  });
+
+  it('does not double-run a single-term query (AND and OR are identical)', () => {
+    let calls = 0;
+    matchConjunctiveFirst(() => {
+      calls++;
+      return [];
+    }, buildFts5Queries('orphan'));
+    expect(calls).toBe(1);
+  });
+});
+
+describe('interleaveRanked (T12073)', () => {
+  it('round-robins so no source is systematically last', () => {
+    expect(interleaveRanked([['a1', 'a2'], ['b1'], ['c1', 'c2', 'c3']])).toEqual([
+      'a1',
+      'b1',
+      'c1',
+      'a2',
+      'c2',
+      'c3',
+    ]);
+  });
+
+  it('preserves each source internal ordering', () => {
+    const out = interleaveRanked([
+      ['a1', 'a2', 'a3'],
+      ['b1', 'b2', 'b3'],
+    ]);
+    expect(out.filter((x) => x.startsWith('a'))).toEqual(['a1', 'a2', 'a3']);
+    expect(out.filter((x) => x.startsWith('b'))).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  it('reaches the LAST source within the first round — the regression', () => {
+    // Concatenation put observations after decisions+patterns+learnings, so
+    // with those three saturating the result window an observation could never
+    // place, however relevant. With 128 decisions and ~5,000 observations that
+    // made the largest store the least reachable.
+    const decisions = Array.from({ length: 10 }, (_, i) => `D${i}`);
+    const patterns = Array.from({ length: 10 }, (_, i) => `P${i}`);
+    const learnings = Array.from({ length: 10 }, (_, i) => `L${i}`);
+    const observations = ['O-relevant'];
+
+    const concatenated = [...decisions, ...patterns, ...learnings, ...observations];
+    expect(concatenated.slice(0, 10)).not.toContain('O-relevant');
+
+    const interleaved = interleaveRanked([decisions, patterns, learnings, observations]);
+    expect(interleaved.slice(0, 10)).toContain('O-relevant');
+  });
+
+  it('handles empty and single-source inputs', () => {
+    expect(interleaveRanked([])).toEqual([]);
+    expect(interleaveRanked([[], []])).toEqual([]);
+    expect(interleaveRanked([['only']])).toEqual(['only']);
+  });
+});

--- a/packages/core/src/memory/__tests__/brain-stub-prune.test.ts
+++ b/packages/core/src/memory/__tests__/brain-stub-prune.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the targeted BRAIN stub prune (T12073).
+ *
+ * The behaviour that matters is not "it deletes rows" — it is that it deletes
+ * ONLY the content-free ones, defaults to not deleting at all, and cannot
+ * reach a substantive record that merely quotes one of the junk strings.
+ *
+ * @task T12073
+ */
+
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_STUB_NARRATIVE,
+  pruneObservationStubs,
+  STUB_PRUNE_RULES,
+} from '../brain-stub-prune.js';
+
+/** Minimal in-memory `brain_observations` with the columns the prune reads. */
+function makeDb(): DatabaseSync {
+  const db = new DatabaseSync(':memory:'); // db-open-allowed: in-memory test fixture
+  db.exec(`
+    CREATE TABLE brain_observations (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      narrative TEXT,
+      verified INTEGER
+    )
+  `);
+  return db;
+}
+
+/** Insert one observation row. */
+function insert(
+  db: DatabaseSync,
+  id: string,
+  title: string,
+  narrative: string | null,
+  verified = 0,
+): void {
+  db.prepare(
+    'INSERT INTO brain_observations (id, title, narrative, verified) VALUES (?,?,?,?)',
+  ).run(id, title, narrative, verified);
+}
+
+describe('pruneObservationStubs (T12073)', () => {
+  it('does NOT delete on a dry run', () => {
+    const db = makeDb();
+    insert(db, 'O-1', 'Task complete: T100', 'Task T100 completed with status: undefined');
+
+    const result = pruneObservationStubs(db, false);
+
+    expect(result.applied).toBe(false);
+    expect(result.matched).toBe(1);
+    expect(result.before).toBe(1);
+    expect(result.after).toBe(1); // unchanged
+  });
+
+  it('deletes the status:undefined artefact when applied', () => {
+    const db = makeDb();
+    insert(db, 'O-1', 'Task complete: T100', 'Task T100 completed with status: undefined');
+    insert(db, 'O-2', 'Task complete: T101', 'Task T101 completed with status: undefined');
+
+    const result = pruneObservationStubs(db, true);
+
+    expect(result.applied).toBe(true);
+    expect(result.matched).toBe(2);
+    expect(result.after).toBe(0);
+    expect(result.byRule['status-undefined']).toBe(2);
+  });
+
+  it('PRESERVES a substantive record that merely quotes the junk string', () => {
+    // The exact hazard: a post-mortem describing the bug contains the literal
+    // "status: undefined". It must survive, and the length guard is what
+    // guarantees that.
+    const db = makeDb();
+    const postMortem = `Root-caused the BRAIN corpus problem. Every completion wrote "status: undefined" because dispatch was generic over T extends HookPayload and inferred T from the argument, so the event and the payload were never related at the type level. ${'x'.repeat(300)}`;
+    expect(postMortem.length).toBeGreaterThan(MAX_STUB_NARRATIVE);
+    insert(db, 'O-keep', 'hook-dispatch-root-cause', postMortem);
+    insert(db, 'O-junk', 'Task complete: T100', 'Task T100 completed with status: undefined');
+
+    const result = pruneObservationStubs(db, true);
+
+    expect(result.matched).toBe(1);
+    const remaining = db.prepare('SELECT id FROM brain_observations').all() as Array<{
+      id: string;
+    }>;
+    expect(remaining.map((r) => r.id)).toEqual(['O-keep']);
+  });
+
+  it('never deletes a verified record, however short', () => {
+    const db = makeDb();
+    insert(db, 'O-v', 'Task complete: T100', 'Task T100 completed with status: undefined', 1);
+
+    const result = pruneObservationStubs(db, true);
+
+    expect(result.matched).toBe(0);
+    expect(result.after).toBe(1);
+  });
+
+  it('leaves ordinary observations untouched', () => {
+    const db = makeDb();
+    insert(db, 'O-real', 'nexus-analyze-destroys-index', 'Short but genuine finding.');
+    insert(db, 'O-start', 'Task start: T100', 'Started work on T100: do the thing');
+
+    const result = pruneObservationStubs(db, true);
+
+    expect(result.byRule['task-start-stub']).toBe(1);
+    const remaining = db.prepare('SELECT id FROM brain_observations').all() as Array<{
+      id: string;
+    }>;
+    expect(remaining.map((r) => r.id)).toEqual(['O-real']);
+  });
+
+  it('tolerates a NULL narrative', () => {
+    const db = makeDb();
+    insert(db, 'O-null', 'some title', null);
+    expect(() => pruneObservationStubs(db, true)).not.toThrow();
+    expect(pruneObservationStubs(db, false).after).toBe(1);
+  });
+
+  it('reports a sample so a dry run shows what would go', () => {
+    const db = makeDb();
+    for (let i = 0; i < 8; i++) {
+      insert(db, `O-${i}`, `Task complete: T${i}`, `Task T${i} completed with status: undefined`);
+    }
+    const result = pruneObservationStubs(db, false);
+    expect(result.matched).toBe(8);
+    expect(result.sample).toHaveLength(5); // capped
+    expect(result.sample[0]?.rule).toBe('status-undefined');
+  });
+
+  it('every rule carries a stated reason', () => {
+    for (const rule of STUB_PRUNE_RULES) {
+      expect(rule.reason.length).toBeGreaterThan(40);
+      expect(rule.id).toMatch(/^[a-z][a-z-]*$/);
+    }
+  });
+});

--- a/packages/core/src/memory/brain-search.ts
+++ b/packages/core/src/memory/brain-search.ts
@@ -383,14 +383,15 @@ function searchWithFts5(
     observations: [],
   };
 
-  // Escape FTS5 special characters for safety
-  const safeQuery = escapeFts5Query(query);
+  // T12073: conjunctive-first. `fts5Queries.and` requires every term (high
+  // precision); the OR form is used only when AND matches nothing, preserving
+  // the recall the disjunctive builder was introduced for (T553).
+  const fts5Queries = buildFts5Queries(query);
 
   if (tables.includes('decisions')) {
     const { clause, params } = buildPeerClause('d', peerId, includeGlobal);
     try {
-      const rows = typedAll<BrainDecisionRow>(
-        nativeDb.prepare(`
+      const stmt = nativeDb.prepare(`
         SELECT d.*
         FROM brain_decisions_fts fts
         JOIN brain_decisions d ON d.rowid = fts.rowid
@@ -399,11 +400,11 @@ function searchWithFts5(
           ${clause}
         ORDER BY bm25(brain_decisions_fts)
         LIMIT ?
-      `),
-        safeQuery,
-        QUALITY_SCORE_THRESHOLD,
-        ...params,
-        limit,
+      `);
+      const rows = matchConjunctiveFirst<BrainDecisionRow>(
+        (matchExpr) =>
+          typedAll<BrainDecisionRow>(stmt, matchExpr, QUALITY_SCORE_THRESHOLD, ...params, limit),
+        fts5Queries,
       );
       result.decisions = rows;
     } catch {
@@ -415,8 +416,7 @@ function searchWithFts5(
   if (tables.includes('patterns')) {
     const { clause, params } = buildPeerClause('p', peerId, includeGlobal);
     try {
-      const rows = typedAll<BrainPatternRow>(
-        nativeDb.prepare(`
+      const stmt = nativeDb.prepare(`
         SELECT p.*
         FROM brain_patterns_fts fts
         JOIN brain_patterns p ON p.rowid = fts.rowid
@@ -425,11 +425,11 @@ function searchWithFts5(
           ${clause}
         ORDER BY bm25(brain_patterns_fts)
         LIMIT ?
-      `),
-        safeQuery,
-        QUALITY_SCORE_THRESHOLD,
-        ...params,
-        limit,
+      `);
+      const rows = matchConjunctiveFirst<BrainPatternRow>(
+        (matchExpr) =>
+          typedAll<BrainPatternRow>(stmt, matchExpr, QUALITY_SCORE_THRESHOLD, ...params, limit),
+        fts5Queries,
       );
       result.patterns = rows;
     } catch {
@@ -440,8 +440,7 @@ function searchWithFts5(
   if (tables.includes('learnings')) {
     const { clause, params } = buildPeerClause('l', peerId, includeGlobal);
     try {
-      const rows = typedAll<BrainLearningRow>(
-        nativeDb.prepare(`
+      const stmt = nativeDb.prepare(`
         SELECT l.*
         FROM brain_learnings_fts fts
         JOIN brain_learnings l ON l.rowid = fts.rowid
@@ -450,11 +449,11 @@ function searchWithFts5(
           ${clause}
         ORDER BY bm25(brain_learnings_fts)
         LIMIT ?
-      `),
-        safeQuery,
-        QUALITY_SCORE_THRESHOLD,
-        ...params,
-        limit,
+      `);
+      const rows = matchConjunctiveFirst<BrainLearningRow>(
+        (matchExpr) =>
+          typedAll<BrainLearningRow>(stmt, matchExpr, QUALITY_SCORE_THRESHOLD, ...params, limit),
+        fts5Queries,
       );
       result.learnings = rows;
     } catch {
@@ -465,8 +464,7 @@ function searchWithFts5(
   if (tables.includes('observations')) {
     const { clause, params } = buildPeerClause('o', peerId, includeGlobal);
     try {
-      const rows = typedAll<BrainObservationRow>(
-        nativeDb.prepare(`
+      const stmt = nativeDb.prepare(`
         SELECT o.*
         FROM brain_observations_fts fts
         JOIN brain_observations o ON o.rowid = fts.rowid
@@ -475,11 +473,11 @@ function searchWithFts5(
           ${clause}
         ORDER BY bm25(brain_observations_fts)
         LIMIT ?
-      `),
-        safeQuery,
-        QUALITY_SCORE_THRESHOLD,
-        ...params,
-        limit,
+      `);
+      const rows = matchConjunctiveFirst<BrainObservationRow>(
+        (matchExpr) =>
+          typedAll<BrainObservationRow>(stmt, matchExpr, QUALITY_SCORE_THRESHOLD, ...params, limit),
+        fts5Queries,
       );
       result.observations = rows;
     } catch {
@@ -651,14 +649,72 @@ function likeSearchObservations(
  * ("EPIC:"), because FTS5's default tokenizer cannot index them and the
  * AND semantics then guaranteed zero matches for the whole query. (T553 bug fix)
  */
-function escapeFts5Query(query: string): string {
-  const rawTokens = query.trim().split(/\s+/).filter(Boolean);
-  if (rawTokens.length === 0) return '""';
+export function escapeFts5Query(query: string): string {
+  return buildFts5Queries(query).or;
+}
 
-  // Keep tokens that have at least one alphanumeric character and are not
-  // pure stop-words (length ≥ 2 after stripping leading/trailing punctuation).
+/**
+ * The two MATCH expressions used by the conjunctive-first retrieval strategy.
+ *
+ * @task T12073
+ */
+export interface Fts5QueryPair {
+  /** All terms required — high precision, may return nothing. */
+  readonly and: string;
+  /** Any term matches — high recall, used only as a fallback. */
+  readonly or: string;
+  /** Number of usable terms extracted from the query. */
+  readonly termCount: number;
+}
+
+/**
+ * Build the AND and OR MATCH expressions for a natural-language query.
+ *
+ * ## Why both, and why prefixes (T12073)
+ *
+ * The previous builder emitted `"tok1" OR "tok2"` — quoted terms joined by OR.
+ * Measured against the live 6,985-observation corpus, that has two failure
+ * modes that together make recall useless for anything but an exact rare token:
+ *
+ * **Quoted terms are exact, so morphological variants are invisible.** A search
+ * for `orphan` matched 113 documents; `orphan*` matched 189. Seventy-six
+ * documents saying "orphaned" or "orphans" could not be found by searching for
+ * "orphan". SQLite FTS5 has no stemmer on the `unicode61` tokenizer, so a
+ * prefix wildcard is the available substitute — and it is a good one, because
+ * it costs nothing on a prefix-indexed b-tree.
+ *
+ * **Pure OR plus BM25 ranks by term rarity, not by term coverage.** A short
+ * document matching ONE query term outranks a long one matching ALL of them,
+ * because BM25 normalises for length. On this corpus that is catastrophic:
+ * 30% of observations are sub-60-character auto-capture stubs, so the
+ * shortest, emptiest records win. Searching `nexus_symbols_fts orphan` under
+ * the old builder returned *"Consolidated: change observations (5 entries)"*
+ * as the top hit — a record with no content at all — while the conjunctive
+ * form returns only documents about orphans in nexus.
+ *
+ * So: require all terms first, and fall back to ANY only when the conjunction
+ * finds nothing. That preserves the recall the OR form was introduced for
+ * (T553: non-word tokens like em dashes zeroing out an implicit-AND query)
+ * without letting it dominate the common case.
+ *
+ * @param query - the raw user query.
+ * @returns AND/OR MATCH expressions and the usable term count.
+ *
+ * @example
+ * ```ts
+ * const q = buildFts5Queries('nexus_symbols_fts orphan');
+ * // q.and === 'nexus_symbols_fts* AND orphan*'
+ * // q.or  === 'nexus_symbols_fts* OR orphan*'
+ * ```
+ *
+ * @task T553
+ * @task T12073
+ */
+export function buildFts5Queries(query: string): Fts5QueryPair {
+  const rawTokens = query.trim().split(/\s+/).filter(Boolean);
   const seen = new Set<string>();
-  const tokens: string[] = [];
+  const terms: string[] = [];
+
   for (const t of rawTokens) {
     // Strip leading/trailing non-word characters (e.g. "EPIC:" → "EPIC", "—" → "")
     const stripped = t.replace(/^\W+|\W+$/g, '');
@@ -667,13 +723,35 @@ function escapeFts5Query(query: string): string {
     const lower = stripped.toLowerCase();
     if (seen.has(lower)) continue; // deduplicate
     seen.add(lower);
-    tokens.push(`"${stripped.replace(/"/g, '""')}"`);
+
+    // Quote to neutralise FTS5 syntax characters, then append the prefix
+    // operator OUTSIDE the quotes — `"foo"*` is the documented way to combine
+    // a quoted string with a prefix match.
+    terms.push(`"${stripped.replace(/"/g, '""')}"*`);
   }
 
-  if (tokens.length === 0) return '""';
+  if (terms.length === 0) return { and: '""', or: '""', termCount: 0 };
+  return { and: terms.join(' AND '), or: terms.join(' OR '), termCount: terms.length };
+}
 
-  // OR semantics: any matching token returns the row, ranked by BM25 relevance.
-  return tokens.join(' OR ');
+/**
+ * Run an FTS5-backed query conjunctively, falling back to disjunctive.
+ *
+ * Single-term queries skip the fallback entirely (AND and OR are identical).
+ *
+ * @param run - executes one MATCH expression and returns its rows.
+ * @param queries - the pair from {@link buildFts5Queries}.
+ * @returns conjunctive rows when non-empty, else disjunctive rows.
+ *
+ * @task T12073
+ */
+export function matchConjunctiveFirst<T>(
+  run: (matchExpr: string) => T[],
+  queries: Fts5QueryPair,
+): T[] {
+  const conjunctive = run(queries.and);
+  if (conjunctive.length > 0 || queries.termCount < 2) return conjunctive;
+  return run(queries.or);
 }
 
 /**
@@ -704,6 +782,36 @@ export interface RrfHit {
   type: string;
   title: string;
   text: string;
+}
+
+/**
+ * Round-robin interleave several independently-ranked lists.
+ *
+ * Takes rank 1 from every list, then rank 2 from every list, and so on, so a
+ * downstream consumer that scores by array position does not systematically
+ * favour whichever list happened to be concatenated first.
+ *
+ * @param lists - per-source lists, each already ordered best-first.
+ * @returns a single list preserving each source's internal order.
+ *
+ * @example
+ * ```ts
+ * interleaveRanked([['a1', 'a2'], ['b1'], ['c1', 'c2', 'c3']]);
+ * // ['a1', 'b1', 'c1', 'a2', 'c2', 'c3']
+ * ```
+ *
+ * @task T12073
+ */
+export function interleaveRanked<T>(lists: ReadonlyArray<readonly T[]>): T[] {
+  const out: T[] = [];
+  const longest = lists.reduce((max, l) => Math.max(max, l.length), 0);
+  for (let i = 0; i < longest; i++) {
+    for (const list of lists) {
+      const item = list[i];
+      if (item !== undefined) out.push(item);
+    }
+  }
+  return out;
 }
 
 /** Fused result produced by reciprocalRankFusion. */
@@ -922,34 +1030,49 @@ export async function hybridSearch(
   }>;
 
   // --- 2. Project FTS results into ranked RrfHit list ---
-  const ftsHits: RrfHit[] = [];
-  for (const d of ftsResults.decisions) {
-    ftsHits.push({
+  //
+  // T12073: INTERLEAVE the four tables instead of concatenating them.
+  //
+  // RRF scores a hit by its POSITION in this array. Concatenating
+  // decisions → patterns → learnings → observations therefore encoded a fixed
+  // precedence that has nothing to do with relevance: every decision outranked
+  // every observation, always. With 128 decisions and 6,985 observations, the
+  // largest and most recent store was structurally the least reachable —
+  // `cleo memory find "caamp marker"` returned unrelated learnings while the
+  // ONE observation matching both terms (verified by direct MATCH) never
+  // placed.
+  //
+  // Each table is already BM25-ordered internally. Round-robin interleaving
+  // preserves that intra-table ordering while removing the inter-table bias,
+  // and avoids comparing BM25 scores across separate indexes — which is not
+  // meaningful, since each has its own corpus statistics.
+  const ftsRanked: RrfHit[][] = [
+    ftsResults.decisions.map((d) => ({
       id: d.id,
-      type: 'decision',
+      type: 'decision' as const,
       title: d.decision,
       text: `${d.decision} — ${d.rationale}`,
-    });
-  }
-  for (const p of ftsResults.patterns) {
-    ftsHits.push({
+    })),
+    ftsResults.patterns.map((p) => ({
       id: p.id,
-      type: 'pattern',
+      type: 'pattern' as const,
       title: p.pattern,
       text: `${p.pattern} — ${p.context}`,
-    });
-  }
-  for (const l of ftsResults.learnings) {
-    ftsHits.push({
+    })),
+    ftsResults.learnings.map((l) => ({
       id: l.id,
-      type: 'learning',
+      type: 'learning' as const,
       title: l.insight,
       text: `${l.insight} (source: ${l.source})`,
-    });
-  }
-  for (const o of ftsResults.observations) {
-    ftsHits.push({ id: o.id, type: 'observation', title: o.title, text: o.narrative ?? o.title });
-  }
+    })),
+    ftsResults.observations.map((o) => ({
+      id: o.id,
+      type: 'observation' as const,
+      title: o.title,
+      text: o.narrative ?? o.title,
+    })),
+  ];
+  const ftsHits: RrfHit[] = interleaveRanked(ftsRanked);
 
   // --- 3. Project vector results into ranked RrfHit list (ascending distance = descending quality) ---
   const vecHits: RrfHit[] = vecResults.map((r) => ({

--- a/packages/core/src/memory/brain-stub-prune.ts
+++ b/packages/core/src/memory/brain-stub-prune.ts
@@ -1,0 +1,211 @@
+/**
+ * Targeted prune of content-free BRAIN observations (T12073).
+ *
+ * ## Why (measured, 2026-08-06)
+ *
+ * Of 6,985 observations in this project's BRAIN:
+ *
+ * | count | share | shape                                          |
+ * |-------|-------|------------------------------------------------|
+ * | 2,012 | 29%   | narrative contains the literal `status: undefined` |
+ * | 2,035 | 29%   | auto-hook `Task start:` / `Task complete:` stubs |
+ * | 2,064 | 30%   | narrative under 60 characters                   |
+ * |   481 | 6.9%  | narrative over 800 characters — i.e. substantive |
+ *
+ * The `status: undefined` rows are pure artefact: `PostToolUse` was dispatched
+ * with a field name the payload does not declare, so `handleToolComplete`
+ * interpolated `undefined` into every completion record. That defect is fixed
+ * (T12071) and can no longer produce new rows — but the existing ones remain,
+ * and they are not merely inert. FTS5's BM25 normalises for document length,
+ * so a 44-character record OUTRANKS a 4,000-character one for any term they
+ * share. The junk actively buries the knowledge.
+ *
+ * ## Safety
+ *
+ * This module is deliberately NOT the older `purgeBrainNoise`, which is a
+ * one-shot script hardcoded to a historical state: it deletes every learning,
+ * every decision but one specific id, and logs to stdout. Running it today
+ * would destroy 127 learnings and 127 decisions.
+ *
+ * Here, instead:
+ *
+ *   - **Dry-run is the default.** Deleting requires an explicit `apply`.
+ *   - Only OBSERVATIONS are considered. Decisions, patterns and learnings are
+ *     never touched.
+ *   - A row is a candidate only if it matches a named, narrow rule AND its
+ *     narrative is under {@link MAX_STUB_NARRATIVE} characters, so a long
+ *     record that merely happens to quote one of these strings survives.
+ *   - Rows carrying `verified = 1` are always preserved.
+ *   - The result reports per-rule counts and a sample, so the caller can see
+ *     what would go before anything does.
+ *
+ * @task T12073
+ */
+
+import type { DatabaseSync } from 'node:sqlite';
+
+/**
+ * Longest narrative still eligible for pruning.
+ *
+ * A genuine write-up that happens to contain "status: undefined" (this
+ * module's own documentation, for instance, or a post-mortem describing the
+ * bug) is far longer than this and is therefore never a candidate.
+ */
+export const MAX_STUB_NARRATIVE = 200;
+
+/** A named prune rule with its SQL predicate. */
+export interface StubPruneRule {
+  /** Stable identifier, reported in {@link StubPruneResult.byRule}. */
+  readonly id: string;
+  /** One-line explanation of what this rule removes and why it is safe. */
+  readonly reason: string;
+  /** SQL predicate over `brain_observations`, ANDed with the global guards. */
+  readonly predicate: string;
+}
+
+/**
+ * The prune rules, each narrow and independently justified.
+ *
+ * Every predicate is ANDed with `length(narrative) <= MAX_STUB_NARRATIVE` and
+ * `verified IS NOT 1`, so no rule can reach a substantive or human-confirmed
+ * record on its own.
+ */
+export const STUB_PRUNE_RULES: readonly StubPruneRule[] = [
+  {
+    id: 'status-undefined',
+    reason:
+      'Artefact of T12071: PostToolUse was dispatched with `newStatus` while the payload declares `status`, so every completion interpolated the literal string "undefined". Carries no information beyond the task id, which the tasks table already holds.',
+    predicate: "narrative LIKE '%status: undefined%'",
+  },
+  {
+    id: 'task-start-stub',
+    reason:
+      'Auto-hook record of the form "Started work on T####: <title>". Both fields are already in the tasks table; the observation adds nothing and is short enough to outrank real memories under BM25.',
+    predicate: "title LIKE 'Task start: T%' AND narrative LIKE 'Started work on T%'",
+  },
+  {
+    id: 'task-complete-stub',
+    reason:
+      'Auto-hook record of the form "Task T#### completed with status: <status>". Duplicates the task row; retained only when it carries a real status AND some other content, which the length guard enforces.',
+    predicate:
+      "title LIKE 'Task complete: T%' AND narrative LIKE 'Task T% completed with status:%'",
+  },
+];
+
+/** One candidate row, for reporting. */
+export interface StubPruneCandidate {
+  readonly id: string;
+  readonly title: string;
+  readonly narrative: string;
+  readonly rule: string;
+}
+
+/** Outcome of a prune run. */
+export interface StubPruneResult {
+  /** Whether rows were actually deleted (`false` = dry run). */
+  readonly applied: boolean;
+  /** Observation count before the run. */
+  readonly before: number;
+  /** Observation count after (equals `before` on a dry run). */
+  readonly after: number;
+  /** Number of rows matched (and deleted, when `applied`). */
+  readonly matched: number;
+  /** Per-rule match counts, keyed by {@link StubPruneRule.id}. */
+  readonly byRule: Record<string, number>;
+  /** Up to 5 example rows, so a dry run shows what would go. */
+  readonly sample: readonly StubPruneCandidate[];
+}
+
+/** Build the WHERE clause shared by counting, sampling and deleting. */
+function ruleClause(rule: StubPruneRule): string {
+  return `(${rule.predicate}) AND length(COALESCE(narrative, '')) <= ${MAX_STUB_NARRATIVE} AND COALESCE(verified, 0) != 1`;
+}
+
+/** Combined predicate across every rule. */
+function allRulesClause(): string {
+  return STUB_PRUNE_RULES.map(ruleClause).join(' OR ');
+}
+
+/**
+ * Count, sample and optionally delete content-free observation stubs.
+ *
+ * @param nativeDb - open handle to the database holding `brain_observations`.
+ * @param apply - when `true`, delete the matched rows; otherwise report only.
+ * @returns counts, per-rule breakdown and a sample of matched rows.
+ *
+ * @example
+ * ```ts
+ * const preview = pruneObservationStubs(db, false);
+ * console.log(`${preview.matched} of ${preview.before} observations are stubs`);
+ * if (preview.matched > 0) pruneObservationStubs(db, true);
+ * ```
+ *
+ * @task T12073
+ */
+export function pruneObservationStubs(nativeDb: DatabaseSync, apply: boolean): StubPruneResult {
+  const countAll = (): number =>
+    (nativeDb.prepare('SELECT COUNT(*) AS c FROM brain_observations').get() as { c: number }).c;
+
+  const before = countAll();
+
+  const byRule: Record<string, number> = {};
+  for (const rule of STUB_PRUNE_RULES) {
+    const row = nativeDb
+      .prepare(`SELECT COUNT(*) AS c FROM brain_observations WHERE ${ruleClause(rule)}`)
+      .get() as { c: number };
+    byRule[rule.id] = row.c;
+  }
+
+  const combined = allRulesClause();
+  const matched = (
+    nativeDb.prepare(`SELECT COUNT(*) AS c FROM brain_observations WHERE ${combined}`).get() as {
+      c: number;
+    }
+  ).c;
+
+  const sample = nativeDb
+    .prepare(
+      `SELECT id, title, COALESCE(narrative, '') AS narrative FROM brain_observations WHERE ${combined} LIMIT 5`,
+    )
+    .all() as Array<{ id: string; title: string; narrative: string }>;
+
+  if (!apply || matched === 0) {
+    return {
+      applied: false,
+      before,
+      after: before,
+      matched,
+      byRule,
+      sample: sample.map((r) => ({ ...r, rule: matchingRule(r.narrative, r.title) })),
+    };
+  }
+
+  // Deleting from brain_observations fires the FTS delete trigger, so the
+  // shadow index stays in sync without a separate rebuild.
+  nativeDb.prepare(`DELETE FROM brain_observations WHERE ${combined}`).run();
+
+  return {
+    applied: true,
+    before,
+    after: countAll(),
+    matched,
+    byRule,
+    sample: sample.map((r) => ({ ...r, rule: matchingRule(r.narrative, r.title) })),
+  };
+}
+
+/**
+ * Best-effort attribution of a sampled row to the rule that matched it.
+ *
+ * Reporting only — the delete uses the combined SQL predicate.
+ *
+ * @param narrative - the row's narrative text.
+ * @param title - the row's title.
+ * @returns the matching rule id, or `'unknown'`.
+ */
+function matchingRule(narrative: string, title: string): string {
+  if (narrative.includes('status: undefined')) return 'status-undefined';
+  if (title.startsWith('Task start: T')) return 'task-start-stub';
+  if (title.startsWith('Task complete: T')) return 'task-complete-stub';
+  return 'unknown';
+}

--- a/packages/core/src/memory/engine-compat.ts
+++ b/packages/core/src/memory/engine-compat.ts
@@ -297,15 +297,52 @@ export async function memoryDecisionFind(
       const categoryClause = includeAgentDispatch
         ? ''
         : "AND (decision_category IS NULL OR decision_category != 'agent_dispatch')";
-      const rows = nativeDb
-        .prepare(
-          `SELECT * FROM brain_decisions
+      // T12073: search the FTS index, not a single LIKE over the whole query.
+      //
+      // `LIKE '%<entire query>%'` treats the query as ONE literal substring, so
+      // any multi-word question fails unless those exact words appear
+      // contiguously. `decision-find --query "index freshness median"` returned
+      // zero hits against a decision whose text contains all three words —
+      // while `brain_decisions_fts` matched it correctly. The decision store
+      // was effectively unsearchable by natural language, which is a large part
+      // of why nothing has been written to it since 2026-06-09.
+      //
+      // Conjunctive-first with a prefix on each term (see buildFts5Queries),
+      // then the original LIKE as a last resort so behaviour never regresses
+      // for a caller relying on literal-substring semantics.
+      const { buildFts5Queries, matchConjunctiveFirst } = await import('./brain-search.js');
+      const ftsQueries = buildFts5Queries(params.query);
+
+      let rows: unknown[] = [];
+      try {
+        const ftsStmt = nativeDb.prepare(
+          `SELECT d.* FROM brain_decisions_fts f
+        JOIN brain_decisions d ON d.rowid = f.rowid
+        WHERE brain_decisions_fts MATCH ?
+        ${categoryClause.replace(/\bdecision_category\b/g, 'd.decision_category')}
+        ORDER BY bm25(brain_decisions_fts)
+        LIMIT ?`,
+        );
+        rows = matchConjunctiveFirst<unknown>(
+          (matchExpr) => ftsStmt.all(matchExpr, limit),
+          ftsQueries,
+        );
+      } catch {
+        // FTS table absent or query rejected — fall through to LIKE.
+        rows = [];
+      }
+
+      if (rows.length === 0) {
+        rows = nativeDb
+          .prepare(
+            `SELECT * FROM brain_decisions
         WHERE (decision LIKE ? OR rationale LIKE ?)
         ${categoryClause}
         ORDER BY created_at DESC
         LIMIT ?`,
-        )
-        .all(likePattern, likePattern, limit);
+          )
+          .all(likePattern, likePattern, limit);
+      }
 
       return { success: true, data: { decisions: rows, total: rows.length } };
     }
@@ -388,6 +425,34 @@ export async function memoryDecisionStore(
       decidedBy: params.decidedBy,
     });
 
+    // T12073: close the REVERSE edge.
+    //
+    // Storing `supersedes` alone leaves the graph navigable in one direction
+    // only: the new decision knows what it replaced, but the replaced one has
+    // an empty `superseded_by` and an open `invalid_at`, so every "is this
+    // still current?" query — including `isLatest`, which gates the query
+    // paths — reports the OBSOLETE decision as valid. Two contradictory
+    // decisions then both read as live, which is precisely the case the
+    // supersession machinery exists to resolve.
+    if (params.supersedes) {
+      try {
+        const { getBrainNativeDb } = await import('../store/memory-sqlite.js');
+        const nativeDb = getBrainNativeDb(root);
+        nativeDb
+          ?.prepare(
+            `UPDATE brain_decisions
+             SET superseded_by = ?,
+                 invalid_at = COALESCE(invalid_at, CURRENT_TIMESTAMP),
+                 outcome = 'superseded'
+             WHERE id = ? AND (superseded_by IS NULL OR superseded_by = '')`,
+          )
+          .run(row.id, params.supersedes);
+      } catch {
+        // Back-link is best-effort: never fail the store because the
+        // superseded row could not be annotated.
+      }
+    }
+
     return {
       success: true,
       data: {
@@ -395,6 +460,7 @@ export async function memoryDecisionStore(
         type: row.type,
         decision: row.decision,
         createdAt: row.createdAt,
+        ...(params.supersedes ? { supersededId: params.supersedes } : {}),
       },
     };
   } catch (error) {


### PR DESCRIPTION
The previous PR stopped BRAIN accumulating junk. It did not make BRAIN **useful** — and I said so rather than fixing it. This is the second half.

You asked: *"is it just a ton of wasted data? is it fast and quick to traverse, can you truly see and understand decisions, contradictions?"* Four independent defects, each measured against the live corpus.

---

## 1. Terms were exact, so morphological variants were invisible

The builder emitted `"orphan"` — a quoted, exact term. FTS5's `unicode61` tokenizer has no stemmer.

| query | documents matched |
|---|---|
| `"orphan"` | 113 |
| `orphan*` | **189** |

**76 documents saying "orphaned" could not be found by searching for "orphan".** Terms now carry the prefix operator.

## 2. Pure OR ranked by term rarity, not term coverage

BM25 normalises for length, so a short document matching **one** query term outranked a long one matching **all** of them. On a corpus that was 30% sub-60-character stubs, the emptiest records won:

```
cleo memory find "nexus_symbols_fts orphan"
  → 1. "Consolidated: change observations (5 entries)"   ← no content at all
```

Now **conjunctive-first**, falling back to disjunctive only when the conjunction finds nothing — preserving the recall the OR form was introduced for (T553: em dashes zeroing an implicit-AND query).

## 3. The four stores were CONCATENATED, and RRF scores by array position

`decisions → patterns → learnings → observations` encoded a fixed precedence unrelated to relevance: **every decision outranked every observation, always.** With 128 decisions and ~5,000 observations, the largest and most recent store was structurally the least reachable.

Now round-robin interleaved — removing the inter-table bias while preserving each table's own BM25 order, and without pretending BM25 scores are comparable across separate indexes.

## 4. `decision-find` never used FTS at all

It ran `LIKE '%<entire query>%'` — **one literal substring** — so any multi-word question failed unless those words appeared contiguously:

```
cleo memory decision-find --query "index freshness median"   → 0 hits
```

…against a decision whose text contains all three words, while `brain_decisions_fts` matched it correctly. **This is a large part of why nothing has been written to the decision store since 2026-06-09: it could not be searched back out.** Now FTS-backed with the same conjunctive-first strategy, LIKE retained as last resort.

## 5. Supersession was one-directional — the "contradictions" question

Storing `--supersedes D11143` recorded the forward edge but left the superseded row's `superseded_by` empty and `invalid_at` open. `isLatest` — the gate **all** query paths use — therefore reported the **obsolete** decision as still valid. Two contradictory decisions both read as live, which is the exact case the machinery exists to resolve.

Verified round-trip after the fix:

```
D11143 | superseded_by=D11144 | outcome=superseded | invalidated
D11144 | supersedes=D11143    | outcome=pending    | live
```

---

## `cleo memory prune-stubs` (dry-run by default)

For the corpus the T12071 defect already produced. Deliberately **not** the existing `purgeBrainNoise`, which is a one-shot script hardcoded to a historical state — running it today would delete all 127 learnings and 127 of 128 decisions.

This one touches **observations only**, and a row must match a named narrow rule **AND** a length guard **AND** `verified != 1`. It reports a sample before deleting anything.

Applied to this project's BRAIN after a full backup:

| | before | after |
|---|---|---|
| observations | 7,000 | **4,989** (2,011 removed, 28%) |
| substantive (>800 chars) | 482 | **482** — zero loss |
| decisions / patterns / learnings | 128 / 14,209 / 127 | **unchanged** |

The 8 surviving rows containing `status: undefined` are the ones that **describe** the bug — a 4,168-char root-cause note and 7 observer analyses. That is exactly what the length guard is for, and there is a test for it.

## Measured recall, before → after

| query | before | after |
|---|---|---|
| `nexus_symbols_fts orphan` | absent from top 10 | **rank 3** |
| `discovery-surface audit` | absent from top 10 | **rank 4** |
| `index freshness median` | 0 decision hits | **1** (the exact decision) |

## Verification

- 80 memory test files / **1,054 tests pass**; 22 new tests
- **7/7** architectural gates; Gate 14 clean
- Workspace build clean; `biome ci` clean
- Prune verified against the live 7,000-row corpus with a full backup taken first

🤖 Generated with [Claude Code](https://claude.com/claude-code)