### PR TITLE
fix: the brain layer runs on ANY machine — provider-agnostic dream cycle, cross-provider failover, keyless local daemon (T12081 · T12082)

### DIFF
--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -223,6 +223,22 @@ export interface CredentialMetadataWire {
   source: CredentialSourceWire | undefined;
   /** Scheme used to present the credential to the provider. */
   authType: AuthTypeWire;
+  /**
+   * Custom API endpoint this credential targets, when it has one.
+   *
+   * NOT a secret — an endpoint URL — so it belongs on the metadata wire rather
+   * than behind the sealed handle. It is load-bearing: without it a consumer
+   * building a transport cannot learn that a credential points at a local or
+   * proxied endpoint, and silently falls back to the vendor's public API.
+   *
+   * T12081: `role-executor` set `baseUrl` from `deriveApiWire(provider)` — the
+   * provider DEFAULT — because this field did not exist. An Ollama credential
+   * carrying `http://localhost:11434/v1` was rewritten to `api.openai.com` and
+   * rejected 401; the same held for LM Studio, vLLM, OpenRouter and Azure.
+   * Every custom-endpoint credential resolved correctly, then called the wrong
+   * host.
+   */
+  baseUrl?: string | null;
 }
 
 // ============================================================================

--- a/packages/contracts/src/operations/llm.ts
+++ b/packages/contracts/src/operations/llm.ts
@@ -164,7 +164,9 @@ export type CredentialSourceWire =
   | 'cred-file'
   | 'claude-creds'
   | 'global-config'
-  | 'project-config';
+  | 'project-config'
+  /** Keyless local inference daemon detected at runtime (T12082). */
+  | 'local-daemon';
 
 /**
  * Authentication scheme used when sending the credential to the provider.
@@ -381,6 +383,19 @@ export interface ResolveLLMForRoleOptions {
    * @task T11759
    */
   profileOverride?: string;
+  /**
+   * Providers to skip during this resolution (T12082).
+   *
+   * Set by the caller after a provider has already failed for this call, so
+   * the retry lands somewhere else. Applies to EVERY tier including config
+   * pins: a pinned provider that just returned a terminal error is not a
+   * better answer for having been pinned.
+   *
+   * Empty/absent leaves resolution completely unchanged.
+   *
+   * @task T12082
+   */
+  excludeProviders?: readonly string[];
 }
 
 // ============================================================================

--- a/packages/core/src/llm/__tests__/local-inference-probe.test.ts
+++ b/packages/core/src/llm/__tests__/local-inference-probe.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for local-inference detection (T12082).
+ *
+ * The failure this guards is not a crash — it is a capability that stops
+ * silently. On 2026-08-06 the dream cycle reported "no usable LLM client"
+ * while an Ollama server with two models loaded answered on loopback in 24 ms.
+ * Nothing was broken except that nothing looked.
+ *
+ * @task T12082
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetLocalInferenceCacheForTests,
+  detectLocalInference,
+} from '../local-inference-probe.js';
+
+/** An Ollama `/api/tags` payload. */
+const OLLAMA_TAGS = {
+  models: [{ name: 'qwen2.5-coder:3b' }, { name: 'qwen2:0.5b' }],
+};
+
+/** An OpenAI-compatible `/v1/models` payload (LM Studio). */
+const OPENAI_MODELS = { data: [{ id: 'local-model' }] };
+
+/**
+ * Build a `fetch` stub that answers only the listed URLs.
+ *
+ * @param routes - map of URL to JSON body; any other URL rejects.
+ * @returns the stub.
+ */
+function fetchStub(routes: Record<string, unknown>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (!(url in routes)) throw new Error(`ECONNREFUSED ${url}`);
+    return {
+      ok: true,
+      json: async () => routes[url],
+    } as Response;
+  }) as typeof fetch;
+}
+
+const OLLAMA_URL = 'http://127.0.0.1:11434/api/tags';
+const LM_STUDIO_URL = 'http://127.0.0.1:1234/v1/models';
+
+describe('detectLocalInference (T12082)', () => {
+  beforeEach(() => {
+    // The shared setup pins this ON so host state cannot change unit-test
+    // outcomes; this suite is the one that exercises the probe itself.
+    vi.stubEnv('CLEO_DISABLE_LOCAL_INFERENCE', '');
+    _resetLocalInferenceCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    _resetLocalInferenceCacheForTests();
+  });
+
+  it('honours the operator opt-out without probing at all', async () => {
+    vi.stubEnv('CLEO_DISABLE_LOCAL_INFERENCE', '1');
+    const spy = vi.fn(fetchStub({ [OLLAMA_URL]: OLLAMA_TAGS }));
+    vi.stubGlobal('fetch', spy);
+
+    await expect(detectLocalInference()).resolves.toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('detects Ollama and reports its models in order', async () => {
+    vi.stubGlobal('fetch', fetchStub({ [OLLAMA_URL]: OLLAMA_TAGS }));
+
+    const local = await detectLocalInference();
+
+    expect(local).not.toBeNull();
+    expect(local?.name).toBe('ollama');
+    // Root for native transports, `/v1` for OpenAI-compatible ones. Mixing the
+    // two 404s late: the native transport appends `/api/chat`.
+    expect(local?.baseUrl).toBe('http://127.0.0.1:11434');
+    expect(local?.openAiBaseUrl).toBe('http://127.0.0.1:11434/v1');
+    // Order matters: the caller uses models[0] as the completion model.
+    expect(local?.models).toEqual(['qwen2.5-coder:3b', 'qwen2:0.5b']);
+  });
+
+  it('falls through to LM Studio when Ollama is absent', async () => {
+    vi.stubGlobal('fetch', fetchStub({ [LM_STUDIO_URL]: OPENAI_MODELS }));
+
+    const local = await detectLocalInference();
+
+    expect(local?.name).toBe('lm-studio');
+    expect(local?.models).toEqual(['local-model']);
+  });
+
+  it('prefers Ollama when BOTH answer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      fetchStub({ [OLLAMA_URL]: OLLAMA_TAGS, [LM_STUDIO_URL]: OPENAI_MODELS }),
+    );
+
+    expect((await detectLocalInference())?.name).toBe('ollama');
+  });
+
+  it('returns null when nothing answers — the common case, and not an error', async () => {
+    vi.stubGlobal('fetch', fetchStub({}));
+
+    await expect(detectLocalInference()).resolves.toBeNull();
+  });
+
+  it('treats a server with ZERO models as absent', async () => {
+    // A running Ollama with nothing pulled cannot serve a completion. Reporting
+    // it as available would swap "no client" for "client that always errors" —
+    // strictly worse, because the second one looks like it should work.
+    vi.stubGlobal('fetch', fetchStub({ [OLLAMA_URL]: { models: [] } }));
+
+    await expect(detectLocalInference()).resolves.toBeNull();
+  });
+
+  it('ignores a non-OK response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      (async () => ({ ok: false, json: async () => OLLAMA_TAGS }) as Response) as typeof fetch,
+    );
+
+    await expect(detectLocalInference()).resolves.toBeNull();
+  });
+
+  it('never throws when the endpoint returns garbage', async () => {
+    vi.stubGlobal(
+      'fetch',
+      (async () =>
+        ({
+          ok: true,
+          json: async () => {
+            throw new Error('not JSON');
+          },
+        }) as unknown as Response) as typeof fetch,
+    );
+
+    await expect(detectLocalInference()).resolves.toBeNull();
+  });
+
+  it('caches the result — a tick may consult it many times', async () => {
+    const spy = vi.fn(fetchStub({ [OLLAMA_URL]: OLLAMA_TAGS }));
+    vi.stubGlobal('fetch', spy);
+
+    await detectLocalInference();
+    await detectLocalInference();
+    await detectLocalInference();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the NEGATIVE result too — absence must not cost a probe per call', async () => {
+    const spy = vi.fn(fetchStub({}));
+    vi.stubGlobal('fetch', spy);
+
+    await detectLocalInference();
+    await detectLocalInference();
+
+    // Two endpoints probed once each, not twice each.
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-probes when forced', async () => {
+    const spy = vi.fn(fetchStub({ [OLLAMA_URL]: OLLAMA_TAGS }));
+    vi.stubGlobal('fetch', spy);
+
+    await detectLocalInference();
+    await detectLocalInference({ force: true });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reads the Ollama `model` field when `name` is missing', async () => {
+    vi.stubGlobal('fetch', fetchStub({ [OLLAMA_URL]: { models: [{ model: 'llama3:8b' }] } }));
+
+    expect((await detectLocalInference())?.models).toEqual(['llama3:8b']);
+  });
+
+  it('drops non-string model ids rather than surfacing them', async () => {
+    vi.stubGlobal(
+      'fetch',
+      fetchStub({ [OLLAMA_URL]: { models: [{ name: 42 }, { name: 'good:1b' }, null] } }),
+    );
+
+    expect((await detectLocalInference())?.models).toEqual(['good:1b']);
+  });
+
+  it('passes an abort signal so a black-holed port cannot stall the caller', async () => {
+    const seen: Array<AbortSignal | undefined> = [];
+    vi.stubGlobal('fetch', (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(init?.signal ?? undefined);
+      throw new Error('refused');
+    }) as typeof fetch);
+
+    await detectLocalInference();
+
+    expect(seen).toHaveLength(2);
+    for (const signal of seen) expect(signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/packages/core/src/llm/__tests__/ollama-live-admission.test.ts
+++ b/packages/core/src/llm/__tests__/ollama-live-admission.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A live local daemon is its own provisioning evidence (T12082).
+ *
+ * `isProvisioned` is synchronous, so it could not probe; it settled for
+ * "`OLLAMA_HOST` is set OR the store has an entry". Liveness was then probed
+ * only for providers already in the provisioned set — circular, so an
+ * undeclared daemon could never be admitted no matter how healthy it was.
+ *
+ * The cost was total rather than marginal: with every cloud credential
+ * expired, all five roles resolved to `no-provisioned-provider` — no
+ * consolidation, no extraction, no hygiene, no dream cycle — while Ollama
+ * answered on loopback in 24 ms with two models loaded.
+ *
+ * @task T12082
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reconcileOllamaModel } from '../cross-provider-selector.js';
+import {
+  _resetLocalInferenceCacheForTests,
+  detectLocalInference,
+} from '../local-inference-probe.js';
+
+describe('local daemon admission (T12082)', () => {
+  beforeEach(() => {
+    vi.stubEnv('CLEO_DISABLE_LOCAL_INFERENCE', '');
+    _resetLocalInferenceCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    _resetLocalInferenceCacheForTests();
+  });
+
+  it('detects an undeclared daemon — no OLLAMA_HOST, no store entry', async () => {
+    vi.stubEnv('OLLAMA_HOST', '');
+    vi.stubGlobal('fetch', (async (input: RequestInfo | URL) => {
+      if (String(input) !== 'http://127.0.0.1:11434/api/tags') throw new Error('refused');
+      return {
+        ok: true,
+        json: async () => ({ models: [{ name: 'qwen2.5-coder:3b' }] }),
+      } as Response;
+    }) as typeof fetch);
+
+    const local = await detectLocalInference();
+
+    // This is the input the selector uses to admit ollama as provisioned.
+    expect(local?.name).toBe('ollama');
+    expect(local?.models).toEqual(['qwen2.5-coder:3b']);
+  });
+});
+
+describe('reconcileOllamaModel (T12082)', () => {
+  it('keeps the RAM-preferred model when it is installed', () => {
+    expect(reconcileOllamaModel('gemma4:e4b', ['gemma4:e4b', 'qwen2:0.5b'])).toBe('gemma4:e4b');
+  });
+
+  it('drops to the same family when the exact tag is not pulled', () => {
+    // 62 GB of RAM scores into the e4b tier; only e2b is on disk.
+    expect(reconcileOllamaModel('gemma4:e4b', ['qwen2:0.5b', 'gemma4:e2b'])).toBe('gemma4:e2b');
+  });
+
+  it('falls back to the first installed model rather than a guaranteed 404', () => {
+    // The old behaviour named a model the daemon does not hold. That surfaces
+    // as "local inference is broken", not "that tag is not installed" — the
+    // wrong diagnosis, and an expensive one.
+    expect(reconcileOllamaModel('gemma4:e4b', ['qwen2.5-coder:3b', 'qwen2:0.5b'])).toBe(
+      'qwen2.5-coder:3b',
+    );
+  });
+
+  it('leaves the preference alone when the installed set is UNKNOWN', () => {
+    // An empty list means "could not ask the daemon", not "nothing is
+    // installed" — overriding on that basis would be guessing.
+    expect(reconcileOllamaModel('gemma4:e4b', [])).toBe('gemma4:e4b');
+  });
+
+  it('matches family by tag prefix, not by substring', () => {
+    // 'gemma4' must not match 'gemma40:x' or 'notgemma4:x'.
+    expect(reconcileOllamaModel('gemma4:e4b', ['gemma40:x', 'notgemma4:y'])).toBe('gemma40:x');
+    expect(reconcileOllamaModel('gemma4:e4b', ['notgemma4:y', 'gemma4:e2b'])).toBe('gemma4:e2b');
+  });
+
+  it('handles a preference with no tag separator', () => {
+    expect(reconcileOllamaModel('llama3', ['llama3:8b'])).toBe('llama3:8b');
+  });
+});

--- a/packages/core/src/llm/__tests__/role-executor-failover.test.ts
+++ b/packages/core/src/llm/__tests__/role-executor-failover.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Cross-provider failover for role calls (T12082).
+ *
+ * `executeForRole` drives the entire brain layer — consolidation, extraction,
+ * hygiene, the dream cycle. It resolved ONE provider and returned `null` on any
+ * failure, so a credential that is present but rejected took every background
+ * capability down with it. Measured on 2026-08-06: an openai Codex OAuth
+ * answering `400 The 'gpt-5.5-pro' model is not supported when using Codex with
+ * a ChatGPT account` disabled the whole layer while other providers — including
+ * a live local daemon — sat unconsulted. The classifier had already computed
+ * `shouldFallback`; nothing acted on it.
+ *
+ * @task T12082
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResolvedLLM } from '../role-resolver.js';
+
+const { mockResolveLLMForRole, mockChatComplete, mockAnthropicComplete, mockOllamaComplete } =
+  vi.hoisted(() => ({
+    mockResolveLLMForRole: vi.fn(),
+    mockChatComplete: vi.fn(),
+    mockAnthropicComplete: vi.fn(),
+    mockOllamaComplete: vi.fn(),
+  }));
+
+vi.mock('../role-resolver.js', () => ({ resolveLLMForRole: mockResolveLLMForRole }));
+
+vi.mock('../credential-pool.js', () => ({
+  CredentialPool: class {
+    markExhausted = vi.fn().mockResolvedValue(undefined);
+    refreshExpiredOAuth = vi.fn().mockResolvedValue(0);
+  },
+}));
+
+vi.mock('../transports/chat-completions.js', () => ({
+  ChatCompletionsTransport: class {
+    complete = mockChatComplete;
+  },
+}));
+
+vi.mock('../transports/anthropic.js', () => ({
+  AnthropicTransport: class {
+    complete = mockAnthropicComplete;
+  },
+}));
+
+vi.mock('../transports/ollama.js', () => ({
+  OllamaTransport: class {
+    complete = mockOllamaComplete;
+  },
+}));
+
+import { _resetRoleWarnLatchForTests, executeForRole } from '../role-executor.js';
+
+/**
+ * Build a resolver envelope for `provider`, with or without a credential.
+ *
+ * @param provider - provider id to resolve to.
+ * @param withCredential - whether a usable credential is present.
+ * @returns the envelope.
+ */
+function resolved(provider: string, withCredential = true): ResolvedLLM {
+  return {
+    provider,
+    model: `${provider}-model`,
+    client: null,
+    credential: withCredential ? { provider, source: 'cred-file', authType: 'api_key' } : null,
+    sealedCredential: withCredential
+      ? {
+          provider,
+          account: 'default',
+          fetch: async () => ({ __decryptedToken: 'DecryptedToken' as const, value: 'tok' }),
+        }
+      : null,
+    source: 'cross-provider',
+    credentialLabel: 'default',
+  } as ResolvedLLM;
+}
+
+/** The exact production failure: present credential, terminal 400 on the model. */
+function codexModelUnsupported(): Error {
+  const err = new Error(
+    `400 {"detail":"The 'gpt-5.5-pro' model is not supported when using Codex with a ChatGPT account."}`,
+  ) as Error & { status: number };
+  err.status = 400;
+  return err;
+}
+
+const OK = { content: 'pong', usage: { inputTokens: 1, outputTokens: 1 }, model: 'ollama-model' };
+
+describe('role-executor cross-provider failover (T12082)', () => {
+  beforeEach(() => {
+    // `clearAllMocks` clears CALLS but leaves the `…Once` implementation queue
+    // in place, so a leftover success from a previous test satisfies the next
+    // one's first attempt. Reset the implementations outright.
+    mockResolveLLMForRole.mockReset();
+    mockChatComplete.mockReset();
+    mockAnthropicComplete.mockReset();
+    mockOllamaComplete.mockReset();
+    _resetRoleWarnLatchForTests();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fails over to another provider after a terminal 400', async () => {
+    mockResolveLLMForRole
+      .mockResolvedValueOnce(resolved('openai'))
+      .mockResolvedValueOnce(resolved('ollama'));
+    mockChatComplete.mockRejectedValueOnce(codexModelUnsupported());
+    mockOllamaComplete.mockResolvedValueOnce(OK);
+
+    const result = await executeForRole('consolidation', 'sys', 'user');
+
+    expect(result?.content).toBe('pong');
+    expect(result?.provider).toBe('ollama');
+  });
+
+  it('tells the second resolution to skip the provider that just failed', async () => {
+    mockResolveLLMForRole
+      .mockResolvedValueOnce(resolved('openai'))
+      .mockResolvedValueOnce(resolved('ollama'));
+    mockChatComplete.mockRejectedValueOnce(codexModelUnsupported());
+    mockOllamaComplete.mockResolvedValueOnce(OK);
+
+    await executeForRole('consolidation', 'sys', 'user');
+
+    expect(mockResolveLLMForRole).toHaveBeenNthCalledWith(
+      1,
+      'consolidation',
+      expect.objectContaining({ excludeProviders: [] }),
+    );
+    expect(mockResolveLLMForRole).toHaveBeenNthCalledWith(
+      2,
+      'consolidation',
+      expect.objectContaining({ excludeProviders: ['openai'] }),
+    );
+  });
+
+  it('fails over when the resolved provider has NO credential', async () => {
+    // Previously an immediate null: the first provider having no key ended the
+    // call even though a configured one was next in line.
+    mockResolveLLMForRole
+      .mockResolvedValueOnce(resolved('anthropic', false))
+      .mockResolvedValueOnce(resolved('ollama'));
+    mockOllamaComplete.mockResolvedValueOnce(OK);
+
+    expect((await executeForRole('consolidation', 'sys', 'user'))?.provider).toBe('ollama');
+  });
+
+  it('stops after MAX_ROLE_FAILOVERS rather than walking every provider', async () => {
+    mockResolveLLMForRole
+      .mockResolvedValueOnce(resolved('openai'))
+      .mockResolvedValueOnce(resolved('gemini'))
+      .mockResolvedValueOnce(resolved('groq'))
+      .mockResolvedValue(resolved('deepseek'));
+    mockChatComplete.mockRejectedValue(codexModelUnsupported());
+
+    expect(await executeForRole('consolidation', 'sys', 'user')).toBeNull();
+    // Initial attempt + 2 failovers. A background pass that fails eleven times
+    // is worse than one that fails fast.
+    expect(mockResolveLLMForRole).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops when the resolver keeps returning the SAME provider', async () => {
+    // A resolver that cannot honour the exclusion (nothing else provisioned)
+    // must not spin.
+    mockResolveLLMForRole.mockResolvedValue(resolved('openai'));
+    mockChatComplete.mockRejectedValue(codexModelUnsupported());
+
+    expect(await executeForRole('consolidation', 'sys', 'user')).toBeNull();
+    expect(mockResolveLLMForRole).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT fail over when the CALLER aborted', async () => {
+    // The caller gave up; trying a second provider would ignore that.
+    const controller = new AbortController();
+    controller.abort();
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+
+    mockResolveLLMForRole.mockResolvedValue(resolved('openai'));
+    mockChatComplete.mockRejectedValue(abortErr);
+
+    expect(
+      await executeForRole('consolidation', 'sys', 'user', { signal: controller.signal }),
+    ).toBeNull();
+    expect(mockResolveLLMForRole).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resolve twice when the first provider succeeds', async () => {
+    mockResolveLLMForRole.mockResolvedValue(resolved('anthropic'));
+    mockAnthropicComplete.mockResolvedValue({ ...OK, model: 'anthropic-model' });
+
+    expect((await executeForRole('consolidation', 'sys', 'user'))?.content).toBe('pong');
+    expect(mockResolveLLMForRole).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -101,6 +101,15 @@ export interface CredentialResult {
    * them as Anthropic OAuth (`sk-ant-oat-*` access / `sk-ant-ort-*` refresh).
    */
   authType: AuthType;
+  /**
+   * Custom API endpoint this credential targets, when the stored record has one.
+   *
+   * T12081: this field did not exist, so the endpoint was dropped at the FIRST
+   * hop of the resolution chain. Consumers then rebuilt it from the provider
+   * default, which rewrote every Ollama / LM Studio / vLLM / OpenRouter /
+   * Azure credential to the vendor's public API and got 401.
+   */
+  baseUrl?: string | null;
 }
 
 /**

--- a/packages/core/src/llm/credentials.ts
+++ b/packages/core/src/llm/credentials.ts
@@ -63,7 +63,13 @@ export type CredentialSource =
   | 'cred-file'
   | 'claude-creds'
   | 'global-config'
-  | 'project-config';
+  | 'project-config'
+  /**
+   * Synthesised for a keyless local inference daemon that answered a liveness
+   * probe (T12082). No stored secret exists or is needed — the placeholder
+   * token satisfies the transport contract, not the endpoint.
+   */
+  | 'local-daemon';
 
 /**
  * Authentication scheme used to send the credential to the provider.

--- a/packages/core/src/llm/cross-provider-selector.ts
+++ b/packages/core/src/llm/cross-provider-selector.ts
@@ -48,6 +48,7 @@ import { getLogger } from '../logger.js';
 import { refreshExpiredOAuthForProvider } from './credential-pool.js';
 import { resolveCredentials } from './credentials.js';
 import { listCredentials, pickCredentialForProviderSync } from './credentials-store.js';
+import { detectLocalInference, listOllamaModels } from './local-inference-probe.js';
 import type { ModelTransport } from './types-config.js';
 
 const logger = getLogger('llm-cross-provider-selector');
@@ -358,6 +359,42 @@ function isProvisioned(provider: ModelTransport): boolean {
   return (cred.apiKey?.trim().length ?? 0) > 0;
 }
 
+/**
+ * Intersect the RAM-preferred Ollama model with the models actually installed.
+ *
+ * Resolution order:
+ *   1. exact tag match — the preferred model is pulled, use it;
+ *   2. same family — `gemma4:e4b` preferred, `gemma4:e2b` installed;
+ *   3. first installed model — some local inference beats none;
+ *   4. the preference unchanged, when the installed set is unknown (empty),
+ *      because an empty list means "could not ask", not "nothing installed".
+ *
+ * @param preferred - model chosen by the RAM/tier heuristic.
+ * @param installed - model ids the daemon reports, in daemon order.
+ * @returns the model to call.
+ *
+ * @example
+ * ```ts
+ * reconcileOllamaModel('gemma4:e4b', ['qwen2.5-coder:3b']); // → 'qwen2.5-coder:3b'
+ * reconcileOllamaModel('gemma4:e4b', ['gemma4:e2b']);       // → 'gemma4:e2b'
+ * reconcileOllamaModel('gemma4:e4b', []);                   // → 'gemma4:e4b'
+ * ```
+ *
+ * @task T12082
+ */
+export function reconcileOllamaModel(preferred: string, installed: readonly string[]): string {
+  if (installed.length === 0) return preferred;
+  if (installed.includes(preferred)) return preferred;
+
+  const family = preferred.split(':')[0];
+  if (family !== undefined && family !== '') {
+    const sameFamily = installed.find((m) => m.split(':')[0] === family);
+    if (sameFamily !== undefined) return sameFamily;
+  }
+
+  return installed[0] ?? preferred;
+}
+
 // ---------------------------------------------------------------------------
 // Scoring
 // ---------------------------------------------------------------------------
@@ -631,9 +668,10 @@ export async function enumerateProvisionedProviders(
  */
 export async function selectBestProvisioned(
   role: string,
-  opts: { projectRoot: string },
+  opts: { projectRoot: string; exclude?: readonly string[] },
 ): Promise<SelectedProviderModel | null> {
   const taskTier = roleTierFor(role);
+  const excluded = new Set(opts.exclude ?? []);
 
   // Refresh-on-use (T11986 · DHQ-087): attempt to refresh any expired-but-
   // refreshable OAuth credential for each provider BEFORE the provisioning
@@ -676,8 +714,35 @@ export async function selectBestProvisioned(
   // tokens are visible to the sync credential store reader).
   const provisionedIds: ModelTransport[] = [];
   for (const id of BUILTIN_PROVIDER_IDS) {
+    if (excluded.has(id)) continue;
     if (isProvisioned(id)) {
       provisionedIds.push(id);
+    }
+  }
+
+  // T12082: a RUNNING local daemon is its own provisioning evidence.
+  //
+  // `isProvisioned` cannot probe (it is sync), so it settles for "OLLAMA_HOST
+  // is set OR the store has an entry" — and liveness was then probed only for
+  // providers already in the provisioned set, which is circular: an unlisted
+  // ollama could never be probed, so it could never be listed.
+  //
+  // The cost of that circularity is total, not marginal. On a machine whose
+  // cloud credentials had all expired, every role resolved to
+  // `no-provisioned-provider` — no consolidation, no extraction, no hygiene,
+  // no dream cycle — while an Ollama daemon with models loaded answered on
+  // loopback in 24 ms. A provider that needs no key should not have to be
+  // declared; it only has to answer.
+  let localModels: readonly string[] = [];
+  if (!excluded.has('ollama') && !provisionedIds.includes('ollama')) {
+    const local = await detectLocalInference();
+    if (local !== null && local.name === 'ollama') {
+      provisionedIds.push('ollama');
+      localModels = local.models;
+      logger.debug(
+        { baseUrl: local.baseUrl, models: local.models },
+        'cross-provider-selector: unlisted ollama daemon is live — admitting as provisioned',
+      );
     }
   }
 
@@ -701,13 +766,18 @@ export async function selectBestProvisioned(
   );
   const { pickCredentialForProvider } = await import('./credentials-store.js');
 
-  // Probe ollama liveness only when ollama is in the provisioned set.
+  // Probe ollama liveness only when ollama is in the provisioned set. A daemon
+  // admitted by the live-probe above is alive by construction — re-probing it
+  // through a second code path would only add a way for the two to disagree.
   const ollamaProvisioned = provisionedIds.includes('ollama');
-  let ollamaAlive = false;
-  if (ollamaProvisioned) {
+  let ollamaAlive = localModels.length > 0;
+  if (ollamaProvisioned && !ollamaAlive) {
     const profile = await getProviderProfile('ollama');
     const ollamaBase = profile?.baseUrl ?? 'http://localhost:11434';
     ollamaAlive = await probeOllamaAlive(ollamaBase);
+    // Declared-and-live: ask the daemon what it actually holds, so the RAM
+    // heuristic below can be intersected with the installed set.
+    if (ollamaAlive) localModels = await listOllamaModels(ollamaBase);
   }
 
   // Score all provisioned providers.
@@ -766,6 +836,12 @@ export async function selectBestProvisioned(
       // Proof-of-life floor — logged as warning by ollamaDefaultModelForTier.
       model = ollamaDefaultModelForTier(winner.tier, ramBytes);
     }
+
+    // T12082: the RAM gate answers "what could this machine run", not "what is
+    // pulled". A resolved model the daemon does not hold is a 404 at call time,
+    // which reads as "local inference is broken" rather than "that tag is not
+    // installed" — so intersect the fit heuristic with the installed set.
+    model = reconcileOllamaModel(model, localModels);
 
     // Log hint if gemma4 family is not in catalog
     const catalogKey = catalogKeyForProvider(winner.id);

--- a/packages/core/src/llm/local-inference-probe.ts
+++ b/packages/core/src/llm/local-inference-probe.ts
@@ -1,0 +1,212 @@
+/**
+ * Runtime detection of a reachable local inference server (T12082).
+ *
+ * ## Why CLEO should find this by itself
+ *
+ * The auxiliary fallback chain exists so that "context compression, brain dream
+ * cycles, hygiene scans" do not fail silently when the primary provider is
+ * unavailable. Its default chain is `anthropic → openrouter → groq` — all
+ * cloud. When every cloud credential is unusable, the chain is exhausted and
+ * the capability simply stops.
+ *
+ * That is exactly the state this machine was in on 2026-08-06: the anthropic
+ * credential was consent-gated, the openai one returned 401 — and an Ollama
+ * server was running the whole time with `qwen2.5-coder:3b` loaded. The dream
+ * cycle reported "no usable LLM client" while free local inference sat one
+ * HTTP request away. Nothing was broken except that nobody looked.
+ *
+ * A background consolidation pass is precisely the workload that should degrade
+ * to a small local model rather than stop: it is not latency-critical, it is
+ * not user-facing, and a shallow synthesis is worth more than none. So the
+ * chain now ends with a local tier that is included ONLY when a server actually
+ * answers.
+ *
+ * ## Why a probe rather than a config flag
+ *
+ * A config flag would need the operator to know their own machine's state and
+ * keep it current. A 300 ms probe against loopback is cheap, is cached for the
+ * process, and is correct by construction — it reports what is true now.
+ *
+ * @task T12082
+ */
+
+/** Loopback endpoints checked, in order. Ollama first — it is the common case. */
+const LOCAL_ENDPOINTS: readonly LocalEndpoint[] = [
+  {
+    name: 'ollama',
+    tagsUrl: 'http://127.0.0.1:11434/api/tags',
+    baseUrl: 'http://127.0.0.1:11434',
+    openAiBaseUrl: 'http://127.0.0.1:11434/v1',
+  },
+  {
+    name: 'lm-studio',
+    tagsUrl: 'http://127.0.0.1:1234/v1/models',
+    baseUrl: 'http://127.0.0.1:1234',
+    openAiBaseUrl: 'http://127.0.0.1:1234/v1',
+  },
+];
+
+/** A candidate local inference endpoint. */
+interface LocalEndpoint {
+  /** Short identifier used in diagnostics. */
+  readonly name: string;
+  /** URL that lists available models — used as the liveness probe. */
+  readonly tagsUrl: string;
+  /** Server ROOT url — what a NATIVE transport (e.g. `ollama_native`) wants. */
+  readonly baseUrl: string;
+  /** OpenAI-compatible base URL — what a `chat_completions` transport wants. */
+  readonly openAiBaseUrl: string;
+}
+
+/** A detected, reachable local inference server. */
+export interface LocalInference {
+  /** Which server answered (`ollama`, `lm-studio`). */
+  readonly name: string;
+  /**
+   * Server ROOT url, e.g. `http://127.0.0.1:11434`.
+   *
+   * The two forms are NOT interchangeable and mixing them fails late: the
+   * native Ollama transport appends `/api/chat`, so handing it the `/v1`
+   * form produces `/v1/api/chat` and a 404 that reads like the daemon is
+   * broken. Use {@link LocalInference.openAiBaseUrl} for OpenAI-compatible
+   * transports and this for native ones.
+   */
+  readonly baseUrl: string;
+  /** OpenAI-compatible base URL, e.g. `http://127.0.0.1:11434/v1`. */
+  readonly openAiBaseUrl: string;
+  /** Model ids the server reports, in the order it reported them. */
+  readonly models: readonly string[];
+}
+
+/** Probe timeout. Loopback either answers immediately or is not there. */
+const PROBE_TIMEOUT_MS = 300;
+
+/** Process-lifetime cache — `undefined` = not yet probed, `null` = none found. */
+let cached: LocalInference | null | undefined;
+
+/**
+ * Extract model ids from either an Ollama `/api/tags` or an OpenAI `/v1/models`
+ * payload, whichever shape came back.
+ *
+ * @param body - parsed JSON response.
+ * @returns model ids, possibly empty.
+ */
+function extractModels(body: unknown): string[] {
+  if (body === null || typeof body !== 'object') return [];
+  const rec = body as { models?: unknown; data?: unknown };
+
+  // Ollama: { models: [{ name, model, … }] }
+  if (Array.isArray(rec.models)) {
+    return rec.models
+      .map((m) =>
+        m !== null && typeof m === 'object'
+          ? ((m as { name?: unknown }).name ?? (m as { model?: unknown }).model)
+          : undefined,
+      )
+      .filter((n): n is string => typeof n === 'string');
+  }
+  // OpenAI-compatible: { data: [{ id }] }
+  if (Array.isArray(rec.data)) {
+    return rec.data
+      .map((m) => (m !== null && typeof m === 'object' ? (m as { id?: unknown }).id : undefined))
+      .filter((n): n is string => typeof n === 'string');
+  }
+  return [];
+}
+
+/**
+ * Detect a reachable local inference server with at least one model loaded.
+ *
+ * Cached for the process lifetime: a background tick may consult this many
+ * times and the answer does not change mid-run in practice.
+ *
+ * Never throws — a probe failure means "not available", which is a normal
+ * result rather than an error.
+ *
+ * @param opts - `force` re-probes, ignoring the cache (tests).
+ * @returns the detected server, or `null` when none answers.
+ *
+ * @example
+ * ```ts
+ * const local = await detectLocalInference();
+ * if (local) console.log(`${local.name} has ${local.models.length} model(s)`);
+ * ```
+ *
+ * @task T12082
+ */
+export async function detectLocalInference(
+  opts: { force?: boolean } = {},
+): Promise<LocalInference | null> {
+  // Operator opt-out. Two audiences: someone on a shared or metered box who
+  // does not want background work routed to a daemon they run for other
+  // purposes, and the test suite — which must produce the same result whether
+  // or not the developer happens to have Ollama running.
+  if (process.env['CLEO_DISABLE_LOCAL_INFERENCE']?.trim()) return null;
+
+  if (!opts.force && cached !== undefined) return cached;
+
+  for (const endpoint of LOCAL_ENDPOINTS) {
+    try {
+      const response = await fetch(endpoint.tagsUrl, {
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+      if (!response.ok) continue;
+      const models = extractModels(await response.json());
+      // A server with no models loaded cannot serve a completion, so it is not
+      // a usable fallback — treat it as absent rather than advertising it.
+      if (models.length === 0) continue;
+      cached = {
+        name: endpoint.name,
+        baseUrl: endpoint.baseUrl,
+        openAiBaseUrl: endpoint.openAiBaseUrl,
+        models,
+      };
+      return cached;
+    } catch {
+      // Unreachable / timed out / non-JSON — try the next endpoint.
+    }
+  }
+
+  cached = null;
+  return cached;
+}
+
+/**
+ * List the models an Ollama daemon actually has pulled.
+ *
+ * The cross-provider selector picks an Ollama model from a RAM heuristic
+ * alone, which answers "what could this machine run", not "what is installed".
+ * Those differ constantly — this machine has 62 GB of RAM and therefore scored
+ * into the `gemma4:e4b` tier while holding only `qwen2.5-coder:3b` and
+ * `qwen2:0.5b`, so the resolved model would have 404'd at the daemon. The fit
+ * heuristic is still right; it just has to be intersected with reality.
+ *
+ * Not cached — the installed set changes whenever the operator pulls a model,
+ * and the call is one loopback request.
+ *
+ * Never throws.
+ *
+ * @param baseUrl - Ollama root URL, e.g. `http://localhost:11434` (no `/v1`).
+ * @returns installed model ids in daemon order, empty when unreachable.
+ *
+ * @task T12082
+ */
+export async function listOllamaModels(baseUrl: string): Promise<string[]> {
+  try {
+    const url = `${baseUrl.replace(/\/+$/, '')}/api/tags`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) });
+    if (!response.ok) return [];
+    return extractModels(await response.json());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Clear the probe cache. Tests only.
+ *
+ * @task T12082
+ */
+export function _resetLocalInferenceCacheForTests(): void {
+  cached = undefined;
+}

--- a/packages/core/src/llm/role-executor.ts
+++ b/packages/core/src/llm/role-executor.ts
@@ -174,7 +174,92 @@ export async function executeForRole(
   userContent: string,
   opts: ExecuteForRoleOptions = {},
 ): Promise<ExecuteForRoleResult | null> {
-  const llm = await resolveLLMForRole(role, { projectRoot: opts.projectRoot });
+  // T12082: one broken provider must not take the role down.
+  //
+  // This path drives the whole brain layer — consolidation, extraction,
+  // hygiene, the dream cycle. It resolved ONE provider and returned null on
+  // any failure, so a credential that is present but rejected (here: an
+  // openai Codex OAuth answering `400 'gpt-5.5-pro' is not supported when
+  // using Codex with a ChatGPT account`) disabled every background capability
+  // while other usable providers sat unconsulted. `shouldFallback` was already
+  // computed by the classifier and then thrown away.
+  //
+  // Failing over costs one extra resolution on an already-failed call, and the
+  // excluded provider is remembered only for the duration of this call — no
+  // persistent state, so a provider that recovers is picked again immediately.
+  const excludeProviders: string[] = [];
+
+  for (let attempt = 0; ; attempt++) {
+    const outcome = await attemptRoleCall(role, systemPrompt, userContent, opts, excludeProviders);
+    if (outcome.kind === 'ok') return outcome.result;
+    if (outcome.kind === 'give-up' || attempt >= MAX_ROLE_FAILOVERS) return null;
+    excludeProviders.push(outcome.provider);
+  }
+}
+
+/**
+ * How many alternate providers {@link executeForRole} may try after the first
+ * one fails.
+ *
+ * Two, not unbounded: each attempt costs a resolution plus a wire call, and a
+ * background pass that walks eleven providers to fail eleven times is worse
+ * than one that fails fast.
+ *
+ * @task T12082
+ */
+const MAX_ROLE_FAILOVERS = 2;
+
+/**
+ * Result of a single provider attempt.
+ *
+ * `give-up` means retrying elsewhere cannot help — the caller aborted, or the
+ * request itself is malformed. `failover` means this provider is unusable but
+ * another one might not be.
+ *
+ * @task T12082
+ */
+type RoleCallOutcome =
+  | { kind: 'ok'; result: ExecuteForRoleResult }
+  | { kind: 'failover'; provider: string }
+  | { kind: 'give-up' };
+
+/**
+ * Execute the role call against exactly one resolved provider.
+ *
+ * Extracted from {@link executeForRole} so the failover loop has a single
+ * attempt to drive; the body is unchanged apart from returning a discriminated
+ * outcome instead of `null`.
+ *
+ * @param role - semantic role.
+ * @param systemPrompt - system instruction.
+ * @param userContent - user message.
+ * @param opts - caller options.
+ * @param excludeProviders - providers that already failed this call.
+ * @returns the outcome of this single attempt.
+ *
+ * @task T9320
+ * @task T12082
+ */
+async function attemptRoleCall(
+  role: RoleName,
+  systemPrompt: string,
+  userContent: string,
+  opts: ExecuteForRoleOptions,
+  excludeProviders: readonly string[],
+): Promise<RoleCallOutcome> {
+  const llm = await resolveLLMForRole(role, {
+    projectRoot: opts.projectRoot,
+    // Snapshot: the loop appends to this array between attempts, and handing
+    // the live reference out would let a resolver observe a list that changes
+    // under it after the call.
+    excludeProviders: [...excludeProviders],
+  });
+
+  // The resolver could not honour the exclusion — nothing else is provisioned.
+  // Calling the same failed provider a second time would repeat its failure and
+  // its side effects (a 401 would quarantine the same credential twice).
+  if (excludeProviders.includes(llm.provider)) return { kind: 'give-up' };
+
   if (!llm.sealedCredential || !llm.credential) {
     // No usable credential for this role's resolved provider. Surface ONE
     // actionable re-auth hint per (role, provider) tuple instead of a silent
@@ -185,7 +270,9 @@ export async function executeForRole(
         `Run 'cleo llm login' (or 'cleo llm add ${llm.provider}') to authenticate, ` +
         `or 'cleo llm profile ${role} <provider>' to bind this role to a configured provider.`,
     );
-    return null;
+    // Another provider may well have a credential — that is worth one more
+    // resolution before the whole capability goes dark.
+    return { kind: 'failover', provider: llm.provider };
   }
 
   const credentialLabel = llm.credentialLabel ?? '<default>';
@@ -269,10 +356,13 @@ export async function executeForRole(
 
     const resp = await transport.complete(request);
     return {
-      content: resp.content ?? '',
-      usage: resp.usage,
-      provider: llm.provider,
-      model: resp.model,
+      kind: 'ok',
+      result: {
+        content: resp.content ?? '',
+        usage: resp.usage,
+        provider: llm.provider,
+        model: resp.model,
+      },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -307,6 +397,13 @@ export async function executeForRole(
         `[role-executor] role=${role} provider=${llm.provider} model=${model} call failed: ${message}`,
       );
     }
-    return null;
+
+    // An abort is the CALLER's decision — retrying elsewhere would ignore it.
+    // Everything else (auth, rate limit, 4xx, 5xx, network) is a property of
+    // this provider, so another one is worth trying.
+    if (classified.reason === 'timeout' && opts.signal?.aborted === true) {
+      return { kind: 'give-up' };
+    }
+    return { kind: 'failover', provider: llm.provider };
   }
 }

--- a/packages/core/src/llm/role-executor.ts
+++ b/packages/core/src/llm/role-executor.ts
@@ -238,7 +238,11 @@ export async function executeForRole(
       expiresAt: null,
       refreshToken: null,
       extraHeaders: {},
-      baseUrl: wire.baseUrl,
+      // T12081: the credential's OWN endpoint wins. Using `wire.baseUrl`
+      // unconditionally rewrote every custom endpoint (Ollama, LM Studio,
+      // vLLM, OpenRouter, Azure) to the provider's public API, which then
+      // rejected the local key with 401.
+      baseUrl: llm.credential?.baseUrl ?? wire.baseUrl,
       awsProfile: null,
     };
     const transport = ModelRunner.buildTransportFromCredential(

--- a/packages/core/src/llm/role-resolver.ts
+++ b/packages/core/src/llm/role-resolver.ts
@@ -50,6 +50,7 @@ import { type CredentialResult, resolveCredentials } from './credentials.js';
 import { getCredentialByLabel, pickCredentialForProvider } from './credentials-store.js';
 import { selectBestProvisioned } from './cross-provider-selector.js';
 import { IMPLICIT_FALLBACK_MODEL } from './fallback-model.js';
+import { detectLocalInference } from './local-inference-probe.js';
 import { makeSealedCredential, tokenPreview } from './sealed-credential.js';
 import { getRegisteredSystemDefault } from './system-of-use-registry.js';
 import { buildAnthropicClient } from './transports/anthropic-client-factory.js';
@@ -76,6 +77,17 @@ export { IMPLICIT_FALLBACK_MODEL };
  * @task T9255
  */
 export const IMPLICIT_FALLBACK_PROVIDER: ModelTransport = 'anthropic';
+
+/**
+ * Placeholder bearer token used for a keyless local inference daemon (T12082).
+ *
+ * Not a secret and not validated by anything: local servers accept any bearer
+ * value. It exists because the transport contract requires a token field, and
+ * because every consumer in this layer gates on `credential != null` — without
+ * a placeholder, a perfectly usable daemon is indistinguishable from an
+ * unconfigured provider.
+ */
+export const LOCAL_PLACEHOLDER_TOKEN = 'local';
 
 /**
  * Implicit fallback model for the `hygiene` role.
@@ -466,6 +478,45 @@ async function selectProviderModel(
 }
 
 /**
+ * Re-route a resolution away from providers the caller has excluded (T12082).
+ *
+ * Called only when `excludeProviders` is non-empty, which happens only after
+ * that provider has already failed the current call. The replacement comes
+ * from the provisioning-aware selector rather than the config cascade, because
+ * every config tier would just name the same excluded pin again.
+ *
+ * When no substitute is provisioned, the original selection is returned
+ * unchanged: the caller is about to fail either way, and preserving the
+ * original keeps its error message pointed at the provider actually
+ * configured.
+ *
+ * @param selected - the resolution produced by the normal cascade.
+ * @param role - logical role being resolved.
+ * @param projectRoot - project root for provisioning lookups.
+ * @param exclude - providers that must not be returned.
+ * @returns the original selection, or a substitute that is not excluded.
+ *
+ * @task T12082
+ */
+async function applyProviderExclusions(
+  selected: SelectedProviderModel,
+  role: RoleName,
+  projectRoot: string,
+  exclude: readonly string[] | undefined,
+): Promise<SelectedProviderModel> {
+  if (exclude === undefined || exclude.length === 0) return selected;
+  if (!exclude.includes(selected.provider)) return selected;
+
+  try {
+    const substitute = await selectBestProvisioned(role, { projectRoot, exclude });
+    if (substitute !== null) return substitute;
+  } catch {
+    // Non-fatal — fall through to the original selection.
+  }
+  return selected;
+}
+
+/**
  * Try the credentials-store first (with `preferLabel` when pinned), then fall
  * back to the 6-tier `resolveCredentials()` chain. Returns `null` only when
  * both produce nothing.
@@ -547,6 +598,37 @@ async function resolveCredentialForRole(
   if (cred.apiKey) {
     return { credential: cred, usedLabel: undefined };
   }
+
+  // T12082: a keyless local daemon has no credential to find, and demanding
+  // one is what kept it unusable.
+  //
+  // Every caller of this resolver gates on `credential != null`, so the
+  // selector could admit a live Ollama, score it, and pick it — and then the
+  // call died one step later with "no usable credential. Run 'cleo llm login'
+  // … to authenticate", advice that is meaningless for a server that accepts
+  // any bearer token. The provider profile already documents the empty-string
+  // placeholder; this is where that placeholder has to be produced.
+  //
+  // Synthesised ONLY when the daemon actually answers, so this never invents a
+  // credential for a provider that is not there.
+  if (provider === 'ollama') {
+    const local = await detectLocalInference();
+    if (local !== null && local.name === 'ollama') {
+      return {
+        credential: {
+          provider,
+          apiKey: LOCAL_PLACEHOLDER_TOKEN,
+          source: 'local-daemon',
+          authType: 'api_key',
+          // ROOT url, not the `/v1` form: `deriveApiWire('ollama')` selects the
+          // NATIVE transport, which appends `/api/chat` itself.
+          baseUrl: local.baseUrl,
+        },
+        usedLabel: undefined,
+      };
+    }
+  }
+
   return { credential: null, usedLabel: undefined };
 }
 
@@ -612,12 +694,24 @@ export async function resolveLLMForRole(
   // `projectRoot` is threaded to tier 7 (cross-provider selector) for any
   // credential resolution that may need the project context (DHQ-081 · T11978).
   const llmBlock = readLlmBlock(config);
-  const { provider, model, credentialLabel, source } = await selectProviderModel(
+  const selected = await selectProviderModel(
     llmBlock,
     role,
     opts?.systemKey,
     opts?.profileOverride,
     projectRoot,
+  );
+
+  // T12082: honour caller-supplied exclusions. A provider is excluded only
+  // because it already failed this very call, so a config pin naming it is no
+  // longer the best answer — re-run the provisioning-aware selection without
+  // it. Without this, one broken provider takes down the role even when other
+  // credentials (and a live local daemon) are sitting right there.
+  const { provider, model, credentialLabel, source } = await applyProviderExclusions(
+    selected,
+    role,
+    projectRoot,
+    opts?.excludeProviders,
   );
 
   // Step 3 — resolve credential.

--- a/packages/core/src/llm/role-resolver.ts
+++ b/packages/core/src/llm/role-resolver.ts
@@ -505,6 +505,8 @@ async function resolveCredentialForRole(
           apiKey: stored.accessToken,
           source: 'cred-file',
           authType: wireAuthType,
+          // T12081: preserve the stored endpoint (Ollama/LM Studio/vLLM/…).
+          baseUrl: stored.baseUrl ?? null,
         },
         usedLabel: stored.label,
       };
@@ -529,6 +531,8 @@ async function resolveCredentialForRole(
           apiKey: picked.accessToken,
           source: 'cred-file',
           authType: wireAuthType,
+          // T12081: preserve the stored endpoint (Ollama/LM Studio/vLLM/…).
+          baseUrl: picked.baseUrl ?? null,
         },
         usedLabel: picked.label,
       };
@@ -670,6 +674,11 @@ export async function resolveLLMForRole(
       provider: credential.provider,
       source: credential.source,
       authType: wireAuthType,
+      // T12081: carry the credential's OWN endpoint. Without it a consumer
+      // building a transport cannot tell that this credential targets a local
+      // or proxied host, and falls back to the provider's public API — which
+      // rejected every Ollama / LM Studio / vLLM / OpenRouter credential 401.
+      baseUrl: credential.baseUrl ?? null,
     };
     sealedCredential = makeSealedCredential({
       provider: credential.provider,

--- a/packages/core/src/sentient/__tests__/dream-local-fallback.test.ts
+++ b/packages/core/src/sentient/__tests__/dream-local-fallback.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Dream-cycle LLM resolution fallback chain (T12081 · T12082).
+ *
+ * Three tiers, in order:
+ *   1. a real Anthropic client (supports the structured-output `parse` path);
+ *   2. ANY resolvable provider via the provider-agnostic `executeForRole`;
+ *   3. a LOCAL inference server detected at runtime.
+ *
+ * Tier 2 exists because `resolveAnthropicForRole` returns null for every
+ * non-anthropic provider — a provider-specific chokepoint inside an otherwise
+ * provider-agnostic system. Tier 3 exists because the auxiliary fallback chain
+ * is entirely cloud (anthropic → openrouter → groq), so when every cloud
+ * credential is unusable the chain is exhausted and consolidation just stops —
+ * which is what happened on 2026-08-06, with an Ollama server running the whole
+ * time.
+ *
+ * These tests drive the chain with mocked modules so no network is touched.
+ *
+ * @task T12082
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `vi.mock` factories are hoisted above every other statement in the file, so
+// the doubles they close over must be created in a hoisted block too.
+const {
+  resolveAnthropicForRole,
+  executeForRole,
+  detectLocalInference,
+  complete,
+  buildTransportFromCredential,
+} = vi.hoisted(() => {
+  const completeFn = vi.fn();
+  return {
+    resolveAnthropicForRole: vi.fn(),
+    executeForRole: vi.fn(),
+    detectLocalInference: vi.fn(),
+    complete: completeFn,
+    buildTransportFromCredential: vi.fn(() => ({ complete: completeFn })),
+  };
+});
+
+vi.mock('../../llm/role-resolver.js', () => ({
+  IMPLICIT_FALLBACK_MODEL: 'claude-sonnet-5',
+  resolveAnthropicForRole,
+  resolveLLMForRole: vi.fn().mockResolvedValue({
+    provider: 'openai',
+    model: 'gpt-5.5-pro',
+    sealedCredential: null,
+  }),
+}));
+
+vi.mock('../../llm/role-executor.js', () => ({ executeForRole }));
+
+vi.mock('../../llm/local-inference-probe.js', () => ({ detectLocalInference }));
+
+vi.mock('../../llm/model-runner.js', () => ({
+  ModelRunner: { buildTransportFromCredential },
+}));
+
+import { SENTIENT_STATE_FILE } from '../daemon.js';
+import { type CollectedObservation, runDreamCycle } from '../dream-cycle.js';
+import { DEFAULT_SENTIENT_STATE, writeSentientState } from '../state.js';
+
+/** A local server with two models loaded, newest first. */
+const OLLAMA = {
+  name: 'ollama',
+  baseUrl: 'http://127.0.0.1:11434',
+  openAiBaseUrl: 'http://127.0.0.1:11434/v1',
+  models: ['qwen2.5-coder:3b', 'qwen2:0.5b'],
+};
+
+/** One memory, shaped as the extractor expects it back from the model. */
+const MEMORIES = [
+  {
+    type: 'learning' as const,
+    content: 'Background consolidation should degrade to local inference, not stop.',
+    importance: 0.8,
+    entities: ['dream-cycle'],
+    justification: 'Observed across five hygiene observations.',
+  },
+];
+
+/**
+ * Build a cluster the cycle will actually synthesise: enough observations
+ * (>= DREAM_CLUSTER_MIN_SIZE) with enough n-gram overlap to cluster together.
+ *
+ * @returns the observations.
+ */
+function makeCluster(): CollectedObservation[] {
+  return Array.from({ length: 6 }, (_, i) => ({
+    id: `O-local-${i}`,
+    title: 'dream cycle local inference fallback',
+    narrative: 'dream cycle local inference fallback ollama loopback consolidation degrade',
+    createdAt: new Date().toISOString(),
+    observationType: 'hygiene:test',
+  }));
+}
+
+describe('dream-cycle LLM fallback chain (T12081 · T12082)', () => {
+  let root: string;
+  let statePath: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'cleo-dream-local-'));
+    statePath = join(root, SENTIENT_STATE_FILE);
+    await writeSentientState(statePath, { ...DEFAULT_SENTIENT_STATE });
+
+    vi.clearAllMocks();
+    buildTransportFromCredential.mockReturnValue({ complete });
+    complete.mockResolvedValue({
+      content: [{ type: 'text', text: JSON.stringify({ memories: MEMORIES }) }],
+    });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the cycle with every side effect stubbed except LLM resolution.
+   *
+   * @returns the outcome.
+   */
+  async function run() {
+    return runDreamCycle({
+      projectRoot: root,
+      statePath,
+      collectObservations: async () => makeCluster(),
+      observeMemory: vi.fn().mockResolvedValue({ id: 'O-digest' }),
+      verifyAndStoreFn: vi.fn().mockResolvedValue({ action: 'stored' }),
+    });
+  }
+
+  it('falls through to LOCAL inference when no cloud credential resolves', async () => {
+    resolveAnthropicForRole.mockResolvedValue(null);
+    executeForRole.mockResolvedValue(null); // dead credential — the 2026-08-06 state
+    detectLocalInference.mockResolvedValue(OLLAMA);
+
+    const outcome = await run();
+
+    expect(outcome.kind).toBe('completed');
+    expect(detectLocalInference).toHaveBeenCalled();
+    // models[0] is the completion model, and the transport is pointed at the
+    // detected loopback base URL rather than any cloud endpoint.
+    expect(complete).toHaveBeenCalledWith(expect.objectContaining({ model: 'qwen2.5-coder:3b' }));
+    // The compat URL, because this shim speaks `chat_completions`.
+    expect(buildTransportFromCredential).toHaveBeenCalledWith(
+      'openai',
+      expect.objectContaining({ baseUrl: OLLAMA.openAiBaseUrl }),
+      'chat_completions',
+    );
+  });
+
+  it('records no-api-key when neither cloud NOR local is available', async () => {
+    resolveAnthropicForRole.mockResolvedValue(null);
+    executeForRole.mockResolvedValue(null);
+    detectLocalInference.mockResolvedValue(null);
+
+    expect((await run()).kind).toBe('no-api-key');
+  });
+
+  it('does NOT reach the local tier when a non-anthropic provider works', async () => {
+    // Tier 2: the provider-agnostic path answers, so nothing local is probed.
+    resolveAnthropicForRole.mockResolvedValue(null);
+    executeForRole.mockResolvedValue({
+      content: JSON.stringify({ memories: MEMORIES }),
+      model: 'gpt-5.5-pro',
+    });
+
+    const outcome = await run();
+
+    expect(outcome.kind).toBe('completed');
+    expect(detectLocalInference).not.toHaveBeenCalled();
+  });
+
+  it('bounds the tier-2 probe so a retrying dead credential cannot stall the pass', async () => {
+    // A provider with a dead credential does not fail fast — it retries with
+    // backoff. Unbounded, that blocks the whole consolidation behind a chain
+    // that will never succeed.
+    resolveAnthropicForRole.mockResolvedValue(null);
+    executeForRole.mockResolvedValue(null);
+    detectLocalInference.mockResolvedValue(null);
+
+    await run();
+
+    expect(executeForRole).toHaveBeenCalledWith(
+      'consolidation',
+      'ping',
+      'ping',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('prefers a real Anthropic client over both fallbacks', async () => {
+    resolveAnthropicForRole.mockResolvedValue({
+      client: {
+        messages: {
+          parse: vi.fn().mockResolvedValue({ parsed_output: { memories: MEMORIES } }),
+          create: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: JSON.stringify({ memories: MEMORIES }) }],
+          }),
+        },
+      },
+      model: 'claude-sonnet-5',
+    });
+
+    const outcome = await run();
+
+    expect(outcome.kind).toBe('completed');
+    expect(executeForRole).not.toHaveBeenCalled();
+    expect(detectLocalInference).not.toHaveBeenCalled();
+  });
+
+  it('survives a local tier that throws — degrades to no-api-key, never crashes', async () => {
+    resolveAnthropicForRole.mockResolvedValue(null);
+    executeForRole.mockResolvedValue(null);
+    detectLocalInference.mockRejectedValue(new Error('probe exploded'));
+
+    expect((await run()).kind).toBe('no-api-key');
+  });
+});

--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -83,6 +83,18 @@ export const DREAM_CLUSTER_MIN_SIZE = 5;
 export const DREAM_MAX_CLUSTERS = 10;
 
 /**
+ * Upper bound on the provider-liveness probe issued while resolving a dream
+ * client (T12082).
+ *
+ * A provider with a dead credential does not fail fast — the transport retries
+ * with backoff, so an unbounded probe blocks the entire consolidation pass
+ * behind a chain that will never succeed. Background work must degrade, not
+ * hang: a provider that cannot answer a 16-token ping in this window is not
+ * usable for consolidation regardless of what it eventually returns.
+ */
+export const DREAM_PROBE_TIMEOUT_MS = 20_000;
+
+/**
  * Jaccard similarity threshold above which two observations are placed in
  * the same cluster. Value in [0, 1]. Higher = tighter clusters.
  */
@@ -554,28 +566,114 @@ async function resolveDreamLlm(
   // returns.
   try {
     const { executeForRole } = await import('../llm/role-executor.js');
-    const probe = await executeForRole('consolidation', 'ping', 'ping', { projectRoot });
-    if (!probe) return null;
+    // Bounded: a provider whose credential is dead answers with retries, not
+    // with an error. Left unbounded this probe stalls the whole consolidation
+    // pass behind a chain that is never going to succeed — observed here as a
+    // dream cycle that ran for over ten minutes without reaching step one.
+    // A ping that cannot answer in DREAM_PROBE_TIMEOUT_MS is not a usable
+    // provider for background work, whatever it eventually returns.
+    const probe = await executeForRole('consolidation', 'ping', 'ping', {
+      projectRoot,
+      maxTokens: 16,
+      signal: AbortSignal.timeout(DREAM_PROBE_TIMEOUT_MS),
+    });
+    // A null probe means the resolved provider has no usable credential. Do NOT
+    // return here — the local tier below is the whole point of having one.
+    if (probe) {
+      const client = {
+        messages: {
+          create: async (body: {
+            system?: string;
+            messages: Array<{ role: string; content: string }>;
+          }) => {
+            const userContent = body.messages
+              .filter((m) => m.role === 'user')
+              .map((m) => m.content)
+              .join('\n\n');
+            const result = await executeForRole('consolidation', body.system ?? '', userContent, {
+              projectRoot,
+            });
+            return { content: [{ type: 'text', text: result?.content ?? '' }] };
+          },
+        },
+      } as unknown as Pick<Anthropic, 'messages'>;
+
+      return { client, model: probe.model };
+    }
+  } catch {
+    // fall through to the local tier
+  }
+
+  // T12082: last tier — a reachable LOCAL inference server.
+  //
+  // The auxiliary fallback chain exists so background work does not fail
+  // silently when the primary provider is unavailable, but its default chain
+  // (anthropic → openrouter → groq) is entirely cloud. When every cloud
+  // credential is unusable the chain is exhausted and consolidation simply
+  // stops — which is what happened here while an Ollama server sat running with
+  // models loaded, one HTTP request away.
+  //
+  // A consolidation pass is exactly the workload that should degrade to a small
+  // local model rather than stop: not latency-critical, not user-facing, and a
+  // shallow synthesis is worth more than none. Detection is a 300 ms loopback
+  // probe, so this costs nothing when no server is present.
+  try {
+    const { detectLocalInference } = await import('../llm/local-inference-probe.js');
+    const local = await detectLocalInference();
+    const model = local?.models[0];
+    if (!local || model === undefined) return null;
+
+    const { ModelRunner } = await import('../llm/model-runner.js');
+    const transport = ModelRunner.buildTransportFromCredential(
+      'openai',
+      {
+        provider: 'openai',
+        label: `${local.name}-autodetected`,
+        // Local servers accept any bearer value; the field is required by the
+        // transport contract, not by the endpoint.
+        token: 'local',
+        authType: 'api_key',
+        expiresAt: null,
+        refreshToken: null,
+        extraHeaders: {},
+        // The compat form: this shim speaks `chat_completions`.
+        baseUrl: local.openAiBaseUrl,
+        awsProfile: null,
+      },
+      'chat_completions',
+    );
 
     const client = {
       messages: {
         create: async (body: {
+          max_tokens: number;
           system?: string;
           messages: Array<{ role: string; content: string }>;
         }) => {
-          const userContent = body.messages
-            .filter((m) => m.role === 'user')
-            .map((m) => m.content)
-            .join('\n\n');
-          const result = await executeForRole('consolidation', body.system ?? '', userContent, {
-            projectRoot,
+          const response = await transport.complete({
+            model,
+            maxTokens: body.max_tokens,
+            ...(body.system !== undefined ? { system: body.system } : {}),
+            messages: body.messages.map((m) => ({
+              role: m.role as 'user' | 'assistant',
+              content: m.content,
+            })),
           });
-          return { content: [{ type: 'text', text: result?.content ?? '' }] };
+          return {
+            content: [
+              {
+                type: 'text',
+                text: Array.isArray(response.content)
+                  ? response.content.map((c: { text?: string }) => c.text ?? '').join('')
+                  : String(response.content ?? ''),
+              },
+            ],
+          };
         },
       },
     } as unknown as Pick<Anthropic, 'messages'>;
 
-    return { client, model: probe.model };
+    return { client, model };
   } catch {
     return null;
   }

--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -533,9 +533,52 @@ Extract durable knowledge from these observations. Return empty array if nothing
 async function resolveDreamLlm(
   projectRoot: string,
 ): Promise<{ client: Pick<Anthropic, 'messages'>; model: string } | null> {
-  const llm = await resolveAnthropicForRole('consolidation', { projectRoot });
-  if (!llm) return null;
-  return { client: llm.client, model: llm.model };
+  // Preferred: a real Anthropic client, which supports the structured-output
+  // `messages.parse` path.
+  const anthropic = await resolveAnthropicForRole('consolidation', { projectRoot });
+  if (anthropic) return { client: anthropic.client, model: anthropic.model };
+
+  // T12081: fall back to ANY resolvable provider via `executeForRole`.
+  //
+  // `resolveAnthropicForRole` returns null for every non-anthropic provider, so
+  // a project whose `consolidation` role resolves to openai, gemini or a local
+  // Ollama endpoint could not run the dream cycle at all — it reported "no
+  // usable Anthropic client" and skipped. A provider-specific chokepoint inside
+  // an otherwise provider-agnostic system, and the reason the dream cycle was
+  // dead on a machine that had working LOCAL inference available the whole time.
+  //
+  // `executeForRole` is the existing provider-agnostic path (resolve → unseal →
+  // ModelRunner.buildTransportFromCredential → complete). Wrapping it in the
+  // `messages.create` shape lets the plain-call extractor run unchanged: it
+  // already asks for `{content: [{type:'text', text}]}`, which is what this
+  // returns.
+  try {
+    const { executeForRole } = await import('../llm/role-executor.js');
+    const probe = await executeForRole('consolidation', 'ping', 'ping', { projectRoot });
+    if (!probe) return null;
+
+    const client = {
+      messages: {
+        create: async (body: {
+          system?: string;
+          messages: Array<{ role: string; content: string }>;
+        }) => {
+          const userContent = body.messages
+            .filter((m) => m.role === 'user')
+            .map((m) => m.content)
+            .join('\n\n');
+          const result = await executeForRole('consolidation', body.system ?? '', userContent, {
+            projectRoot,
+          });
+          return { content: [{ type: 'text', text: result?.content ?? '' }] };
+        },
+      },
+    } as unknown as Pick<Anthropic, 'messages'>;
+
+    return { client, model: probe.model };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -628,7 +671,12 @@ async function synthesiseCluster(
 
   try {
     const format = await buildZodFormat(DreamSynthesisResponseSchema);
-    if (format) {
+    // T12081: the provider-agnostic shim implements `create` only. Guard on
+    // `parse` rather than letting an undefined call throw into the catch-all,
+    // which would silently yield zero memories for every non-anthropic provider.
+    const hasParse =
+      typeof (client.messages as unknown as { parse?: unknown }).parse === 'function';
+    if (format && hasParse) {
       const messages = client.messages as unknown as {
         parse: (body: Record<string, unknown>) => Promise<{
           parsed_output?: { memories?: DreamExtractedMemory[] };

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -66,6 +66,15 @@ if (!process.env.XDG_CACHE_HOME) {
 if (!process.env.AGENTS_HOME) {
   process.env.AGENTS_HOME = join(sandbox, 'agents');
 }
+// T12082: the cross-provider selector now admits a LIVE local inference daemon
+// as provisioned — a provider that needs no key should not have to be declared,
+// only to answer. That makes host state a test input: on a developer machine
+// running Ollama, every "nothing is provisioned" assertion in the LLM suite
+// flips. Pin it off by default; the tests that exercise the local path unset
+// this variable themselves.
+if (!process.env.CLEO_DISABLE_LOCAL_INFERENCE) {
+  process.env.CLEO_DISABLE_LOCAL_INFERENCE = '1';
+}
 if (!process.env.NEXUS_HOME) {
   process.env.NEXUS_HOME = join(sandbox, 'nexus');
 }


### PR DESCRIPTION
Two commits, one thread: **the entire brain layer — consolidation, extraction, hygiene, the dream cycle — was dead on this machine, and free local inference was answering on loopback in 24 ms the whole time.**

## T12081 — the dream cycle could not use a non-Anthropic provider

`resolveDreamLlm` called `resolveAnthropicForRole`, which returns `null` for **every** non-anthropic provider — a provider-specific chokepoint inside an otherwise provider-agnostic system. Now falls through to the provider-agnostic `executeForRole`.

Also: `role-executor` rebuilt the endpoint from the provider default, rewriting every custom `baseUrl` (Ollama, LM Studio, vLLM, Azure) to the vendor's public API, which then rejected the local key with 401. The credential's own endpoint now wins, and `baseUrl` is carried through `CredentialResult` / `CredentialMetadataWire` instead of being dropped at the first hop.

## T12082 — four defects, each alone sufficient to kill the layer

| # | Defect | Consequence |
|---|--------|-------------|
| 1 | **No failover.** `executeForRole` resolved ONE provider, returned `null` on any failure | An openai Codex OAuth answering `400 'gpt-5.5-pro' is not supported when using Codex with a ChatGPT account` disabled every background capability. `classifyError` already computed `shouldFallback`; nothing read it |
| 2 | **A live daemon was never admitted.** `isProvisioned` is sync → cannot probe → settles for "`OLLAMA_HOST` set OR store entry"; liveness was probed *only for already-provisioned providers* | Circular. An undeclared daemon could never be admitted however healthy → `no-provisioned-provider` for all five roles |
| 3 | **Model chosen from RAM alone.** 62 GB scores into the `gemma4:e4b` tier; this box holds `qwen2.5-coder:3b` | The resolved tag 404s at the daemon, which reads as "local inference is broken", not "that tag is not pulled" |
| 4 | **A keyless provider cannot produce a credential.** Every consumer gates on `credential != null` | Even once ollama won the scoring it died one step later advising `cleo llm login` — meaningless for a server that accepts any bearer value |

Fixes: bounded failover (2 alternates, excluded provider skipped on retry, caller aborts still give up) · a live local daemon is admitted as provisioned · the RAM heuristic is intersected with the installed set (exact tag → same family → first installed) · a `local-daemon` credential source synthesised **only** when the daemon answers.

Plus: the dream cycle's provider probe is bounded at 20 s — a dead credential does not fail fast, it retries, and an unbounded probe stalls the whole pass behind a chain that will never succeed.

`LocalInference` carries **both** `baseUrl` (root) and `openAiBaseUrl` (`/v1`): the native Ollama transport appends `/api/chat`, so handing it the compat form yields `/v1/api/chat`.

## Proven live — zero configuration (`llm.roles = {}`)

```
RESOLVED  provider=openai model=gpt-5.5-pro
openai    400 — model not supported on this account
   ->     EXEC_MS 1784   model qwen2.5-coder:3b   content "yes"

dream cycle   kind: completed   (6.1 s)
30 observations -> 10 clusters -> 2 synthesised -> 3 stored, 0 rejected
```

Three consecutive dream-cycle runs completed. Before this branch: `no-api-key`.

## Tests

39 new across 4 files. The shared vitest setup pins `CLEO_DISABLE_LOCAL_INFERENCE=1` — admitting host state into resolution otherwise makes every "nothing is provisioned" assertion depend on whether the developer runs Ollama. That flag ships as a real operator opt-out too.

`packages/core`: **12725 passed**. The 17 failures are the pre-existing `getNative(...).integrateWorktree is not a function` napi breakage, present on `main` and untouched here. Gates 1–7, 10, 11, 13, 14 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)