### PR TITLE
fix: selfimprove --execute lied about why it did nothing, and fix-gen had no failover (T12084)

### DIFF
--- a/packages/contracts/src/llm/system-resolver.ts
+++ b/packages/contracts/src/llm/system-resolver.ts
@@ -124,6 +124,16 @@ export interface ResolveLLMForSystemOptions {
    * without changing the system identity.
    */
   roleOverride?: RoleName;
+  /**
+   * Providers to skip for this resolution (T12084).
+   *
+   * Mirrors `ResolveLLMForRoleOptions.excludeProviders` and exists for the same
+   * reason: a caller that has just watched a provider fail needs its retry to
+   * land elsewhere. Without it, every consumer of this resolver — fix-gen among
+   * them — is permanently pinned to the first provider the selector picks, no
+   * matter how reliably it fails.
+   */
+  excludeProviders?: readonly string[];
 
   /**
    * When `true`, the resolver skips the provider-registry defaultModel lookup

--- a/packages/core/src/llm/__tests__/role-executor-failover.test.ts
+++ b/packages/core/src/llm/__tests__/role-executor-failover.test.ts
@@ -191,7 +191,7 @@ describe('role-executor cross-provider failover (T12082)', () => {
     expect(mockResolveLLMForRole).toHaveBeenCalledTimes(1);
   });
 
-  it('does NOT carry the caller\'s modelOverride across a failover', async () => {
+  it("does NOT carry the caller's modelOverride across a failover", async () => {
     // A model id belongs to one provider. Measured before the fix: an anthropic
     // 429 failed over and then asked openai for `claude-fable-5` (400) and
     // ollama for `claude-fable-5` (404 model not found) — so failover could

--- a/packages/core/src/llm/__tests__/role-executor-failover.test.ts
+++ b/packages/core/src/llm/__tests__/role-executor-failover.test.ts
@@ -191,6 +191,31 @@ describe('role-executor cross-provider failover (T12082)', () => {
     expect(mockResolveLLMForRole).toHaveBeenCalledTimes(1);
   });
 
+  it('does NOT carry the caller\'s modelOverride across a failover', async () => {
+    // A model id belongs to one provider. Measured before the fix: an anthropic
+    // 429 failed over and then asked openai for `claude-fable-5` (400) and
+    // ollama for `claude-fable-5` (404 model not found) — so failover could
+    // never work for a caller who pinned a model, which is exactly the caller
+    // who most needs it.
+    mockResolveLLMForRole
+      .mockResolvedValueOnce(resolved('anthropic'))
+      .mockResolvedValueOnce(resolved('ollama'));
+    const rateLimited = new Error('429 rate_limit_error') as Error & { status: number };
+    rateLimited.status = 429;
+    mockAnthropicComplete.mockRejectedValueOnce(rateLimited);
+    mockOllamaComplete.mockResolvedValueOnce(OK);
+
+    await executeForRole('consolidation', 'sys', 'user', { modelOverride: 'claude-fable-5' });
+
+    // First attempt honours the override; the failover uses ollama's own model.
+    expect(mockAnthropicComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-fable-5' }),
+    );
+    expect(mockOllamaComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'ollama-model' }),
+    );
+  });
+
   it('does not resolve twice when the first provider succeeds', async () => {
     mockResolveLLMForRole.mockResolvedValue(resolved('anthropic'));
     mockAnthropicComplete.mockResolvedValue({ ...OK, model: 'anthropic-model' });

--- a/packages/core/src/llm/role-executor.ts
+++ b/packages/core/src/llm/role-executor.ts
@@ -276,7 +276,15 @@ async function attemptRoleCall(
   }
 
   const credentialLabel = llm.credentialLabel ?? '<default>';
-  const model = opts.modelOverride ?? llm.model;
+  // T12085: a model id belongs to ONE provider. Carrying the caller's
+  // `modelOverride` across a failover asks the substitute provider for a model
+  // it has never heard of — measured: an anthropic 429 failed over and then
+  // asked openai for `claude-fable-5` (400) and ollama for `claude-fable-5`
+  // (404 "model not found"), so failover was guaranteed to fail for exactly the
+  // callers who pinned a model. After a failover the substitute's OWN resolved
+  // model wins; the override applies only to the caller's first-choice provider.
+  const isFailover = excludeProviders.length > 0;
+  const model = isFailover ? llm.model : (opts.modelOverride ?? llm.model);
 
   const request: TransportRequest = {
     model,

--- a/packages/core/src/llm/system-resolver.ts
+++ b/packages/core/src/llm/system-resolver.ts
@@ -303,6 +303,8 @@ export async function resolveLLMForSystem(
       // T11759: pin a named profile (e.g. a `.cantbook` stage's `profile:`) as
       // the highest-priority resolution tier. Absent/incomplete → falls through.
       ...(opts?.profile !== undefined ? { profileOverride: opts.profile } : {}),
+      // T12084: carry exclusions through to the provisioning-aware tier.
+      ...(opts?.excludeProviders !== undefined ? { excludeProviders: opts.excludeProviders } : {}),
     });
   } catch (err) {
     // Mirror role-resolver's never-throw contract: return a null-credential

--- a/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
+++ b/packages/core/src/selfimprove/__tests__/fix-gen.test.ts
@@ -102,9 +102,11 @@ function fakeGenerator(output: FixGenOutput): FixGenerator {
 
 describe('fix-gen — pure helpers', () => {
   it('fixPatchPath sanitizes the scenario and resolves against cwd', () => {
-    // `/`, `.`, `.`, `/` → 4 dashes; no traversal escapes the cwd.
+    // `/`, `.`, `.`, `/` → 4 dashes; no traversal escapes the cwd. T12084: the
+    // patch lives under `.cleo/` (gitignored), never the repo root, so an
+    // untracked candidate cannot be swept onto a branch by `git add -A`.
     const p = fixPatchPath('weird/../name', '/tmp/proj');
-    expect(p).toBe('/tmp/proj/selfimprove-weird----name.patch');
+    expect(p).toBe('/tmp/proj/.cleo/selfimprove/weird----name.patch');
   });
 
   it('looksLikeUnifiedDiff accepts a real diff and rejects prose / empty', () => {
@@ -194,7 +196,7 @@ describe('fix-gen — generateFixPatch with a deterministic fake', () => {
 
     expect(res.kind).toBe('written');
     if (res.kind !== 'written') throw new Error('unreachable');
-    expect(res.patchPath).toBe(join(root, `selfimprove-${SCENARIO}.patch`));
+    expect(res.patchPath).toBe(join(root, '.cleo', 'selfimprove', `${SCENARIO}.patch`));
     expect(res.model).toBe('fake-model');
     expect(existsSync(res.patchPath)).toBe(true);
     const written = readFileSync(res.patchPath, 'utf8');
@@ -407,7 +409,7 @@ describe('run-loop CAPSTONE — regression → fix-gen → DRAFT PR (determinist
     expect(res.outcome).toBe('regression-acted');
     expect(res.fixGen?.kind).toBe('written');
     expect(generator.propose).toHaveBeenCalledTimes(1);
-    const patchPath = join(projectRoot, `selfimprove-${SCENARIO}.patch`);
+    const patchPath = join(projectRoot, '.cleo', 'selfimprove', `${SCENARIO}.patch`);
     expect(existsSync(patchPath)).toBe(true);
     if (res.fixGen?.kind === 'written') {
       expect(res.fixGen.patchPath).toBe(patchPath);
@@ -450,12 +452,17 @@ describe('run-loop CAPSTONE — regression → fix-gen → DRAFT PR (determinist
     // DHQ still emitted (execute), but fix-gen never ran and no patch exists.
     expect(res.fixGen).toBeNull();
     expect(generator.propose).not.toHaveBeenCalled();
-    expect(existsSync(join(projectRoot, `selfimprove-${SCENARIO}.patch`))).toBe(false);
+    expect(existsSync(join(projectRoot, '.cleo', 'selfimprove', `${SCENARIO}.patch`))).toBe(false);
 
-    // With no patch on disk the egress degrades to the existing no-patch skip.
-    expect(res.draftPr?.kind).toBe('error');
-    if (res.draftPr?.kind === 'error') {
-      expect(res.draftPr.code).toBe('E_NOT_FOUND');
+    // With no patch on disk the egress degrades to a no-patch SKIP — which is
+    // what this test has always been named for. It previously asserted
+    // `error`/`E_NOT_FOUND`, i.e. the assertion encoded the defect while the
+    // title stated the contract, so the suite stayed green while `--execute`
+    // reported "Patch file not found at …" — a path nobody was ever going to
+    // write — on every gated run (T12084).
+    expect(res.draftPr?.kind).toBe('skipped');
+    if (res.draftPr?.kind === 'skipped') {
+      expect(res.draftPr.reason).toContain('CLEO_PI_RUNNER_ENABLED');
     }
   });
 

--- a/packages/core/src/selfimprove/__tests__/run-loop.test.ts
+++ b/packages/core/src/selfimprove/__tests__/run-loop.test.ts
@@ -216,7 +216,14 @@ describe('runSelfImprove — regression → draft-PR (mocked gh, dry-run)', () =
       expect(res.draftPr.steps.some((s) => /push.*\bmain\b/.test(s))).toBe(false);
     } else {
       // dry-run is the default egress (execute flows to openDraftPr but the patch is absent)
-      expect(res.draftPr?.kind === 'dry-run' || res.draftPr?.kind === 'error').toBe(true);
+      // T12084: with fix-gen gated off there is no patch, so the egress is a
+      // SKIP. `dry-run`/`error` remain valid for the other paths — the point
+      // of this assertion is that no real push fired.
+      expect(
+        res.draftPr?.kind === 'dry-run' ||
+          res.draftPr?.kind === 'error' ||
+          res.draftPr?.kind === 'skipped',
+      ).toBe(true);
     }
   });
 });

--- a/packages/core/src/selfimprove/draft-pr.ts
+++ b/packages/core/src/selfimprove/draft-pr.ts
@@ -178,8 +178,22 @@ export interface DraftPrFailure {
   readonly message: string;
 }
 
+/**
+ * The stage did not run because there was nothing to propose (T12084).
+ *
+ * Distinct from `error`: no patch exists because fix-generation was gated off
+ * or produced nothing, which is the DESIGNED path — the loop still emits its
+ * DHQ row. Reporting that as `E_NOT_FOUND: Patch file not found` names a file
+ * nobody was ever going to write and reads as a broken self-improvement loop.
+ */
+export interface DraftPrSkipped {
+  readonly kind: 'skipped';
+  /** Why no PR was attempted, in terms the reader can act on. */
+  readonly reason: string;
+}
+
 /** Discriminated-union result of {@link openDraftPr}. */
-export type DraftPrResult = DraftPrDryRun | DraftPrOk | DraftPrFailure;
+export type DraftPrResult = DraftPrDryRun | DraftPrOk | DraftPrFailure | DraftPrSkipped;
 
 /**
  * Sanitize a scenario name into a filesystem/ref-safe stem.

--- a/packages/core/src/selfimprove/fix-gen.ts
+++ b/packages/core/src/selfimprove/fix-gen.ts
@@ -38,8 +38,8 @@
  * @task T11975
  */
 
-import { writeFileSync } from 'node:fs';
-import { resolve as resolvePath } from 'node:path';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import { cwd as processCwd } from 'node:process';
 import { redact } from '@cleocode/utils';
 import type { Logger } from 'pino';
@@ -208,7 +208,11 @@ export interface GenerateFixPatchOptions {
  */
 export function fixPatchPath(scenario: string, cwd?: string): string {
   const safeScenario = scenario.replace(/[^a-z0-9-]/gi, '-');
-  return resolvePath(cwd ?? processCwd(), `selfimprove-${safeScenario}.patch`);
+  // T12084: under `.cleo/`, NOT the repo root. A candidate patch is an
+  // untracked file, and an untracked file in the repo root is exactly what
+  // T12007 swept onto a public branch via `git add -A`. `.cleo/` is gitignored,
+  // so the patch stays inspectable without being sweepable.
+  return resolvePath(cwd ?? processCwd(), join('.cleo', 'selfimprove', `${safeScenario}.patch`));
 }
 
 /**
@@ -404,6 +408,7 @@ export async function generateFixPatch(opts: GenerateFixPatchOptions): Promise<F
 
   // Normalize a trailing newline so `git apply` accepts the hunk.
   const diff = output.diff.endsWith('\n') ? output.diff : `${output.diff}\n`;
+  mkdirSync(dirname(patchPath), { recursive: true });
   writeFileSync(patchPath, diff, 'utf8');
   const bytes = Buffer.byteLength(diff, 'utf8');
   logger.info(
@@ -434,6 +439,14 @@ export async function generateFixPatch(opts: GenerateFixPatchOptions): Promise<F
  * const out = await gen.propose(request); // resolves model via E9, never raw client
  * ```
  */
+/**
+ * How many alternate providers fix-gen may try after one fails (T12084).
+ *
+ * Two, matching the role-executor. A background stage that walks every
+ * provider to fail every time costs more than it can possibly return.
+ */
+const MAX_FIXGEN_FAILOVERS = 2;
+
 export function createLlmFixGenerator(opts: { projectRoot?: string } = {}): FixGenerator {
   return {
     async propose(request: FixGenRequest): Promise<FixGenOutput> {
@@ -443,67 +456,98 @@ export function createLlmFixGenerator(opts: { projectRoot?: string } = {}): FixG
       const { ModelRunner } = await import('../llm/model-runner.js');
 
       // 1. E9 resolution chokepoint. Never throws (resolver contract).
+      //
+      // T12084: with failover. This path does NOT go through `executeForRole`,
+      // so the cross-provider failover added there never applied here — fix-gen
+      // stayed pinned to whatever the selector picked first and died with the
+      // same `400 'gpt-5.5-pro' is not supported when using Codex with a
+      // ChatGPT account` on every run, reporting only `llm-call-failed`. One
+      // chokepoint gaining failover does not help the callers of the other one.
       const projectRoot = opts.projectRoot ?? request.repoContext.projectRoot;
-      const resolved = await resolveLLMForSystem(FIXGEN_SYSTEM, { projectRoot });
-      if (!resolved.sealedCredential && resolved.authType !== 'aws_sdk') {
-        return { kind: 'none', reason: 'no-credential-resolved' };
-      }
+      const excludeProviders: string[] = [];
 
-      // 2. Materialize the plaintext ONLY at the wire boundary (E10), build a
-      //    clean descriptor, and construct the transport inside ModelRunner.
-      const apiKey = resolved.sealedCredential
-        ? (await resolved.sealedCredential.fetch()).value
-        : null;
-      const built = await ModelRunner.build({
-        provider: resolved.provider,
-        model: resolved.model,
-        credential: resolved.credential
-          ? {
-              provider: resolved.credential.provider,
-              apiKey,
-              source: resolved.credential.source,
-              authType: resolved.credential.authType,
-            }
-          : null,
-        source: resolved.source,
-        ...(resolved.credentialLabel !== undefined
-          ? { credentialLabel: resolved.credentialLabel }
-          : {}),
-        apiMode: resolved.apiMode,
-        baseUrl: resolved.baseUrl,
-        authType: resolved.authType,
-        ...(resolved.capabilities !== undefined ? { capabilities: resolved.capabilities } : {}),
-      });
-
-      // 3. ONE non-streaming completion. The system prompt is threaded onto the
-      //    request via `systemSuffix` (ConcreteSession maps it to
-      //    `TransportRequest.system`); the user turn carries the regression detail.
-      const { system, user } = buildFixGenPrompt(request);
-      try {
-        const response = await built.session.send([{ role: 'user', content: user }], {
-          systemSuffix: system,
+      for (let attempt = 0; attempt <= MAX_FIXGEN_FAILOVERS; attempt++) {
+        const resolved = await resolveLLMForSystem(FIXGEN_SYSTEM, {
+          projectRoot,
+          excludeProviders: [...excludeProviders],
         });
-        const text = (response.content ?? '').trim();
-        if (text.length === 0 || text === 'NO_PATCH') {
-          // Attach a redacted, bounded excerpt so the caller can log it onto
-          // the DHQ evidence row without having to re-run. The empty-reply case
-          // carries no useful excerpt; only the non-empty case (e.g. prose like
-          // "I cannot fix this") is worth capturing.
-          const rawReply = text.length > 0 ? truncateReply(text) : undefined;
-          return {
-            kind: 'none',
-            reason: 'model-declined',
-            ...(rawReply !== undefined ? { rawReply } : {}),
-          };
+        if (!resolved.sealedCredential && resolved.authType !== 'aws_sdk') {
+          return { kind: 'none', reason: 'no-credential-resolved' };
         }
-        return { kind: 'patch', diff: stripCodeFences(text), model: response.model };
-      } catch (err) {
-        logger.warn(
-          { system: FIXGEN_SYSTEM, err: err instanceof Error ? err.message : String(err) },
-          'fix-gen LLM call failed — degrading to no-patch',
-        );
-        return { kind: 'none', reason: 'llm-call-failed' };
+        if (excludeProviders.includes(resolved.provider)) {
+          // Nothing else is provisioned — retrying the same provider would just
+          // repeat its failure.
+          return { kind: 'none', reason: 'llm-call-failed' };
+        }
+
+        // 2. Materialize the plaintext ONLY at the wire boundary (E10), build a
+        //    clean descriptor, and construct the transport inside ModelRunner.
+        const apiKey = resolved.sealedCredential
+          ? (await resolved.sealedCredential.fetch()).value
+          : null;
+        const built = await ModelRunner.build({
+          provider: resolved.provider,
+          model: resolved.model,
+          credential: resolved.credential
+            ? {
+                provider: resolved.credential.provider,
+                apiKey,
+                source: resolved.credential.source,
+                authType: resolved.credential.authType,
+              }
+            : null,
+          source: resolved.source,
+          ...(resolved.credentialLabel !== undefined
+            ? { credentialLabel: resolved.credentialLabel }
+            : {}),
+          apiMode: resolved.apiMode,
+          baseUrl: resolved.baseUrl,
+          authType: resolved.authType,
+          ...(resolved.capabilities !== undefined ? { capabilities: resolved.capabilities } : {}),
+        });
+
+        // 3. ONE non-streaming completion. The system prompt is threaded onto the
+        //    request via `systemSuffix` (ConcreteSession maps it to
+        //    `TransportRequest.system`); the user turn carries the regression detail.
+        const { system, user } = buildFixGenPrompt(request);
+        try {
+          const response = await built.session.send([{ role: 'user', content: user }], {
+            systemSuffix: system,
+          });
+          const text = (response.content ?? '').trim();
+          if (text.length === 0 || text === 'NO_PATCH') {
+            // Attach a redacted, bounded excerpt so the caller can log it onto
+            // the DHQ evidence row without having to re-run. The empty-reply case
+            // carries no useful excerpt; only the non-empty case (e.g. prose like
+            // "I cannot fix this") is worth capturing.
+            const rawReply = text.length > 0 ? truncateReply(text) : undefined;
+            return {
+              kind: 'none',
+              reason: 'model-declined',
+              ...(rawReply !== undefined ? { rawReply } : {}),
+            };
+          }
+          return { kind: 'patch', diff: stripCodeFences(text), model: response.model };
+        } catch (err) {
+          logger.warn(
+            {
+              system: FIXGEN_SYSTEM,
+              provider: resolved.provider,
+              model: resolved.model,
+              attempt: attempt + 1,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            attempt < MAX_FIXGEN_FAILOVERS
+              ? 'fix-gen LLM call failed — failing over to another provider'
+              : 'fix-gen LLM call failed — degrading to no-patch',
+          );
+          if (attempt >= MAX_FIXGEN_FAILOVERS) {
+            return { kind: 'none', reason: 'llm-call-failed' };
+          }
+          excludeProviders.push(resolved.provider);
+        }
       }
+      return { kind: 'none', reason: 'llm-call-failed' };
     },
   };
 }

--- a/packages/core/src/selfimprove/run-loop.ts
+++ b/packages/core/src/selfimprove/run-loop.ts
@@ -53,6 +53,7 @@
  * @task T11913
  */
 
+import { existsSync } from 'node:fs';
 import type { Logger } from 'pino';
 import { type ExecutionEnvBackend, resolveExecutionEnv } from '../llm/pi/resolve-execution-env.js';
 import { resolveOrCwd } from '../paths.js';
@@ -410,28 +411,60 @@ export async function runSelfImprove(opts: RunSelfImproveOptions): Promise<SelfI
     }
 
     // ── 5. open ONE DRAFT PR (counts against maxPrs=1) + record url back ────────
+    //
+    // T12084: only when there is actually a patch to propose. Fix-gen is the
+    // only thing that writes this file and it is gated behind the Pi runner, so
+    // on a plain `--execute` the file never exists — and the stage reported
+    // `E_NOT_FOUND: Patch file not found at …`, naming a path nobody was ever
+    // going to write. That reads as a broken self-improvement loop when the
+    // loop had in fact done its whole job: detected the regression and filed
+    // the DHQ.
+    //
+    // The budget is still charged BEFORE the check, so a `maxPrs = 0` run halts
+    // pre-flight exactly as before — the cap governs whether this run may reach
+    // egress at all, and must not become unenforceable just because this
+    // particular run had nothing to push.
     let draftPr: DraftPrResult | null = null;
+    // `fixPatchPath` already resolves against cwd — the same absolute path the
+    // fix-gen stage writes and the egress guard checks.
+    const patchPath = fixPatchPath(opts.scenario, opts.cwd);
     try {
       breaker.chargeOrTrip({ prs: 1 });
-      draftPr = await openDraftPr({
-        scenario: opts.scenario,
-        // SAME path fix-gen writes to (sanitized, resolved against cwd) so the
-        // egress `existsSync` guard finds exactly the file 4b produced.
-        diffPath: fixPatchPath(opts.scenario, opts.cwd),
-        title: `fix(selfimprove): ${opts.scenario} regression`,
-        body: `Auto-detected regression in the \`${opts.scenario}\` dogfood scenario (run ${runId}).`,
-        execute,
-        ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-        ...(opts.draftPrRun !== undefined ? { run: opts.draftPrRun } : {}),
-        ...(opts.draftPrProvisionWorktree !== undefined
-          ? { provisionWorktree: opts.draftPrProvisionWorktree }
-          : {}),
-        ...(opts.draftPrRemoveWorktree !== undefined
-          ? { removeWorktree: opts.draftPrRemoveWorktree }
-          : {}),
-      });
-      if (draftPr.kind === 'ok') {
-        await adapter.recordPrUrl(questionHash, draftPr.prUrl);
+      if (!existsSync(patchPath)) {
+        draftPr = {
+          kind: 'skipped',
+          reason: piRunnerEnabled
+            ? `Fix-generation ran but produced no patch at '${patchPath}' — the DHQ row is ` +
+              `filed; there is nothing to propose.`
+            : `Fix-generation is gated off (CLEO_PI_RUNNER_ENABLED!=1), so no patch was ` +
+              `generated. The DHQ row is filed. Set CLEO_PI_RUNNER_ENABLED=1 together with ` +
+              `--execute to have CLEO author a candidate fix and open a draft PR.`,
+        };
+        logger.info(
+          { scenario: opts.scenario, runId, reason: draftPr.reason },
+          'self-improve draft-PR SKIPPED — no patch to propose',
+        );
+      } else {
+        draftPr = await openDraftPr({
+          scenario: opts.scenario,
+          // SAME path fix-gen writes to (sanitized, resolved against cwd) so the
+          // egress `existsSync` guard finds exactly the file 4b produced.
+          diffPath: fixPatchPath(opts.scenario, opts.cwd),
+          title: `fix(selfimprove): ${opts.scenario} regression`,
+          body: `Auto-detected regression in the \`${opts.scenario}\` dogfood scenario (run ${runId}).`,
+          execute,
+          ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+          ...(opts.draftPrRun !== undefined ? { run: opts.draftPrRun } : {}),
+          ...(opts.draftPrProvisionWorktree !== undefined
+            ? { provisionWorktree: opts.draftPrProvisionWorktree }
+            : {}),
+          ...(opts.draftPrRemoveWorktree !== undefined
+            ? { removeWorktree: opts.draftPrRemoveWorktree }
+            : {}),
+        });
+        if (draftPr.kind === 'ok') {
+          await adapter.recordPrUrl(questionHash, draftPr.prUrl);
+        }
       }
     } catch (err) {
       return tripFromError(


### PR DESCRIPTION
> **Stacked on #1162.** Base is `fix/T12081-dream-provider-agnostic-v2`, because this depends on `excludeProviders` from T12082. Retarget to `main` after #1162 merges.

Ran the self-improvement loop in `--execute` — the mode that had never been exercised. Three defects, in the order you hit them.

## 1. It reported a missing file nobody was ever going to write

```
draftPr: { kind: 'error', code: 'E_NOT_FOUND',
           message: "Patch file not found at '…/selfimprove-<scenario>.patch'" }
```

Fix-gen is the only writer of that file and it is gated behind `CLEO_PI_RUNNER_ENABLED=1`, so on a plain `--execute` it never exists. The loop had done its whole job — detected the regression, filed the DHQ — then reported a failure naming a path the operator cannot create.

The module docs already specified the right behaviour (*"no patch ⇒ the egress guard skips the PR"*) and the test was **named** `GATE OFF: … egress is a no-patch skip` — while asserting `error`/`E_NOT_FOUND`. The assertion encoded the defect; the title stated the contract. Same shape as the selfimprove golden in T12077: test and implementation agreed with each other and disagreed with the spec.

Now a first-class `DraftPrSkipped { kind, reason }` naming the next action. The PR budget is still charged **before** the check, so `maxPrs = 0` still halts pre-flight — a cap must not become unenforceable because this particular run had nothing to push.

## 2. Fix-gen had no failover — the T12082 fix did not reach it

With the gate armed it died every run with only `llm-call-failed`. It does **not** go through `executeForRole`, so T12082's failover never applied: it resolves via `resolveLLMForSystem` → `ModelRunner.build` → `session.send` and stayed pinned to a provider answering `400 'gpt-5.5-pro' is not supported when using Codex with a ChatGPT account`.

**One chokepoint gaining failover does not help the callers of the other one.** `excludeProviders` is now threaded through `resolveLLMForSystem`; fix-gen fails over up to `MAX_FIXGEN_FAILOVERS = 2` and logs provider/model/attempt.

Proven live:

```
FIXGEN  attempt 1  openai/gpt-5.5-pro  → 400 model not supported
        failover   → ollama/qwen2.5-coder:3b
fixGen: { kind: 'written', bytes: 461, model: 'qwen2.5-coder:3b' }
draftPr: E_DRAFT_PR_FAILED — git apply rejected the patch
```

A structurally valid unified diff, authored by a local 3B model, then **rejected by `git apply`** because its context lines did not match — and the egress refused to cut a PR. That is the designed guard working: a weak model cannot push a bad patch past `git apply`, and never touches `main`.

## 3. The candidate patch was written to the REPO ROOT

An untracked file in the repo root is exactly what T12007 swept onto a public branch via `git add -A`. Patches now live under `.cleo/selfimprove/<scenario>.patch` — gitignored, inspectable, not sweepable. Verified: `git status` shows zero stray patch files after a run.

## Tests

`packages/core` `src/selfimprove` + `src/llm`: **1503 passed**. Two pre-existing assertions updated to the documented contract (a `skipped` egress and the new patch location); both had encoded the behaviour this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)