### PR TITLE
fix: empty changelog sections, --commit-plan committed nothing, and CI cannot re-derive a plan (T12092)

### DIFF
--- a/.changeset/t12092-changelog-and-committed-plan.md
+++ b/.changeset/t12092-changelog-and-committed-plan.md
@@ -1,0 +1,29 @@
+---
+id: t12092-changelog-and-committed-plan
+tasks: [T12092]
+kind: fix
+summary: changelog emitted empty sections; --commit-plan silently committed nothing; and the workflow cannot re-derive a plan because CI has no tasks.db
+---
+
+Three defects found while trying to actually publish v2026.8.3.
+
+**1. The changelog emitted empty sections.** Every Keep-a-Changelog heading rendered unconditionally, so a fix-only release shipped:
+
+```
+### Added
+
+### Changed
+
+### Fixed
+- …
+```
+
+An empty heading under a shipped version reads as a forgotten section and teaches readers to skim past headings. Only sections with entries now render; the canonical ORDER — which is what the test was really protecting — is unchanged.
+
+**2. `--commit-plan` committed nothing, silently.** The plan lives at `.cleo/release/<version>.plan.json` and `.cleo/` is gitignored, so `git add <path>` refuses it ("use -f if you really want to add them"). The commit then had nothing staged. Now force-added.
+
+**3. The premise underneath both was wrong.** `commitPlanFile`'s doc claimed *"the workflow can re-derive the plan envelope from `releases` + tasks.db without it"*. It cannot: `.cleo/tasks.db` is deliberately gitignored (ADR-013 §9 — committing it is the T5158 data-loss vector), so a CI runner has **no task database** and `cleo release plan --tasks …` exits 4 (`E_NOT_FOUND`) there.
+
+Proven by dispatching manually to isolate CLEO from `gh`: the scope arrived intact and the workflow built `SCOPE_ARGS+=(--tasks "T12081,…")` correctly, then `cleo release plan` exited 4.
+
+So committing the plan is not an optional extra — it is the **only** way a task- or epic-scoped release can be planned. `plan-blob-sha256` is now forwarded exactly when `--commit-plan` was used, so the workflow VERIFIES the committed plan instead of regenerating one it cannot compute. Sending the hash without the file would fail verification; omitting it with the file present would pointlessly regenerate.

--- a/packages/core/src/release/__tests__/changesets-aggregator.test.ts
+++ b/packages/core/src/release/__tests__/changesets-aggregator.test.ts
@@ -55,15 +55,16 @@ describe('aggregateChangesetsForRelease', () => {
     expect(result.entryCount).toBe(3);
     expect(result.kinds.size).toBe(3);
     expect(result.markdown).toContain('## v2026.6.0 — 2026-05-20');
-    expect(renderedSections(result.markdown)).toEqual([
-      'Added',
-      'Changed',
-      'Fixed',
-      'Deprecated',
-      'Removed',
-      'Security',
-      'BREAKING CHANGES',
-    ]);
+    // T12092: only sections WITH entries render, in canonical Keep-a-Changelog
+    // order. This previously asserted all seven headings always render, which
+    // shipped a real changelog reading "### Added" / "### Changed" with nothing
+    // under them for a fix-only release — an empty heading under a shipped
+    // version reads as a forgotten section and teaches readers to skim past
+    // headings. The determinism this test exists to protect is the ORDER, which
+    // is unchanged; only the always-present part is dropped.
+    expect(renderedSections(result.markdown)).toEqual(['Added', 'Changed', 'Fixed']);
+    expect(result.markdown).not.toContain('### Deprecated');
+    expect(result.markdown).not.toContain('### Security');
     expect(result.markdown).toContain('- New API endpoint. _(provenance: [T9001](');
     expect(result.markdown).toContain('- Stop the bleed. _(provenance: [T9002](');
     expect(result.markdown).toContain('- Update README. _(provenance: [T9003](');

--- a/packages/core/src/release/changesets-aggregator.ts
+++ b/packages/core/src/release/changesets-aggregator.ts
@@ -279,9 +279,23 @@ export function aggregateChangesetsForRelease(
 
   const header = title ? `## ${version} — ${date} — ${title}` : `## ${version} — ${date}`;
 
-  const body = RELEASE_NOTE_SECTION_ORDER.map((section) =>
-    renderGroup(section, groups.get(section) ?? []),
-  ).join('\n\n');
+  // T12092: render ONLY sections that have entries. Every section was emitted
+  // unconditionally, so a fix-only release shipped a changelog reading
+  //
+  //     ### Added
+  //     <blank>
+  //     ### Changed
+  //     <blank>
+  //     ### Fixed
+  //     - …
+  //
+  // Empty headings under a real release read as "we forgot to write this" and
+  // train the reader to skim past section headers entirely.
+  const body = RELEASE_NOTE_SECTION_ORDER.filter(
+    (section) => (groups.get(section) ?? []).length > 0,
+  )
+    .map((section) => renderGroup(section, groups.get(section) ?? []))
+    .join('\n\n');
 
   const markdown = `${header}\n\n${body}\n`;
 

--- a/packages/core/src/release/open.ts
+++ b/packages/core/src/release/open.ts
@@ -398,8 +398,18 @@ async function readReleaseStatus(
 
 /**
  * R-062: commit the plan file to the active branch when `--commit-plan` is
- * supplied. The default flow leaves the plan uncommitted; the workflow can
- * re-derive the plan envelope from `releases` + tasks.db without it.
+ * supplied.
+ *
+ * T12092: the old doc claimed "the workflow can re-derive the plan envelope
+ * from `releases` + tasks.db without it". It cannot. `.cleo/tasks.db` is
+ * deliberately gitignored (ADR-013 §9 — committing it is the T5158 data-loss
+ * vector), so a CI runner has NO task database and `cleo release plan --tasks
+ * …` exits 4 (`E_NOT_FOUND`) there. Committing the plan is therefore the ONLY
+ * way a task- or epic-scoped release can be planned, not an optional extra.
+ *
+ * The plan lives under `.cleo/`, which is gitignored, so staging REQUIRES
+ * `-f`. Without it `git add` refuses the path and this function committed
+ * nothing while reporting success.
  *
  * @internal
  */
@@ -408,7 +418,10 @@ function commitPlanFile(planPath: string, version: string, projectRoot: string):
   const relPath = planPath.startsWith(projectRoot)
     ? planPath.slice(projectRoot.length).replace(/^\/+/, '')
     : planPath;
-  runGitWithLockRetry(['add', relPath], {
+  // `-f`: the plan lives under the gitignored `.cleo/`, so a plain `git add`
+  // refuses it ("use -f if you really want to add them") and the commit below
+  // would then have nothing staged.
+  runGitWithLockRetry(['add', '-f', relPath], {
     cwd: projectRoot,
     encoding: 'utf-8',
     stdio: 'pipe',
@@ -575,6 +588,15 @@ export async function releaseOpen(
   // Keep this `--field` set in lockstep with the YAML inputs declaration and
   // the `release-open-field-schema.test.ts` parity check.
   const dispatchFields = ['--field', `version=${opts.version}`];
+  // T12092: forward the plan hash ONLY when the plan was committed. The
+  // workflow's verify branch reads the plan FILE from its checkout, so the hash
+  // is meaningful exactly when the file is present there — and committing is
+  // the only way it can be, since `.cleo/` is gitignored. Sending the hash
+  // without the file would fail verification; omitting it with the file present
+  // would pointlessly regenerate a plan CI cannot compute (no tasks.db).
+  if (commitPlan) {
+    dispatchFields.push('--field', `plan-blob-sha256=${planBlobSha256}`);
+  }
   if (opts.epic !== undefined && opts.epic !== '') {
     dispatchFields.push('--field', `epic=${opts.epic}`);
   }


### PR DESCRIPTION
Three defects found while trying to actually publish v2026.8.3.

## 1. The changelog emitted empty sections

Every Keep-a-Changelog heading rendered unconditionally, so a fix-only release shipped:

```
### Added

### Changed

### Fixed
- …
```

An empty heading under a shipped version reads as a forgotten section and teaches readers to skim past headings. Only sections with entries now render. The canonical **order** — what that test was really protecting — is unchanged, and the test now asserts both the order of present sections and the absence of empty ones.

## 2. `--commit-plan` committed nothing, silently

The plan lives at `.cleo/release/<version>.plan.json`, and `.cleo/` is gitignored — so `git add <path>` refuses it ("use -f if you really want to add them") and the commit had nothing staged. Now force-added.

## 3. The premise underneath both was wrong

`commitPlanFile`'s doc claimed *"the workflow can re-derive the plan envelope from `releases` + tasks.db without it"*. **It cannot.** `.cleo/tasks.db` is deliberately gitignored (ADR-013 §9 — committing it is the T5158 data-loss vector), so a CI runner has **no task database** and `cleo release plan --tasks …` exits 4 (`E_NOT_FOUND`) there.

Proven by dispatching manually to isolate CLEO from `gh` — the scope arrived intact and the workflow built the args correctly:

```
SCOPE_ARGS+=(--tasks "T12081,…,T12089")
cleo release plan "v2026.8.3" "${SCOPE_ARGS[@]}"   →  exit 4
```

So committing the plan is not an optional extra — it is the **only** way a task- or epic-scoped release can be planned. `plan-blob-sha256` is now forwarded exactly when `--commit-plan` was used, so the workflow **verifies** the committed plan instead of regenerating one it cannot compute. Sending the hash without the file would fail verification; omitting it with the file present would pointlessly regenerate.

This is the fifth and final hop in the T12089 chain: CLI arg → registry declaration → handler mapping → `gh --field` → **the plan must exist in the checkout**.

`packages/core/src/release`: **364 passed** · `lint-changesets` 271 → 272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)