### PR TITLE
fix: cleo release open could not cut ANY release — forward the plan scope (T12089)

### DIFF
--- a/.changeset/t12089-release-open-forwards-scope.md
+++ b/.changeset/t12089-release-open-forwards-scope.md
@@ -1,0 +1,23 @@
+---
+id: t12089-release-open-forwards-scope
+tasks: [T12089]
+kind: fix
+summary: cleo release open could not cut ANY release — it dispatched only `version`, so the workflow planned with no scope and exited 2 at Prepare bump-PR
+---
+
+`cleo release open` sent exactly one input: `version`. With no `plan-blob-sha256`, `release-prepare.yml` takes its "generate a fresh plan" branch and runs:
+
+```bash
+cleo release plan "$VERSION" "${EPIC_ARGS[@]}" --json > "$PLAN_FILE"
+```
+
+`EPIC_ARGS` is empty unless an `epic` input was supplied — and `cleo release plan` requires `--saga | --epic | --tasks`. So it exited 2 and **every release died at *Prepare bump-PR***, after lint, typecheck, both test shards and build had all passed. The code was fine; the pipeline could not ship it.
+
+`--epic` was not a workaround either: an epic drags in sibling tasks that legitimately have no evidence yet, failing the plan with `E_EVIDENCE_INSUFFICIENT` (22 such tasks on the epic used here).
+
+**Changes**
+
+- `release-prepare.yml` + its template gain a `tasks` input (comma-separated IDs) for task-scoped releases; both scope inputs are forwarded to `cleo release plan`, and a missing scope now fails with a readable reason instead of surfacing an argparse error from a nested command.
+- `cleo release open` gains `--epic` / `--tasks` and forwards them as workflow inputs. `plan-blob-sha256` is still deliberately NOT forwarded — the verify branch needs the plan FILE in the workflow checkout and `.cleo/` is gitignored, so the hash alone cannot be validated there; `--commit-plan` is that path.
+
+**Test-gap note:** the existing `release-open-field-schema` parity case dispatches *without* a scope, so `epic`/`tasks` never appeared among the passed keys and an undeclared input would have sailed through to a live HTTP 422 — the exact failure that test exists to prevent. Two cases added: one asserting the scope rides along AND that both keys are declared in the real workflow YAML, one asserting empty scope values are omitted rather than sent as empty inputs.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -40,6 +40,10 @@ on:
         description: 'Epic task ID (e.g. T9999) used by `cleo release plan`'
         type: string
         required: false
+      tasks:
+        description: 'Comma-separated task IDs (e.g. T101,T102) used by `cleo release plan` when the release is task-scoped rather than epic-scoped'
+        type: string
+        required: false
       channel:
         description: 'Release channel'
         type: choice
@@ -310,11 +314,24 @@ jobs:
           PLAN_FILE=".cleo/release/${{ inputs.version }}.plan.json"
           if [ -z "${{ inputs.plan-blob-sha256 }}" ]; then
             echo "No plan-blob-sha256 input — generating fresh plan."
-            EPIC_ARGS=()
+            # T12089: `cleo release plan` REQUIRES a scope (--saga | --epic |
+            # --tasks). This branch previously passed none whenever `epic` was
+            # empty, so `plan` exited 2 and every release died here at
+            # "Prepare bump-PR" — after a full green preflight. Forward whichever
+            # scope the dispatcher supplied, and if none was, say so plainly
+            # instead of surfacing an argparse error from a nested command.
+            SCOPE_ARGS=()
             if [ -n "${{ inputs.epic }}" ]; then
-              EPIC_ARGS=(--epic "${{ inputs.epic }}")
+              SCOPE_ARGS+=(--epic "${{ inputs.epic }}")
             fi
-            cleo release plan "${{ inputs.version }}" "${EPIC_ARGS[@]}" --json > "$PLAN_FILE"
+            if [ -n "${{ inputs.tasks }}" ]; then
+              SCOPE_ARGS+=(--tasks "${{ inputs.tasks }}")
+            fi
+            if [ ${#SCOPE_ARGS[@]} -eq 0 ]; then
+              echo "::error::No release scope supplied. Dispatch with 'epic' or 'tasks' (cleo release plan requires --saga, --epic or --tasks), or pass plan-blob-sha256 with a committed plan file."
+              exit 1
+            fi
+            cleo release plan "${{ inputs.version }}" "${SCOPE_ARGS[@]}" --json > "$PLAN_FILE"
           else
             echo "Verifying pre-computed plan against sha256=${{ inputs.plan-blob-sha256 }}"
             if [ ! -f "$PLAN_FILE" ]; then

--- a/packages/cleo/src/cli/commands/release.ts
+++ b/packages/cleo/src/cli/commands/release.ts
@@ -416,6 +416,17 @@ const openCommand = defineCommand({
       type: 'boolean',
       description: 'Commit the plan file to the active branch before dispatching',
     },
+    // T12089: the workflow regenerates the plan when no committed plan is
+    // supplied, and `cleo release plan` requires a scope — so one of these must
+    // ride along or the dispatched run dies at "Prepare bump-PR".
+    epic: {
+      type: 'string',
+      description: 'Epic task ID forwarded as the plan scope (e.g. T9999)',
+    },
+    tasks: {
+      type: 'string',
+      description: 'Comma-separated task IDs forwarded as the plan scope (task-scoped release)',
+    },
   },
   async run({ args }) {
     await dispatchFromCli(
@@ -427,6 +438,8 @@ const openCommand = defineCommand({
         workflow: args.workflow as string | undefined,
         watch: args.watch === true,
         commitPlan: args['commit-plan'] === true,
+        epic: args.epic as string | undefined,
+        tasks: args.tasks as string | undefined,
       },
       { command: 'release' },
     );

--- a/packages/core/src/release/__tests__/release-open-field-schema.test.ts
+++ b/packages/core/src/release/__tests__/release-open-field-schema.test.ts
@@ -223,6 +223,70 @@ afterEach(async () => {
 });
 
 describe('releaseOpen — workflow input schema parity (T10105)', () => {
+  it('forwards the plan SCOPE, and both scope keys are declared in the YAML (T12089)', async () => {
+    // Why this case exists: `release open` used to dispatch ONLY `version`. The
+    // workflow then regenerated the plan, and `cleo release plan` requires
+    // `--saga | --epic | --tasks`, so it exited 2 at "Prepare bump-PR" — AFTER
+    // lint, typecheck, both test shards and build had all passed. Every release
+    // died there.
+    //
+    // The pre-existing parity case cannot catch this: it dispatches without a
+    // scope, so `epic`/`tasks` never appear among the passed keys and an
+    // undeclared input would sail through to a live HTTP 422.
+    const version = 'v2026.6.1';
+    writePlanFile(version);
+    writeStubWorkflow();
+    await seedReleaseRow(version);
+
+    const runner = makeStubRunner();
+    const result = await releaseOpen(
+      { version, projectRoot: testDir, epic: 'T9999', tasks: 'T101,T102' },
+      runner,
+    );
+    expect(result.success).toBe(true);
+
+    const dispatched = runner.calls.find((c) => c.args[0] === 'workflow' && c.args[1] === 'run');
+    expect(dispatched).toBeDefined();
+
+    const passed = new Map<string, string>();
+    const args = dispatched?.args ?? [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--field' && typeof args[i + 1] === 'string') {
+        const pair = args[i + 1] as string;
+        const eq = pair.indexOf('=');
+        if (eq > 0) passed.set(pair.slice(0, eq), pair.slice(eq + 1));
+      }
+    }
+
+    // The scope actually rides along...
+    expect(passed.get('epic')).toBe('T9999');
+    expect(passed.get('tasks')).toBe('T101,T102');
+
+    // ...and both keys are declared in the REAL workflow, so the GitHub Actions
+    // API cannot reject the dispatch with "Unexpected inputs provided".
+    const declared = readWorkflowInputKeys();
+    expect(declared).toContain('epic');
+    expect(declared).toContain('tasks');
+  });
+
+  it('omits the scope fields entirely when no scope was supplied', async () => {
+    // An empty `--field epic=` would be sent as a real (empty) input, and the
+    // workflow's `-n` guard would treat it as absent anyway — but passing empty
+    // values muddies the audit trail of what was actually dispatched.
+    const version = 'v2026.6.2';
+    writePlanFile(version);
+    writeStubWorkflow();
+    await seedReleaseRow(version);
+
+    const runner = makeStubRunner();
+    await releaseOpen({ version, projectRoot: testDir, epic: '', tasks: '' }, runner);
+
+    const dispatched = runner.calls.find((c) => c.args[0] === 'workflow' && c.args[1] === 'run');
+    const joined = (dispatched?.args ?? []).join(' ');
+    expect(joined).not.toContain('epic=');
+    expect(joined).not.toContain('tasks=');
+  });
+
   it('release-prepare.yml declares `version` as the only required input', () => {
     const requiredInputs = readRequiredWorkflowInputKeys();
     expect(requiredInputs.sort()).toEqual(['version']);

--- a/packages/core/src/release/open.ts
+++ b/packages/core/src/release/open.ts
@@ -92,6 +92,23 @@ export interface ReleaseOpenOptions {
    */
   commitPlan?: boolean;
   /**
+   * Epic task ID forwarded to the workflow's `epic` input (T12089).
+   *
+   * The workflow regenerates the plan when no `plan-blob-sha256` is supplied,
+   * and `cleo release plan` REQUIRES a scope — so without this (or
+   * {@link tasks}) the dispatched run dies at "Prepare bump-PR" after a full
+   * green preflight.
+   */
+  epic?: string;
+  /**
+   * Comma-separated task IDs forwarded to the workflow's `tasks` input (T12089).
+   *
+   * Use for a task-scoped release, where an epic would drag in sibling tasks
+   * that legitimately have no evidence yet and fail the plan with
+   * `E_EVIDENCE_INSUFFICIENT`.
+   */
+  tasks?: string;
+  /**
    * Project root override. Defaults to the canonical project root resolved
    * via {@link getProjectRoot} (walks up from `process.cwd()` for monorepo
    * subdir invocations; honours `CLEO_ROOT` / `CLEO_PROJECT_ROOT`).
@@ -539,18 +556,33 @@ export async function releaseOpen(
     }
   }
 
-  // ── R-060 / T10105: dispatch the workflow ─────────────────────────────
+  // ── R-060 / T10105 / T12089: dispatch the workflow ────────────────────
   // Canonical input schema for `release-prepare.yml workflow_dispatch.inputs`:
   //   - `version` (string, required) — CalVer release version with v-prefix
+  //   - `epic`  (string, optional)   — plan scope
+  //   - `tasks` (string, optional)   — plan scope (comma-separated)
   //
-  // The pre-T10105 implementation also passed `plan-blob-sha256` which is
-  // NOT declared in the workflow's `inputs:` block; `gh workflow run`
-  // tolerated it locally but the GitHub Actions API rejected it with
-  // HTTP 422 "Unexpected inputs provided" on at least one ship attempt.
-  // Keep this `--field` set in lockstep with the YAML inputs declaration
-  // and the `release-open-field-schema.test.ts` parity check.
+  // T12089: sending ONLY `version` made every release fail. With no
+  // `plan-blob-sha256` the workflow regenerates the plan, and `cleo release
+  // plan` requires `--saga | --epic | --tasks`, so it exited 2 at "Prepare
+  // bump-PR" — after lint, typecheck, both test shards and build had all
+  // passed. The scope must ride along.
+  //
+  // `plan-blob-sha256` is still NOT forwarded: the verify branch needs the plan
+  // FILE present in the workflow checkout, and `.cleo/` is gitignored, so the
+  // hash alone cannot be validated there. Use `--commit-plan` for that path.
+  //
+  // Keep this `--field` set in lockstep with the YAML inputs declaration and
+  // the `release-open-field-schema.test.ts` parity check.
+  const dispatchFields = ['--field', `version=${opts.version}`];
+  if (opts.epic !== undefined && opts.epic !== '') {
+    dispatchFields.push('--field', `epic=${opts.epic}`);
+  }
+  if (opts.tasks !== undefined && opts.tasks !== '') {
+    dispatchFields.push('--field', `tasks=${opts.tasks}`);
+  }
   try {
-    runner.runGh(['workflow', 'run', workflow, '--field', `version=${opts.version}`], projectRoot);
+    runner.runGh(['workflow', 'run', workflow, ...dispatchFields], projectRoot);
   } catch (err) {
     return engineError<ReleaseOpenResult>(
       E_GH_NOT_AUTHENTICATED,

--- a/packages/core/templates/workflows/release-prepare.yml.tmpl
+++ b/packages/core/templates/workflows/release-prepare.yml.tmpl
@@ -40,6 +40,10 @@ on:
         description: 'Epic task ID (e.g. T9999) used by `cleo release plan`'
         type: string
         required: false
+      tasks:
+        description: 'Comma-separated task IDs (e.g. T101,T102) used by `cleo release plan` when the release is task-scoped rather than epic-scoped'
+        type: string
+        required: false
       channel:
         description: 'Release channel'
         type: choice
@@ -310,11 +314,24 @@ jobs:
           PLAN_FILE=".cleo/release/${{ inputs.version }}.plan.json"
           if [ -z "${{ inputs.plan-blob-sha256 }}" ]; then
             echo "No plan-blob-sha256 input — generating fresh plan."
-            EPIC_ARGS=()
+            # T12089: `cleo release plan` REQUIRES a scope (--saga | --epic |
+            # --tasks). This branch previously passed none whenever `epic` was
+            # empty, so `plan` exited 2 and every release died here at
+            # "Prepare bump-PR" — after a full green preflight. Forward whichever
+            # scope the dispatcher supplied, and if none was, say so plainly
+            # instead of surfacing an argparse error from a nested command.
+            SCOPE_ARGS=()
             if [ -n "${{ inputs.epic }}" ]; then
-              EPIC_ARGS=(--epic "${{ inputs.epic }}")
+              SCOPE_ARGS+=(--epic "${{ inputs.epic }}")
             fi
-            cleo release plan "${{ inputs.version }}" "${EPIC_ARGS[@]}" --json > "$PLAN_FILE"
+            if [ -n "${{ inputs.tasks }}" ]; then
+              SCOPE_ARGS+=(--tasks "${{ inputs.tasks }}")
+            fi
+            if [ ${#SCOPE_ARGS[@]} -eq 0 ]; then
+              echo "::error::No release scope supplied. Dispatch with 'epic' or 'tasks' (cleo release plan requires --saga, --epic or --tasks), or pass plan-blob-sha256 with a committed plan file."
+              exit 1
+            fi
+            cleo release plan "${{ inputs.version }}" "${SCOPE_ARGS[@]}" --json > "$PLAN_FILE"
           else
             echo "Verifying pre-computed plan against sha256=${{ inputs.plan-blob-sha256 }}"
             if [ ! -f "$PLAN_FILE" ]; then


### PR DESCRIPTION
`cleo release open` dispatched exactly one input: `version`. With no `plan-blob-sha256`, `release-prepare.yml` takes its "generate a fresh plan" branch:

```bash
cleo release plan "$VERSION" "${EPIC_ARGS[@]}" --json > "$PLAN_FILE"
```

`EPIC_ARGS` is empty unless an `epic` input was supplied — and `cleo release plan` requires `--saga | --epic | --tasks`. So it exited 2 and **every release died at *Prepare bump-PR***, after lint, typecheck, both test shards and build had all passed. Observed on run [31148765283](https://github.com/kryptobaseddev/cleo/actions/runs/31148765283): 4/4 preflight jobs green, then `Resolve release plan` exit 2.

`--epic` was not a workaround: an epic drags in sibling tasks that legitimately have no evidence yet, failing the plan with `E_EVIDENCE_INSUFFICIENT` (22 such tasks on the epic in question).

## Changes

- **`release-prepare.yml` + its template** gain a `tasks` input (comma-separated IDs) for task-scoped releases. Both scope inputs are forwarded to `cleo release plan`, and a missing scope now fails with a readable reason instead of surfacing an argparse error from a nested command.
- **`cleo release open`** gains `--epic` / `--tasks` and forwards them as workflow inputs.

`plan-blob-sha256` is still deliberately **not** forwarded: the verify branch needs the plan *file* present in the workflow checkout and `.cleo/` is gitignored, so the hash alone cannot be validated there. `--commit-plan` is that path.

## The test gap this also closes

The existing `release-open-field-schema` parity case dispatches **without** a scope, so `epic`/`tasks` never appeared among the passed keys — an undeclared input would have sailed through to a live HTTP 422, the exact failure that test exists to prevent. Two cases added:

1. the scope rides along **and** both keys are declared in the real workflow YAML;
2. empty scope values are omitted rather than sent as empty inputs.

## Verification

`packages/core/src/release`: **364 passed** · Deployed-template parity **PASS** · `cleo check arch` **8/8** · `lint-changesets` 270 → 271.

Unblocks v2026.8.3, whose eight tasks (T12081–T12088) are all `done` with evidence and whose changeset entries + changelog landed in #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)