### PR TITLE
fix: vitest OOM guard was dead since Vitest 4 · worktree destroy lied · dream cycle re-did its own work (T12086 · T12087 · T12088)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "gen:tier-snapshot:check": "pnpm --filter @cleocode/core run gen:tier-snapshot:check",
     "render:invariants": "pnpm --filter @cleocode/contracts run build:ts && node packages/contracts/scripts/render-invariants-docs.mjs",
     "render:invariants:check": "pnpm --filter @cleocode/contracts run build:ts && node packages/contracts/scripts/render-invariants-docs.mjs --check",
-    "hooks:install": "simple-git-hooks"
+    "hooks:install": "simple-git-hooks",
+    "lint:vitest-memory-safe": "node scripts/lint-vitest-memory-safe.mjs"
   },
   "simple-git-hooks": {
     "commit-msg": "node scripts/hooks/commit-msg-release-lint.mjs \"$1\"",

--- a/packages/adapters/vitest.config.ts
+++ b/packages/adapters/vitest.config.ts
@@ -9,9 +9,14 @@
 
 import { defineConfig } from 'vitest/config';
 import { withWorkspaceSubpathAliases } from '../../vitest-workspace-resolver.js';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/adapters',
     globals: true,

--- a/packages/animations/vitest.config.ts
+++ b/packages/animations/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/animations',
     globals: true,

--- a/packages/brain/vitest.config.ts
+++ b/packages/brain/vitest.config.ts
@@ -8,9 +8,14 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/brain',
     globals: true,

--- a/packages/caamp/vitest.config.ts
+++ b/packages/caamp/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/caamp',
     globals: true,

--- a/packages/cant/vitest.config.ts
+++ b/packages/cant/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/cant',
     globals: true,

--- a/packages/cleo-os/vitest.config.ts
+++ b/packages/cleo-os/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/cleo-os',
     globals: true,

--- a/packages/cleo/src/cli/commands/check.ts
+++ b/packages/cleo/src/cli/commands/check.ts
@@ -462,6 +462,7 @@ const checkProvenanceCommand = defineCommand({
  *   Gate 5 (T9837e): lint-cli-package-boundary.mjs     — no helper > 30 LOC in CLI commands
  *   Gate 6 (T11640): lint-no-bare-get-active-session.mjs — no NEW bare getActiveSession() callsites
  *   Gate 7 (T12041): lint-no-domain-db-singleton.mjs    — no NEW per-domain DB singleton cache
+ *   Gate 8 (T12087): lint-vitest-memory-safe.mjs       — every vitest config bounds fork count + heap
  *
  * Each gate is run in --check mode (baseline tolerance). A gate whose script
  * does not yet exist on disk is reported as "skipped" (non-blocking) to allow
@@ -544,6 +545,15 @@ const checkArchCommand = defineCommand({
         script: 'scripts/lint-no-domain-db-singleton.mjs',
         description:
           'No NEW per-domain DB singleton cache (bind via the ProjectStore/GlobalStore ports)',
+      },
+      {
+        // T12087: zero-tolerance. An unbounded fork pool froze this machine
+        // twice, and it only ever bites locally — CI runners have 2-4 cores, so
+        // the unsafe default passes there and takes down the developer instead.
+        id: 'gate-8',
+        task: 'T12087',
+        script: 'scripts/lint-vitest-memory-safe.mjs',
+        description: 'Every vitest config spreads the memory-safe fork bounds (workers + heap cap)',
       },
     ] as const;
 

--- a/packages/cleo/vitest.config.ts
+++ b/packages/cleo/vitest.config.ts
@@ -17,9 +17,14 @@ import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { withWorkspaceSubpathAliases } from '../../vitest-workspace-resolver.js';
 import { CLEO_TEST_QUARANTINE } from './vitest.quarantine.js';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/cleo',
     globals: true,

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -8,9 +8,14 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/contracts',
     globals: true,

--- a/packages/core/src/sentient/__tests__/dream-watermark.test.ts
+++ b/packages/core/src/sentient/__tests__/dream-watermark.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Incremental + adaptive consolidation policy (T12088).
+ *
+ * Three measured defects motivate these:
+ *
+ * 1. Consecutive dream cycles collected 25 → 28 → 30 → 36 → 37 observations —
+ *    re-clustering and re-sending the SAME material every pass. Dedup at the
+ *    storage gate hid the waste while it consumed the whole LLM budget.
+ * 2. The sentient loop was dead for three months; every observation from that
+ *    period aged past the 24 h window and was consolidated NEVER, not later.
+ * 3. A fixed `clusterMinSize: 5` meant a freshly dropped-in CLEO — which never
+ *    has 5 similar observations — completed with `memoriesStored: 0`
+ *    indefinitely, so it could not begin learning at all.
+ *
+ * @task T12088
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ADAPTIVE_CLUSTER_DIVISOR,
+  adaptiveClusterMinSize,
+  DEFAULT_NOMINAL_LOOKBACK_MS,
+  MAX_ADAPTIVE_CLUSTER_SIZE,
+  MAX_CATCHUP_LOOKBACK_MS,
+  MIN_ADAPTIVE_CLUSTER_SIZE,
+  nextWatermark,
+  resolveLookbackMs,
+  selectUnconsolidated,
+} from '../dream-watermark.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-08-06T12:00:00.000Z');
+
+describe('resolveLookbackMs (T12088)', () => {
+  it('uses the nominal window on a first run (no watermark)', () => {
+    // Unchanged behaviour: a brand-new project has nothing consolidated.
+    expect(resolveLookbackMs(null, DAY, NOW)).toBe(DAY);
+  });
+
+  it('WIDENS the window to cover a gap while the daemon was off', () => {
+    // The three-month-dead-loop case: without this, everything older than 24 h
+    // is skipped permanently rather than caught up.
+    const fiveDaysAgo = new Date(NOW - 5 * DAY).toISOString();
+    expect(resolveLookbackMs(fiveDaysAgo, DAY, NOW)).toBe(5 * DAY);
+  });
+
+  it('never NARROWS below the nominal window', () => {
+    // A watermark from a minute ago must not shrink the pass to 60 s and starve
+    // clustering of the context it needs to group anything.
+    const aMinuteAgo = new Date(NOW - 60_000).toISOString();
+    expect(resolveLookbackMs(aMinuteAgo, DAY, NOW)).toBe(DAY);
+  });
+
+  it('caps catch-up so one tick cannot pull in an entire corpus', () => {
+    const ancient = new Date(NOW - 400 * DAY).toISOString();
+    expect(resolveLookbackMs(ancient, DAY, NOW)).toBe(MAX_CATCHUP_LOOKBACK_MS);
+  });
+
+  it('falls back to nominal on an unparseable watermark', () => {
+    // Corrupt state must degrade to the old behaviour, never to "no work".
+    expect(resolveLookbackMs('not-a-date', DAY, NOW)).toBe(DAY);
+  });
+
+  it('defaults the nominal window to 24 h', () => {
+    expect(resolveLookbackMs(null)).toBe(DEFAULT_NOMINAL_LOOKBACK_MS);
+  });
+});
+
+describe('adaptiveClusterMinSize (T12088)', () => {
+  it('lets a YOUNG project consolidate pairs', () => {
+    // The drop-in case. At the old fixed 5 this returned nothing, forever.
+    expect(adaptiveClusterMinSize(6)).toBe(MIN_ADAPTIVE_CLUSTER_SIZE);
+    expect(adaptiveClusterMinSize(15)).toBe(MIN_ADAPTIVE_CLUSTER_SIZE);
+  });
+
+  it('scales with the corpus', () => {
+    expect(adaptiveClusterMinSize(30)).toBe(3);
+    expect(adaptiveClusterMinSize(40)).toBe(4);
+  });
+
+  it('demands real repetition once the project is MATURE', () => {
+    expect(adaptiveClusterMinSize(50)).toBe(MAX_ADAPTIVE_CLUSTER_SIZE);
+    expect(adaptiveClusterMinSize(5000)).toBe(MAX_ADAPTIVE_CLUSTER_SIZE);
+  });
+
+  it('never returns below the floor or above the ceiling', () => {
+    for (const n of [0, 1, 3, 9, 10, 11, 49, 51, 1_000_000]) {
+      const v = adaptiveClusterMinSize(n);
+      expect(v).toBeGreaterThanOrEqual(MIN_ADAPTIVE_CLUSTER_SIZE);
+      expect(v).toBeLessThanOrEqual(MAX_ADAPTIVE_CLUSTER_SIZE);
+    }
+  });
+
+  it('treats an empty corpus as mature rather than trivially clusterable', () => {
+    // 0 observations must not imply "minimum 2" — there is nothing to cluster,
+    // and returning the floor would invite synthesising from noise.
+    expect(adaptiveClusterMinSize(0)).toBe(MAX_ADAPTIVE_CLUSTER_SIZE);
+  });
+
+  it('crosses each threshold exactly at the divisor boundary', () => {
+    expect(adaptiveClusterMinSize(3 * ADAPTIVE_CLUSTER_DIVISOR)).toBe(3);
+    expect(adaptiveClusterMinSize(3 * ADAPTIVE_CLUSTER_DIVISOR - 1)).toBe(2);
+  });
+});
+
+describe('selectUnconsolidated (T12088)', () => {
+  const obs = [
+    { id: 'a', createdAt: '2026-08-05 10:00:00' },
+    { id: 'b', createdAt: '2026-08-06 09:00:00' },
+    { id: 'c', createdAt: '2026-08-06 11:00:00' },
+  ];
+
+  it('returns everything when there is no watermark', () => {
+    expect(selectUnconsolidated(obs, null)).toHaveLength(3);
+  });
+
+  it('drops what was already consolidated', () => {
+    // This is the 25 → 28 → 30 → 36 → 37 waste, eliminated.
+    expect(selectUnconsolidated(obs, '2026-08-06 09:00:00').map((o) => o.id)).toEqual(['c']);
+  });
+
+  it('is exclusive at the boundary — the watermark itself is NOT reprocessed', () => {
+    expect(selectUnconsolidated(obs, '2026-08-06 11:00:00')).toEqual([]);
+  });
+
+  it('does not mutate its input', () => {
+    const copy = [...obs];
+    selectUnconsolidated(obs, '2026-08-05 10:00:00');
+    expect(obs).toEqual(copy);
+  });
+});
+
+describe('nextWatermark (T12088)', () => {
+  it('returns the newest createdAt regardless of input order', () => {
+    expect(
+      nextWatermark([
+        { createdAt: '2026-08-06 11:00:00' },
+        { createdAt: '2026-08-06 12:00:00' },
+        { createdAt: '2026-08-05 10:00:00' },
+      ]),
+    ).toBe('2026-08-06 12:00:00');
+  });
+
+  it('returns null for an empty batch so progress cannot skip unread material', () => {
+    // A no-op pass must leave the existing watermark alone.
+    expect(nextWatermark([])).toBeNull();
+  });
+});

--- a/packages/core/src/sentient/dream-cycle.ts
+++ b/packages/core/src/sentient/dream-cycle.ts
@@ -53,6 +53,12 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { z } from 'zod';
 import { IMPLICIT_FALLBACK_MODEL, resolveAnthropicForRole } from '../llm/role-resolver.js';
 import type { MemoryCandidate } from '../memory/extraction-gate.js';
+import {
+  adaptiveClusterMinSize,
+  nextWatermark,
+  resolveLookbackMs,
+  selectUnconsolidated,
+} from './dream-watermark.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -254,6 +260,15 @@ export interface DreamCycleOptions {
    * Kill-switch check. When omitted, reads `statePath` via `readSentientState`.
    */
   isKilled?: () => Promise<boolean>;
+  /**
+   * Test seam (T12088): pin the consolidation watermark instead of reading
+   * sentient state. `null` means "no watermark" (first run).
+   */
+  dreamWatermark?: string | null;
+  /**
+   * Test seam (T12088): observe the watermark write instead of persisting it.
+   */
+  onWatermarkWrite?: (watermark: string) => void;
   /**
    * Lookback window in ms. Defaults to {@link DREAM_LOOKBACK_MS} (24 h).
    */
@@ -981,6 +996,67 @@ async function describeDreamLlmResolution(projectRoot: string): Promise<string> 
  *
  * @task T1680
  */
+/**
+ * Read the consolidation watermark from sentient state (T12088).
+ *
+ * Never throws — an unreadable state file yields `null`, which means "no
+ * watermark", i.e. fall back to the nominal lookback. Degrading to the previous
+ * fixed-window behaviour is correct; refusing to consolidate would not be.
+ *
+ * @param statePath - path to the sentient state file.
+ * @param options - dream options (test seam: `dreamWatermark`).
+ * @returns ISO timestamp already consolidated, or `null`.
+ *
+ * @task T12088
+ */
+async function readDreamWatermark(
+  statePath: string,
+  options: DreamCycleOptions,
+): Promise<string | null> {
+  if (options.dreamWatermark !== undefined) return options.dreamWatermark;
+  try {
+    const { readSentientState } = await import('./state.js');
+    const state = (await readSentientState(statePath)) as { dreamWatermark?: string | null };
+    return state.dreamWatermark ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the consolidation watermark into sentient state (T12088).
+ *
+ * A `null` watermark (empty batch) is a no-op: an empty pass must not advance
+ * progress past material it never read.
+ *
+ * Never throws — losing a watermark write costs one redundant pass, whereas
+ * throwing here would discard a completed consolidation.
+ *
+ * @param statePath - path to the sentient state file.
+ * @param watermark - newest processed `createdAt`, or `null`.
+ * @param options - dream options (test seam: `onWatermarkWrite`).
+ *
+ * @task T12088
+ */
+async function writeDreamWatermark(
+  statePath: string,
+  watermark: string | null,
+  options: DreamCycleOptions,
+): Promise<void> {
+  if (watermark === null) return;
+  if (options.onWatermarkWrite) {
+    options.onWatermarkWrite(watermark);
+    return;
+  }
+  try {
+    const { readSentientState, writeSentientState } = await import('./state.js');
+    const state = await readSentientState(statePath);
+    await writeSentientState(statePath, { ...state, dreamWatermark: watermark });
+  } catch {
+    // Non-fatal: the next pass simply re-reads this window.
+  }
+}
+
 export async function runDreamCycle(options: DreamCycleOptions): Promise<DreamCycleOutcome> {
   const { projectRoot, statePath } = options;
 
@@ -1061,19 +1137,37 @@ export async function runDreamCycle(options: DreamCycleOptions): Promise<DreamCy
     };
   }
 
-  // Step 3: collect observations.
-  const lookbackMs = options.lookbackMs ?? DREAM_LOOKBACK_MS;
+  // Step 3: collect observations — INCREMENTALLY (T12088).
+  //
+  // The window was previously a fixed `now - 24h` with no record of what had
+  // already been consolidated, so every run re-clustered and re-sent the same
+  // material (measured: 25 → 28 → 30 → 36 → 37 across consecutive runs), while
+  // anything that aged past 24 h was consolidated NEVER rather than later.
+  //
+  // The watermark WIDENS the window when the daemon has been off and never
+  // narrows it below the nominal lookback — clustering still needs context.
+  const nominalLookbackMs = options.lookbackMs ?? DREAM_LOOKBACK_MS;
+  const watermark = await readDreamWatermark(statePath, options);
+  const lookbackMs = resolveLookbackMs(watermark, nominalLookbackMs);
   const collect = options.collectObservations ?? defaultCollectObservations;
-  let observations: CollectedObservation[];
+  let collected: CollectedObservation[];
   try {
-    observations = await collect(projectRoot, lookbackMs);
+    collected = await collect(projectRoot, lookbackMs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     digest.warnings.push(`collection error: ${message}`);
-    observations = [];
+    collected = [];
   }
 
+  // Synthesis targets only what is genuinely new; the wider set above still
+  // informed clustering context.
+  const observations = selectUnconsolidated(collected, watermark);
   digest.observationsCollected = observations.length;
+  if (collected.length !== observations.length) {
+    digest.warnings.push(
+      `incremental: ${collected.length - observations.length} observation(s) already consolidated (watermark ${watermark ?? 'none'})`,
+    );
+  }
 
   if (observations.length === 0) {
     return {
@@ -1095,7 +1189,11 @@ export async function runDreamCycle(options: DreamCycleOptions): Promise<DreamCy
   }
 
   // Step 5 + 6: synthesise eligible clusters, store memories.
-  const clusterMinSize = options.clusterMinSize ?? DREAM_CLUSTER_MIN_SIZE;
+  //
+  // T12088: the minimum scales with the corpus. A fixed 5 meant a freshly
+  // dropped-in CLEO — which never has 5 similar observations — completed with
+  // `memoriesStored: 0` indefinitely, i.e. it could not begin learning at all.
+  const clusterMinSize = options.clusterMinSize ?? adaptiveClusterMinSize(observations.length);
   const maxClusters = options.maxClusters ?? DREAM_MAX_CLUSTERS;
   const minImportance = options.minImportance ?? DREAM_MIN_IMPORTANCE;
 
@@ -1167,6 +1265,11 @@ export async function runDreamCycle(options: DreamCycleOptions): Promise<DreamCy
     const message = err instanceof Error ? err.message : String(err);
     digest.warnings.push(`digest observation write error: ${message}`);
   }
+
+  // T12088: advance the watermark so the NEXT pass starts where this one ended.
+  // Written only on the completed path — a pass that errored out must be able to
+  // re-read the same material rather than skip it.
+  await writeDreamWatermark(statePath, nextWatermark(observations), options);
 
   return {
     kind: 'completed',

--- a/packages/core/src/sentient/dream-watermark.ts
+++ b/packages/core/src/sentient/dream-watermark.ts
@@ -1,0 +1,168 @@
+/**
+ * Incremental + adaptive consolidation policy for the dream cycle (T12088).
+ *
+ * ## What was fixed
+ *
+ * The collector was a fixed window with no memory of its own progress:
+ *
+ * ```sql
+ * WHERE created_at >= (now - 24h) ORDER BY created_at ASC LIMIT 2000
+ * ```
+ *
+ * Three consequences, all observed live on 2026-08-06:
+ *
+ * 1. **Every run redid the previous run's work.** Consecutive cycles collected
+ *    25 → 28 → 30 → 36 → 37 observations — the same material re-clustered and
+ *    re-sent to the LLM each time. Dedup at the storage gate hid it, so the
+ *    waste was invisible while consuming the entire LLM budget of every pass.
+ *
+ * 2. **Anything older than the window was consolidated NEVER.** Not "later" —
+ *    never. The sentient loop was dead for three months; every observation from
+ *    that period aged out of the 24 h window unread and became permanently
+ *    invisible to consolidation. A memory system whose intake silently expires
+ *    is not an "ever-growing memory".
+ *
+ * 3. **A fixed `clusterMinSize: 5` meant a new project could not learn.** A
+ *    freshly dropped-in CLEO has a handful of observations, never 5 similar
+ *    ones, so the cycle completed with `memoriesStored: 0` indefinitely. The
+ *    goal is that CLEO learns "like an infant to expert"; the threshold was set
+ *    for the expert end and blocked the infant end entirely.
+ *
+ * ## The policy
+ *
+ * - **Watermark.** Consolidation records the newest `createdAt` it processed.
+ *   The next run starts there, so work is never repeated.
+ * - **The watermark widens, never narrows.** When it is older than the nominal
+ *   lookback (daemon was off), the window reaches back to it instead of
+ *   clamping to `now - 24h`. A gap is caught up, not dropped.
+ * - **First run has no watermark**, so it uses the nominal lookback — existing
+ *   behaviour, unchanged.
+ * - **Adaptive minimum cluster size** scales with how much the project has
+ *   actually observed, so a young project consolidates pairs while a mature one
+ *   still demands real repetition before promoting a memory.
+ *
+ * @task T12088
+ */
+
+/** Nominal lookback when no watermark exists yet (24 h). */
+export const DEFAULT_NOMINAL_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Hard ceiling on how far back a catch-up pass will reach (30 days).
+ *
+ * Without a bound, a watermark from months ago would pull an entire corpus into
+ * one pass and spend the whole LLM budget on the first tick after a long
+ * outage. Older material belongs to an explicit backfill, not a background tick.
+ */
+export const MAX_CATCHUP_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Smallest cluster the adaptive policy will ever synthesise. */
+export const MIN_ADAPTIVE_CLUSTER_SIZE = 2;
+
+/** Largest cluster minimum the adaptive policy will ever demand. */
+export const MAX_ADAPTIVE_CLUSTER_SIZE = 5;
+
+/**
+ * Observations per unit of required cluster size.
+ *
+ * At 20 observations the minimum is 2 (a young project can pair things up); by
+ * 50 it reaches the mature default of 5, where a memory must be backed by real
+ * repetition.
+ */
+export const ADAPTIVE_CLUSTER_DIVISOR = 10;
+
+/**
+ * Resolve the effective lookback for this pass.
+ *
+ * @param watermark - ISO timestamp of the newest observation already
+ *   consolidated, or `null` on a first run.
+ * @param nominalMs - the configured window (default 24 h).
+ * @param nowMs - current time in ms (injected for determinism in tests).
+ * @returns the lookback to use, always ≥ `nominalMs` and ≤
+ *   {@link MAX_CATCHUP_LOOKBACK_MS}.
+ *
+ * @example
+ * ```ts
+ * // Daemon off for 5 days → widen to 5 days rather than losing 4 of them.
+ * resolveLookbackMs('2026-08-01T00:00:00Z', DAY, Date.parse('2026-08-06T00:00:00Z'));
+ * // → 5 * DAY
+ * ```
+ *
+ * @task T12088
+ */
+export function resolveLookbackMs(
+  watermark: string | null,
+  nominalMs: number = DEFAULT_NOMINAL_LOOKBACK_MS,
+  nowMs: number = Date.now(),
+): number {
+  if (watermark === null) return nominalMs;
+
+  const marked = Date.parse(watermark);
+  if (Number.isNaN(marked)) return nominalMs;
+
+  // Never NARROW below the nominal window: a very recent watermark must not
+  // shrink the pass to seconds and starve clustering of context.
+  const widened = Math.max(nominalMs, nowMs - marked);
+  return Math.min(widened, MAX_CATCHUP_LOOKBACK_MS);
+}
+
+/**
+ * Minimum cluster size appropriate to the size of the observation corpus.
+ *
+ * @param totalObservations - how many observations exist in the window.
+ * @returns a value in `[MIN_ADAPTIVE_CLUSTER_SIZE, MAX_ADAPTIVE_CLUSTER_SIZE]`.
+ *
+ * @example
+ * ```ts
+ * adaptiveClusterMinSize(6);   // → 2  (a young project can still learn)
+ * adaptiveClusterMinSize(30);  // → 3
+ * adaptiveClusterMinSize(500); // → 5  (mature: demand real repetition)
+ * ```
+ *
+ * @task T12088
+ */
+export function adaptiveClusterMinSize(totalObservations: number): number {
+  if (totalObservations <= 0) return MAX_ADAPTIVE_CLUSTER_SIZE;
+  const scaled = Math.floor(totalObservations / ADAPTIVE_CLUSTER_DIVISOR);
+  return Math.min(MAX_ADAPTIVE_CLUSTER_SIZE, Math.max(MIN_ADAPTIVE_CLUSTER_SIZE, scaled));
+}
+
+/**
+ * Drop observations at or before the watermark.
+ *
+ * Applied AFTER collection so the widened window still supplies clustering
+ * context, while synthesis effort concentrates on what is genuinely new. The
+ * comparison is on the ISO `createdAt` string, which sorts lexicographically
+ * for a fixed format — the same ordering the collector's `ORDER BY` relies on.
+ *
+ * @param observations - collected observations, any order.
+ * @param watermark - ISO timestamp already consolidated, or `null`.
+ * @returns observations strictly newer than the watermark.
+ *
+ * @task T12088
+ */
+export function selectUnconsolidated<T extends { createdAt: string }>(
+  observations: readonly T[],
+  watermark: string | null,
+): T[] {
+  if (watermark === null) return [...observations];
+  return observations.filter((o) => o.createdAt > watermark);
+}
+
+/**
+ * The newest `createdAt` in a batch — the watermark to persist after a pass.
+ *
+ * @param observations - observations processed in this pass.
+ * @returns the max ISO timestamp, or `null` for an empty batch, leaving any
+ *   existing watermark untouched so a no-op pass cannot advance progress past
+ *   material it never read.
+ *
+ * @task T12088
+ */
+export function nextWatermark(observations: readonly { createdAt: string }[]): string | null {
+  let max: string | null = null;
+  for (const o of observations) {
+    if (max === null || o.createdAt > max) max = o.createdAt;
+  }
+  return max;
+}

--- a/packages/core/src/sentient/state.ts
+++ b/packages/core/src/sentient/state.ts
@@ -94,6 +94,23 @@ export interface SentientState {
   /** Reason supplied when killSwitch was last set (diagnostic only). */
   killSwitchReason: string | null;
   /**
+   * Consolidation high-water mark — the newest observation `created_at` the
+   * dream cycle has already synthesised (T12088).
+   *
+   * `null`/absent on a fresh state means "nothing consolidated yet", and the
+   * cycle falls back to its nominal lookback window.
+   *
+   * Why this is persisted rather than recomputed: the cycle previously used a
+   * fixed `now - 24h` window with no record of its own progress, so each run
+   * re-clustered and re-sent material it had already consolidated, while
+   * anything that aged past the window was consolidated NEVER rather than
+   * later. The watermark makes intake incremental AND lets a pass widen its
+   * window to catch up after the daemon has been off.
+   *
+   * @task T12088
+   */
+  dreamWatermark?: string | null;
+  /**
    * T1074: true when the daemon was paused by `pauseAllTiers(...)` as part of
    * an owner-triggered revert. Separate from `killSwitch` because resume
    * requires owner attestation (not just `cleo sentient resume`).

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -16,9 +16,14 @@
 
 import { defineConfig } from 'vitest/config';
 import { withWorkspaceSubpathAliases } from '../../vitest-workspace-resolver.js';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/core',
     globals: true,

--- a/packages/git-shim/vitest.config.ts
+++ b/packages/git-shim/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/git-shim',
     globals: true,

--- a/packages/lafs/vitest.config.ts
+++ b/packages/lafs/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/lafs',
     globals: true,

--- a/packages/nexus/vitest.config.ts
+++ b/packages/nexus/vitest.config.ts
@@ -8,9 +8,14 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/nexus',
     globals: true,

--- a/packages/paths/vitest.config.ts
+++ b/packages/paths/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/paths',
     include: ['src/**/*.test.ts'],

--- a/packages/playbooks/vitest.config.ts
+++ b/packages/playbooks/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/playbooks',
     globals: true,

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/runtime',
     globals: true,

--- a/packages/skills/vitest.config.ts
+++ b/packages/skills/vitest.config.ts
@@ -8,9 +8,14 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/skills',
     globals: true,

--- a/packages/studio/vitest.config.ts
+++ b/packages/studio/vitest.config.ts
@@ -13,6 +13,7 @@
 
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   plugins: [
@@ -22,6 +23,10 @@ export default defineConfig({
     }),
   ],
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/studio',
     globals: true,

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     // Inherit the root memory-safe maxWorkers + per-fork heap cap (T11860).
     // Without this, `pnpm test:pkg @cleocode/utils` runs vitest's default
     // (CPU-1 ≈ 23 forks) with no heap cap and can OOM-freeze a big local box.

--- a/packages/worktree/src/__tests__/worktree-locate.test.ts
+++ b/packages/worktree/src/__tests__/worktree-locate.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Locating a worktree by asking git (T12086).
+ *
+ * The bug these guard is not a crash — it is a cleanup verb that reports
+ * `worktreeRemoved: true, branchDeleted: true` while the directory, the git
+ * registration, and the branch all still exist. Measured 2026-08-06: 23
+ * worktrees destroyed "successfully", zero actually removed, because
+ * `destroyWorktree` recomputed the path from the CURRENT project-hash scheme
+ * and assumed the branch was `task/<taskId>` with no slug.
+ *
+ * 42 worktrees accumulated behind that silent success.
+ *
+ * @task T12086
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseWorktreePorcelain } from '../worktree-locate.js';
+
+/** Real `git worktree list --porcelain` output, including a locked entry. */
+const PORCELAIN = `worktree /mnt/projects/cleocode
+HEAD 21336e5a9f0e6cb2fb2a3f4e5d6c7b8a9f0e1d2c
+branch refs/heads/main
+
+worktree /home/u/.local/share/cleo/worktrees/L21udC9wcm9qZWN0cy9jbGVvY29kZQ/T11248
+HEAD aaaa111122223333444455556666777788889999
+branch refs/heads/task/T11248-cleo-exodus
+locked
+
+worktree /home/u/.local/share/cleo/worktrees/1e3146b7352ba279/T12029
+HEAD bbbb111122223333444455556666777788889999
+branch refs/heads/task/T12029
+
+worktree /home/u/.local/share/cleo/worktrees/1e3146b7352ba279/T9999
+HEAD cccc111122223333444455556666777788889999
+detached
+`;
+
+describe('parseWorktreePorcelain (T12086)', () => {
+  it('parses every entry with its path, branch and lock state', () => {
+    const entries = parseWorktreePorcelain(PORCELAIN);
+
+    expect(entries).toHaveLength(4);
+    expect(entries[0]).toEqual({ path: '/mnt/projects/cleocode', branch: 'main', locked: false });
+  });
+
+  it('strips refs/heads/ and PRESERVES the branch slug', () => {
+    // The whole bug: the real branch is `task/T11248-cleo-exodus`, so a lookup
+    // for `task/T11248` matches nothing and the delete is silently skipped.
+    const entries = parseWorktreePorcelain(PORCELAIN);
+    const t11248 = entries.find((e) => e.path.endsWith('/T11248'));
+
+    expect(t11248?.branch).toBe('task/T11248-cleo-exodus');
+    expect(t11248?.branch).not.toBe('task/T11248');
+  });
+
+  it('reports a locked worktree as locked', () => {
+    // `git worktree remove` refuses a locked entry; destroy must unlock first
+    // rather than assume the removal worked.
+    const entries = parseWorktreePorcelain(PORCELAIN);
+    expect(entries.find((e) => e.path.endsWith('/T11248'))?.locked).toBe(true);
+    expect(entries.find((e) => e.path.endsWith('/T12029'))?.locked).toBe(false);
+  });
+
+  it('reports a detached worktree with a null branch', () => {
+    const entries = parseWorktreePorcelain(PORCELAIN);
+    expect(entries.find((e) => e.path.endsWith('/T9999'))?.branch).toBeNull();
+  });
+
+  it('finds a worktree under a LEGACY project-hash directory', () => {
+    // This is the path a recomputed `computeProjectHash()` cannot produce, so
+    // `existsSync(recomputed)` was false and destroy concluded "already gone".
+    const entries = parseWorktreePorcelain(PORCELAIN);
+    const legacy = entries.find((e) => e.path.split('/').pop() === 'T11248');
+
+    expect(legacy).toBeDefined();
+    expect(legacy?.path).toContain('L21udC9wcm9qZWN0cy9jbGVvY29kZQ');
+  });
+
+  it('returns an empty list for empty input rather than a phantom entry', () => {
+    expect(parseWorktreePorcelain('')).toEqual([]);
+    expect(parseWorktreePorcelain('\n\n')).toEqual([]);
+  });
+
+  it('handles a final record with no trailing blank line', () => {
+    const raw = 'worktree /a/b\nHEAD 1234\nbranch refs/heads/feat/x';
+    expect(parseWorktreePorcelain(raw)).toEqual([
+      { path: '/a/b', branch: 'feat/x', locked: false },
+    ]);
+  });
+
+  it('does not leak state between records', () => {
+    // A locked first entry must not mark a subsequent unlocked one as locked.
+    const raw = 'worktree /a\nlocked\n\nworktree /b\nbranch refs/heads/main\n';
+    const entries = parseWorktreePorcelain(raw);
+    expect(entries[0]).toEqual({ path: '/a', branch: null, locked: true });
+    expect(entries[1]).toEqual({ path: '/b', branch: 'main', locked: false });
+  });
+});

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -90,3 +90,5 @@ export {
   ensureWorktreeBuildReady,
 } from './worktree-preflight.js';
 export { pruneWorktrees } from './worktree-prune.js';
+
+export * from './worktree-locate.js';

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -76,6 +76,7 @@ export {
   listWorktreesByProjectRoot,
   resolveWorktreeRoot,
 } from './worktree-list.js';
+export * from './worktree-locate.js';
 export type { MigrateWorktreeResult } from './worktree-migrate.js';
 export {
   discoverParentProjectRoot,
@@ -90,5 +91,3 @@ export {
   ensureWorktreeBuildReady,
 } from './worktree-preflight.js';
 export { pruneWorktrees } from './worktree-prune.js';
-
-export * from './worktree-locate.js';

--- a/packages/worktree/src/worktree-destroy.ts
+++ b/packages/worktree/src/worktree-destroy.ts
@@ -15,9 +15,9 @@ import type { DestroyWorktreeOptions, DestroyWorktreeResult } from '@cleocode/co
 import { getGitRoot, gitSilent, gitSync } from './git.js';
 import { destroyWorktree as napiDestroyWorktree } from './napi-binding.js';
 import { computeProjectHash, resolveTaskWorktreePath } from './paths.js';
-import { locateTaskWorktree } from './worktree-locate.js';
 import { appendWorktreeAuditLog, removeWorktreeFromSentinelIndex } from './worktree-audit.js';
 import { runWorktreeHooks } from './worktree-hooks.js';
+import { locateTaskWorktree } from './worktree-locate.js';
 
 /**
  * Destroy the git worktree for a task.

--- a/packages/worktree/src/worktree-destroy.ts
+++ b/packages/worktree/src/worktree-destroy.ts
@@ -15,6 +15,7 @@ import type { DestroyWorktreeOptions, DestroyWorktreeResult } from '@cleocode/co
 import { getGitRoot, gitSilent, gitSync } from './git.js';
 import { destroyWorktree as napiDestroyWorktree } from './napi-binding.js';
 import { computeProjectHash, resolveTaskWorktreePath } from './paths.js';
+import { locateTaskWorktree } from './worktree-locate.js';
 import { appendWorktreeAuditLog, removeWorktreeFromSentinelIndex } from './worktree-audit.js';
 import { runWorktreeHooks } from './worktree-hooks.js';
 
@@ -48,9 +49,16 @@ export async function destroyWorktree(
   const { taskId, deleteBranch = true, force = false, hooks = [] } = options;
 
   const gitRoot = getGitRoot(projectRoot);
+
+  // T12086: ask git where the worktree IS and which branch it holds, instead of
+  // recomputing both by convention. A worktree provisioned under an earlier
+  // project-hash scheme is not at the recomputed path, and real branches carry
+  // a slug (`task/T11248-cleo-exodus`, not `task/T11248`) — so both derivations
+  // missed, and the function reported success for work it never did.
+  const located = locateTaskWorktree(projectRoot, taskId);
   const projectHash = computeProjectHash(projectRoot);
-  const worktreePath = resolveTaskWorktreePath(projectHash, taskId);
-  const branch = `task/${taskId}`;
+  const worktreePath = located?.path ?? resolveTaskWorktreePath(projectHash, taskId);
+  const branch = located?.branch ?? `task/${taskId}`;
 
   let worktreeRemoved = false;
   let branchDeleted = false;
@@ -141,8 +149,13 @@ export async function destroyWorktree(
         }
       }
     }
+  } else if (located !== null) {
+    // Registered with git but absent from disk — a stale registration. Pruning
+    // it IS the removal; without this the entry lingers forever.
+    gitSilent(['worktree', 'prune'], gitRoot);
+    worktreeRemoved = true;
   } else {
-    worktreeRemoved = true; // already gone
+    worktreeRemoved = true; // genuinely absent: not on disk, not registered
   }
 
   // Step 4: Optionally delete the branch.
@@ -151,8 +164,16 @@ export async function destroyWorktree(
       const branchExists = gitSync(['branch', '--list', branch], gitRoot);
       if (branchExists) {
         gitSync(['branch', '-D', branch], gitRoot);
+        branchDeleted = true;
+      } else {
+        // T12086: previously returned `branchDeleted: true` here. Reporting a
+        // deletion that did not happen is worse than reporting the miss — it is
+        // how a branch survives every cleanup pass unnoticed.
+        branchDeleted = false;
+        if (!error) {
+          error = `Branch '${branch}' not found — nothing deleted. The worktree's own HEAD is the source of truth for its branch name; a task id alone is not.`;
+        }
       }
-      branchDeleted = true;
     } catch (err) {
       if (!error) {
         error = `Failed to delete branch: ${err instanceof Error ? err.message : String(err)}`;

--- a/packages/worktree/src/worktree-locate.ts
+++ b/packages/worktree/src/worktree-locate.ts
@@ -1,0 +1,148 @@
+/**
+ * Locate a task's worktree by asking git, not by recomputing a path (T12086).
+ *
+ * ## Why this exists
+ *
+ * `destroyWorktree` derived everything by convention:
+ *
+ * ```ts
+ * const worktreePath = resolveTaskWorktreePath(computeProjectHash(projectRoot), taskId);
+ * const branch = `task/${taskId}`;
+ * ```
+ *
+ * Both assumptions fail in the field, and both fail **silently reporting
+ * success**:
+ *
+ * 1. **The path.** `computeProjectHash` produces the CURRENT hash scheme. A
+ *    worktree provisioned under an earlier scheme lives at a different
+ *    directory, so `existsSync(worktreePath)` is false and the code takes its
+ *    `else` branch — `worktreeRemoved = true // already gone` — for a worktree
+ *    that is still registered and still on disk. Measured 2026-08-06: 23
+ *    worktrees under `…/worktrees/L21udC9wcm9qZWN0cy9jbGVvY29kZQ/` all reported
+ *    `worktreeRemoved: true` and none were touched.
+ *
+ * 2. **The branch.** Real branches carry a slug — `task/T11248-cleo-exodus`,
+ *    not `task/T11248`. `git branch --list task/T11248` matches nothing, the
+ *    delete is skipped, and `branchDeleted = true` is returned anyway.
+ *
+ * The cost of a cleanup verb that claims success without acting is not one bad
+ * call — it is that nobody notices the mess growing. 42 worktrees accumulated
+ * behind exactly this.
+ *
+ * ## The rule
+ *
+ * `git worktree list --porcelain` is the authoritative registry of what exists
+ * and which branch each entry has checked out. Ask it. Fall back to the
+ * computed path only when git knows nothing, and then say so.
+ *
+ * @task T12086
+ */
+
+import { getGitRoot, gitSync } from './git.js';
+
+/** A worktree as git itself reports it. */
+export interface LocatedWorktree {
+  /** Absolute path git has registered. */
+  readonly path: string;
+  /** Branch checked out there, or `null` when detached. */
+  readonly branch: string | null;
+  /** Whether git holds a lock on this entry. */
+  readonly locked: boolean;
+}
+
+/**
+ * Parse `git worktree list --porcelain` into structured entries.
+ *
+ * The porcelain format is a blank-line-separated series of records:
+ * `worktree <path>`, then optional `HEAD <sha>`, `branch <ref>`, `locked`,
+ * `bare`, `detached`.
+ *
+ * @param raw - stdout of `git worktree list --porcelain`.
+ * @returns one entry per registered worktree, in git's order.
+ *
+ * @task T12086
+ */
+export function parseWorktreePorcelain(raw: string): LocatedWorktree[] {
+  const out: LocatedWorktree[] = [];
+  let path: string | null = null;
+  let branch: string | null = null;
+  let locked = false;
+
+  /** Flush the record under construction, if any. */
+  const flush = (): void => {
+    if (path !== null) out.push({ path, branch, locked });
+    path = null;
+    branch = null;
+    locked = false;
+  };
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trimEnd();
+    if (trimmed === '') {
+      flush();
+      continue;
+    }
+    if (trimmed.startsWith('worktree ')) {
+      flush();
+      path = trimmed.slice('worktree '.length);
+    } else if (trimmed.startsWith('branch ')) {
+      branch = trimmed.slice('branch '.length).replace(/^refs\/heads\//, '');
+    } else if (trimmed === 'locked' || trimmed.startsWith('locked ')) {
+      locked = true;
+    }
+  }
+  flush();
+  return out;
+}
+
+/**
+ * List every worktree git has registered for this repository.
+ *
+ * Never throws — an unreadable registry yields an empty list, which callers
+ * treat as "git knows nothing", NOT as "nothing exists".
+ *
+ * @param projectRoot - any path inside the repository.
+ * @returns registered worktrees.
+ *
+ * @task T12086
+ */
+export function listRegisteredWorktrees(projectRoot: string): LocatedWorktree[] {
+  try {
+    const gitRoot = getGitRoot(projectRoot);
+    return parseWorktreePorcelain(gitSync(['worktree', 'list', '--porcelain'], gitRoot));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find the registered worktree belonging to `taskId`.
+ *
+ * Matching is on the path's final segment, which is the canonical layout
+ * (`…/worktrees/<projectHash>/<taskId>`) regardless of which hash scheme
+ * produced the parent directory — that is exactly the drift a recomputed path
+ * cannot survive.
+ *
+ * @param projectRoot - any path inside the repository.
+ * @param taskId - task whose worktree to find (e.g. `T11248`).
+ * @returns the entry, or `null` when git has no worktree for this task.
+ *
+ * @example
+ * ```ts
+ * const wt = locateTaskWorktree('/repo', 'T11248');
+ * // → { path: '…/worktrees/L21udC…/T11248', branch: 'task/T11248-cleo-exodus', locked: true }
+ * ```
+ *
+ * @task T12086
+ */
+export function locateTaskWorktree(projectRoot: string, taskId: string): LocatedWorktree | null {
+  const wanted = taskId.trim();
+  if (wanted === '') return null;
+
+  for (const entry of listRegisteredWorktrees(projectRoot)) {
+    const segments = entry.path.split(/[/\\]/).filter((s) => s !== '');
+    const last = segments[segments.length - 1];
+    if (last === wanted) return entry;
+  }
+  return null;
+}

--- a/packages/worktree/vitest.config.ts
+++ b/packages/worktree/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
 
 export default defineConfig({
   test: {
+    // Memory-safe fork bounds (T12087) — spread FIRST so anything below
+    // can still override deliberately. Applies on a DIRECT per-package run,
+    // which `extends: true` does not cover.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     extends: true,
     name: '@cleocode/worktree',
     globals: true,

--- a/scripts/.lint-stdout-discipline-baseline.json
+++ b/scripts/.lint-stdout-discipline-baseline.json
@@ -24,8 +24,8 @@
     "packages/cleo/src/cli/commands/briefing.ts:192",
     "packages/cleo/src/cli/commands/check.ts:39",
     "packages/cleo/src/cli/commands/check.ts:442",
-    "packages/cleo/src/cli/commands/check.ts:627",
-    "packages/cleo/src/cli/commands/check.ts:629",
+    "packages/cleo/src/cli/commands/check.ts:637",
+    "packages/cleo/src/cli/commands/check.ts:639",
     "packages/cleo/src/cli/commands/deps.ts:328",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
@@ -55,5 +55,5 @@
     "packages/cleo/src/cli/commands/status.ts:289",
     "packages/cleo/src/cli/commands/worktree.ts:274"
   ],
-  "updatedAt": "2026-08-05T05:29:12.934Z"
+  "updatedAt": "2026-08-07T03:30:49.574Z"
 }

--- a/scripts/.lint-stdout-write-allowlist-baseline.json
+++ b/scripts/.lint-stdout-write-allowlist-baseline.json
@@ -28,8 +28,8 @@
     "packages/cleo/src/cli/commands/briefing.ts:192",
     "packages/cleo/src/cli/commands/check.ts:39",
     "packages/cleo/src/cli/commands/check.ts:442",
-    "packages/cleo/src/cli/commands/check.ts:627",
-    "packages/cleo/src/cli/commands/check.ts:629",
+    "packages/cleo/src/cli/commands/check.ts:637",
+    "packages/cleo/src/cli/commands/check.ts:639",
     "packages/cleo/src/cli/commands/deps.ts:328",
     "packages/cleo/src/cli/commands/event.ts:238",
     "packages/cleo/src/cli/commands/event.ts:249",
@@ -60,5 +60,5 @@
     "packages/cleo/src/cli/commands/worktree.ts:274",
     "packages/nexus/src/__tests__/bench-nexus.ts:389"
   ],
-  "updatedAt": "2026-08-05T05:29:13.884Z"
+  "updatedAt": "2026-08-07T03:30:39.194Z"
 }

--- a/scripts/lint-vitest-memory-safe.mjs
+++ b/scripts/lint-vitest-memory-safe.mjs
@@ -35,8 +35,7 @@
  * @task T12087
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { globSync } from 'node:fs';
+import { existsSync, globSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO = process.cwd();
@@ -82,6 +81,19 @@ for (const rel of configs) {
     continue;
   }
 
+  // Vitest 4 REMOVED `test.poolOptions` and ignores it with only a stderr
+  // deprecation warning. T11839's heap cap was written in that shape, so it was
+  // dead from the Vitest 4 upgrade onward while still reading as present in the
+  // config — the machine kept freezing behind a fix that looked applied.
+  if (/\bpoolOptions\s*:/.test(src)) {
+    violations.push(
+      `${rel}: uses \`poolOptions\`, which Vitest 4 REMOVED and silently ignores. ` +
+        `Move the setting to its top-level equivalent (\`execArgv\`, \`isolate\`, ` +
+        `\`maxWorkers\`, \`vmMemoryLimit\`). A silently-ignored guard is worse than a ` +
+        `missing one: it passes review and is absent at runtime.`,
+    );
+  }
+
   const after = src.slice(spreadIdx);
   if (/\bmaxWorkers\s*:/.test(after)) {
     violations.push(
@@ -91,7 +103,7 @@ for (const rel of configs) {
   }
   if (/execArgv\s*:/.test(after)) {
     violations.push(
-      `${rel}: re-declares \`poolOptions.forks.execArgv\` AFTER the spread, dropping ` +
+      `${rel}: re-declares \`execArgv\` AFTER the spread, dropping ` +
         `\`--max-old-space-size\`. One leaky test then grows until the kernel intervenes.`,
     );
   }
@@ -115,6 +127,4 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
-console.log(
-  `lint-vitest-memory-safe: OK — ${configs.length} vitest config(s) spread ${MARKER}.`,
-);
+console.log(`lint-vitest-memory-safe: OK — ${configs.length} vitest config(s) spread ${MARKER}.`);

--- a/scripts/lint-vitest-memory-safe.mjs
+++ b/scripts/lint-vitest-memory-safe.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Gate: every vitest config MUST spread the memory-safe fork bounds (T12087).
+ *
+ * ## What this prevents
+ *
+ * `pool: 'forks'` at vitest's default `maxWorkers` (CPU-1) spawns ~23 forks on a
+ * 24-core box. Each loads the `@cleocode/core` graph (~2.7 GB), and with no V8
+ * ceiling one leaky test grows without bound: ~62 GB → kernel OOM → the machine
+ * freezes and the session dies. It happened twice on 2026-08-06.
+ *
+ * T11839 fixed it in the ROOT config and leaned on `test.extends: true` to
+ * propagate. That covers `pnpm run test` but NOT the convenient path:
+ *
+ *     vitest run --root packages/core     # this package IS the root
+ *     pnpm run test:pkg <name>            # same
+ *
+ * A guard present on one invocation path and absent on another is no guard, so
+ * `vitest.memory-safe.ts` is now the SSoT and every config spreads it directly.
+ * This gate keeps a new package (or a well-meaning edit) from silently opting
+ * out again.
+ *
+ * ## Checks
+ *
+ *   1. `vitest.memory-safe.ts` exists and exports MEMORY_SAFE_TEST_DEFAULTS.
+ *   2. Every `vitest.config.ts` (root + `packages/*`) imports AND spreads it.
+ *   3. No config re-declares `maxWorkers` / `poolOptions.forks.execArgv` after
+ *      the spread — that would silently override the ceiling.
+ *   4. No config overrides `pool` away from `'forks'` (per-worker V8 flags do
+ *      not apply to worker_threads, so the heap cap would evaporate).
+ *
+ * Zero-tolerance: there is no baseline. A machine-freezing default is not
+ * something to burn down gradually.
+ *
+ * @task T12087
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO = process.cwd();
+const SSOT = 'vitest.memory-safe.ts';
+const MARKER = 'MEMORY_SAFE_TEST_DEFAULTS';
+
+/** Strip line + block comments so a commented-out override is not a violation. */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const violations = [];
+
+// 1 — the SSoT itself.
+const ssotPath = join(REPO, SSOT);
+if (!existsSync(ssotPath)) {
+  violations.push(`${SSOT} is missing — it is the single source of the fork bounds.`);
+} else if (!readFileSync(ssotPath, 'utf8').includes(`export const ${MARKER}`)) {
+  violations.push(`${SSOT} does not export ${MARKER}.`);
+}
+
+// 2-4 — every config.
+const configs = ['vitest.config.ts', ...globSync('packages/*/vitest.config.ts', { cwd: REPO })];
+
+for (const rel of configs) {
+  const abs = join(REPO, rel);
+  if (!existsSync(abs)) continue;
+  const src = stripComments(readFileSync(abs, 'utf8'));
+
+  if (!src.includes(MARKER)) {
+    violations.push(
+      `${rel}: does not spread ${MARKER}. A direct \`vitest run --root <pkg>\` would ` +
+        `then run with vitest's default fork count and NO heap ceiling. ` +
+        `Add \`import { ${MARKER} } from '<rel>/vitest.memory-safe.js'\` and spread it ` +
+        `first inside \`test: { … }\`.`,
+    );
+    continue;
+  }
+
+  const spreadIdx = src.indexOf(`...${MARKER}`);
+  if (spreadIdx === -1) {
+    violations.push(`${rel}: imports ${MARKER} but never spreads it (\`...${MARKER}\`).`);
+    continue;
+  }
+
+  const after = src.slice(spreadIdx);
+  if (/\bmaxWorkers\s*:/.test(after)) {
+    violations.push(
+      `${rel}: re-declares \`maxWorkers\` AFTER the spread, overriding the RAM-derived ` +
+        `ceiling. Remove it, or raise the ceiling in ${SSOT} where the reasoning lives.`,
+    );
+  }
+  if (/execArgv\s*:/.test(after)) {
+    violations.push(
+      `${rel}: re-declares \`poolOptions.forks.execArgv\` AFTER the spread, dropping ` +
+        `\`--max-old-space-size\`. One leaky test then grows until the kernel intervenes.`,
+    );
+  }
+  const poolOverride = after.match(/\bpool\s*:\s*'([a-z]+)'/);
+  if (poolOverride && poolOverride[1] !== 'forks') {
+    violations.push(
+      `${rel}: overrides \`pool\` to '${poolOverride[1]}' after the spread. Per-worker V8 ` +
+        `flags only apply to the fork pool, so the heap ceiling would not exist.`,
+    );
+  }
+}
+
+if (violations.length > 0) {
+  console.error(`lint-vitest-memory-safe: FAIL — ${violations.length} violation(s):\n`);
+  for (const v of violations) console.error(`  • ${v}`);
+  console.error(
+    `\nWhy this is zero-tolerance: an unbounded fork pool on a large dev box is a ` +
+      `machine-freezing default, and it only ever bites locally — CI runners have ` +
+      `2-4 cores, so it passes there and takes down the developer instead.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `lint-vitest-memory-safe: OK — ${configs.length} vitest config(s) spread ${MARKER}.`,
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
-import { cpus, totalmem } from 'node:os';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
+import { MEMORY_SAFE_TEST_DEFAULTS } from './vitest.memory-safe.js';
 import { withWorkspaceSubpathAliases } from './vitest-workspace-resolver.js';
 
 // ---------------------------------------------------------------------------
@@ -17,18 +17,8 @@ import { withWorkspaceSubpathAliases } from './vitest-workspace-resolver.js';
 // single leaky/heavy test OOMs only its OWN fork (failing that one test)
 // instead of freezing the machine.
 // ---------------------------------------------------------------------------
-const GB = 1024 ** 3;
-const RAM_BUDGET_PER_FORK_GB = 6;
-const MEMORY_SAFE_MAX_WORKERS = Math.max(
-  1,
-  Math.min(
-    Math.max(1, cpus().length - 1),
-    Math.floor(totalmem() / (RAM_BUDGET_PER_FORK_GB * GB)),
-    6,
-  ),
-);
-/** Per-fork V8 old-space cap (MB) — bounds a single runaway/leaky test fork. */
-const FORK_HEAP_MB = 4096;
+// Memory-safe fork settings now live in ./vitest.memory-safe.ts so a DIRECT
+// per-package run inherits them too (T12087).
 
 export default defineConfig({
   // ---------------------------------------------------------------------------
@@ -84,19 +74,12 @@ export default defineConfig({
     // @see T658 Phase 1: vitest fork isolation
     // @see T630/T633 root-cause: vi.mock pollution across shards
     // ---------------------------------------------------------------------------
-    pool: 'forks',
-    isolate: true,
-    // Memory-safe concurrency (T11839 · see MEMORY_SAFE_MAX_WORKERS above).
-    // Bound BOTH the number of parallel forks and each fork's heap so running
-    // the suite on a 24-core/62 GB box cannot OOM-freeze the machine. Inherited
-    // by every package config via `test.extends: true`.
-    maxWorkers: MEMORY_SAFE_MAX_WORKERS,
-    minWorkers: 1,
-    poolOptions: {
-      forks: {
-        execArgv: [`--max-old-space-size=${FORK_HEAP_MB}`],
-      },
-    },
+    // Memory-safe concurrency (T11839 · T12087). Spread from the SSoT rather
+    // than declared here, because `test.extends: true` does NOT reach a direct
+    // `vitest run --root packages/<pkg>` invocation — that package IS the root,
+    // so there is nothing to extend. Every package config spreads the same
+    // object; `scripts/lint-vitest-memory-safe.mjs` enforces it.
+    ...MEMORY_SAFE_TEST_DEFAULTS,
     // T753: Force-kill worker forks that fail to exit after teardown.
     // Without this, workers with open SQLite handles or process.once('SIGTERM')
     // handlers that call async code can block the runner indefinitely.

--- a/vitest.memory-safe.ts
+++ b/vitest.memory-safe.ts
@@ -96,9 +96,16 @@ export const MEMORY_SAFE_TEST_DEFAULTS = {
   isolate: true,
   maxWorkers: MEMORY_SAFE_MAX_WORKERS,
   minWorkers: 1,
-  poolOptions: {
-    forks: {
-      execArgv: [`--max-old-space-size=${FORK_HEAP_MB}`],
-    },
-  },
+  // TOP-LEVEL `execArgv`, not `poolOptions.forks.execArgv`.
+  //
+  // Vitest 4 REMOVED `test.poolOptions` ("All previous poolOptions are now
+  // top-level options") and ignores the old shape with only a deprecation
+  // warning on stderr. T11839 wrote the nested form, so from the Vitest 4
+  // upgrade onward the fork count was still bounded (`maxWorkers` is top-level)
+  // while the per-fork heap ceiling silently evaporated — which is why the
+  // machine kept freezing despite a fix that looked present in the config.
+  //
+  // A config option that is silently ignored is worse than one that errors: the
+  // guard reads as active in review and is absent at runtime.
+  execArgv: [`--max-old-space-size=${FORK_HEAP_MB}`],
 } as const;

--- a/vitest.memory-safe.ts
+++ b/vitest.memory-safe.ts
@@ -1,0 +1,104 @@
+/**
+ * Memory-safe vitest fork settings — the SSoT every config must spread (T12087).
+ *
+ * ## The freeze this prevents
+ *
+ * `pool: 'forks'` with vitest's default `maxWorkers` (CPU-1) spawns ~23 forks on
+ * a 24-core box. Each loads the heavy `@cleocode/core` graph (sqlite/vec0 native
+ * + the full SDK) at roughly 2.7 GB, and without an explicit V8 ceiling a single
+ * leaky test grows unbounded. 23 × 2.7 GB ≈ 62 GB → kernel OOM → the whole
+ * machine freezes and the session dies.
+ *
+ * ## Why this file exists instead of living in the root config
+ *
+ * T11839 fixed this in the ROOT `vitest.config.ts` and relied on
+ * `test.extends: true` in each package config to inherit it. That covers
+ * `pnpm run test` (which resolves the workspace root) but NOT a direct
+ * per-package invocation:
+ *
+ * ```bash
+ * vitest run --root packages/core        # packages/core IS the root — nothing to extend
+ * pnpm run test:pkg <name>               # same
+ * ```
+ *
+ * A guard that applies on one invocation path and silently not on another is
+ * indistinguishable from no guard, because the unsafe path is the convenient
+ * one. It froze this machine twice on 2026-08-06, both times from a scoped
+ * `--root packages/core` run.
+ *
+ * So the settings live in a plain module that every config imports and spreads
+ * **directly**. No inheritance, no invocation-path dependency, and a lint gate
+ * (`scripts/lint-vitest-memory-safe.mjs`) fails any package config that omits
+ * it.
+ *
+ * @task T12087
+ * @task T11839
+ */
+
+import { cpus, totalmem } from 'node:os';
+
+/** Bytes per GiB. */
+const GB = 1024 ** 3;
+
+/**
+ * RAM budget assumed per fork. Sized from the measured ~2.7 GB peak of a
+ * core-graph test fork plus headroom, so `totalmem / this` is a safe fork count.
+ */
+export const RAM_BUDGET_PER_FORK_GB = 6;
+
+/**
+ * Hard ceiling on parallel forks regardless of machine size.
+ *
+ * Beyond this the suite is I/O- and SQLite-lock-bound rather than CPU-bound, so
+ * more forks buy nothing and cost memory.
+ */
+export const MAX_FORKS_CEILING = 6;
+
+/** Per-fork V8 old-space cap (MB) — bounds ONE runaway test to its own fork. */
+export const FORK_HEAP_MB = 4096;
+
+/**
+ * Fork count bounded by CPU **and** physical RAM **and** a hard ceiling.
+ *
+ * On a 24-core / 62 GB box: `min(23, 10, 6)` = 6 forks × 4 GB = a 24 GB
+ * ceiling. On a 2-core CI runner: `min(1, …)` = 1.
+ */
+export const MEMORY_SAFE_MAX_WORKERS = Math.max(
+  1,
+  Math.min(
+    Math.max(1, cpus().length - 1),
+    Math.floor(totalmem() / (RAM_BUDGET_PER_FORK_GB * GB)),
+    MAX_FORKS_CEILING,
+  ),
+);
+
+/**
+ * Spread this into EVERY `defineConfig({ test: … })` in the repo.
+ *
+ * `pool: 'forks'` + `isolate: true` are included because the memory ceiling is
+ * only meaningful for the fork pool — a config that overrides the pool back to
+ * threads would silently escape `execArgv`, since worker_threads do not take
+ * per-worker V8 flags this way.
+ *
+ * @example
+ * ```ts
+ * import { MEMORY_SAFE_TEST_DEFAULTS } from '../../vitest.memory-safe.js';
+ *
+ * export default defineConfig({
+ *   test: { ...MEMORY_SAFE_TEST_DEFAULTS, name: '@cleocode/core', … },
+ * });
+ * ```
+ *
+ * @task T12087
+ */
+export const MEMORY_SAFE_TEST_DEFAULTS = {
+  pool: 'forks',
+  isolate: true,
+  maxWorkers: MEMORY_SAFE_MAX_WORKERS,
+  minWorkers: 1,
+  poolOptions: {
+    forks: {
+      execArgv: [`--max-old-space-size=${FORK_HEAP_MB}`],
+    },
+  },
+} as const;


### PR DESCRIPTION
Three defects, all found from the owner's own symptoms: *"vitest keeps freezing the system"* and *"you have a HUGE mess of 42 worktrees"*.

## T12087 — the OOM guard was BOTH misplaced and silently ignored

`pool: 'forks'` at vitest's default `maxWorkers` (CPU-1) spawns ~23 forks on this 24-core box; each loads the `@cleocode/core` graph (~2.7 GB). ~62 GB → kernel OOM → machine freezes, session dies. Twice today.

**Defect A — the guard was only on the path nobody types.** T11839 fixed it in the ROOT config and relied on `test.extends: true`. That covers `pnpm run test`, but NOT:

```bash
vitest run --root packages/core     # this package IS the root — nothing to extend
pnpm run test:pkg <name>            # same
```

Measured: **0 of 19** per-package configs declared `maxWorkers` or a heap cap.

**Defect B — and the heap cap was a no-op anyway.** vitest told me directly:

```
DEPRECATED  `test.poolOptions` was removed in Vitest 4.
            All previous poolOptions are now top-level options.
```

T11839 wrote `poolOptions.forks.execArgv`. **Vitest 4 removed that shape and ignores it with a stderr warning.** So since the Vitest 4 upgrade the fork *count* was bounded while the per-fork V8 ceiling evaporated — the machine kept freezing behind a fix that read as present in the config. A silently-ignored option is worse than a missing one: it passes review and is absent at runtime.

**Fix:** bounds live in `vitest.memory-safe.ts` as an SSoT that all 20 configs spread **directly** (no inheritance, no invocation-path dependence), in the correct Vitest 4 shape. Proven three ways:

```
resolved config   pool=forks maxWorkers=6 execArgv=["--max-old-space-size=4096"]   (all 20)
live forks        3 processes carrying --max-old-space-size=4096
deprecation       gone
```

6 forks × 4 GB = a 24 GB ceiling here; 1 fork on a 2-core runner.

**New gate 8 (`cleo check arch`), zero-tolerance, no baseline** — rejects a missing spread, a post-spread `maxWorkers`/`execArgv` override, a `pool` switched away from `forks` (per-worker V8 flags don't apply to threads), and any `poolOptions:` at all. Verified against both a `maxWorkers: 23` and a reintroduced `poolOptions` regression. **8 gates pass.**

## T12086 — `cleo worktree destroy` reported success without acting

```
$ cleo worktree destroy T11248 --force
{ "worktreeRemoved": true, "branchDeleted": true }
```

Directory, git registration, and branch all still present. 23 worktrees "destroyed" this way, none removed. **This is how 42 accumulated** — the cleanup verb claimed to work, so nobody looked.

Both halves derived their target by convention instead of asking git: the path came from `computeProjectHash()` (worktrees under an earlier hash scheme live elsewhere → `existsSync` false → `else { worktreeRemoved = true // already gone }`), and the branch was assumed `task/<taskId>` when real branches carry a slug (`task/T11248-cleo-exodus`).

**Fix:** `worktree-locate.ts` reads `git worktree list --porcelain` — the authoritative registry — for the real path, real branch, and lock state. Destroy uses those, prunes a stale registration instead of calling it "already gone", and reports `branchDeleted: false` **with a reason** when nothing matched. It now also tells the truth when it can't act:

```
E_DESTROY_FAILED: Branch 'task/T11547' not found — nothing deleted.
```

(that worktree is really named `T11547b`.)

**Result: 42 worktrees → 1.** Every removal verified first — content present in main, CLEO task `done`, and all uncommitted state archived to `.cleo/rescued-docs/worktree-archive-2026-08-06` (334 KB). An orphaned 323-line design doc was rescued into the docs SSoT; an uncommitted 205-line `gc-subsystem.ts` draft was confirmed superseded by the 229-line version that shipped in `core/src/gc/`. 5.7 GB of banned-location sibling checkouts freed.

## T12088 — the dream cycle had no memory of its own progress

```sql
WHERE created_at >= (now - 24h) ORDER BY created_at ASC LIMIT 2000
```

No watermark. Three consequences, all measured:

1. **Every pass redid the previous pass's work** — consecutive runs collected 25 → 28 → 30 → 36 → 37 observations, re-clustering and re-sending the same material. Storage-gate dedup hid the waste while it consumed each pass's entire LLM budget.
2. **Anything older than the window was consolidated NEVER, not later.** The loop was dead for three months (T12077); every observation from that period aged out unread and became permanently invisible. A memory system whose intake silently expires is not an "ever-growing memory".
3. **A fixed `clusterMinSize: 5` meant a NEW project could not learn** — a fresh CLEO never has 5 similar observations, so it completed `memoriesStored: 0` indefinitely. My own drop-in e2e had to pass `clusterMinSize: 2`; that workaround should have been read as a design bug.

**Fix:** persisted `SentientState.dreamWatermark` makes intake incremental; the window **widens** to catch up after an outage and never narrows below the nominal 24 h (clustering needs context), capped at 30 days; cluster minimum scales 2 → 5 with corpus size.

```
watermark before: none
run 1 → completed, observationsCollected: 38   (first pass, full window)
run 2 → completed, observationsCollected: 1    (only the new digest)
watermark after: 2026-08-07 03:25:28
```

38 → 1. The watermark advances only on the `completed` path, so a failed pass re-reads rather than skips, and an empty batch never advances past unread material.

## Verification

Actions was in a **major outage** earlier; checks are re-attempted here. Locally: `pnpm run build` ✅ · `pnpm biome ci .` ✅ (1 pre-existing warning) · `cleo check arch` **8/8** ✅ · `packages/core/src/sentient` **514 passed** · `packages/worktree` 8 new tests ✅ · 18 new dream-policy tests ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)