### PR TITLE
chore: add the missing changeset entries for T12081–T12088 + regenerate the changelog

### DIFF
--- a/.changeset/t12081-t12082-brain-layer-provider-agnostic.md
+++ b/.changeset/t12081-t12082-brain-layer-provider-agnostic.md
@@ -1,0 +1,21 @@
+---
+id: t12081-t12082-brain-layer-provider-agnostic
+tasks: [T12081, T12082]
+kind: fix
+summary: the brain layer runs on ANY machine — provider-agnostic dream cycle, cross-provider failover, keyless local-daemon admission
+---
+
+The entire background layer — consolidation, extraction, hygiene, the dream cycle — was dead on any machine whose first-choice provider failed, while free local inference answered on loopback in 24 ms.
+
+**T12081** — `resolveDreamLlm` called `resolveAnthropicForRole`, which returns `null` for every non-anthropic provider: a provider-specific chokepoint inside an otherwise provider-agnostic system. It now falls through to the provider-agnostic `executeForRole`. Separately, the role executor rebuilt the endpoint from the provider default, rewriting every custom `baseUrl` (Ollama, LM Studio, vLLM, Azure) to the vendor's public API, which then rejected the local key with 401. The credential's own endpoint now wins, and `baseUrl` is carried through `CredentialResult` / `CredentialMetadataWire` instead of being dropped at the first hop.
+
+**T12082** — four further defects, each individually sufficient to kill the layer:
+
+1. **No failover.** `executeForRole` resolved ONE provider and returned `null` on any failure, so an openai Codex OAuth answering `400 'gpt-5.5-pro' is not supported when using Codex with a ChatGPT account` disabled everything. `classifyError` already computed `shouldFallback`; nothing read it. Now bounded failover (2 alternates) with the failed provider excluded from the retry resolution; a caller abort still gives up.
+2. **A live local daemon could never be admitted.** `isProvisioned` is synchronous so it cannot probe, settling for "`OLLAMA_HOST` set OR a store entry"; liveness was then probed only for providers already in the provisioned set — circular. A provider that needs no key should not have to be declared, only to answer.
+3. **The model was chosen from RAM alone.** 62 GB scored into the `gemma4:e4b` tier on a box holding `qwen2.5-coder:3b`, so the resolved tag 404s at the daemon — which reads as "local inference is broken" rather than "that tag is not pulled". The fit heuristic is now intersected with the installed set.
+4. **A keyless provider could not produce a credential.** Every consumer gates on `credential != null`, so even once ollama won the scoring it died one step later advising `cleo llm login` — meaningless for a server accepting any bearer value. A `local-daemon` credential source is synthesised only when the daemon actually answers.
+
+Also bounds the dream cycle's provider probe at 20 s: a dead credential does not fail fast, it retries, and an unbounded probe stalls the whole pass behind a chain that will never succeed.
+
+Proven live with `llm.roles = {}` and no configuration: openai 400 → failover → `qwen2.5-coder:3b` answered in 1.78 s; dream cycle `completed` in 6.1 s across three consecutive runs.

--- a/.changeset/t12083-tool-applicability.md
+++ b/.changeset/t12083-tool-applicability.md
@@ -1,0 +1,22 @@
+---
+id: t12083-tool-applicability
+tasks: [T12083]
+kind: fix
+summary: no task could EVER be completed in a project without TypeScript — gate rigour now scales to the project's real toolchain
+---
+
+Found by dropping CLEO into a fresh plain-JavaScript repo and driving the whole lifecycle. A correct worker implemented a function, wrote a test, ran the suite, committed, and recorded `implemented` + `testsPassed`. Then `cleo complete` refused:
+
+```
+Error: Task T003 failed verification gates: qaPassed (45)
+```
+
+`qaPassed` requires `tool:typecheck`, whose node language default is `npx tsc --noEmit` — which in a project with no TypeScript answers *"This is not the tsc command you are looking for"* and exits 1. Same for `tool:lint` → `npx biome check .`. **In any project lacking a typechecker and a linter the gate is unsatisfiable, so no task can ever be completed however correct the work**, and the autonomous loop runs `failure → backoff → backoff` on work that is finished and committed.
+
+The comment on those defaults claimed they exist so "a fresh project still gets a working default". They are not working defaults — they are guesses about a project, and in a bare project the guess is wrong.
+
+The fix is an asymmetry: a command the operator **declared** (`typecheck.command` in `project-context.json`) always runs; a command CLEO **guessed** runs only when the project shows evidence of that toolchain (config file, `package.json` script of that name, or matching dependency). Otherwise resolution returns the new `E_TOOL_NOT_APPLICABLE` and the evidence layer records a first-class `notApplicable` atom **with its reason** — the gate is satisfied by absence and the audit trail says so, rather than implying a tool ran. A project that later adopts TypeScript is held to it automatically.
+
+Rigour here is unchanged: cleocode has `tsconfig.json`, `biome.json`, and both scripts, so every gate still bites. Verified in both directions.
+
+The full drop-in chain went from 8/15 to 15/15 checks: init → nexus analyze → nexus impact on unseen symbols → saga/epic/tasks → three unattended tick→worker→commit→evidence→complete cycles → BRAIN observations → dream cycle on local inference → paraphrase recall of a pattern it synthesised from its own work → nexus resolving a symbol that did not exist when CLEO arrived.

--- a/.changeset/t12084-t12085-selfimprove-execute-and-model-pinning.md
+++ b/.changeset/t12084-t12085-selfimprove-execute-and-model-pinning.md
@@ -1,0 +1,23 @@
+---
+id: t12084-t12085-selfimprove-execute-and-model-pinning
+tasks: [T12084, T12085]
+kind: fix
+summary: selfimprove --execute reported the wrong reason, fix-gen had no failover, and failover asked every substitute for the first provider's model
+---
+
+**T12084** — `--execute` had never been exercised, and was broken three ways:
+
+1. **It reported a file nobody writes.** `E_NOT_FOUND: Patch file not found at …selfimprove-<scenario>.patch` — fix-gen is that file's only writer and is gated behind `CLEO_PI_RUNNER_ENABLED=1`. The loop had done its whole job (detected the regression, filed the DHQ) and then reported a failure naming a path the operator cannot create. The module docs already specified *"no patch ⇒ the egress guard skips the PR"* and the test was **named** `egress is a no-patch skip` while asserting `error`/`E_NOT_FOUND` — the assertion encoded the defect while the title stated the contract. Now a first-class `DraftPrSkipped { kind, reason }` naming the next action. The PR budget is still charged before the check, so `maxPrs = 0` still halts pre-flight.
+2. **Fix-gen had no failover.** It does not route through `executeForRole`, so T12082's failover never reached it — it resolves via `resolveLLMForSystem` → `ModelRunner.build` → `session.send`. One chokepoint gaining failover does not help the callers of the other one. `excludeProviders` now threads through `resolveLLMForSystem`; fix-gen fails over up to 2 providers and logs provider/model/attempt.
+3. **The candidate patch was written to the repo ROOT.** An untracked file there is exactly what T12007 swept onto a public branch via `git add -A`. Patches now live under `.cleo/selfimprove/<scenario>.patch` — gitignored, inspectable, not sweepable.
+
+**T12085** — surfaced the moment a real anthropic credential existed:
+
+```
+anthropic  claude-fable-5 → 429     openai  claude-fable-5 → 400
+ollama     claude-fable-5 → 404 model not found
+```
+
+A model id belongs to one provider. Carrying the caller's `modelOverride` across a failover asks each substitute for a model it has never heard of, so failover was guaranteed to fail for exactly the callers who pin a model — the ones who most need it. After a failover the substitute's own resolved model wins; the override applies only to the caller's first-choice provider.
+
+Proven live end to end: `anthropic 429 → openai 400 → ollama/qwen2.5-coder:3b` authored a unified diff, `git apply` rejected it, and the egress refused to cut a PR — the designed guard working, `main` untouched.

--- a/.changeset/t12086-worktree-locate.md
+++ b/.changeset/t12086-worktree-locate.md
@@ -1,0 +1,22 @@
+---
+id: t12086-worktree-locate
+tasks: [T12086]
+kind: fix
+summary: cleo worktree destroy reported worktreeRemoved/branchDeleted without acting — resolve path and branch from git, not by convention
+---
+
+```
+$ cleo worktree destroy T11248 --force
+{ "worktreeRemoved": true, "branchDeleted": true }
+```
+
+The directory, the git registration, and the branch were all still there. 23 worktrees were "destroyed" this way and none were removed. **This is how 42 worktrees accumulated** — the cleanup verb claimed to work, so nobody looked.
+
+Both halves derived their target by convention instead of asking git:
+
+1. `resolveTaskWorktreePath(computeProjectHash(projectRoot), taskId)` produces the CURRENT hash scheme. Worktrees provisioned under an earlier scheme live at a different directory, so `existsSync` was false and the code took its `else { worktreeRemoved = true // already gone }` branch.
+2. `branch = \`task/${taskId}\`` — real branches carry a slug (`task/T11248-cleo-exodus`). The lookup missed, the delete was skipped, and `branchDeleted = true` was returned anyway.
+
+New `worktree-locate.ts` reads `git worktree list --porcelain` — the authoritative registry — and returns the actual path, actual branch, and lock state. `destroyWorktree` uses those, prunes a stale registration instead of calling it "already gone", and reports `branchDeleted: false` **with a reason** when no branch matched. It now also tells the truth when it cannot act: `E_DESTROY_FAILED: Branch 'task/T11547' not found — nothing deleted` (that worktree is really named `T11547b`).
+
+Result: 42 worktrees → 1. Every removal verified first — content present in main, CLEO task `done`, all uncommitted state archived. An orphaned 323-line design doc was rescued into the docs SSoT; an uncommitted `gc-subsystem.ts` draft was confirmed superseded by the version that shipped in `core/src/gc/`. 5.7 GB of banned-location sibling checkouts freed.

--- a/.changeset/t12087-vitest-memory-safe-ssot.md
+++ b/.changeset/t12087-vitest-memory-safe-ssot.md
@@ -1,0 +1,18 @@
+---
+id: t12087-vitest-memory-safe-ssot
+tasks: [T12087]
+kind: fix
+summary: the vitest OOM guard was both misplaced AND dead since Vitest 4 — bounds now live in one SSoT every config spreads, enforced by gate 8
+---
+
+`pool: 'forks'` at vitest's default `maxWorkers` (CPU-1) spawns ~23 forks on a 24-core box, each loading the `@cleocode/core` graph (~2.7 GB). ~62 GB → kernel OOM → the machine freezes and the session dies. It happened twice on 2026-08-06.
+
+**Defect A — the guard was only on the path nobody types.** T11839 fixed this in the ROOT `vitest.config.ts` and relied on `test.extends: true` to propagate. That covers `pnpm run test`, but not `vitest run --root packages/core` or `pnpm run test:pkg <name>` — that package IS the root, so there is nothing to extend. Measured: **0 of 19** per-package configs declared `maxWorkers` or a heap cap.
+
+**Defect B — and the heap cap was a no-op anyway.** Vitest 4 **removed** `test.poolOptions` ("All previous poolOptions are now top-level options") and ignores the old shape with only a stderr deprecation. T11839 wrote `poolOptions.forks.execArgv`, so from the Vitest 4 upgrade onward the fork COUNT was still bounded (`maxWorkers` is top-level) while the per-fork V8 ceiling silently evaporated — which is why the machine kept freezing behind a fix that read as present in the config. **A silently-ignored config option is worse than a missing one: it passes review and is absent at runtime.**
+
+Bounds now live in `vitest.memory-safe.ts` as an SSoT that all 20 configs import and spread **directly** — no inheritance, no dependence on which directory vitest considers the root — in the correct Vitest 4 shape (top-level `execArgv`). Verified three ways: every resolved config reports `pool=forks maxWorkers=6 execArgv=["--max-old-space-size=4096"]`, live forks carry the flag, and the deprecation warning is gone. 6 forks × 4 GB = a 24 GB ceiling on a 24-core/62 GB box; 1 fork on a 2-core CI runner.
+
+**New gate 8** (`cleo check arch`), zero-tolerance with no baseline: rejects a missing spread, a post-spread `maxWorkers`/`execArgv` override, a `pool` switched away from `forks` (per-worker V8 flags do not apply to worker_threads), and any `poolOptions:` usage at all. Verified against both a `maxWorkers: 23` and a reintroduced `poolOptions` regression.
+
+An unbounded fork pool is a machine-freezing default that only ever bites locally — CI runners have 2-4 cores, so it passes there and takes down the developer instead.

--- a/.changeset/t12088-dream-cycle-incremental.md
+++ b/.changeset/t12088-dream-cycle-incremental.md
@@ -1,0 +1,22 @@
+---
+id: t12088-dream-cycle-incremental
+tasks: [T12088]
+kind: fix
+summary: the dream cycle re-processed its own window every pass, lost anything older than 24h forever, and could never start learning on a new project
+---
+
+The observation collector was a fixed window with no record of its own progress:
+
+```sql
+WHERE created_at >= (now - 24h) ORDER BY created_at ASC LIMIT 2000
+```
+
+Three consequences, all measured:
+
+1. **Every pass redid the previous pass's work.** Consecutive runs collected 25 → 28 → 30 → 36 → 37 observations — the same material re-clustered and re-sent to the LLM each time. Dedup at the storage gate hid the waste while it consumed the entire LLM budget of every pass.
+2. **Anything older than the window was consolidated NEVER, not later.** The sentient loop was dead for three months (T12077); every observation from that period aged out unread and became permanently invisible to consolidation. A memory system whose intake silently expires is not an "ever-growing memory".
+3. **A fixed `clusterMinSize: 5` meant a new project could not learn at all.** A freshly dropped-in CLEO never has 5 similar observations, so the cycle completed `memoriesStored: 0` indefinitely. The goal is "infant to expert"; the threshold was set for the expert end and blocked the infant end.
+
+Now: a persisted `SentientState.dreamWatermark` makes intake incremental; the watermark **widens** the window to catch up after an outage and never narrows below the nominal 24 h (clustering still needs context), capped at 30 days so one tick cannot swallow an entire corpus; and the minimum cluster size scales 2 → 5 with the size of the corpus.
+
+Proven live: watermark absent → run 1 collected 38 observations; run 2 collected **1** (only the new digest). The watermark advances solely on the `completed` path, so a failed pass re-reads its material rather than skipping it, and an empty batch never advances progress past something it did not read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [2026.8.3] (2026-08-07)
+
+### Added
+
+
+
+### Changed
+
+
+
+### Fixed
+
+- the brain layer runs on ANY machine — provider-agnostic dream cycle, cross-provider failover, keyless local-daemon admission _(provenance: [T12081](https://github.com/kryptobaseddev/cleo/search?q=T12081&type=commits), [T12082](https://github.com/kryptobaseddev/cleo/search?q=T12082&type=commits))_
+- no task could EVER be completed in a project without TypeScript — gate rigour now scales to the project's real toolchain _(provenance: [T12083](https://github.com/kryptobaseddev/cleo/search?q=T12083&type=commits))_
+- selfimprove --execute reported the wrong reason, fix-gen had no failover, and failover asked every substitute for the first provider's model _(provenance: [T12084](https://github.com/kryptobaseddev/cleo/search?q=T12084&type=commits), [T12085](https://github.com/kryptobaseddev/cleo/search?q=T12085&type=commits))_
+- cleo worktree destroy reported worktreeRemoved/branchDeleted without acting — resolve path and branch from git, not by convention _(provenance: [T12086](https://github.com/kryptobaseddev/cleo/search?q=T12086&type=commits))_
+- the vitest OOM guard was both misplaced AND dead since Vitest 4 — bounds now live in one SSoT every config spreads, enforced by gate 8 _(provenance: [T12087](https://github.com/kryptobaseddev/cleo/search?q=T12087&type=commits))_
+- the dream cycle re-processed its own window every pass, lost anything older than 24h forever, and could never start learning on a new project _(provenance: [T12088](https://github.com/kryptobaseddev/cleo/search?q=T12088&type=commits))_
+
+### Deprecated
+
+
+
+### Removed
+
+
+
+### Security
+
+
+
+### BREAKING CHANGES
+
 ## [2026.8.2] (2026-08-05)
 
 ### Added


### PR DESCRIPTION
`cleo release plan v2026.8.3` reported `changesetEntryCount: 0` and wrote:

```
## [2026.8.3] (2026-08-07)

_No changeset entries parsed for this release._
```

Eight fixes shipped today with **no** `.changeset/*.md` entries. The repo derives release notes from those files, so v2026.8.3 would have had no notes describing any of its contents. That's a gap in my own work, not in the tooling.

Six entries added (two cover paired tasks), each stating the defect, the measured evidence, and why the fix is shaped as it is:

| entry | covers |
|---|---|
| `t12081-t12082-brain-layer-provider-agnostic` | provider-agnostic dream cycle · cross-provider failover · keyless local-daemon admission · model↔installed-set reconciliation |
| `t12083-tool-applicability` | no task could complete in a project without TypeScript |
| `t12084-t12085-selfimprove-execute-and-model-pinning` | `--execute` reported a file nobody writes · fix-gen had no failover · `modelOverride` leaked across failover |
| `t12086-worktree-locate` | `worktree destroy` reported success without acting (how 42 worktrees accumulated) |
| `t12087-vitest-memory-safe-ssot` | OOM guard misplaced **and** dead since Vitest 4 removed `poolOptions` |
| `t12088-dream-cycle-incremental` | incremental intake via watermark · adaptive cluster minimum |

`lint-changesets`: 264 → **270** entries, all valid. Re-planning now reports `changesetEntryCount: 6`, `evidenceComplete: true`, and the changelog carries provenance links for all eight tasks.

**This does not cut the release.** That is blocked on **T12089**: `cleo release open` dispatches only `version`, so `release-prepare.yml` takes its "generate a fresh plan" branch and runs `cleo release plan "$VERSION"` with no scope — which now hard-fails on `--saga|--epic|--tasks is required` and exits 2 at *Prepare bump-PR*. Release preflight (lint, typecheck, both test shards, build) passed first, so the code is fine and the pipeline is not. This PR makes the release notes correct whenever T12089 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)