### PR TITLE
fix: dream cycle claimed "no API key" when a valid one existed — every LLM path routes to an unkeyed provider (T12078)

### DIFF
--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -732,6 +732,43 @@ async function resolveDefaultVerifyAndStore(): Promise<
 // ---------------------------------------------------------------------------
 
 /**
+ * One-line explanation of why {@link resolveDreamLlm} produced no client.
+ *
+ * Distinguishes "the role resolved to a provider this path cannot use" from
+ * "no credential at all", because the remedies are different: the first needs
+ * a role/config change or a provider-agnostic runner, the second needs a
+ * login.
+ *
+ * Never throws — diagnostics must not break the caller's error path.
+ *
+ * @param projectRoot - project root used for resolution.
+ * @returns a human-readable reason, always non-empty.
+ *
+ * @task T12078
+ */
+async function describeDreamLlmResolution(projectRoot: string): Promise<string> {
+  try {
+    const { resolveLLMForRole } = await import('../llm/role-resolver.js');
+    const llm = await resolveLLMForRole('consolidation', { projectRoot });
+    if (llm.provider !== 'anthropic') {
+      return (
+        `The 'consolidation' role resolved to provider '${llm.provider}' (model ` +
+        `'${llm.model}'), but this path requires anthropic. Either configure ` +
+        `llm.roles.consolidation for anthropic, or restore an anthropic ` +
+        `credential (\`cleo login anthropic\`) so the cross-provider selector ` +
+        `stops excluding it.`
+      );
+    }
+    if (!llm.sealedCredential) {
+      return 'Resolved provider anthropic, but no usable credential — run `cleo login anthropic`.';
+    }
+    return 'Resolved provider anthropic with a credential, but no client was constructed.';
+  } catch (err) {
+    return `LLM resolution failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+/**
  * Run one full dream cycle.
  *
  * Steps:
@@ -803,10 +840,30 @@ export async function runDreamCycle(options: DreamCycleOptions): Promise<DreamCy
   }
 
   if (!client) {
+    // T12078: report WHY, not a guess.
+    //
+    // This message used to assert "No LLM API key found (checked
+    // ANTHROPIC_API_KEY, ~/.claude/.credentials.json, ~/.cleo/config.json)".
+    // That was frequently false, and its falseness hid a real outage: on this
+    // machine a VALID Anthropic OAuth token sat in
+    // `~/.claude/.credentials.json` while the dream cycle reported no key at
+    // all. The actual chain was:
+    //
+    //   • CLEO's own credential store held two Anthropic OAuth entries, both
+    //     long expired (2026-05-18, 2026-07-12), whose refresh failed;
+    //   • `cross-provider-selector` therefore EXCLUDED anthropic and resolved
+    //     the `consolidation` role to openai/gpt-5.5-pro;
+    //   • `resolveAnthropicForRole` returns null for any non-anthropic
+    //     provider, so this path saw `client === null`.
+    //
+    // Three different causes — no credential, an expired one, or a role
+    // resolved to a provider this Anthropic-only path cannot use — all
+    // collapsed into one message that named only the first. Naming the
+    // resolved provider is what makes the difference visible.
+    const resolvedProvider = await describeDreamLlmResolution(projectRoot);
     return {
       kind: 'no-api-key',
-      detail:
-        'No LLM API key found (checked ANTHROPIC_API_KEY, ~/.claude/.credentials.json, ~/.cleo/config.json) — dream cycle skipped',
+      detail: `Dream cycle skipped — no usable Anthropic client. ${resolvedProvider}`,
     };
   }
 


### PR DESCRIPTION
Testing the autonomous layer under real credentials surfaced why the dream cycle never runs on this machine — and the error message was actively hiding it.

## The false claim

```
No LLM API key found (checked ANTHROPIC_API_KEY, ~/.claude/.credentials.json,
~/.cleo/config.json) — dream cycle skipped
```

That is **not true here.** `~/.claude/.credentials.json` holds a **valid** Anthropic OAuth token:

| field | value |
|---|---|
| `expiresAt` | 2026-08-06T16:07Z (valid at time of test) |
| `refreshTokenExpiresAt` | 2026-09-02 |
| `subscriptionType` | max |

## The real chain

1. CLEO's **own** credential store holds two Anthropic OAuth entries, **both long expired** — `2026-05-18` and `2026-07-12` — whose refresh fails.
2. `cross-provider-selector` therefore **excludes anthropic** and resolves the `consolidation` role to **openai / gpt-5.5-pro**.
3. `resolveAnthropicForRole` returns `null` for any non-anthropic provider → the dream cycle sees `client === null`.
4. There is no OpenAI key either, so the fallback fails too.

Three distinct causes — no credential, an expired one, or a role resolved to a provider this Anthropic-only path cannot use — all collapsed into one message that named only the first.

## After

```
Dream cycle skipped — no usable Anthropic client. The 'consolidation' role
resolved to provider 'openai' (model 'gpt-5.5-pro'), but this path requires
anthropic. Either configure llm.roles.consolidation for anthropic, or restore
an anthropic credential (`cleo login anthropic`) so the cross-provider selector
stops excluding it.
```

## Why this matters beyond the dream cycle

This is the same root cause as the `dialectic.generate_object_failed` / `AI_RetryError` on `gpt-5.5-pro` that has appeared in **every** command this session. **Every LLM-dependent path** — dream cycle, dialectic, selfimprove fix-gen — routes to an unkeyed provider and fails.

Note also that `~/.cleo/config.json` sets `llm.default = claude-fable-5` with an empty `roles` map. The user configured a Claude model; the selector routes to OpenAI because Anthropic is excluded. The configuration is not being honoured, and nothing said so.

## Deliberately NOT fixed here

The underlying staleness — CLEO snapshot-copied the Claude Code OAuth credential in May and never re-read the live file, so its copy rotted while the source stayed valid — is filed as **T12078** rather than patched in this PR. That is security-sensitive resolution code, and the remedy (`cleo login anthropic`) is an interactive owner action. It wants review, not an unattended rewrite at the end of a long session.

## Verification

- 34 files / **486 tests** pass in the sentient suite
- New message reproduced against the live (mis)configuration
- Credential metadata inspected without reading or logging any secret values

🤖 Generated with [Claude Code](https://claude.com/claude-code)