### PR TITLE
fix: no task could EVER be completed in a project without TypeScript (T12083)

### DIFF
--- a/packages/contracts/src/task.ts
+++ b/packages/contracts/src/task.ts
@@ -192,7 +192,23 @@ export type EvidenceAtom =
       failCount: number;
       skipCount: number;
     }
-  | { kind: 'tool'; tool: string; exitCode: number; stdoutTail: string }
+  | {
+      kind: 'tool';
+      tool: string;
+      exitCode: number;
+      stdoutTail?: string;
+      /**
+       * The project has no such toolchain, so the gate is satisfied by absence
+       * rather than by a run (T12083).
+       *
+       * Recorded explicitly so the audit trail never implies a tool ran that
+       * did not. Only ever set for a GUESSED language default — a command
+       * declared in `project-context.json` is always executed.
+       */
+      notApplicable?: boolean;
+      /** Why the tool was judged inapplicable. Present iff `notApplicable`. */
+      reason?: string;
+    }
   | { kind: 'url'; url: string }
   | { kind: 'note'; note: string }
   | { kind: 'override'; reason: string }

--- a/packages/core/src/tasks/__tests__/tool-applicability.test.ts
+++ b/packages/core/src/tasks/__tests__/tool-applicability.test.ts
@@ -1,0 +1,150 @@
+/**
+ * A language default must not demand a toolchain the project does not have
+ * (T12083).
+ *
+ * Measured on a fresh drop-in: `cleo init` on a plain JavaScript project, a
+ * correct worker implements a function, writes a test, RUNS the suite, commits,
+ * records `implemented` + `testsPassed` — and then `cleo complete` refuses:
+ *
+ *     Task T003 failed verification gates: qaPassed (45)
+ *
+ * because `qaPassed` wants `tool:typecheck`, whose node language default is
+ * `npx tsc --noEmit`, which in a project with no TypeScript answers
+ * *"This is not the tsc command you are looking for"* and exits 1. No task in
+ * that project can EVER be completed, however correct the work.
+ *
+ * The asymmetry that fixes it: a command the operator DECLARED always runs; a
+ * command CLEO guessed runs only when the project shows evidence of that
+ * toolchain.
+ *
+ * @task T12083
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resolveToolCommand } from '../tool-resolver.js';
+
+let root: string;
+
+/** Write a `package.json` into the sandbox. */
+async function pkg(content: Record<string, unknown>): Promise<void> {
+  await writeFile(join(root, 'package.json'), JSON.stringify(content), 'utf-8');
+}
+
+/** Write `.cleo/project-context.json` into the sandbox. */
+async function context(content: Record<string, unknown>): Promise<void> {
+  await mkdir(join(root, '.cleo'), { recursive: true });
+  await writeFile(join(root, '.cleo/project-context.json'), JSON.stringify(content), 'utf-8');
+}
+
+describe('tool applicability (T12083)', () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'cleo-tool-applic-'));
+  });
+
+  describe('a plain JavaScript project', () => {
+    beforeEach(async () => {
+      await pkg({ name: 'calcbox', type: 'module', scripts: { test: 'node test/calc.test.js' } });
+      await context({ primaryType: 'node' });
+    });
+
+    it('reports typecheck as NOT APPLICABLE instead of running `npx tsc`', async () => {
+      const r = resolveToolCommand('typecheck', root);
+
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.codeName).toBe('E_TOOL_NOT_APPLICABLE');
+      // The reason must name the remedy that actually works here.
+      expect(r.reason).toContain('project-context.json');
+    });
+
+    it('reports lint as NOT APPLICABLE with no linter config or dependency', () => {
+      const r = resolveToolCommand('lint', root);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.codeName).toBe('E_TOOL_NOT_APPLICABLE');
+    });
+
+    it('still resolves `test`, which the project genuinely has', () => {
+      // Applicability is per-tool. A project without a typechecker still has
+      // tests, and `testsPassed` must keep biting.
+      const r = resolveToolCommand('test', root);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.command.canonical).toBe('test');
+    });
+  });
+
+  describe('markers that make a tool applicable', () => {
+    beforeEach(async () => {
+      await context({ primaryType: 'node' });
+    });
+
+    it('tsconfig.json makes typecheck applicable', async () => {
+      await pkg({ name: 'x' });
+      writeFileSync(join(root, 'tsconfig.json'), '{}');
+      expect(resolveToolCommand('typecheck', root).ok).toBe(true);
+    });
+
+    it('a `typecheck` script makes typecheck applicable', async () => {
+      await pkg({ name: 'x', scripts: { typecheck: 'tsc --noEmit' } });
+      expect(resolveToolCommand('typecheck', root).ok).toBe(true);
+    });
+
+    it('a typescript devDependency makes typecheck applicable', async () => {
+      await pkg({ name: 'x', devDependencies: { typescript: '^5.0.0' } });
+      expect(resolveToolCommand('typecheck', root).ok).toBe(true);
+    });
+
+    it('biome.json makes lint applicable', async () => {
+      await pkg({ name: 'x' });
+      writeFileSync(join(root, 'biome.json'), '{}');
+      expect(resolveToolCommand('lint', root).ok).toBe(true);
+    });
+
+    it('an eslint config makes lint applicable', async () => {
+      await pkg({ name: 'x' });
+      writeFileSync(join(root, 'eslint.config.mjs'), 'export default [];');
+      expect(resolveToolCommand('lint', root).ok).toBe(true);
+    });
+  });
+
+  describe('an explicitly DECLARED command is always applicable', () => {
+    it('runs a declared typecheck command even with no toolchain markers', async () => {
+      // The operator said so. Applicability is only ever consulted for a guess.
+      await pkg({ name: 'x' });
+      await context({ primaryType: 'node', typecheck: { command: 'make typecheck' } });
+
+      const r = resolveToolCommand('typecheck', root);
+
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.command.source).toBe('project-context');
+        expect(r.command.cmd).toBe('make');
+      }
+    });
+  });
+
+  describe('tools with no applicability marker are unaffected', () => {
+    it('resolves `build` by language default without a marker check', async () => {
+      // Only guesses that are KNOWN to be wrong in a bare project are gated.
+      // Everything else keeps its previous behaviour exactly.
+      await pkg({ name: 'x' });
+      await context({ primaryType: 'node' });
+
+      const r = resolveToolCommand('build', root);
+      expect(r.ok).toBe(true);
+    });
+  });
+
+  describe('non-node project types keep their defaults', () => {
+    it('does not gate a rust typecheck', async () => {
+      // No marker table for rust: `cargo check` is a safe default because a
+      // rust project by definition has cargo.
+      await context({ primaryType: 'rust' });
+      const r = resolveToolCommand('typecheck', root);
+      expect(r.ok).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/tasks/__tests__/tool-resolver.test.ts
+++ b/packages/core/src/tasks/__tests__/tool-resolver.test.ts
@@ -27,6 +27,20 @@ function writeProjectContext(root: string, ctx: Record<string, unknown>): void {
   writeFileSync(join(root, '.cleo', 'project-context.json'), JSON.stringify(ctx, null, 2));
 }
 
+/**
+ * Give the sandbox the toolchain markers a node project would really have.
+ *
+ * T12083 gates GUESSED language defaults on evidence that the project uses that
+ * toolchain, so a test about language-default *provenance* has to be run in a
+ * project where the default is applicable — otherwise it is a test about
+ * applicability instead. The marker-less case is covered in
+ * `tool-applicability.test.ts`.
+ */
+function writeNodeToolchain(root: string): void {
+  writeFileSync(join(root, 'tsconfig.json'), '{}');
+  writeFileSync(join(root, 'biome.json'), '{}');
+}
+
 describe('resolveToolCommand — project-context overrides', () => {
   let dir: string;
   beforeEach(() => {
@@ -169,6 +183,7 @@ describe('resolveToolCommand — language defaults (no project-context)', () => 
       projectTypes: ['node'],
       primaryType: 'node',
     });
+    writeNodeToolchain(dir);
     const r = resolveToolCommand('tsc', dir);
     expect(r.ok).toBe(true);
     if (r.ok) {
@@ -450,6 +465,7 @@ describe('resolveToolCommand — T12027 generalized overrides (lint/typecheck/au
       primaryType: 'node',
       lint: { command: '' },
     });
+    writeNodeToolchain(dir);
     const r = resolveToolCommand('lint', dir);
     expect(r.ok).toBe(true);
     if (r.ok) {
@@ -465,6 +481,7 @@ describe('resolveToolCommand — T12027 generalized overrides (lint/typecheck/au
       primaryType: 'node',
       lint: {},
     });
+    writeNodeToolchain(dir);
     const r = resolveToolCommand('lint', dir);
     expect(r.ok).toBe(true);
     if (r.ok) {

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -1204,6 +1204,25 @@ async function validateTestRun(path: string, projectRoot: string): Promise<AtomV
 
 async function validateTool(tool: string, projectRoot: string): Promise<AtomValidation> {
   const resolution = resolveToolCommand(tool, projectRoot);
+
+  // T12083: the project has no such toolchain. This is a fact about the
+  // project, not a failure of the work — a plain JavaScript project cannot
+  // typecheck, and demanding it means no task in that project can ever be
+  // completed however correct the work is.
+  //
+  // Recorded as a first-class `not-applicable` atom rather than silently
+  // passed: the audit trail must show that the gate was satisfied by absence
+  // and say WHY, so a project that later adopts the toolchain starts being
+  // held to it automatically. Rigour is unchanged wherever the tool exists —
+  // applicability is only consulted for guessed language defaults, never for a
+  // command the operator declared.
+  if (!resolution.ok && resolution.codeName === 'E_TOOL_NOT_APPLICABLE') {
+    return {
+      ok: true,
+      atom: { kind: 'tool', tool, exitCode: 0, notApplicable: true, reason: resolution.reason },
+    };
+  }
+
   if (!resolution.ok) {
     return {
       ok: false,

--- a/packages/core/src/tasks/tool-resolver.ts
+++ b/packages/core/src/tasks/tool-resolver.ts
@@ -110,7 +110,11 @@ export interface ResolvedToolCommand {
  */
 export type ResolveToolResult =
   | { ok: true; command: ResolvedToolCommand }
-  | { ok: false; reason: string; codeName: 'E_TOOL_UNKNOWN' | 'E_TOOL_UNAVAILABLE' };
+  | {
+      ok: false;
+      reason: string;
+      codeName: 'E_TOOL_UNKNOWN' | 'E_TOOL_UNAVAILABLE' | 'E_TOOL_NOT_APPLICABLE';
+    };
 
 // ---------------------------------------------------------------------------
 // Aliases — preserved for backward compatibility with evidence written
@@ -319,6 +323,85 @@ function parseCommandString(raw: string): CommandShape | null {
   return { cmd, args: parts.slice(1) };
 }
 
+/**
+ * Markers that prove a project actually uses a given toolchain (T12083).
+ *
+ * Consulted ONLY for language-default resolutions. An explicit command in
+ * `project-context.json` is always applicable — the operator said so.
+ *
+ * A marker is a config file, a `package.json` script of the canonical name, or
+ * a declared dependency. Any one is enough.
+ */
+const APPLICABILITY_MARKERS: Partial<
+  Record<ProjectType, Partial<Record<CanonicalTool, { files: string[]; deps: string[] }>>>
+> = {
+  node: {
+    typecheck: { files: ['tsconfig.json', 'jsconfig.json'], deps: ['typescript'] },
+    lint: {
+      files: [
+        'biome.json',
+        'biome.jsonc',
+        '.eslintrc',
+        '.eslintrc.js',
+        '.eslintrc.cjs',
+        '.eslintrc.json',
+        'eslint.config.js',
+        'eslint.config.mjs',
+        '.oxlintrc.json',
+      ],
+      deps: ['@biomejs/biome', 'eslint', 'oxlint'],
+    },
+  },
+};
+
+/**
+ * Does this project actually have the toolchain a language default assumes?
+ *
+ * The node default for `typecheck` is `npx tsc --noEmit`. In a plain
+ * JavaScript project that is not a "working default" — `npx` reports
+ * *"This is not the tsc command you are looking for"* and exits 1, so the
+ * `qaPassed` gate can never be satisfied and **no task can ever be completed**.
+ * A correct worker that implements, tests, and commits is then rejected for
+ * lacking a typechecker in a project that has nothing to typecheck.
+ *
+ * That is the drop-into-any-project blocker: gate rigour has to scale to the
+ * project's actual toolchain, not to the one CLEO was built in.
+ *
+ * @param canonical - canonical tool name.
+ * @param projectRoot - absolute project root.
+ * @param primaryType - detected project type.
+ * @returns `true` when the toolchain is present, or when no marker is defined
+ *   for this (type, tool) pair — unknown means "assume applicable", which
+ *   preserves every existing gate.
+ *
+ * @task T12083
+ */
+function isToolApplicable(
+  canonical: CanonicalTool,
+  projectRoot: string,
+  primaryType: ProjectType,
+): boolean {
+  const marker = APPLICABILITY_MARKERS[primaryType]?.[canonical];
+  if (!marker) return true;
+
+  if (marker.files.some((f) => existsSync(join(projectRoot, f)))) return true;
+
+  try {
+    const pkg = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf-8')) as {
+      scripts?: Record<string, string>;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    if (pkg.scripts?.[canonical]) return true;
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    if (marker.deps.some((d) => d in deps)) return true;
+  } catch {
+    // No package.json / unreadable — fall through to "not applicable".
+  }
+
+  return false;
+}
+
 interface ResolveOptions {
   /**
    * Override for `primaryType` lookup — set in tests where no real
@@ -425,6 +508,22 @@ export function resolveToolCommand(
         `Add an explicit command to .cleo/project-context.json (testing.command / build.command / lint.command / typecheck.command / audit.command / security-scan.command) ` +
         `or extend LANGUAGE_DEFAULTS in @cleocode/core/tasks/tool-resolver.ts.`,
       codeName: 'E_TOOL_UNAVAILABLE',
+    };
+  }
+
+  // T12083: a language default is a guess about the project. Only run it when
+  // the project shows evidence of that toolchain — otherwise the gate demands
+  // a tool the project has no reason to own.
+  if (!isToolApplicable(canonical, projectRoot, primaryType)) {
+    return {
+      ok: false,
+      reason:
+        `Tool "${toolName}" is not applicable to this project: no ${canonical} toolchain ` +
+        `was detected (no config file, no "${canonical}" script in package.json, and no ` +
+        `matching dependency). The default for primaryType="${primaryType}" would have run ` +
+        `\`${def.cmd} ${def.args.join(' ')}\`, which cannot succeed here. Add ` +
+        `${canonical}.command to .cleo/project-context.json to declare one explicitly.`,
+      codeName: 'E_TOOL_NOT_APPLICABLE',
     };
   }
 


### PR DESCRIPTION
Found by dropping CLEO into a fresh plain-JavaScript repo and driving the whole lifecycle, which is the thing it is supposed to be good at.

A correct worker implemented a function, wrote a test, **ran** the suite, committed, and recorded `implemented` + `testsPassed`. Then:

```
Error: Task T003 failed verification gates: qaPassed (45)
```

`qaPassed` requires `tool:typecheck`. The node language default is `npx tsc --noEmit`, which in a project with no TypeScript answers *"This is not the tsc command you are looking for"* and exits 1. Same for `tool:lint` → `npx biome check .`.

**In any project without a typechecker and a linter, the gate is unsatisfiable, so no task can ever be completed however correct the work.** The autonomous loop goes `failure → backoff → backoff` forever on work that is finished and committed.

The comment on those defaults claimed they exist so "a fresh project still gets a working default". They are not working defaults — they are guesses about a project, and in a bare project the guess is wrong.

## The asymmetry that fixes it

| Source | Behaviour |
|--------|-----------|
| Operator **declared** it (`typecheck.command` in `project-context.json`) | Always runs. They said so |
| CLEO **guessed** it (language default) | Runs only when the project shows evidence of the toolchain — config file, `package.json` script of that name, or matching dependency |

Otherwise resolution returns the new `E_TOOL_NOT_APPLICABLE` and the evidence layer records a first-class `notApplicable` atom **with the reason**. The gate is satisfied by absence and the audit trail says so, rather than implying a tool ran that did not. A project that later adopts TypeScript is held to it automatically, no config change.

Verified in both directions:

```
cleocode          lint → npx biome check .    typecheck → npx tsc --noEmit    RUNS
bare JS project   lint → NOT-APPLICABLE       typecheck → NOT-APPLICABLE
```

Rigour here is unchanged — cleocode has `tsconfig.json`, `biome.json`, and both scripts.

## End-to-end on a project CLEO had never seen — 15/15

`init --map-codebase` · `nexus analyze` (11 nodes / 8 relations / 179 ms) · `nexus impact` on unseen symbols · saga → epic → 3 tasks · **three** real unattended tick → worker → commit → evidence → complete cycles · 5/5 operations tested and passing · BRAIN observations written · dream cycle `completed` on local inference (7 obs → 3 clusters → 2 memories stored) · paraphrase recall returns the pattern it synthesised **from its own work** · `nexus impact divide` resolves a symbol that did not exist when CLEO arrived.

The identical run scored **8/15** before this commit and stopped at `qaPassed`.

## Tests

11 new in `tool-applicability.test.ts`, covering every marker and the declared-command override. Three pre-existing tests asserted language-default *provenance* from fixtures with no toolchain; their expectations are untouched and their fixtures now carry the markers a node project would really have.

`packages/core/src/tasks`: **1427 passed**. Gates 1–7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)