### PR TITLE
fix: heavy-tool concurrency was bounded by cores, permitting 144 GiB of heap (T12091)

### DIFF
--- a/.changeset/t12091-heavy-tool-ram-budget.md
+++ b/.changeset/t12091-heavy-tool-ram-budget.md
@@ -1,0 +1,17 @@
+---
+id: t12091-heavy-tool-ram-budget
+tasks: [T12091]
+kind: fix
+summary: two independently-bounded concurrency caps composed to 144 GiB of permitted heap on a 62 GiB machine — heavy tool budgets are now derived from RAM, not core count
+---
+
+`cleo` runs a project's own test command to satisfy `tool:test` evidence. Two separate caps governed that, and both were core-derived:
+
+- `defaultMaxConcurrent('test', cpus)` = `floor(cpus/4)` → **6** concurrent full suites on a 24-core box
+- `computeClassBudget('test-run')` = `max(1, floor(cpus/4))` → the same 6
+
+Each of those runs is itself permitted 6 vitest forks × a 4 GiB heap cap by `vitest.memory-safe.ts` (T12087). Multiplied out: **6 × 6 × 4 = 144 GiB on 62 GiB of RAM.** No single bound was ever violated, which is exactly why the machine froze with every guard reporting healthy.
+
+The dimensional error is the root cause: what limits a test run is memory, and core count says nothing about memory — a 24-core/16 GiB VM was handed the same 6 slots as a 24-core/256 GiB server. Both sites now divide available RAM by the worst-case per-run footprint and take the lower of that and the core budget. `agent-session` in the governor had this shape correct already; `test-run` did not.
+
+Reactive PSI scaling is not a substitute and is kept only as a second line: `some avg10` is a ten-second average, and a fork fleet exhausts RAM faster than that window can report it.

--- a/packages/core/src/resources/__tests__/governor.test.ts
+++ b/packages/core/src/resources/__tests__/governor.test.ts
@@ -54,10 +54,49 @@ describe('computeClassBudget (T11999)', () => {
   });
 
   it('test-run scales down under pressure: base → half (some>10) → 1 (some>25)', () => {
-    const base = computeClassBudget('test-run', makeSample({ someAvg10: 0 }), BUDGET_OPTS);
-    expect(base).toBe(4); // max(1, 16/4)
-    expect(computeClassBudget('test-run', makeSample({ someAvg10: 15 }), BUDGET_OPTS)).toBe(2); // halved
-    expect(computeClassBudget('test-run', makeSample({ someAvg10: 30 }), BUDGET_OPTS)).toBe(1); // floor
+    // T12091: base is now clamped by MemAvailable too, so this case needs enough
+    // free RAM for the core budget to be the binding constraint —
+    // ⌊(128−2)/24⌋ = 5, clamped to ⌊16/4⌋ = 4.
+    const ample = { memAvailableGb: 128 };
+    const base = computeClassBudget('test-run', makeSample({ ...ample }), BUDGET_OPTS);
+    expect(base).toBe(4);
+    expect(
+      computeClassBudget('test-run', makeSample({ ...ample, someAvg10: 15 }), BUDGET_OPTS),
+    ).toBe(2); // halved
+    expect(
+      computeClassBudget('test-run', makeSample({ ...ample, someAvg10: 30 }), BUDGET_OPTS),
+    ).toBe(1); // floor
+  });
+
+  it('test-run is bounded by MemAvailable, not just cores (T12091)', () => {
+    // The measured freeze: a core-only budget admitted ⌊24/4⌋ = 6 concurrent
+    // runs while each run is permitted 6 vitest forks × 4 GiB — 144 GiB of heap
+    // on a 62 GiB box, with no single bound violated.
+    const opts = { cpuCount: 24, totalMemBytes: 62 * GB } as const;
+    // 60 GiB available − 2 GiB headroom = 58; ⌊58/24⌋ = 2 (was 6).
+    expect(computeClassBudget('test-run', makeSample({ memAvailableGb: 60 }), opts)).toBe(2);
+    // 30 GiB available → ⌊28/24⌋ = 1.
+    expect(computeClassBudget('test-run', makeSample({ memAvailableGb: 30 }), opts)).toBe(1);
+    // Not even one run fits — still 1, never 0: the per-run vitest cap governs
+    // from there, and refusing outright would make tests unrunnable on a small
+    // machine rather than merely slow.
+    expect(computeClassBudget('test-run', makeSample({ memAvailableGb: 8 }), opts)).toBe(1);
+  });
+
+  it('scoped-build shares the test-run memory bound', () => {
+    const opts = { cpuCount: 24, totalMemBytes: 62 * GB } as const;
+    expect(computeClassBudget('scoped-build', makeSample({ memAvailableGb: 60 }), opts)).toBe(2);
+  });
+
+  it('honours an explicit testRunEstRamMb estimate', () => {
+    // A project whose suite is light should not be pinned by the monorepo's
+    // 24 GiB worst case: ⌊(60−2)/2⌋ = 29, clamped to ⌊16/4⌋ = 4.
+    expect(
+      computeClassBudget('test-run', makeSample({ memAvailableGb: 60 }), {
+        ...BUDGET_OPTS,
+        testRunEstRamMb: 2048,
+      }),
+    ).toBe(4);
   });
 
   it('agent-session clamps by MemAvailable and cpus-2', () => {

--- a/packages/core/src/resources/governor.ts
+++ b/packages/core/src/resources/governor.ts
@@ -107,6 +107,15 @@ export interface BudgetOptions {
   readonly headroomMb?: number;
   /** Estimated RAM per agent session (incl. ~300 MB MCP suite), MiB. Default 4096. */
   readonly agentEstRamMb?: number;
+  /**
+   * Estimated worst-case RAM for ONE `test-run` / `scoped-build`, in MiB.
+   * Default 24576 (24 GiB) — a full `pnpm run test` is permitted 6 vitest forks
+   * × a 4 GiB heap cap by `vitest.memory-safe.ts`, and the governor has to
+   * admit against what a run may actually hold, not what it usually holds.
+   *
+   * @task T12091
+   */
+  readonly testRunEstRamMb?: number;
   /** `some avg10` (pp) at/above which test/build budgets halve. Default 10. */
   readonly holdSomeAvg10?: number;
   /** `some avg10` (pp) at/above which test/build budgets floor to 1. Default 25. */
@@ -131,8 +140,9 @@ function someAvg10(sample: ResourceSample): number {
  * - `interactive-cli` → `Infinity` (never gated).
  * - `full-build` → `1` machine-wide, pressure-independent.
  * - `agent-session` → `clamp(1, ⌊(MemAvailable − headroom)/estRamMb⌋, cpus−2)`.
- * - `test-run` / `scoped-build` → `max(1, ⌊cpus/4⌋)`, ×0.5 when `some>hold`,
- *   floored to 1 when `some>floor`.
+ * - `test-run` / `scoped-build` → `clamp(1, ⌊(MemAvailable − headroom)/estRamMb⌋,
+ *   ⌊cpus/4⌋)`, ×0.5 when `some>hold`, floored to 1 when `some>floor` (T12091:
+ *   was core-only, which authorised 144 GiB of heap on a 62 GiB box).
  * - `llm-call` → `max(1, cpus−2)` (primarily gated by the llm-queue elsewhere).
  * - `db-heavy` → `1`, deferred (→0) under `backoff`-level pressure.
  * - `background-autonomous` → `1` only when pressure is `ok`, else `0`.
@@ -169,7 +179,15 @@ export function computeClassBudget(
       return Math.max(1, cpus - 2);
     case 'test-run':
     case 'scoped-build': {
-      const base = Math.max(1, Math.floor(cpus / 4));
+      // T12091: this was core-only — `max(1, ⌊cpus/4⌋)` — which on a 24-core
+      // box admitted 6 concurrent runs. Each run is itself allowed 6 vitest
+      // forks × 4 GiB, so the governor was authorising 144 GiB of heap on a
+      // 62 GiB machine and the box froze without any single bound being
+      // violated. What limits a test run is MEMORY; cores say nothing about it.
+      // Mirrors the `agent-session` shape, which had this right all along.
+      const estRamBytes = (opts.testRunEstRamMb ?? 24576) * MB;
+      const byMem = Math.floor((availBytes - headroomBytes) / estRamBytes);
+      const base = clamp(1, byMem, Math.max(1, Math.floor(cpus / 4)));
       if (some > floor) return 1;
       if (some > hold) return Math.max(1, Math.floor(base / 2));
       return base;

--- a/packages/core/src/tasks/__tests__/tool-semaphore.test.ts
+++ b/packages/core/src/tasks/__tests__/tool-semaphore.test.ts
@@ -70,13 +70,17 @@ afterEach(() => {
   restoreCleoHome();
 });
 
-describe('defaultMaxConcurrent', () => {
-  // T12091: heavy tools are bounded by RAM as well as cores. RAM is passed
-  // explicitly so these assertions do not depend on the host running them —
-  // the old core-only rule silently gave a 16 GiB VM the same 6 slots as a
-  // 256 GiB server.
-  const AMPLE_RAM_GIB = 1024;
+/**
+ * RAM figure large enough that the CORE budget is the binding constraint.
+ *
+ * T12091 made heavy-tool budgets RAM-derived, so every assertion about the
+ * core rule must pin RAM explicitly — otherwise the expected value depends on
+ * whichever host runs the suite (a 16 GiB CI runner and a 62 GiB workstation
+ * resolve different budgets from identical inputs).
+ */
+const AMPLE_RAM_GIB = 1024;
 
+describe('defaultMaxConcurrent', () => {
   it('returns max(1, cpus/4) for test/build when RAM is not the binding constraint', () => {
     expect(defaultMaxConcurrent('test', 16, AMPLE_RAM_GIB)).toBe(4);
     expect(defaultMaxConcurrent('build', 16, AMPLE_RAM_GIB)).toBe(4);
@@ -159,12 +163,24 @@ describe('resolveMaxConcurrent', () => {
   });
 
   it('falls back to defaultMaxConcurrent when env is unset', () => {
-    expect(resolveMaxConcurrent('test', 16)).toBe(4);
+    expect(resolveMaxConcurrent('test', 16, AMPLE_RAM_GIB)).toBe(4);
   });
 
   it('ignores non-numeric env values', () => {
     process.env.CLEO_TOOL_CONCURRENCY_TEST = 'abc';
-    expect(resolveMaxConcurrent('test', 16)).toBe(4);
+    expect(resolveMaxConcurrent('test', 16, AMPLE_RAM_GIB)).toBe(4);
+  });
+
+  it('lets RAM bind the fallback below the core budget (T12091)', () => {
+    // Without an env override, a low-RAM host must not be handed the core
+    // budget — this is the composition that froze the workstation.
+    expect(resolveMaxConcurrent('test', 24, 62)).toBe(2);
+    expect(resolveMaxConcurrent('test', 24, 16)).toBe(1);
+  });
+
+  it('an env override still bypasses the RAM bound — it is the one escape hatch', () => {
+    process.env.CLEO_TOOL_CONCURRENCY_TEST = '8';
+    expect(resolveMaxConcurrent('test', 24, 16)).toBe(8);
   });
 });
 
@@ -290,13 +306,18 @@ describe('acquireGlobalSlot pressure scaling (T12001)', () => {
   it('shrinks the acquirable window to 1 under backoff pressure, recovers on release', async () => {
     isolateCleoHome();
     const high = makeSample(30); // some>25 → effectiveMax = 1 for 'test'
-    const first = await acquireGlobalSlot('test', { pressureSample: high, cpuCount: 16 });
+    const first = await acquireGlobalSlot('test', {
+      pressureSample: high,
+      cpuCount: 16,
+      totalRamGib: AMPLE_RAM_GIB,
+    });
     try {
       // Only one slot is eligible under high pressure → second acquire times out.
       await expect(
         acquireGlobalSlot('test', {
           pressureSample: high,
           cpuCount: 16,
+          totalRamGib: AMPLE_RAM_GIB,
           pollMs: 10,
           timeoutMs: 100,
         }),
@@ -308,6 +329,7 @@ describe('acquireGlobalSlot pressure scaling (T12001)', () => {
     const again = await acquireGlobalSlot('test', {
       pressureSample: high,
       cpuCount: 16,
+      totalRamGib: AMPLE_RAM_GIB,
       timeoutMs: 200,
     });
     await again();
@@ -319,11 +341,13 @@ describe('acquireGlobalSlot pressure scaling (T12001)', () => {
     const a = await acquireGlobalSlot('test', {
       pressureSample: low,
       cpuCount: 16,
+      totalRamGib: AMPLE_RAM_GIB,
       timeoutMs: 500,
     });
     const b = await acquireGlobalSlot('test', {
       pressureSample: low,
       cpuCount: 16,
+      totalRamGib: AMPLE_RAM_GIB,
       timeoutMs: 500,
     });
     // Two concurrent grants coexist under low pressure.

--- a/packages/core/src/tasks/__tests__/tool-semaphore.test.ts
+++ b/packages/core/src/tasks/__tests__/tool-semaphore.test.ts
@@ -71,12 +71,48 @@ afterEach(() => {
 });
 
 describe('defaultMaxConcurrent', () => {
-  it('returns max(1, cpus/4) for test/build', () => {
-    expect(defaultMaxConcurrent('test', 16)).toBe(4);
-    expect(defaultMaxConcurrent('build', 16)).toBe(4);
-    expect(defaultMaxConcurrent('test', 1)).toBe(1);
-    expect(defaultMaxConcurrent('test', 2)).toBe(1);
-    expect(defaultMaxConcurrent('test', 8)).toBe(2);
+  // T12091: heavy tools are bounded by RAM as well as cores. RAM is passed
+  // explicitly so these assertions do not depend on the host running them —
+  // the old core-only rule silently gave a 16 GiB VM the same 6 slots as a
+  // 256 GiB server.
+  const AMPLE_RAM_GIB = 1024;
+
+  it('returns max(1, cpus/4) for test/build when RAM is not the binding constraint', () => {
+    expect(defaultMaxConcurrent('test', 16, AMPLE_RAM_GIB)).toBe(4);
+    expect(defaultMaxConcurrent('build', 16, AMPLE_RAM_GIB)).toBe(4);
+    expect(defaultMaxConcurrent('test', 1, AMPLE_RAM_GIB)).toBe(1);
+    expect(defaultMaxConcurrent('test', 2, AMPLE_RAM_GIB)).toBe(1);
+    expect(defaultMaxConcurrent('test', 8, AMPLE_RAM_GIB)).toBe(2);
+  });
+
+  it('lets RAM bind BELOW the core budget for test/build', () => {
+    // The measured freeze: 24 cores / 62 GiB permitted 6 concurrent suites at
+    // 6 forks × 4 GiB each = 144 GiB of heap on a 62 GiB box.
+    expect(defaultMaxConcurrent('test', 24, 62)).toBe(2);
+    expect(defaultMaxConcurrent('build', 24, 62)).toBe(2);
+  });
+
+  it('floors to ONE slot when a single run exceeds total RAM', () => {
+    // A many-core, low-RAM VM is the worst case for the old rule: it got 6.
+    expect(defaultMaxConcurrent('test', 24, 16)).toBe(1);
+    expect(defaultMaxConcurrent('test', 64, 8)).toBe(1);
+  });
+
+  it('never returns below 1, whatever the inputs', () => {
+    for (const [cpus, ram] of [
+      [0, 0],
+      [1, 0.5],
+      [-4, -1],
+    ] as const) {
+      expect(defaultMaxConcurrent('test', cpus, ram)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('leaves light tools on the core-derived budget — RAM does not bind them', () => {
+    // lint/typecheck are single-process; bounding them by RAM would serialise
+    // cheap work for no reason.
+    expect(defaultMaxConcurrent('lint', 16, 8)).toBe(8);
+    expect(defaultMaxConcurrent('typecheck', 16, 8)).toBe(8);
   });
 
   it('returns max(2, cpus/2) for lint/typecheck/audit/security-scan', () => {

--- a/packages/core/src/tasks/tool-semaphore.ts
+++ b/packages/core/src/tasks/tool-semaphore.ts
@@ -101,6 +101,17 @@ export interface AcquireSlotOptions {
    */
   cpuCount?: number;
   /**
+   * Override `os.totalmem()` (in GiB) for tests.
+   *
+   * T12091 made the heavy-tool budget RAM-derived, which would otherwise make
+   * the slot count depend on whatever host the suite runs on — a 16 GiB CI
+   * runner and a 62 GiB workstation resolve different budgets for identical
+   * inputs. Injecting it keeps semaphore behaviour deterministic.
+   *
+   * @internal
+   */
+  totalRamGib?: number;
+  /**
    * Memory-pressure sample used to scale the effective slot count for the
    * pressure-sensitive `test`/`build` tools (T12001, Epic T11992). When
    * omitted, a best-effort live sample is taken (fail-open to the static slot
@@ -206,7 +217,11 @@ export function defaultMaxConcurrent(
  *
  * @task T1534
  */
-export function resolveMaxConcurrent(canonical: CanonicalTool, cpuCount?: number): number {
+export function resolveMaxConcurrent(
+  canonical: CanonicalTool,
+  cpuCount?: number,
+  totalRamGib?: number,
+): number {
   const envKey = `CLEO_TOOL_CONCURRENCY_${canonical.toUpperCase().replace(/-/g, '_')}`;
   const raw = process.env[envKey];
   if (raw !== undefined && raw !== '') {
@@ -216,7 +231,11 @@ export function resolveMaxConcurrent(canonical: CanonicalTool, cpuCount?: number
       return parsed;
     }
   }
-  return defaultMaxConcurrent(canonical, cpuCount ?? availableParallelism());
+  return defaultMaxConcurrent(
+    canonical,
+    cpuCount ?? availableParallelism(),
+    totalRamGib ?? totalmem() / 1024 ** 3,
+  );
 }
 
 /**
@@ -344,7 +363,7 @@ export async function acquireGlobalSlot(
   canonical: CanonicalTool,
   opts: AcquireSlotOptions = {},
 ): Promise<ReleaseSlotFn> {
-  const max = resolveMaxConcurrent(canonical, opts.cpuCount);
+  const max = resolveMaxConcurrent(canonical, opts.cpuCount, opts.totalRamGib);
   if (!Number.isFinite(max) || max <= 0) {
     return NOOP_RELEASE;
   }

--- a/packages/core/src/tasks/tool-semaphore.ts
+++ b/packages/core/src/tasks/tool-semaphore.ts
@@ -18,23 +18,32 @@
  *
  * Defaults (configurable via env):
  *
- *   | Tool           | Default        | CPU profile                         |
- *   |----------------|----------------|-------------------------------------|
- *   | test, build    | max(1, cpus/4) | runs its own worker pool already    |
- *   | lint, typecheck| max(2, cpus/2) | usually single-threaded, lighter    |
- *   | audit          | max(2, cpus/2) | network-bound, small RAM            |
- *   | security-scan  | max(2, cpus/2) | network-bound, small RAM            |
+ *   | Tool           | Default                          | Binding constraint        |
+ *   |----------------|----------------------------------|---------------------------|
+ *   | test, build    | min(RAM/24GiB, cpus/4), min 1    | MEMORY (each run forks)   |
+ *   | lint, typecheck| max(2, cpus/2)                   | CPU (single-process)      |
+ *   | audit          | max(2, cpus/2)                   | network-bound, small RAM  |
+ *   | security-scan  | max(2, cpus/2)                   | network-bound, small RAM  |
+ *
+ * T12091: `test`/`build` were `max(1, cpus/4)` — 6 slots on a 24-core box. Since
+ * each `pnpm run test` is itself allowed 6 vitest forks × 4 GiB, the two bounds
+ * composed to 144 GiB of permitted heap on 62 GiB of RAM. Neither layer was
+ * individually violated, which is exactly why the machine froze without any
+ * guard firing. Heavy tools are now bounded by the dimension that actually
+ * limits them — see {@link defaultMaxConcurrent}.
  *
  * Override via `CLEO_TOOL_CONCURRENCY_<CANONICAL>` (e.g.
  * `CLEO_TOOL_CONCURRENCY_TEST=2`). Set to `0` or a negative number to
- * disable the limit for that tool.
+ * disable the limit for that tool — which also disables the RAM bound, so it is
+ * the one setting that can still oversubscribe the machine.
  *
  * @task T1534
+ * @task T12091
  * @adr ADR-061
  */
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { availableParallelism } from 'node:os';
+import { availableParallelism, totalmem } from 'node:os';
 import { join } from 'node:path';
 
 import lockfile from 'proper-lockfile';
@@ -108,18 +117,76 @@ export interface AcquireSlotOptions {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute the default max-concurrency for a canonical tool given the CPU
- * count. CPU-heavy runners (test, build) get a quarter of cores; lighter
- * tools (lint, typecheck, audit, security-scan) get half. Always at least 1.
+ * Worst-case resident footprint of ONE `tool:test` / `tool:build` invocation,
+ * in GiB.
+ *
+ * This is not a guess. `vitest.memory-safe.ts` permits
+ * `MEMORY_SAFE_MAX_WORKERS` forks (up to 6) each capped at `FORK_HEAP_MB`
+ * (4096), so a single `pnpm run test` may legitimately hold ~24 GiB before any
+ * guard fires. Keep this in step with that file if either bound changes.
+ *
+ * @task T12091
+ */
+export const HEAVY_TOOL_FOOTPRINT_GIB = 24;
+
+/**
+ * Compute the default max-concurrency for a canonical tool.
+ *
+ * ## Why this is RAM-derived, not core-derived (T12091)
+ *
+ * This returned `floor(cpus / 4)` for `test`/`build`, which on a 24-core box is
+ * **6 concurrent full test suites**. Each of those is itself allowed 6 vitest
+ * forks × a 4 GiB heap cap, so the composed permission was
+ *
+ *     6 runs × 6 forks × 4 GiB = 144 GiB
+ *
+ * on a 62 GiB machine. Both layers were individually "bounded" and their
+ * composition was 2.3× the hardware — which is precisely how this box froze
+ * repeatedly: no single guard was violated. The per-invocation cap (T12087) and
+ * this cross-invocation cap were written independently and never multiplied out.
+ *
+ * The dimensional error is the root of it: what limits a test run is MEMORY, and
+ * core count says nothing about memory. A 24-core/16 GiB VM got the same 6 slots
+ * as a 24-core/256 GiB server. So heavy tools now divide TOTAL RAM by
+ * {@link HEAVY_TOOL_FOOTPRINT_GIB} and are additionally capped by cores, never
+ * exceeding what the machine can actually hold.
+ *
+ * Reactive pressure scaling ({@link pressureScaleSlots}) is not a substitute:
+ * PSI `some avg10` is a ten-second average, and a fork fleet can exhaust RAM
+ * faster than that window can report it. Admission has to be right up front.
+ *
+ * Light tools (lint, typecheck, audit, security-scan) are single-process and
+ * short, and keep the core-derived half-of-cores budget.
+ *
+ * @param canonical - the canonical tool class.
+ * @param cpuCount  - logical cores available.
+ * @param totalRamGib - total machine RAM in GiB; defaults to a live reading.
+ * @returns the machine-wide slot count, always ≥ 1.
+ *
+ * @example
+ * ```ts
+ * // 24 cores, 62 GiB → floor(62/24) = 2 (was 6, permitting 144 GiB of heap)
+ * defaultMaxConcurrent('test', 24, 62); // → 2
+ * // 24 cores, 16 GiB → 1: one suite is already more than this box can hold
+ * defaultMaxConcurrent('test', 24, 16); // → 1
+ * ```
  *
  * @task T1534
+ * @task T12091
  */
-export function defaultMaxConcurrent(canonical: CanonicalTool, cpuCount: number): number {
+export function defaultMaxConcurrent(
+  canonical: CanonicalTool,
+  cpuCount: number,
+  totalRamGib: number = totalmem() / 1024 ** 3,
+): number {
   const cpus = Math.max(1, cpuCount);
   switch (canonical) {
     case 'test':
-    case 'build':
-      return Math.max(1, Math.floor(cpus / 4));
+    case 'build': {
+      const byRam = Math.floor(totalRamGib / HEAVY_TOOL_FOOTPRINT_GIB);
+      const byCpu = Math.floor(cpus / 4);
+      return Math.max(1, Math.min(byRam, byCpu));
+    }
     case 'lint':
     case 'typecheck':
     case 'audit':


### PR DESCRIPTION
## What was actually happening

The machine kept freezing during test runs, with every guard reporting healthy. It was not one broken bound — it was two correct-looking bounds multiplying.

`cleo` spawns the project's own test command to satisfy `tool:test` evidence (`packages/core/src/tasks/evidence.ts` → `runCommand`). How many may run at once was decided in **two** places, both from CPU count:

| Site | Rule | On this box (24 cores) |
|---|---|---|
| `tasks/tool-semaphore.ts` `defaultMaxConcurrent` | `floor(cpus/4)` | **6** concurrent full suites |
| `resources/governor.ts` `computeClassBudget('test-run')` | `max(1, floor(cpus/4))` | **6** |

And each individual run is permitted, by `vitest.memory-safe.ts` (T12087), 6 forks × a 4 GiB heap cap:

```
6 concurrent runs × 6 forks × 4 GiB = 144 GiB permitted on a 62 GiB box
```

Measured live before changing anything:

```
cpus            = 24
total RAM       = 62.5 GB
CLEO test slots = 6      (floor(cpus/4))
vitest forks/run= 6      (MEMORY_SAFE_MAX_WORKERS)
heap cap/fork   = 4 GB
WORST CASE      = 144 GB of permitted heap on a 63 GB box
```

No single bound was ever violated — which is precisely why nothing caught it. The per-invocation cap (T12087) and the cross-invocation cap (T1534) were written independently and never multiplied out.

## The dimensional error

What limits a test run is **memory**; core count carries no information about memory. A 24-core/16 GiB VM was handed the same 6 slots as a 24-core/256 GiB server. Both sites now take

```
min( floor(availableRAM / worstCasePerRun), floor(cpus / 4) )    floor 1
```

`agent-session` in the same `switch` already had exactly this shape. `test-run` sat next to it and did not.

- `HEAVY_TOOL_FOOTPRINT_GIB = 24` is documented as derived from `MEMORY_SAFE_MAX_WORKERS × FORK_HEAP_MB`, not guessed, with a note to keep the two in step.
- The governor's estimate is tunable per project via `testRunEstRamMb`, so a light suite isn't pinned by this monorepo's worst case.
- Reactive PSI scaling stays as a second line, not the first: `some avg10` is a ten-second average, and a fork fleet exhausts RAM faster than that window reports it.

**Effect on this box:** `test` goes from 6 slots to 2, and to 1 whenever less than ~50 GiB is free.

Also removed a leaked `slot-4.lock.lock` that a dead process had held in the `tool-test` semaphore since Aug 7 19:38 — it was silently consuming one of the slots.

## Verification

- Every new assertion checked arithmetically out-of-band (14 `defaultMaxConcurrent` cases, 7 governor cases) — all pass
- `tsc -b` clean, `biome check` clean
- **The test suite is deliberately not run locally.** It is the thing that freezes this machine; CI's 2–4 core runners are the correct place for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)