### PR TITLE
fix: name the consent gate that silently kills every LLM path (T12078)

### DIFF
--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -732,6 +732,54 @@ async function resolveDefaultVerifyAndStore(): Promise<
 // ---------------------------------------------------------------------------
 
 /**
+ * Why anthropic was excluded from provider selection, when it was.
+ *
+ * T12078: the interesting case is `skipped-consent`. CLEO deliberately will not
+ * import another tool's credential without opt-in, so the `claude-code` seeder
+ * refuses to read `~/.claude/.credentials.json` until
+ * `auth.claudeCodeConsentGiven` is set. That is correct security design — but
+ * it is invisible at the point of failure, and its symptom is identical to
+ * "you have no credentials": the stored anthropic entries simply age out (here:
+ * 2026-05-18 and 2026-07-12), refresh fails, the selector drops anthropic, and
+ * every LLM-dependent feature dies quietly while a perfectly valid token sits
+ * in a file CLEO has chosen not to read.
+ *
+ * Naming the consent flag turns a multi-hour investigation into one command.
+ *
+ * @returns a remedy sentence; never throws.
+ *
+ * @task T12078
+ */
+async function describeAnthropicExclusion(): Promise<string> {
+  try {
+    const { getCredentialPool } = await import('../llm/credential-pool.js');
+    const pool = getCredentialPool();
+    // Seeder status is populated by a seed pass; in a fresh process it is empty
+    // until one runs. A non-forced seed honours the 60s cache, so this is cheap
+    // and idempotent on the error path.
+    await pool.seed().catch(() => undefined);
+    const status = await pool.getSeederStatus();
+    const claudeCode = status.find((s) => s.sourceId === 'claude-code');
+    if (claudeCode?.lastResult === 'skipped-consent') {
+      return (
+        'Anthropic was excluded because its stored credentials are expired and the ' +
+        'claude-code seeder is gated on consent (lastResult=skipped-consent), so the ' +
+        'valid token in ~/.claude/.credentials.json is never imported. Fix with ' +
+        'EITHER `cleo config set auth.claudeCodeConsentGiven true` (authorise CLEO to ' +
+        'read Claude Code credentials) OR `cleo login anthropic`.'
+      );
+    }
+    return (
+      'Either configure llm.roles.consolidation for anthropic, or restore an ' +
+      'anthropic credential (`cleo login anthropic`) so the cross-provider ' +
+      'selector stops excluding it.'
+    );
+  } catch {
+    return 'Run `cleo login anthropic` to restore an anthropic credential.';
+  }
+}
+
+/**
  * One-line explanation of why {@link resolveDreamLlm} produced no client.
  *
  * Distinguishes "the role resolved to a provider this path cannot use" from
@@ -751,12 +799,10 @@ async function describeDreamLlmResolution(projectRoot: string): Promise<string> 
     const { resolveLLMForRole } = await import('../llm/role-resolver.js');
     const llm = await resolveLLMForRole('consolidation', { projectRoot });
     if (llm.provider !== 'anthropic') {
+      const why = await describeAnthropicExclusion();
       return (
         `The 'consolidation' role resolved to provider '${llm.provider}' (model ` +
-        `'${llm.model}'), but this path requires anthropic. Either configure ` +
-        `llm.roles.consolidation for anthropic, or restore an anthropic ` +
-        `credential (\`cleo login anthropic\`) so the cross-provider selector ` +
-        `stops excluding it.`
+        `'${llm.model}'), but this path requires anthropic. ${why}`
       );
     }
     if (!llm.sealedCredential) {

--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -759,7 +759,9 @@ async function describeAnthropicExclusion(): Promise<string> {
     // and idempotent on the error path.
     await pool.seed().catch(() => undefined);
     const status = await pool.getSeederStatus();
-    const claudeCode = status.find((s) => s.sourceId === 'claude-code');
+    // 'claude-code' below is a credential SEEDER id, not a model literal — the
+    // chokepoint rule's pattern cannot tell the two apart, hence the opt-out.
+    const claudeCode = status.find((s) => s.sourceId === 'claude-code'); // llm-resolve-allowed: seeder id, not a model
     if (claudeCode?.lastResult === 'skipped-consent') {
       return (
         'Anthropic was excluded because its stored credentials are expired and the ' +


### PR DESCRIPTION
Finishes root-causing the LLM outage from #1157. The chain terminates in a **deliberate security control that is invisible at the point of failure.**

## The terminal cause

```
getSeederStatus() →
  { sourceId: 'claude-code', provider: 'anthropic', lastResult: 'skipped-consent' }
```

CLEO will not import another tool's credential without opt-in — the `claude-code` seeder refuses to read `~/.claude/.credentials.json` until `auth.claudeCodeConsentGiven` is set.

**That design is right.** The problem is that its symptom is indistinguishable from *"you have no credentials"*:

1. the seeder never runs, so stored Anthropic entries are never refreshed;
2. they age out (here **2026-05-18** and **2026-07-12**) and refresh fails;
3. `cross-provider-selector` drops anthropic;
4. roles resolve to **openai / gpt-5.5-pro**, which has no usable client;
5. every LLM-dependent feature dies quietly — **dream cycle, dialectic, selfimprove fix-gen** — while a **valid** token sits in a file CLEO has chosen not to read.

## Ruling out the alternatives

I checked the two things that would have made this a storage bug rather than a policy gate:

- **`addCredential` is a true upsert** — it filters by `provider`+`label` then re-inserts, so a fresh credential *would* replace a stale one.
- **A forced re-seed works**: `pool.seed({force: true})` → `{added: 3, failed: 0, skipped: 1}` — the single skip being `claude-code`, on consent.

Nothing is stuck. The import is simply **gated**, and nothing said so.

## After

```
Dream cycle skipped — no usable Anthropic client. The 'consolidation' role
resolved to provider 'openai' (model 'gpt-5.5-pro'), but this path requires
anthropic. Anthropic was excluded because its stored credentials are expired
and the claude-code seeder is gated on consent (lastResult=skipped-consent),
so the valid token in ~/.claude/.credentials.json is never imported. Fix with
EITHER `cleo config set auth.claudeCodeConsentGiven true` (authorise CLEO to
read Claude Code credentials) OR `cleo login anthropic`.
```

## What this PR deliberately does NOT do

**It does not grant consent.** Authorising CLEO to read another tool's credential store is the owner's decision, not something an agent should do on their behalf mid-session. This PR only makes the gate **legible**.

Seeder status is empty in a fresh process until a seed pass runs, so the diagnostic triggers a non-forced `seed()` first — that honours the 60 s cache and only ever runs on the error path.

## Verification

- **125 files / 1,847 tests** pass across `sentient` + `llm`
- Message reproduced against the live configuration
- Credential metadata inspected throughout without reading or logging any secret value

🤖 Generated with [Claude Code](https://claude.com/claude-code)