### PR TITLE
fix: the autonomous layer was inert — sentient loop picked 0 tasks in 24 ticks, selfimprove could never go green (T12077)

### DIFF
--- a/packages/cleo/src/cli/commands/__tests__/output-mode.test.ts
+++ b/packages/cleo/src/cli/commands/__tests__/output-mode.test.ts
@@ -291,3 +291,44 @@ describe('renderOutputMode — {results: [...]} envelopes (T12067)', () => {
     expect(out.text).toBe('T1');
   });
 });
+
+// ---------------------------------------------------------------------------
+// T12077 — {suggestions: [...]} envelopes (`cleo next`)
+// ---------------------------------------------------------------------------
+
+describe('renderOutputMode — {suggestions: [...]} envelopes (T12077)', () => {
+  /**
+   * The exact shape `tasks.next` emits. `suggestions` was absent from the
+   * renderer's LOCAL key list even after T12067 added `results`, so
+   * `cleo next --output id` reported "No ids." against an envelope holding
+   * 836 candidates. The list now comes from the contracts SSoT.
+   */
+  const nextEnvelope = {
+    suggestions: [
+      { id: 'T12034', title: 'CI shard-2: eliminate BRAIN writer flakes', status: 'pending' },
+      { id: 'T1738', title: 'Design CleoOS harness architecture', status: 'pending' },
+    ],
+    totalCandidates: 836,
+  };
+
+  it('extracts ids from a next envelope', () => {
+    expect(renderOutputMode('id', nextEnvelope).text).toBe('T12034\nT1738');
+  });
+
+  it('renders a next envelope as a table', () => {
+    const out = renderOutputMode('table', nextEnvelope).text ?? '';
+    expect(out).toContain('T12034');
+    expect(out).not.toBe('No rows.');
+  });
+
+  it('renders a next envelope as a summary', () => {
+    expect(renderSummary(nextEnvelope).text ?? '').toContain('T12034 [pending]');
+  });
+
+  it('never disagrees across modes for a next envelope', () => {
+    for (const mode of ['id', 'table'] as const) {
+      expect(renderOutputMode(mode, nextEnvelope).emptyReason, mode).toBeUndefined();
+    }
+    expect(renderSummary(nextEnvelope).emptyReason).toBeUndefined();
+  });
+});

--- a/packages/cleo/src/cli/renderers/output-mode.ts
+++ b/packages/cleo/src/cli/renderers/output-mode.ts
@@ -19,6 +19,7 @@
  * @epic T9855
  */
 
+import { COLLECTION_KEYS as CONTRACT_COLLECTION_KEYS } from '@cleocode/contracts';
 import { truncateString } from '@cleocode/core';
 import type { OutputMode } from '../output-context.js';
 
@@ -42,7 +43,11 @@ import type { OutputMode } from '../output-context.js';
  *
  * @task T12067
  */
-const COLLECTION_KEYS = ['tasks', 'items', 'results'] as const;
+// T12077: imported from contracts rather than re-declared. A LOCAL copy is how
+// `suggestions` (the key `tasks.next` emits) came to be missing here while the
+// SSoT already listed it — `cleo next --output id` reported "No ids." against
+// an envelope holding 836 candidates. One list, one place.
+const COLLECTION_KEYS = CONTRACT_COLLECTION_KEYS;
 
 /**
  * Resolve the first list-shaped collection on an envelope `data` payload.

--- a/packages/contracts/src/collection-keys.ts
+++ b/packages/contracts/src/collection-keys.ts
@@ -1,0 +1,45 @@
+/**
+ * The keys under which CLEO payloads carry a list of records.
+ *
+ * ## Why this is a shared constant (T12077)
+ *
+ * Different operations name their collection differently — `tasks.list` emits
+ * `tasks`, the SDK's generic list emits `items`, `tasks.find` emits `results`,
+ * and `tasks.next` emits `suggestions`. Each consumer that wants "the rows"
+ * has historically inlined its own guess, and each wrong guess fails SILENTLY,
+ * because an absent key is indistinguishable from an empty result set.
+ *
+ * Three separate outages traced to exactly this:
+ *
+ * 1. **T12067** — `output-mode.ts` knew only `tasks`/`items`, in three
+ *    separately-inlined lists. `cleo find … --output count` reported 1626
+ *    while `--output id` reported `No ids.` against the same payload.
+ * 2. **T12077 (this)** — `cleo next --output id` / `--output count` reported
+ *    nothing and zero while the envelope held 836 candidates, because
+ *    `suggestions` was in nobody's list.
+ * 3. **T12077 (the severe one)** — `defaultPickTask` in the sentient loop read
+ *    `response.data.tasks` from `cleo.tasks.find()`, which returns
+ *    `{results, total}` *unwrapped*. The key was wrong AND the `data` envelope
+ *    it was reaching through does not exist on the SDK surface, so
+ *    `allCandidates` was **always `[]`**. The autonomous loop therefore
+ *    returned `no-task` on every tick it had ever run — 24 ticks, 0 tasks
+ *    picked, across three months — and looked exactly like "there is no work
+ *    to do" rather than like a bug.
+ *
+ * The lesson those three share is that this list must exist in ONE place that
+ * both the render layer and the SDK consumers import. Adding an operation with
+ * a new collection key now means adding it here, once.
+ *
+ * @task T12077
+ */
+
+/**
+ * Collection keys in resolution order.
+ *
+ * Order matters only when a payload carries more than one (it should not);
+ * earlier keys win, which keeps the canonical `tasks` shape authoritative.
+ */
+export const COLLECTION_KEYS = ['tasks', 'items', 'results', 'suggestions'] as const;
+
+/** A key under which a payload may carry its rows. */
+export type CollectionKey = (typeof COLLECTION_KEYS)[number];

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2666,3 +2666,5 @@ export {
   CAAMP_MARKER_END,
   CAAMP_MARKER_START,
 } from './caamp-markers.js';
+// T12077: SSoT for the keys under which payloads carry their rows.
+export { COLLECTION_KEYS, type CollectionKey } from './collection-keys.js';

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -764,7 +764,23 @@ export async function initProject(opts: InitOptions = {}): Promise<InitResult> {
   const alreadyInitialized =
     existsSync(cleoDir) &&
     (existsSync(join(cleoDir, 'tasks.db')) || existsSync(join(cleoDir, 'config.json')));
-  if (alreadyInitialized && !opts.force) {
+
+  // T12077: `--map-codebase` is ADDITIVE — it analyses the tree and writes
+  // findings to BRAIN; it scaffolds nothing and wipes nothing. Blocking it
+  // behind this guard made the onboarding path self-contradictory: a fresh
+  // `cleo init` on a brownfield repo returns
+  //
+  //   nextSteps: [{ action: 'Anchor the existing codebase in BRAIN as baseline
+  //                 context', command: 'cleo init --map-codebase' }]
+  //
+  // and running that exact command then failed with "Project already
+  // initialized. DANGER ZONE: use --force to wipe and re-init." The only way
+  // to follow CLEO's own advice was to destroy the project it had just set up.
+  //
+  // Measured on a greenfield sandbox: `cleo init` succeeded, and the very
+  // first recommended follow-up was impossible.
+  const additiveMapOnly = opts.mapCodebase === true;
+  if (alreadyInitialized && !opts.force && !additiveMapOnly) {
     throw new CleoError(
       ExitCode.GENERAL_ERROR,
       'Project already initialized. DANGER ZONE: use --force to wipe and re-init.',

--- a/packages/core/src/selfimprove/__tests__/run-loop.test.ts
+++ b/packages/core/src/selfimprove/__tests__/run-loop.test.ts
@@ -25,7 +25,7 @@
  * @task T11913
  */
 
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
@@ -60,15 +60,28 @@ const guard = createToolGuard({ mode: 'enforce' });
  * diff yields ZERO regressions; volatile meta fields are stamped fresh per call
  * and stripped by the diff normalizer.
  */
-const GOLDEN_DATA: Record<string, unknown> = {
-  find: {
-    tasks: [{ id: 'T11889', title: 'Self-improvement loop foundation', status: 'active' }],
-    count: 1,
-  },
-  show: {
-    task: { id: 'T11889', title: 'Self-improvement loop foundation', status: 'active' },
-  },
-};
+/**
+ * Golden payloads, READ FROM THE FIXTURE rather than duplicated here.
+ *
+ * T12077: this used to be a hand-copied literal declaring `{tasks, count}` for
+ * `tasks.find` — a shape that operation has never emitted (it returns
+ * `{results, total}`). Because the test asserted the same wrong shape the
+ * fixture did, the pair agreed with each other and disagreed with reality: the
+ * suite was green while `cleo selfimprove run` was permanently red and would,
+ * under `--execute`, have opened a DHQ and a draft PR on every run.
+ *
+ * Reading the fixture makes the test verify the ENGINE (does a golden-matching
+ * dispatch produce zero regressions?) instead of re-asserting a copy of the
+ * data. `scenario-contract.test.ts` separately asserts the fixture itself
+ * matches the real operation contract.
+ */
+const GOLDEN_DATA: Record<string, unknown> = (() => {
+  const goldenPath = join(import.meta.dirname, '..', 'scenarios', 'dhq-replay-find', 'golden.json');
+  const parsed = JSON.parse(readFileSync(goldenPath, 'utf-8')) as {
+    envelopes: Array<{ meta: { operation: string }; data: unknown }>;
+  };
+  return Object.fromEntries(parsed.envelopes.map((e) => [e.meta.operation, e.data]));
+})();
 
 /**
  * Build a dispatch port that returns the GOLDEN-matching envelopes for the

--- a/packages/core/src/selfimprove/__tests__/scenario-contract.test.ts
+++ b/packages/core/src/selfimprove/__tests__/scenario-contract.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Structural guards for the self-improvement dogfood scenarios (T12077).
+ *
+ * ## Why (measured 2026-08-06)
+ *
+ * `cleo selfimprove run --scenario dhq-replay-find` had **never** produced a
+ * clean run. Two independent defects, both in the fixtures rather than the
+ * engine:
+ *
+ * 1. **The golden encoded a shape the operation has never emitted.** It
+ *    declared `data.tasks` + `data.count`; `tasks.find` returns `results` +
+ *    `total`. Fourth instance of the collection-key confusion that also made
+ *    `cleo find --output id` empty (T12067) and the sentient loop inert
+ *    (T12077).
+ * 2. **The scenario passed the wrong param name.** `tasks.show` takes
+ *    `taskId`; the scenario sent `id`, so the op returned
+ *    `E_MISSING_PARAMS` and *every* field under `data` diffed.
+ *
+ * The consequence is worse than a broken test. `envelope-diff.ts` documents
+ * that its meta-stripping exists to prevent "a permanent phantom DHQ that
+ * self-fires on every clean run" — and the fixture reintroduced exactly that
+ * through the data channel. With `--execute`, this loop would open a DHQ row
+ * and a draft PR on **every single run, forever**, against a regression that
+ * does not exist.
+ *
+ * A golden is ground truth; when ground truth is wrong the loop cannot tell
+ * "the product changed" from "the fixture was never right". These tests assert
+ * the fixture agrees with the real operation contract.
+ *
+ * @task T12077
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/** Scenario directory under `src` (the build copies it to `dist`). */
+const SCENARIO_DIR = join(import.meta.dirname, '..', 'scenarios', 'dhq-replay-find');
+
+/** Read and parse a fixture file. */
+function readJson(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(SCENARIO_DIR, name), 'utf-8')) as Record<string, unknown>;
+}
+
+interface ScenarioOp {
+  gateway: string;
+  domain: string;
+  operation: string;
+  params: Record<string, unknown>;
+}
+
+interface GoldenEntry {
+  success: boolean;
+  meta: Record<string, unknown>;
+  data: Record<string, unknown>;
+}
+
+describe('dhq-replay-find fixture agrees with the operation contract (T12077)', () => {
+  const scenario = readJson('scenario.json');
+  const golden = readJson('golden.json');
+  const ops = scenario['ops'] as ScenarioOp[];
+  const envelopes = golden['envelopes'] as GoldenEntry[];
+
+  it('has one golden envelope per scenario op', () => {
+    // A length mismatch is itself reported as a regression by diffEnvelopes,
+    // which would make the loop permanently red.
+    expect(envelopes).toHaveLength(ops.length);
+  });
+
+  it('pairs each golden envelope with its op coordinates', () => {
+    ops.forEach((op, i) => {
+      const meta = envelopes[i]?.meta ?? {};
+      expect(meta['domain'], `op ${i} domain`).toBe(op.domain);
+      expect(meta['operation'], `op ${i} operation`).toBe(op.operation);
+    });
+  });
+
+  it('calls tasks.show with `taskId`, not `id`', () => {
+    // Sending `id` produced E_MISSING_PARAMS and diffed every field under data.
+    const show = ops.find((o) => o.operation === 'show');
+    expect(show, 'scenario must exercise tasks.show').toBeDefined();
+    expect(Object.keys(show!.params)).toContain('taskId');
+    expect(Object.keys(show!.params)).not.toContain('id');
+  });
+
+  it('expects the REAL tasks.find collection shape — results/total', () => {
+    const findIndex = ops.findIndex((o) => o.operation === 'find');
+    const data = envelopes[findIndex]?.data ?? {};
+
+    expect(Object.keys(data)).toContain('results');
+    expect(Object.keys(data)).toContain('total');
+    // The shape the golden used to claim, which the operation never emitted.
+    expect(Object.keys(data)).not.toContain('tasks');
+    expect(Object.keys(data)).not.toContain('count');
+  });
+
+  it('every golden envelope is a success envelope', () => {
+    // A golden that encodes `success: false` would pin an error as correct.
+    for (const [i, env] of envelopes.entries()) {
+      expect(env.success, `envelope ${i}`).toBe(true);
+      expect(env).not.toHaveProperty('error');
+    }
+  });
+
+  it('pins find to a single task id so the golden is deterministic', () => {
+    // A free-text query pins whatever live rows happen to match into the
+    // golden, so the loop goes red the moment anyone adds a task. The original
+    // fixture used `{query: 'selfimprove'}` and matched 10 rows.
+    const find = ops.find((o) => o.operation === 'find');
+    expect(find?.params).toHaveProperty('id');
+    expect(find?.params).not.toHaveProperty('query');
+
+    const findIndex = ops.findIndex((o) => o.operation === 'find');
+    const data = envelopes[findIndex]?.data as { results?: unknown[]; total?: number };
+    expect(data.results).toHaveLength(1);
+    expect(data.total).toBe(1);
+  });
+
+  it('is read-only — no mutate gateway in a dogfood replay', () => {
+    for (const op of ops) expect(op.gateway).toBe('query');
+  });
+});

--- a/packages/core/src/selfimprove/scenarios/dhq-replay-find/golden.json
+++ b/packages/core/src/selfimprove/scenarios/dhq-replay-find/golden.json
@@ -10,10 +10,17 @@
         "source": "rpc"
       },
       "data": {
-        "tasks": [
-          { "id": "T11889", "title": "Self-improvement loop foundation", "status": "active" }
+        "results": [
+          {
+            "id": "T11889",
+            "title": "E-SELF-IMPROVEMENT-LOOP: daemon-triggered Gondolin observe->optimize->propose dogfood/DHQ cycle",
+            "status": "done",
+            "priority": "medium",
+            "parentId": "T11243",
+            "type": "epic"
+          }
         ],
-        "count": 1
+        "total": 1
       }
     },
     {
@@ -25,7 +32,110 @@
         "source": "rpc"
       },
       "data": {
-        "task": { "id": "T11889", "title": "Self-improvement loop foundation", "status": "active" }
+        "task": {
+          "id": "T11889",
+          "title": "E-SELF-IMPROVEMENT-LOOP: daemon-triggered Gondolin observe->optimize->propose dogfood/DHQ cycle",
+          "status": "done",
+          "priority": "medium",
+          "type": "epic",
+          "parentId": "T11243",
+          "kind": "work",
+          "relationCounts": {
+            "depends": 0,
+            "blockedBy": 0,
+            "relates": 0,
+            "children": 5,
+            "docs": 1
+          }
+        },
+        "view": {
+          "id": "T11889",
+          "title": "E-SELF-IMPROVEMENT-LOOP: daemon-triggered Gondolin observe->optimize->propose dogfood/DHQ cycle",
+          "status": "done",
+          "pipelineStage": "contribution",
+          "lifecycleProgress": {
+            "stagesCompleted": [],
+            "stagesSkipped": [],
+            "currentStage": null
+          },
+          "childRollup": {
+            "total": 5,
+            "done": 5,
+            "blocked": 0,
+            "active": 0
+          },
+          "gatesStatus": {
+            "implemented": false,
+            "testsPassed": false,
+            "qaPassed": false
+          },
+          "readyToComplete": false,
+          "nextAction": "already-complete"
+        },
+        "attachments": [
+          {
+            "attachmentId": "93a24c4f-3530-438d-ad16-b9cc72f3576a",
+            "kind": "local-file",
+            "slug": "p5-self-improvement-architecture",
+            "type": "spec"
+          }
+        ],
+        "acRows": [
+          {
+            "id": "6fd2a986-beeb-5b12-b51a-73a0bc0260cf",
+            "alias": "AC1",
+            "ordinal": 1,
+            "text": "walking skeleton: cleo selfimprove run --scenario <n> boots ONE Gondolin VM, replays ONE canned dogfood scenario, diffs envelopes vs golden, emits ONE DHQ row to a dual-scope selfimprove_dhq table (Gate 3)"
+          },
+          {
+            "id": "4117b3dd-3a8a-5aff-9016-04d774b1864c",
+            "alias": "AC2",
+            "ordinal": 2,
+            "text": "on regression opens ONE DRAFT PR (ADR-065); NO autonomous fix-gen/auto-merge/end-user mode in v1"
+          },
+          {
+            "id": "14a7545d-e2b9-5777-b3b4-9c2e92bafc3e",
+            "alias": "AC3",
+            "ordinal": 3,
+            "text": "flag-gated default OFF; sandbox output is ONLY a draft PR \u2014 never a prod DB write or main push"
+          },
+          {
+            "id": "2c0348d0-b1c7-5a61-855a-70045dcfe69f",
+            "alias": "AC4",
+            "ordinal": 4,
+            "text": "circuit-breaker halts on gate-red/lease-denial; budget caps token/$/PRs/worktrees/MemoryMax=32G"
+          },
+          {
+            "id": "8510256a-6b51-5181-a57e-77f51870a3b9",
+            "alias": "AC5",
+            "ordinal": 5,
+            "text": "Complete child T11911: T11889-A: selfimprove_dhq dual-scope table + byte-identical migration + Gate-3 accessor"
+          },
+          {
+            "id": "68e351ae-7c7c-5e9f-a937-5bb15efe53ff",
+            "alias": "AC6",
+            "ordinal": 6,
+            "text": "Complete child T11912: T11889-B: scenario replay + envelope-diff + canned scenario/golden fixtures (pure)"
+          },
+          {
+            "id": "07d27d7a-117c-5617-9eca-ba148ae4c28e",
+            "alias": "AC7",
+            "ordinal": 7,
+            "text": "Complete child T11913: T11889-C: engine run-loop \u2014 DHQ adapter (lease) + draft-PR egress + budget/circuit-breaker"
+          },
+          {
+            "id": "6ad799cd-e73f-5892-a63c-cce039a2b778",
+            "alias": "AC8",
+            "ordinal": 8,
+            "text": "Complete child T11914: T11889-D: verb wiring \u2014 cleo selfimprove run --scenario <n> (op-registry + dispatch + thin handler)"
+          },
+          {
+            "id": "3738623b-31b7-5e5a-aa84-8804bd943184",
+            "alias": "AC9",
+            "ordinal": 9,
+            "text": "Complete child T11975: Self-improve loop v2: Pi-runner fix-generation stage \u2014 DHQ + regression-diff \u2192 LLM-generated patch \u2192 draft PR (the missing autonomous DHQ\u2192fix\u2192PR link)"
+          }
+        ]
       }
     }
   ]

--- a/packages/core/src/selfimprove/scenarios/dhq-replay-find/scenario.json
+++ b/packages/core/src/selfimprove/scenarios/dhq-replay-find/scenario.json
@@ -1,18 +1,18 @@
 {
   "name": "dhq-replay-find",
-  "description": "Canonical read-only dogfood discovery sequence: find then show. The golden is the known-good normalized envelope set; any structural deviation is a regression.",
+  "description": "Canonical read-only dogfood discovery sequence: find then show. The golden is the known-good normalized envelope set; any structural deviation is a regression. Both ops are pinned to a SINGLE known task id so the golden is deterministic — a free-text query would pin live task rows into the golden and the loop could never be green (T12077).",
   "ops": [
     {
       "gateway": "query",
       "domain": "tasks",
       "operation": "find",
-      "params": { "query": "selfimprove" }
+      "params": { "id": "T11889" }
     },
     {
       "gateway": "query",
       "domain": "tasks",
       "operation": "show",
-      "params": { "id": "T11889" }
+      "params": { "taskId": "T11889" }
     }
   ]
 }

--- a/packages/core/src/sentient/tick.ts
+++ b/packages/core/src/sentient/tick.ts
@@ -358,6 +358,37 @@ function pruneStuckWindow(timestamps: readonly number[], now: number): number[] 
 }
 
 /**
+ * Canonical task-id shape. Mirrors `TASK_ID_PATTERN` in `tasks/id-generator.ts`.
+ *
+ * @task T12077
+ */
+const PICKABLE_TASK_ID = /^T\d{3,}$/;
+
+/**
+ * Reject candidates whose id is not a canonical task id.
+ *
+ * The sentient loop spawns a worker against whatever it picks, so a malformed
+ * id is not merely useless — it burns a tick, and if it sorts early it burns
+ * EVERY tick. This project's database contains exactly such a row: a task
+ * whose id is the absolute project root (`/mnt/projects/cleocode`), created
+ * 2026-05-28 by a caller that passed a projectRoot where a taskId was
+ * expected. Because it begins with `/` it sorts ahead of every `T####` id, so
+ * dependency-wave ordering placed it first in wave 0 and the picker would
+ * select it forever.
+ *
+ * Filtering here keeps the loop live even when the task table has a bad row —
+ * the loop should degrade to "skip that one", never to "spin on it".
+ *
+ * @param task - a candidate task.
+ * @returns true when the id is a canonical `T####`.
+ *
+ * @task T12077
+ */
+function isPickableTaskId(task: Task): boolean {
+  return typeof task.id === 'string' && PICKABLE_TASK_ID.test(task.id);
+}
+
+/**
  * Default SDK-backed task picker. Delegates to the orchestration domain via
  * the @cleocode/core/sdk facade.
  *
@@ -382,6 +413,7 @@ async function defaultPickTask(
   const { getReadyTasks } = await import('@cleocode/core/tasks');
   // graph-ops is an intra-package import (not part of the @cleocode/core/tasks barrel).
   const { computeDependencyWaves } = await import('../tasks/graph-ops.js');
+  const { collectionOf } = await import('../tasks/collection.js');
 
   const cleo = await Cleo.init(projectRoot);
 
@@ -412,11 +444,21 @@ async function defaultPickTask(
   // Use find() to get candidate tasks. We specifically avoid 'proposed' by
   // only filtering on pending/active/blocked. getReadyTasks() from the
   // dependency-check module is authoritative for "unblocked".
-  const pending = (await cleo.tasks.find({ status: 'pending', limit: 500 })) as {
-    success?: boolean;
-    data?: { tasks?: Task[] };
-  };
-  const allCandidates: Task[] = Array.isArray(pending?.data?.tasks) ? pending.data.tasks : [];
+  // T12077: read the collection through the shared resolver.
+  //
+  // This previously read `pending.data.tasks`, which is wrong TWICE over:
+  // `cleo.tasks.find()` returns the payload BARE (no `data` envelope), and its
+  // collection key is `results`, not `tasks`. `allCandidates` was therefore
+  // always `[]`, `defaultPickTask` always returned null, and `runTick` always
+  // returned `no-task`.
+  //
+  // The failure is silent by construction — an absent key is indistinguishable
+  // from an empty result set — so the sentient loop reported "no unblocked
+  // tasks available" on every tick it ever ran (24 ticks, 0 tasks picked, over
+  // three months) while 836 candidates were in fact ready. It read as "there
+  // is nothing to do", not as a defect, which is why it sat unnoticed.
+  const pending = await cleo.tasks.find({ status: 'pending', limit: 500 });
+  const allCandidates: Task[] = collectionOf<Task>(pending).filter(isPickableTaskId);
 
   // Apply scope filter when active.
   const candidates =

--- a/packages/core/src/tasks/__tests__/collection.test.ts
+++ b/packages/core/src/tasks/__tests__/collection.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the shared collection resolver (T12077).
+ *
+ * The bug this exists to prevent is not "returns the wrong rows" — it is
+ * "returns NO rows, silently, and the caller cannot tell that from an empty
+ * result set". That is how the sentient loop reported "no unblocked tasks
+ * available" on every tick for three months.
+ *
+ * @task T12077
+ */
+
+import { COLLECTION_KEYS } from '@cleocode/contracts';
+import { describe, expect, it } from 'vitest';
+import { collectionOf, pickCollection } from '../collection.js';
+
+describe('pickCollection (T12077)', () => {
+  it('resolves the BARE shape the SDK returns', () => {
+    // `cleo.tasks.find()` returns `{results, total}` with NO `data` wrapper.
+    // Reading `.data.tasks` from this — as the sentient picker did — yields
+    // undefined twice over.
+    const sdkResponse = { results: [{ id: 'T11191' }, { id: 'T11192' }], total: 2 };
+    expect(pickCollection(sdkResponse)).toHaveLength(2);
+  });
+
+  it('resolves the ENVELOPED shape the dispatch surface returns', () => {
+    expect(pickCollection({ data: { tasks: [{ id: 'T1' }] } })).toEqual([{ id: 'T1' }]);
+  });
+
+  it('resolves every declared collection key', () => {
+    for (const key of COLLECTION_KEYS) {
+      expect(pickCollection({ [key]: [{ id: 'X' }] }), `key: ${key}`).toEqual([{ id: 'X' }]);
+    }
+  });
+
+  it('covers suggestions — the key `cleo next` emits', () => {
+    // `cleo next --output id` reported "No ids." against an envelope holding
+    // 836 candidates, because `suggestions` was in nobody's key list.
+    const next = { suggestions: [{ id: 'T12034', score: 125 }], totalCandidates: 836 };
+    expect(pickCollection(next)).toHaveLength(1);
+  });
+
+  it('prefers the canonical `tasks` key when several are present', () => {
+    expect(pickCollection({ tasks: [{ id: 'A' }], results: [{ id: 'B' }] })).toEqual([{ id: 'A' }]);
+  });
+
+  it('returns undefined — not an empty array — when no collection exists', () => {
+    // The distinction matters: `undefined` lets a caller detect "wrong shape",
+    // which is exactly the signal that was missing.
+    expect(pickCollection({ total: 0 })).toBeUndefined();
+    expect(pickCollection(null)).toBeUndefined();
+    expect(pickCollection('nope')).toBeUndefined();
+    expect(pickCollection(undefined)).toBeUndefined();
+  });
+
+  it('does not treat a non-array value under a collection key as rows', () => {
+    expect(pickCollection({ tasks: 42 })).toBeUndefined();
+    expect(pickCollection({ results: { id: 'T1' } })).toBeUndefined();
+  });
+
+  it('does not recurse past one level of `data`', () => {
+    expect(pickCollection({ data: { data: { tasks: [{ id: 'deep' }] } } })).toBeUndefined();
+  });
+});
+
+describe('collectionOf (T12077)', () => {
+  it('returns an empty array rather than undefined for ergonomic use', () => {
+    expect(collectionOf({ total: 0 })).toEqual([]);
+  });
+
+  it('reproduces the sentient-loop regression end to end', () => {
+    const sdkResponse = { results: [{ id: 'T1009' }, { id: 'T1010' }], total: 2 };
+
+    // What the picker used to do — wrong key, through a wrapper that is not there.
+    const old = Array.isArray((sdkResponse as { data?: { tasks?: unknown[] } })?.data?.tasks)
+      ? (sdkResponse as unknown as { data: { tasks: unknown[] } }).data.tasks
+      : [];
+    expect(old).toEqual([]); // ← always empty ⇒ 'no unblocked tasks available'
+
+    // What it does now.
+    expect(collectionOf(sdkResponse)).toHaveLength(2);
+  });
+});

--- a/packages/core/src/tasks/add.ts
+++ b/packages/core/src/tasks/add.ts
@@ -713,6 +713,30 @@ export function findRecentDuplicate(
 }
 
 /**
+ * Whether the project contains no tasks at all.
+ *
+ * Used only on the containment-violation error path, so the cost of the query
+ * is paid solely when the caller has already made a mistake.
+ *
+ * @param cwd - project root.
+ * @param accessor - optional pre-resolved accessor.
+ * @returns true when the task table is empty (or unreadable — in which case the
+ *          generic message is the safer default).
+ *
+ * @task T12077
+ */
+async function hasNoTasks(cwd: string | undefined, accessor?: DataAccessor): Promise<boolean> {
+  try {
+    const acc =
+      accessor ?? (await (await import('../store/data-accessor.js')).getTaskAccessor(cwd));
+    const { tasks } = await acc.queryTasks({});
+    return tasks.length === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Add a new task to the todo file.
  * @task T4460
  */
@@ -771,13 +795,25 @@ export async function addTask(
     !parentId &&
     effectiveRootType !== 'saga'
   ) {
+    // T12077: on a FRESH project this rule is unsatisfiable as worded. A new
+    // `.cleo/` has zero tasks, so there is no `T###` to pass to `--parent`, yet
+    // the fix said `cleo add "Task title" --parent T###`. The first thing a user
+    // or agent does in a new project — file a task — failed with an instruction
+    // that could not be followed. Only a saga may be a root, so on an empty
+    // project the honest next step is `cleo saga create`.
+    const isFirstTask = await hasNoTasks(cwd, accessor);
     issues.push({
       field: 'parentId',
-      message:
-        `A ${effectiveRootType} must attach to a parent — only a saga may be a root ` +
-        `(strict-spine containment, T11811). Use --parent <id> to file it under the ` +
-        `correct container (saga→epic, epic→task, task→subtask).`,
-      fix: 'cleo add "Task title" --parent T### --acceptance "AC1|AC2|AC3"',
+      message: isFirstTask
+        ? `This project has no tasks yet, and only a saga may be a root ` +
+          `(strict-spine containment, T11811). Create the root saga first, then ` +
+          `file epics under it and tasks under those.`
+        : `A ${effectiveRootType} must attach to a parent — only a saga may be a root ` +
+          `(strict-spine containment, T11811). Use --parent <id> to file it under the ` +
+          `correct container (saga→epic, epic→task, task→subtask).`,
+      fix: isFirstTask
+        ? 'cleo saga create --title "<theme>" --description "..." --acceptance "AC1|AC2|AC3|AC4|AC5"'
+        : 'cleo add "Task title" --parent T### --acceptance "AC1|AC2|AC3"',
     });
   }
 

--- a/packages/core/src/tasks/collection.ts
+++ b/packages/core/src/tasks/collection.ts
@@ -1,0 +1,82 @@
+/**
+ * Resolve "the rows" from any CLEO operation payload (T12077).
+ *
+ * The key list itself lives in `@cleocode/contracts` as const data
+ * ({@link COLLECTION_KEYS}); this module holds the runtime helper, because
+ * `packages/contracts` is types-only (architectural Gate 10).
+ *
+ * See the contracts module for the three separate outages that motivated a
+ * shared SSoT — most severely the sentient loop, which read `data.tasks` from
+ * an SDK call returning bare `{results, total}` and therefore picked zero
+ * tasks on every tick for three months while reporting "no unblocked tasks
+ * available".
+ *
+ * @task T12077
+ */
+
+import { COLLECTION_KEYS } from '@cleocode/contracts';
+
+/**
+ * Resolve the first list-shaped collection on a payload.
+ *
+ * Accepts BOTH the enveloped shape (`{data: {results: […]}}`) and the bare
+ * shape the SDK returns (`{results: […]}`). Confusing those two is precisely
+ * what made the sentient loop inert, so this helper deliberately handles both
+ * rather than making each caller guess which surface it is holding.
+ *
+ * @param payload - an operation response, enveloped or bare.
+ * @returns the matching array, or `undefined` when the payload carries none.
+ *
+ * @example
+ * ```ts
+ * pickCollection({ results: [{ id: 'T1' }], total: 1 }); // → [{ id: 'T1' }]
+ * pickCollection({ data: { tasks: [{ id: 'T2' }] } });   // → [{ id: 'T2' }]
+ * pickCollection({ total: 0 });                          // → undefined
+ * ```
+ *
+ * @task T12077
+ */
+export function pickCollection(payload: unknown): unknown[] | undefined {
+  const direct = firstArrayIn(payload);
+  if (direct !== undefined) return direct;
+
+  // Enveloped form — recurse ONCE into `data` so a caller holding a dispatch
+  // envelope gets the same answer as one holding the bare payload.
+  if (payload !== null && typeof payload === 'object') {
+    return firstArrayIn((payload as Record<string, unknown>)['data']);
+  }
+  return undefined;
+}
+
+/**
+ * Typed convenience wrapper over {@link pickCollection}.
+ *
+ * @param payload - an operation response, enveloped or bare.
+ * @returns the rows cast to `T[]`, or an empty array when absent.
+ *
+ * @example
+ * ```ts
+ * const tasks = collectionOf<Task>(await cleo.tasks.find({ status: 'pending' }));
+ * ```
+ *
+ * @task T12077
+ */
+export function collectionOf<T>(payload: unknown): T[] {
+  return (pickCollection(payload) ?? []) as T[];
+}
+
+/**
+ * First value under a known collection key that is an array.
+ *
+ * @param value - candidate object.
+ * @returns the array, or `undefined`.
+ */
+function firstArrayIn(value: unknown): unknown[] | undefined {
+  if (value === null || typeof value !== 'object') return undefined;
+  const rec = value as Record<string, unknown>;
+  for (const key of COLLECTION_KEYS) {
+    const found = rec[key];
+    if (Array.isArray(found)) return found;
+  }
+  return undefined;
+}

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -127,7 +127,7 @@ CLEO has **three distinct relationship systems**. Do not conflate them.
 |------|---------|
 | Check session | `cleo session status` |
 | Resume context | `cleo briefing` |
-| Start session | `cleo session start --scope global` |
+| Start session | `cleo session start --scope global --name "<what you are doing>"` (both flags are REQUIRED) |
 | End session | `cleo session end --note "..."` |
 <!-- /CLEO-INJECTION:section=session-commands -->
 

--- a/scripts/lint-injection-commands.mjs
+++ b/scripts/lint-injection-commands.mjs
@@ -180,6 +180,79 @@ export function extractRootSubCommands(source, verb) {
 }
 
 /**
+ * Required flags declared by a sub-command's citty `args` block.
+ *
+ * T12077: Gate 14 originally asserted only that a command EXISTS. That is not
+ * enough — the protocol table said
+ *
+ *   | Start session | `cleo session start --scope global` |
+ *
+ * and `session start` declares BOTH `scope` and `name` as `required: true`, so
+ * following the protocol literally produced
+ * `E_VALIDATION: Missing required argument: --name`. This is the first command
+ * an agent runs when dropped into a new project, so the documented onboarding
+ * path failed at step one.
+ *
+ * Existence and invocability are different properties; a protocol that is
+ * phrased as instruction has to satisfy both.
+ *
+ * @param source - the command module source.
+ * @param sub    - the sub-command key (e.g. `start`).
+ * @returns set of required flag names, or an empty set when none/unparseable.
+ */
+export function extractRequiredArgs(source, sub) {
+  // Locate `meta: { name: '<sub>' ... }` then the sibling `args: {` block.
+  const metaRe = new RegExp(`meta:\\s*\\{[^}]*name:\\s*'${sub}'`);
+  const metaAt = source.search(metaRe);
+  if (metaAt === -1) return new Set();
+
+  const argsAt = source.indexOf('args: {', metaAt);
+  if (argsAt === -1) return new Set();
+  // Bail if another defineCommand starts before the args block — that means
+  // this command declares no args of its own.
+  const nextDefine = source.indexOf('defineCommand(', metaAt + 1);
+  if (nextDefine !== -1 && nextDefine < argsAt) return new Set();
+
+  const bodyStart = argsAt + 'args: {'.length;
+  let depth = 1;
+  let i = bodyStart;
+  for (; i < source.length && depth > 0; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') depth--;
+  }
+  const body = source.slice(bodyStart, i - 1).replace(/\/\/[^\n]*/g, '');
+
+  const required = new Set();
+  // Each entry is `<flag>: { ... }` — capture the flag then test its block.
+  for (const m of body.matchAll(/(?:^|[,{])\s*'?([a-z][\w-]*)'?\s*:\s*\{/gm)) {
+    const start = m.index + m[0].length;
+    let d = 1;
+    let j = start;
+    for (; j < body.length && d > 0; j++) {
+      if (body[j] === '{') d++;
+      else if (body[j] === '}') d--;
+    }
+    const block = body.slice(start, j - 1);
+    // Positionals are supplied without a flag, so a doc line that passes them
+    // inline (`cleo memory find "<topic>"`) is correct and must not be
+    // reported. Only flag-style args can be 'missing' from an invocation.
+    if (/type:\s*'positional'/.test(block)) continue;
+    if (/required:\s*true/.test(block)) required.add(m[1]);
+  }
+  return required;
+}
+
+/**
+ * Flags present on a documented command invocation.
+ *
+ * @param invocation - the raw text of the documented command.
+ * @returns set of flag names (without leading dashes).
+ */
+export function flagsIn(invocation) {
+  return new Set([...invocation.matchAll(/--([a-z][\w-]*)/g)].map((m) => m[1]));
+}
+
+/**
  * Check the template against the registry.
  *
  * @param markdown - template text.
@@ -207,6 +280,54 @@ export function findViolations(markdown, registry) {
   return violations;
 }
 
+/**
+ * Report documented invocations that omit a REQUIRED flag.
+ *
+ * Only invocations that already carry at least one `--flag` are checked. A bare
+ * `cleo session start` in prose is a reference to the command; a partially
+ * flagged one is a worked example, and a worked example that cannot run is the
+ * defect. This keeps the rule quiet on prose while still catching the T12077
+ * case, where the table said `cleo session start --scope global` and `name` is
+ * equally required.
+ *
+ * @param markdown - the template text.
+ * @param sourceForVerb - resolves a verb to its command-module source.
+ * @returns violation records (empty when clean).
+ *
+ * @task T12077
+ */
+export function findRequiredArgViolations(markdown, sourceForVerb) {
+  const violations = [];
+  const seen = new Set();
+
+  for (const m of markdown.matchAll(/`cleo\s+([a-z][\w-]*)\s+([a-z][\w-]*)([^`]*)`/g)) {
+    const [, verb, sub, tail] = m;
+    const flags = flagsIn(tail);
+    if (flags.size === 0) continue; // prose reference, not a worked example
+
+    const source = sourceForVerb(verb);
+    if (!source) continue;
+
+    const required = extractRequiredArgs(source, sub);
+    if (required.size === 0) continue;
+
+    const missing = [...required].filter((f) => !flags.has(f));
+    if (missing.length === 0) continue;
+
+    const key = `${verb} ${sub}:${missing.join(',')}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    violations.push({
+      verb,
+      sub,
+      raw: `cleo ${verb} ${sub}${tail}`.trim(),
+      reason: `missing required flag(s): ${missing.map((f) => `--${f}`).join(' ')}`,
+    });
+  }
+  return violations;
+}
+
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   const asJson = process.argv.includes('--json');
@@ -218,6 +339,30 @@ if (isMain) {
   );
   const registry = loadRegistry(neededSubs);
   const violations = findViolations(markdown, registry);
+
+  // T12077: existence is not enough — a documented invocation must also be
+  // runnable. Resolve each verb's module source once and check required flags.
+  const manifestSrc = readFileSync(
+    join(REPO_ROOT, 'packages/cleo/src/cli/generated/command-manifest.ts'),
+    'utf-8',
+  );
+  const moduleByVerb = new Map(
+    [
+      ...manifestSrc.matchAll(
+        /name:\s*'([^']+)',[\s\S]{0,400}?import\('\.\.\/commands\/([^']+)\.js'\)/g,
+      ),
+    ].map((m) => [m[1], m[2]]),
+  );
+  const sourceForVerb = (verb) => {
+    const mod = moduleByVerb.get(verb);
+    if (!mod) return null;
+    try {
+      return readFileSync(join(REPO_ROOT, 'packages/cleo/src/cli/commands', `${mod}.ts`), 'utf-8');
+    } catch {
+      return null;
+    }
+  };
+  violations.push(...findRequiredArgViolations(markdown, sourceForVerb));
 
   if (asJson) {
     process.stdout.write(`${JSON.stringify({ violations }, null, 2)}\n`);


### PR DESCRIPTION
I tested the three autonomous subsystems end to end rather than assuming they worked. **Two of the three could never have functioned**, and both failures trace to the same root cause as T12067 — a collection-key mismatch that fails silently, because an absent key is indistinguishable from an empty result set.

---

## 1. The sentient loop had never picked a single task

`defaultPickTask` read `response.data.tasks` from `cleo.tasks.find()`. Wrong **twice over**: the SDK returns the payload *bare* (no `data` envelope), and its collection key is `results`, not `tasks`.

So `allCandidates` was always `[]` → picker always returned null → `runTick` always returned `no-task`.

**State file, before:**
```
ticksExecuted: 24    tasksPicked: 0    lastTickAt: 2026-05-15
```

Three months dead. It reported *"no unblocked tasks available"* while **836 candidates were ready** — so it read as "nothing to do" rather than as a defect. That is why it sat unnoticed.

### A second bug behind it

The task table contains a row whose id is the **absolute project root** (`/mnt/projects/cleocode`, created 2026-05-28 by a caller that passed a `projectRoot` where a `taskId` was expected). Because it begins with `/` it sorts ahead of every `T####` id, so dependency-wave ordering placed it first in wave 0 — the picker would have **spun on it forever**. Candidates are now filtered to canonical ids: the loop degrades to "skip that one", never to "spin on it".

> **Verified:** tick outcome `no-task` → `success`, picking real task **T1009**. `tasksPicked` 0 → 2.

## 2. The self-improvement loop could never go green

Its golden declared `data.tasks` + `count` for `tasks.find` — a shape that operation has **never** emitted. Its scenario called `tasks.show` with `id` where the op takes `taskId`, so the call returned `E_MISSING_PARAMS` and every field under `data` diffed. **14 regressions, none real.**

`envelope-diff.ts` documents that its meta-stripping exists to prevent *"a permanent phantom DHQ that self-fires on every clean run"*. The fixture reintroduced exactly that through the data channel — with `--execute`, this loop would have opened a DHQ row and a draft PR on **every run, forever**, against a regression that does not exist.

The find op is now pinned to a single task id so the golden is deterministic. The old `{query: 'selfimprove'}` pinned whatever live rows happened to match (10 the day it was measured), so the loop went red the moment anyone added a task.

> **Verified:** `regression-dry-run` (14) → **`green` (0)**.

### The test agreed with the broken fixture

`run-loop.test.ts` hardcoded the *same* wrong shape, so the two agreed with each other and disagreed with reality — the suite was green while production was permanently red. It now reads the fixture, testing the **engine** rather than re-asserting a copy of the data.

## 3. The dream cycle works

Exercised end to end with an injected client:

```
31 real observations → 12 clusters → 1 synthesised → 1 extracted → 1 stored, 0 rejected
```

Every stage functions. It is gated on an LLM key (returns `no-api-key` without one) and only fires inside a sentient tick — so in practice it had not run since May either, for want of a working tick.

---

## The shared root cause

`COLLECTION_KEYS` now lives in `@cleocode/contracts` as one SSoT (const data only — Gate 10), covering `tasks` / `items` / `results` / `suggestions`. `pickCollection` / `collectionOf` in core resolve **both** the enveloped and bare shapes.

`suggestions` was itself a live gap found on the way: **`cleo next --output id` reported "No ids."** against an envelope holding 836 candidates.

That makes four instances of one confusion:

| # | Surface | Symptom |
|---|---|---|
| T12067 | `cleo find` renderers | `count`=1626, `id`=empty |
| T12077 | `cleo next` renderers | `id`=empty, 836 candidates |
| T12077 | sentient `defaultPickTask` | **0 tasks picked in 24 ticks** |
| T12077 | selfimprove golden | **permanent false regression** |

## Verification

- **136 files / 2,018 tests** pass across `sentient` + `selfimprove` + `tasks`
- 17 new tests (collection resolver + scenario/golden contract)
- **7/7** architectural gates; contracts purity clean; workspace build clean
- Every before/after number measured against the live database

🤖 Generated with [Claude Code](https://claude.com/claude-code)