### PR TITLE
chore(release): attach the v2026.8.3 plan + changelog

### DIFF
--- a/.cleo/release/v2026.8.3.plan.json
+++ b/.cleo/release/v2026.8.3.plan.json
@@ -1,0 +1,242 @@
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.8.3",
+  "resolvedVersion": "v2026.8.3",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T11396",
+  "releaseKind": "regular",
+  "createdAt": "2026-08-09T03:04:53.374Z",
+  "createdBy": "keatonhoskins",
+  "previousVersion": "v2026.8.2",
+  "previousTag": "v2026.8.2",
+  "previousShippedAt": "2026-08-05T14:07:29.873Z",
+  "tasks": [
+    {
+      "id": "T12081",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "Dream cycle could not use a non-anthropic provider; custom baseUrl was rewritten",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12082",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "Brain layer died with its first provider: no failover, keyless local daemon never admitted",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12083",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "No task could EVER be completed in a project without TypeScript",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12084",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "selfimprove --execute reported a patch file nobody writes; fix-gen had no failover",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12085",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "Failover asked every substitute provider for the FIRST provider's model",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12086",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "cleo worktree destroy reported worktreeRemoved/branchDeleted without acting",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12087",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "Vitest OOM guard was absent per-package AND dead since Vitest 4 (poolOptions removed)",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12088",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "Dream cycle re-processed its own window every pass and could never start learning",
+      "evidenceAtoms": [
+        "pr:1166"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12089",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "cleo release open cannot cut ANY release: dispatches only version, workflow fallback plans with no scope",
+      "evidenceAtoms": [
+        "pr:1168"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12092",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "Changelog emitted empty Keep-a-Changelog sections; --commit-plan silently staged nothing; CI cannot re-derive a release plan (no tasks.db)",
+      "evidenceAtoms": [
+        "pr:1171"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    }
+  ],
+  "changelog": {
+    "features": [],
+    "fixes": [
+      "T12081",
+      "T12082",
+      "T12083",
+      "T12084",
+      "T12085",
+      "T12086",
+      "T12087",
+      "T12088",
+      "T12089",
+      "T12092"
+    ],
+    "chores": [],
+    "breaking": []
+  },
+  "gates": [
+    {
+      "name": "test",
+      "atom": "tool:test",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-09T03:04:53.374Z",
+      "resolvedCommand": "pnpm run test",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "build",
+      "atom": "tool:build",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-09T03:04:53.374Z",
+      "resolvedCommand": "pnpm run build",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "lint",
+      "atom": "tool:lint",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-09T03:04:53.374Z",
+      "resolvedCommand": "npx biome check .",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "typecheck",
+      "atom": "tool:typecheck",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-09T03:04:53.374Z",
+      "resolvedCommand": "npx tsc --noEmit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "audit",
+      "atom": "tool:audit",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-09T03:04:53.374Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "security-scan",
+      "atom": "tool:security-scan",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-09T03:04:53.374Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    }
+  ],
+  "platformMatrix": [
+    {
+      "platform": "any",
+      "publisher": "npm",
+      "package": "@cleocode/cleo"
+    }
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true,
+    "preflightWarnings": [
+      "Skipped 264 out-of-scope changeset entries whose task anchors are not part of this release plan"
+    ]
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned",
+  "meta": {
+    "firstEverRelease": false,
+    "archetype": "node",
+    "releaseNotes": "## v2026.8.3 — 2026-08-09\n\n### Fixed\n\n- the brain layer runs on ANY machine — provider-agnostic dream cycle, cross-provider failover, keyless local-daemon admission _(provenance: [T12081](https://github.com/kryptobaseddev/cleo/search?q=T12081&type=commits), [T12082](https://github.com/kryptobaseddev/cleo/search?q=T12082&type=commits))_\n- no task could EVER be completed in a project without TypeScript — gate rigour now scales to the project's real toolchain _(provenance: [T12083](https://github.com/kryptobaseddev/cleo/search?q=T12083&type=commits))_\n- selfimprove --execute reported the wrong reason, fix-gen had no failover, and failover asked every substitute for the first provider's model _(provenance: [T12084](https://github.com/kryptobaseddev/cleo/search?q=T12084&type=commits), [T12085](https://github.com/kryptobaseddev/cleo/search?q=T12085&type=commits))_\n- cleo worktree destroy reported worktreeRemoved/branchDeleted without acting — resolve path and branch from git, not by convention _(provenance: [T12086](https://github.com/kryptobaseddev/cleo/search?q=T12086&type=commits))_\n- the vitest OOM guard was both misplaced AND dead since Vitest 4 — bounds now live in one SSoT every config spreads, enforced by gate 8 _(provenance: [T12087](https://github.com/kryptobaseddev/cleo/search?q=T12087&type=commits))_\n- the dream cycle re-processed its own window every pass, lost anything older than 24h forever, and could never start learning on a new project _(provenance: [T12088](https://github.com/kryptobaseddev/cleo/search?q=T12088&type=commits))_\n- cleo release open could not cut ANY release — it dispatched only `version`, so the workflow planned with no scope and exited 2 at Prepare bump-PR _(provenance: [T12089](https://github.com/kryptobaseddev/cleo/search?q=T12089&type=commits))_\n- changelog emitted empty sections; --commit-plan silently committed nothing; and the workflow cannot re-derive a plan because CI has no tasks.db _(provenance: [T12092](https://github.com/kryptobaseddev/cleo/search?q=T12092&type=commits))_\n",
+    "changesetEntryCount": 8,
+    "changesetIds": [
+      "t12081-t12082-brain-layer-provider-agnostic",
+      "t12083-tool-applicability",
+      "t12084-t12085-selfimprove-execute-and-model-pinning",
+      "t12086-worktree-locate",
+      "t12087-vitest-memory-safe-ssot",
+      "t12088-dream-cycle-incremental",
+      "t12089-release-open-forwards-scope",
+      "t12092-changelog-and-committed-plan"
+    ],
+    "taskIds": [
+      "T12081",
+      "T12082",
+      "T12083",
+      "T12084",
+      "T12085",
+      "T12086",
+      "T12087",
+      "T12088",
+      "T12089",
+      "T12092"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
-## [2026.8.3] (2026-08-07)
-
-### Added
-
-
-
-### Changed
-
-
+## [2026.8.3] (2026-08-09)
 
 ### Fixed
 
@@ -18,20 +10,8 @@
 - cleo worktree destroy reported worktreeRemoved/branchDeleted without acting — resolve path and branch from git, not by convention _(provenance: [T12086](https://github.com/kryptobaseddev/cleo/search?q=T12086&type=commits))_
 - the vitest OOM guard was both misplaced AND dead since Vitest 4 — bounds now live in one SSoT every config spreads, enforced by gate 8 _(provenance: [T12087](https://github.com/kryptobaseddev/cleo/search?q=T12087&type=commits))_
 - the dream cycle re-processed its own window every pass, lost anything older than 24h forever, and could never start learning on a new project _(provenance: [T12088](https://github.com/kryptobaseddev/cleo/search?q=T12088&type=commits))_
-
-### Deprecated
-
-
-
-### Removed
-
-
-
-### Security
-
-
-
-### BREAKING CHANGES
+- cleo release open could not cut ANY release — it dispatched only `version`, so the workflow planned with no scope and exited 2 at Prepare bump-PR _(provenance: [T12089](https://github.com/kryptobaseddev/cleo/search?q=T12089&type=commits))_
+- changelog emitted empty sections; --commit-plan silently committed nothing; and the workflow cannot re-derive a plan because CI has no tasks.db _(provenance: [T12092](https://github.com/kryptobaseddev/cleo/search?q=T12092&type=commits))_
 
 ## [2026.8.2] (2026-08-05)
 


### PR DESCRIPTION
Two commits the release needs present on `main` before the workflow can verify anything.

**`chore(release): attach plan for v2026.8.3`** — `.cleo/release/v2026.8.3.plan.json`, force-added because `.cleo/` is gitignored (that force-add is the T12092 fix; before it, `--commit-plan` staged nothing and reported success).

This file is what makes the release possible at all: `.cleo/tasks.db` is deliberately gitignored (ADR-013 §9), so a CI runner has no task database and cannot compute a task-scoped plan — it exits 4 (`E_NOT_FOUND`). The plan must be computed where the DB lives and carried in.

**`chore(release): changelog for v2026.8.3`** — generated by `cleo release plan`, now with a single `### Fixed` section and no empty headings (T12092), 8 provenance-linked entries covering T12081–T12089 and T12092.

Once merged, `cleo release open v2026.8.3 --commit-plan --tasks …` forwards `plan-blob-sha256`, and the workflow verifies this committed plan instead of regenerating one it cannot produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)