### PR TITLE
fix: superseded-store diagnosis + hard memory ceiling on heavy tool spawns (T12095, T12096)

### DIFF
--- a/.changeset/t12095-superseded-store-diagnosis.md
+++ b/.changeset/t12095-superseded-store-diagnosis.md
@@ -1,0 +1,16 @@
+---
+id: t12095-superseded-store-diagnosis
+tasks: [T12095]
+kind: fix
+summary: a healthy migrated project read as CORRUPT — three leftovers from the cleo.db migration sent an agent in circles over a 1123-task database that was completely intact
+---
+
+Post-E6 (ADR-068) the project store is `.cleo/cleo.db` with task rows in PREFIXED tables (`tasks_tasks`, …). Three artefacts conspire to say otherwise:
+
+1. `.cleo/tasks.db` — the pre-migration store — is left on disk under the name every doc still uses for "live".
+2. Snapshots are written `tasks-<ts>.db` while actually snapshotting `cleo.db`, so a 408 KB legacy file sits beside 58 MB files bearing its own name.
+3. `cleo.db` keeps a bare, empty `tasks` table next to the populated `tasks_tasks`, so a direct SQL probe finds the decoy.
+
+Measured in a real project: an agent looped on "the current tasks.db is 417KB which is much smaller than the backups (58MB) — maybe it was rotated/rebuilt", then began theorising the store might be `llmtxt.db`. The data was fine — 1,123 tasks, 106 sessions, an active session, 47 pending.
+
+`cleo doctor superseded-store` answers it in one read-only call, naming each superseded file and proving which store holds the data by counting rows in both. It stays silent when `cleo.db` is absent, so it can never tell an operator to delete their only database, and it withholds the archive recommendation when the legacy file still holds rows. The injection template every agent reads now states where the data lives and warns against reasoning about `.db` file sizes.

--- a/.changeset/t12096-heavy-tool-spawn-ceiling.md
+++ b/.changeset/t12096-heavy-tool-spawn-ceiling.md
@@ -1,0 +1,18 @@
+---
+id: t12096-heavy-tool-spawn-ceiling
+tasks: [T12096]
+kind: fix
+summary: one tool:test atom could fan out to 15 unbounded vitest pools in a consuming project — CLEO now sets a hard memory ceiling at the spawn point
+---
+
+T12091 bounded how many `tool:test` INVOCATIONS run at once, but it counts an entire process tree as one slot. In a workspace that is not one test run. Measured in /mnt/projects/PepsVida:
+
+    cleo verify T1046 --gate testsPassed --evidence tool:test
+      └─ npm test → pnpm -r --if-present run test
+          └─ concurrent vitest across {apps,lib}/*   (15 packages have test scripts)
+
+CLEO's semaphore saw ONE slot. The project has no vitest config capping workers or heap — the memory-safe SSoT and its gate live in cleocode and protect only cleocode. A single evidence atom could therefore expand to 15 concurrent unbounded fork pools.
+
+A consuming project cannot be relied on to bound its own runner, and CLEO is the process that starts it, so the ceiling belongs at the spawn point. Three levers, each verified against the installed tool rather than assumed: NODE_OPTIONS=--max-old-space-size (appended, never clobbering), VITEST_MAX_WORKERS (read out of vitest 4.1.4's dist — it OVERRIDES the resolved config, so it binds projects that set their own), and npm_config_workspace_concurrency (confirmed via `pnpm config get`). Applied to test/build only; any value the project set deliberately is preserved.
+
+Worst case on a 62 GiB box goes from unbounded × unbounded × unbounded to 1 package × 6 workers × 4 GiB = 24 GiB.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ Runbooks: `docs/release/merge-queue-runbook.md`, `docs/release/verb-matrix.md`, 
 
 ## Runtime Data Safety (ADR-013 §9)
 
-`.cleo/tasks.db`, `.cleo/brain.db`, `.cleo/config.json`, `.cleo/project-info.json` are **not tracked in git** — committing them risks data loss on branch switch (git overwrites the live file while SQLite WAL sidecars desync).
+`.cleo/cleo.db`, `.cleo/brain.db`, `.cleo/config.json`, `.cleo/project-info.json` are **not tracked in git** — committing them risks data loss on branch switch (git overwrites the live file while SQLite WAL sidecars desync).
 
 - **Manual snapshot:** `cleo backup add` — `VACUUM INTO` (SQLite) + atomic tmp-then-rename (JSON).
 - **Auto snapshot:** `cleo session end` → `vacuumIntoBackupAll` writes timestamped snapshots under `.cleo/backups/sqlite/` (10 per DB, oldest rotated out).
@@ -250,3 +250,24 @@ Runbooks: `docs/release/merge-queue-runbook.md`, `docs/release/verb-matrix.md`, 
 - **Fresh clones:** `cleo init` recreates config + project-info; DBs are created empty on first access.
 
 **NEVER** `git add` any of these four files. Root and nested `.gitignore` block this; manual overrides re-open the T5158 data-loss vector.
+
+### The store is `cleo.db`, and three things say otherwise (T12095)
+
+Post-E6 (ADR-068) the project store is **`.cleo/cleo.db`** with task rows in
+PREFIXED tables (`tasks_tasks`, `tasks_sessions`, …). Three leftovers make a
+healthy project look corrupt, and an agent that reasons about `.db` file sizes
+instead of asking the CLI will believe all three:
+
+| Artefact | Reality |
+|----------|---------|
+| `.cleo/tasks.db` — small, months old | The **pre-migration** store. The migration does not delete it, so it survives under the name every doc used to mean "live". |
+| `.cleo/backups/sqlite/tasks-<ts>.db` — ~100× larger | Snapshots **of `cleo.db`**. `openTasksDbForSnapshot` routes through the dual-scope chokepoint; the `tasks-` prefix is a legacy label kept for the rotation regex. `restore backup --file tasks.db` is therefore correct *and* misleading. |
+| A bare `tasks` table inside `cleo.db`, 0 rows | An empty relic beside the populated `tasks_tasks`. A direct SQL probe finds the decoy. |
+
+So a 408 KB `tasks.db` beside 58 MB `tasks-*.db` snapshots is the NORMAL layout
+of a migrated project — measured 2026-08-09 in a project with 1,123 intact tasks,
+where an agent spent a session theorising truncation, rotation, and then that the
+real store might be `llmtxt.db`.
+
+`cleo doctor superseded-store` answers it in one call: it names each superseded
+file and proves which store holds the data by counting rows in both. Read-only.

--- a/packages/cleo/src/cli/commands/doctor-superseded-store.ts
+++ b/packages/cleo/src/cli/commands/doctor-superseded-store.ts
@@ -1,0 +1,64 @@
+/**
+ * `cleo doctor superseded-store` — answer "which database is the real one?".
+ *
+ * After the E6 dual-scope migration (ADR-068) a project's store is
+ * `.cleo/cleo.db`, with task rows in PREFIXED tables (`tasks_tasks`, …). The
+ * pre-migration `.cleo/tasks.db` is left on disk under the name that every doc,
+ * ADR-013 §9 note, and `cleo restore backup --file tasks.db` invocation still
+ * uses — and snapshots are written as `tasks-<ts>.db` while actually
+ * snapshotting `cleo.db`. A 408 KB `tasks.db` therefore sits beside 58 MB files
+ * bearing its own name, which reads exactly like a truncated live database.
+ *
+ * Measured 2026-08-09: an agent in a project with 1,123 healthy tasks looped on
+ * "the current tasks.db is 417KB, much smaller than the backups (58MB) — maybe
+ * it was rotated/rebuilt", and moved on to guessing the store might be
+ * `llmtxt.db`. The data was fine. This command exists so that question costs one
+ * call: it names the superseded file and PROVES which store is authoritative by
+ * counting rows in both.
+ *
+ * Read-only. It never deletes anything — the recommendation is printed and the
+ * operator decides.
+ *
+ * @task T12095
+ * @see ADR-068 — dual-scope DB chokepoint
+ */
+
+import { getProjectRoot } from '@cleocode/core';
+import { scanSupersededStores } from '@cleocode/core/doctor/superseded-store.js';
+import { defineCommand } from '../lib/define-cli-command.js';
+import { cliOutput } from '../renderers/index.js';
+
+/**
+ * `cleo doctor superseded-store` subcommand.
+ *
+ * Exits non-zero when at least one superseded file is present, so it can gate a
+ * cleanup step in a script. A clean project exits 0 with an empty list.
+ *
+ * @task T12095
+ */
+export const doctorSupersededStoreCommand = defineCommand({
+  meta: {
+    name: 'superseded-store',
+    description:
+      'Report pre-dual-scope store files (.cleo/tasks.db, .cleo/brain.db) still on disk under ' +
+      'their old LIVE names after the cleo.db migration, proving which store holds the data. ' +
+      'Read-only — deletes nothing.',
+  },
+  args: {
+    json: { type: 'boolean', description: 'Output as JSON' },
+    human: { type: 'boolean', description: 'Force human-readable output' },
+    quiet: { type: 'boolean', description: 'Suppress non-essential output' },
+  },
+  async run() {
+    const result = scanSupersededStores(getProjectRoot());
+
+    cliOutput(result, {
+      command: 'doctor',
+      operation: 'doctor.superseded-store.run',
+    });
+
+    if (result.entries.length > 0 && (process.exitCode === undefined || process.exitCode === 0)) {
+      process.exitCode = 1;
+    }
+  },
+});

--- a/packages/cleo/src/cli/commands/doctor.ts
+++ b/packages/cleo/src/cli/commands/doctor.ts
@@ -37,6 +37,7 @@ import { doctorLegacyBackupsCommand } from './doctor-legacy-backups.js';
 import { runDoctorProjects } from './doctor-projects.js';
 import { doctorReleaseReadinessCommand } from './doctor-release-readiness.js';
 import { doctorRepairCommand } from './doctor-repair.js';
+import { doctorSupersededStoreCommand } from './doctor-superseded-store.js';
 import { readMigrationConflicts } from './migrate-agents-v2.js';
 
 // ============================================================================
@@ -235,6 +236,8 @@ export const doctorCommand = defineCommand({
     'db-substrate': doctorDbSubstrateCommand,
     // T10309 / Saga T10281 / Epic T10282 — Legacy-backup walker
     'legacy-backups': doctorLegacyBackupsCommand,
+    // T12095 — pre-dual-scope store files still on disk under their old LIVE names
+    'superseded-store': doctorSupersededStoreCommand,
     // T11777 / Saga T11242 / Epic T11249 — exodus stranded-residue check (+ --fix)
     'exodus-residue': doctorExodusResidueCommand,
     // T11837 / Saga T11242 / Epic T11833 — read-only exodus health report

--- a/packages/core/src/doctor/__tests__/superseded-store.test.ts
+++ b/packages/core/src/doctor/__tests__/superseded-store.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Superseded-store detection (T12095).
+ *
+ * The behaviour under test is a diagnosis, so the assertions are about not
+ * lying in either direction: a migrated project's leftover `tasks.db` must be
+ * named as dead, and a project that has NOT migrated must never be told its
+ * live database is a leftover.
+ *
+ * @task T12095
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite'; // db-open-allowed: test fixture seeding
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LIVE_STORE_FILENAME, scanSupersededStores } from '../superseded-store.js';
+
+let root: string;
+let cleoDir: string;
+
+/** Create a SQLite file with `table` populated by `rows` empty records. */
+function seed(path: string, table: string, rows: number): void {
+  const db = new DatabaseSync(path); // db-open-allowed: test fixture seeding
+  db.exec(`CREATE TABLE "${table}" (id INTEGER PRIMARY KEY)`);
+  for (let i = 0; i < rows; i++) db.exec(`INSERT INTO "${table}" (id) VALUES (${i + 1})`);
+  db.close();
+}
+
+/** Backdate a file so mtime ordering is deterministic, not race-dependent. */
+function backdate(path: string, daysAgo: number): void {
+  const t = new Date(Date.parse('2026-08-09T00:00:00Z') - daysAgo * 86_400_000);
+  utimesSync(path, t, t);
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'cleo-superseded-'));
+  cleoDir = join(root, '.cleo');
+  mkdirSync(cleoDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('scanSupersededStores (T12095)', () => {
+  it('names a leftover tasks.db as superseded and proves it with row counts', () => {
+    // The measured PepsVida shape: empty legacy file, populated prefixed table.
+    seed(join(cleoDir, 'tasks.db'), 'tasks', 0);
+    seed(join(cleoDir, LIVE_STORE_FILENAME), 'tasks_tasks', 1123);
+    backdate(join(cleoDir, 'tasks.db'), 60);
+    backdate(join(cleoDir, LIVE_STORE_FILENAME), 0);
+
+    const { entries } = scanSupersededStores(root);
+    expect(entries).toHaveLength(1);
+    const [e] = entries;
+    expect(e?.name).toBe('tasks.db');
+    expect(e?.rowsInSuperseded).toBe(0);
+    expect(e?.rowsInLive).toBe(1123);
+    expect(e?.safeToArchive).toBe(true);
+    // The reason must carry the evidence, because it is printed verbatim to an
+    // agent that has already convinced itself the DB is truncated.
+    expect(e?.reason).toContain('1123');
+    expect(e?.reason).toContain(LIVE_STORE_FILENAME);
+  });
+
+  it('reports NOTHING when the project never migrated', () => {
+    // Without cleo.db, `tasks.db` IS the live store. Flagging it would tell an
+    // operator to delete their only database.
+    seed(join(cleoDir, 'tasks.db'), 'tasks', 42);
+
+    const result = scanSupersededStores(root);
+    expect(result.liveStoreExists).toBe(false);
+    expect(result.entries).toEqual([]);
+  });
+
+  it('withholds the archive recommendation when the legacy file still holds rows', () => {
+    // Both populated → the migration may be incomplete. Naming it is useful;
+    // recommending deletion is not.
+    seed(join(cleoDir, 'tasks.db'), 'tasks', 7);
+    seed(join(cleoDir, LIVE_STORE_FILENAME), 'tasks_tasks', 1123);
+    backdate(join(cleoDir, 'tasks.db'), 30);
+    backdate(join(cleoDir, LIVE_STORE_FILENAME), 0);
+
+    const [e] = scanSupersededStores(root).entries;
+    expect(e?.rowsInSuperseded).toBe(7);
+    expect(e?.safeToArchive).toBe(false);
+    expect(e?.reason).toContain('NOT recommended');
+  });
+
+  it('ignores a legacy file NEWER than cleo.db', () => {
+    // Newer means something may still be writing it — stay silent rather than
+    // advise removal of live data.
+    seed(join(cleoDir, 'tasks.db'), 'tasks', 0);
+    seed(join(cleoDir, LIVE_STORE_FILENAME), 'tasks_tasks', 5);
+    backdate(join(cleoDir, LIVE_STORE_FILENAME), 10);
+    backdate(join(cleoDir, 'tasks.db'), 0);
+
+    expect(scanSupersededStores(root).entries).toEqual([]);
+  });
+
+  it('is clean on a tidied project', () => {
+    seed(join(cleoDir, LIVE_STORE_FILENAME), 'tasks_tasks', 5);
+    expect(scanSupersededStores(root).entries).toEqual([]);
+  });
+
+  it('survives a legacy file that is not valid SQLite', () => {
+    // A truncated or garbage file must degrade to "unreadable", not throw and
+    // take the whole doctor run down.
+    seed(join(cleoDir, LIVE_STORE_FILENAME), 'tasks_tasks', 5);
+    backdate(join(cleoDir, LIVE_STORE_FILENAME), 0);
+    const junk = join(cleoDir, 'tasks.db');
+    writeFileSync(junk, 'not a database', 'utf-8');
+    backdate(junk, 30);
+
+    const [e] = scanSupersededStores(root).entries;
+    expect(e?.rowsInSuperseded).toBeNull();
+    expect(e?.safeToArchive).toBe(false);
+  });
+});

--- a/packages/core/src/doctor/index.ts
+++ b/packages/core/src/doctor/index.ts
@@ -62,6 +62,9 @@ export {
   PRAGMA_VALUE_NORMALISERS,
 } from './pragma-ssot.js';
 export { auditSagaHierarchy } from './saga-audit.js';
+// T12095 — pre-dual-scope store files still on disk under their old LIVE names.
+export type { SupersededStoreEntry, SupersededStoreScanResult } from './superseded-store.js';
+export { LIVE_STORE_FILENAME, scanSupersededStores } from './superseded-store.js';
 export type { PruneOptions, ScanOptions } from './worktree-orphans.js';
 export {
   auditWorktreeOrphansComprehensive,

--- a/packages/core/src/doctor/superseded-store.ts
+++ b/packages/core/src/doctor/superseded-store.ts
@@ -174,7 +174,12 @@ export function scanSupersededStores(projectRoot: string): SupersededStoreScanRe
 
     const rowsInSuperseded = countRows(path, bareTable);
     const rowsInLive = countRows(liveStorePath, liveTable);
-    const safeToArchive = (rowsInLive ?? 0) > 0 && (rowsInSuperseded ?? 0) === 0;
+    // `rowsInSuperseded === 0` must be EXPLICIT, never `?? 0`. `null` means the
+    // file could not be read — corrupt, locked, truncated, or not SQLite — and
+    // "I could not read it" is not "it is empty". Coalescing the two would
+    // recommend archiving precisely the file whose contents are unknown, which
+    // is the one case where being wrong loses data.
+    const safeToArchive = (rowsInLive ?? 0) > 0 && rowsInSuperseded === 0;
 
     const reason = safeToArchive
       ? `superseded by ${LIVE_STORE_FILENAME}: ${rowsInSuperseded ?? 0} rows in ${file}#${bareTable} ` +

--- a/packages/core/src/doctor/superseded-store.ts
+++ b/packages/core/src/doctor/superseded-store.ts
@@ -1,0 +1,205 @@
+/**
+ * Detect pre-dual-scope store files left on disk under their old LIVE names.
+ *
+ * ## The failure this exists to stop (T12095)
+ *
+ * Before the E6 dual-scope migration (ADR-068), a project's task database was
+ * `.cleo/tasks.db`. Afterwards it is `.cleo/cleo.db`, and task rows live in
+ * PREFIXED tables (`tasks_tasks`, `tasks_sessions`, …) rather than bare `tasks`.
+ * The migration does not delete the old file, so a migrated project has
+ *
+ *     .cleo/cleo.db     60 MB   modified today      ← the real store
+ *     .cleo/tasks.db   408 KB   modified in June    ← superseded, still named
+ *                                                     as though it were live
+ *
+ * Three separate things then point an agent at the wrong file:
+ *
+ * 1. The old name is the one every doc, ADR-013 §9 note and `cleo restore
+ *    backup --file tasks.db` invocation still says out loud.
+ * 2. Snapshots are written as `.cleo/backups/sqlite/tasks-<ts>.db` even though
+ *    they are snapshots of `cleo.db`. So the superseded 408 KB file sits beside
+ *    58 MB files bearing its own name — which reads unmistakably as truncation.
+ * 3. `cleo.db` ALSO contains a bare, empty `tasks` table next to the populated
+ *    `tasks_tasks`. Any direct SQL probe finds the empty decoy.
+ *
+ * Measured on 2026-08-09: an agent in a healthy project with 1,123 tasks looped
+ * on "the current tasks.db is 417KB which is much smaller than the backups
+ * (58MB) — maybe it was rotated/rebuilt", then began theorising that the real
+ * store might be `llmtxt.db`. Nothing was wrong with the data. The layout
+ * manufactured a corruption signal, and the agent believed it over the CLI.
+ *
+ * This check names the file, proves which store is authoritative by counting
+ * rows in both, and says what to do — so the question is answered in one call
+ * instead of becoming an investigation.
+ *
+ * @task T12095
+ * @see ADR-068 — dual-scope DB chokepoint
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+/**
+ * A store file that has been superseded by `cleo.db` but still exists under the
+ * name that used to mean "the live database".
+ */
+export interface SupersededStoreEntry {
+  /** Absolute path of the superseded file. */
+  readonly path: string;
+  /** Bare filename, e.g. `tasks.db`. */
+  readonly name: string;
+  /** Size in bytes. */
+  readonly sizeBytes: number;
+  /** Last modification time, ISO 8601. */
+  readonly modifiedAt: string;
+  /**
+   * Rows found in the superseded file's own task table, if it has one.
+   * `null` when the file has no such table or could not be read.
+   */
+  readonly rowsInSuperseded: number | null;
+  /** Rows found in the LIVE store's prefixed table. */
+  readonly rowsInLive: number | null;
+  /**
+   * True when the live store demonstrably holds the data and this file does
+   * not — i.e. it is safe to archive. False keeps the entry but withholds the
+   * recommendation, because "delete the other database" must never be advised
+   * on a guess.
+   */
+  readonly safeToArchive: boolean;
+  /** Human-readable justification, suitable for printing verbatim. */
+  readonly reason: string;
+}
+
+/** Result of {@link scanSupersededStores}. */
+export interface SupersededStoreScanResult {
+  /** Absolute project root that was scanned. */
+  readonly projectRoot: string;
+  /** Absolute path of the live dual-scope store. */
+  readonly liveStorePath: string;
+  /** Whether the live store exists — when false, nothing is superseded. */
+  readonly liveStoreExists: boolean;
+  /** Superseded files found, newest-modified first. */
+  readonly entries: readonly SupersededStoreEntry[];
+}
+
+/**
+ * Legacy store filenames paired with the live table that replaced their
+ * contents. The bare table name is the pre-migration one; the prefixed name is
+ * where the rows live now.
+ */
+const SUPERSEDED_STORES: readonly {
+  readonly file: string;
+  readonly bareTable: string;
+  readonly liveTable: string;
+}[] = [
+  { file: 'tasks.db', bareTable: 'tasks', liveTable: 'tasks_tasks' },
+  { file: 'brain.db', bareTable: 'brain_observations', liveTable: 'brain_observations' },
+] as const;
+
+/** The dual-scope store filename (ADR-068). */
+export const LIVE_STORE_FILENAME = 'cleo.db';
+
+/**
+ * Count rows in a table, or `null` when the table or file is unreadable.
+ *
+ * Read-only and never throws: a superseded file may be truncated, locked, or
+ * not even SQLite, and none of that should break the survey.
+ */
+function countRows(dbPath: string, table: string): number | null {
+  if (!existsSync(dbPath)) return null;
+  let db: DatabaseSync | null = null;
+  try {
+    // db-open-allowed: read-only forensic probe of a SUPERSEDED file no accessor owns — routing it through the chokepoint would register a live handle for the very store we are proving is dead
+    db = new DatabaseSync(dbPath, { readOnly: true }); // db-open-allowed: read-only probe of a superseded, unowned file
+    const exists = db
+      .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name = ?")
+      .get(table);
+    if (exists === undefined) return null;
+    const row = db.prepare(`SELECT COUNT(*) AS c FROM "${table}"`).get() as
+      | { c: number }
+      | undefined;
+    return row?.c ?? null;
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* already closed or never opened */
+    }
+  }
+}
+
+/**
+ * Scan a project for store files superseded by `cleo.db`.
+ *
+ * Read-only — deletes nothing and opens nothing for write. The caller decides
+ * what to do with the recommendation.
+ *
+ * @param projectRoot - absolute path to the project root.
+ * @returns the survey; `entries` is empty for a project that never migrated or
+ *   that has already been tidied.
+ *
+ * @example
+ * ```ts
+ * const scan = scanSupersededStores('/mnt/projects/PepsVida');
+ * for (const e of scan.entries) console.log(e.name, e.reason);
+ * // tasks.db  superseded by cleo.db: 0 rows here vs 1123 in cleo.db#tasks_tasks …
+ * ```
+ *
+ * @task T12095
+ */
+export function scanSupersededStores(projectRoot: string): SupersededStoreScanResult {
+  const liveStorePath = join(projectRoot, '.cleo', LIVE_STORE_FILENAME);
+  const liveStoreExists = existsSync(liveStorePath);
+
+  if (!liveStoreExists) {
+    // No dual-scope store means nothing has been superseded — a pre-migration
+    // project's `tasks.db` IS its live database and must not be flagged.
+    return { projectRoot, liveStorePath, liveStoreExists: false, entries: [] };
+  }
+
+  const liveMtimeMs = statSync(liveStorePath).mtimeMs;
+  const entries: SupersededStoreEntry[] = [];
+
+  for (const { file, bareTable, liveTable } of SUPERSEDED_STORES) {
+    const path = join(projectRoot, '.cleo', file);
+    if (!existsSync(path)) continue;
+
+    const stat = statSync(path);
+    // A file NEWER than cleo.db is not obviously dead — say nothing rather than
+    // risk advising removal of something still being written.
+    if (stat.mtimeMs >= liveMtimeMs) continue;
+
+    const rowsInSuperseded = countRows(path, bareTable);
+    const rowsInLive = countRows(liveStorePath, liveTable);
+    const safeToArchive = (rowsInLive ?? 0) > 0 && (rowsInSuperseded ?? 0) === 0;
+
+    const reason = safeToArchive
+      ? `superseded by ${LIVE_STORE_FILENAME}: ${rowsInSuperseded ?? 0} rows in ${file}#${bareTable} ` +
+        `vs ${rowsInLive} in ${LIVE_STORE_FILENAME}#${liveTable}. Last written ` +
+        `${stat.mtime.toISOString().slice(0, 10)}, while ${LIVE_STORE_FILENAME} was written ` +
+        `${new Date(liveMtimeMs).toISOString().slice(0, 10)}. Its name is the one the docs and ` +
+        `\`cleo restore backup --file tasks.db\` still say, and snapshots are named ` +
+        `\`tasks-<ts>.db\` even though they snapshot ${LIVE_STORE_FILENAME} — so this file reads ` +
+        `as a truncated live DB when it is simply the pre-migration one.`
+      : `predates ${LIVE_STORE_FILENAME} but still holds ${rowsInSuperseded ?? 'an unknown number of'} ` +
+        `rows in ${bareTable} (live ${liveTable}: ${rowsInLive ?? 'unreadable'}). NOT recommended for ` +
+        `removal — reconcile the contents first.`;
+
+    entries.push({
+      path,
+      name: file,
+      sizeBytes: stat.size,
+      modifiedAt: stat.mtime.toISOString(),
+      rowsInSuperseded,
+      rowsInLive,
+      safeToArchive,
+      reason,
+    });
+  }
+
+  entries.sort((a, b) => Date.parse(b.modifiedAt) - Date.parse(a.modifiedAt));
+  return { projectRoot, liveStorePath, liveStoreExists: true, entries };
+}

--- a/packages/core/src/tasks/__tests__/heavy-tool-env.test.ts
+++ b/packages/core/src/tasks/__tests__/heavy-tool-env.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Heavy-tool spawn ceiling (T12096).
+ *
+ * The property that matters is that the ceiling BINDS a project which has no
+ * memory-safe config of its own — that was the measured failure — while never
+ * overriding a value the project set deliberately.
+ *
+ * @task T12096
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  GIB_PER_WORKER,
+  HEAVY_TOOL_HEAP_MB,
+  heavyToolEnv,
+  heavyToolWorkers,
+  MAX_HEAVY_WORKERS,
+  MIN_HEAVY_WORKERS,
+  mergeNodeOptions,
+  WORKSPACE_CONCURRENCY,
+} from '../heavy-tool-env.js';
+
+describe('heavyToolWorkers (T12096)', () => {
+  it('scales with RAM and clamps at both ends', () => {
+    expect(heavyToolWorkers(62)).toBe(MAX_HEAVY_WORKERS); // ⌊62/6⌋=10 → 6
+    expect(heavyToolWorkers(24)).toBe(4);
+    expect(heavyToolWorkers(12)).toBe(2);
+    expect(heavyToolWorkers(4)).toBe(MIN_HEAVY_WORKERS); // ⌊4/6⌋=0 → 1
+    expect(heavyToolWorkers(0)).toBe(MIN_HEAVY_WORKERS);
+  });
+
+  it('uses GIB_PER_WORKER as the divisor', () => {
+    expect(heavyToolWorkers(GIB_PER_WORKER * 3)).toBe(3);
+  });
+});
+
+describe('mergeNodeOptions (T12096)', () => {
+  it('creates NODE_OPTIONS when absent', () => {
+    expect(mergeNodeOptions(undefined, 4096)).toBe('--max-old-space-size=4096');
+    expect(mergeNodeOptions('', 4096)).toBe('--max-old-space-size=4096');
+  });
+
+  it('APPENDS rather than clobbering — other flags must survive', () => {
+    // Dropping a project's `--experimental-*` flags would break the very command
+    // we are trying to bound.
+    expect(mergeNodeOptions('--experimental-vm-modules', 4096)).toBe(
+      '--experimental-vm-modules --max-old-space-size=4096',
+    );
+  });
+
+  it('leaves an existing --max-old-space-size alone', () => {
+    // A deliberate choice outranks our default, in either direction.
+    expect(mergeNodeOptions('--max-old-space-size=8192', 4096)).toBe('--max-old-space-size=8192');
+    expect(mergeNodeOptions('--max-old-space-size 8192', 4096)).toBe('--max-old-space-size 8192');
+  });
+});
+
+describe('heavyToolEnv (T12096)', () => {
+  it('bounds a test spawn on all three levers', () => {
+    // The PepsVida case: 15 workspace packages with test scripts, no vitest
+    // config capping anything.
+    const env = heavyToolEnv('test', {}, 62);
+    expect(env.NODE_OPTIONS).toBe(`--max-old-space-size=${HEAVY_TOOL_HEAP_MB}`);
+    expect(env.VITEST_MAX_WORKERS).toBe(String(MAX_HEAVY_WORKERS));
+    expect(env.npm_config_workspace_concurrency).toBe(String(WORKSPACE_CONCURRENCY));
+  });
+
+  it('bounds build the same way', () => {
+    expect(heavyToolEnv('build', {}, 62).NODE_OPTIONS).toBeDefined();
+  });
+
+  it('leaves LIGHT tools completely alone', () => {
+    // Serialising lint/typecheck would cost time and buy nothing — they are
+    // single-process.
+    for (const t of ['lint', 'typecheck', 'audit', 'security-scan'] as const) {
+      expect(heavyToolEnv(t, {}, 62)).toEqual({});
+    }
+  });
+
+  it('respects every value the project already set', () => {
+    const env = heavyToolEnv(
+      'test',
+      {
+        VITEST_MAX_WORKERS: '12',
+        npm_config_workspace_concurrency: '4',
+        NODE_OPTIONS: '--max-old-space-size=16384',
+      },
+      62,
+    );
+    expect(env.VITEST_MAX_WORKERS).toBeUndefined();
+    expect(env.npm_config_workspace_concurrency).toBeUndefined();
+    expect(env.NODE_OPTIONS).toBe('--max-old-space-size=16384');
+  });
+
+  it('still bounds workers on a small machine', () => {
+    expect(heavyToolEnv('test', {}, 8).VITEST_MAX_WORKERS).toBe('1');
+  });
+
+  it('worst case is bounded by RAM, which is the whole point', () => {
+    // packages-in-flight × workers × heap must not exceed the machine. The old
+    // arrangement had no bound on the first factor at all.
+    const env = heavyToolEnv('test', {}, 62);
+    const workers = Number(env.VITEST_MAX_WORKERS);
+    const packages = Number(env.npm_config_workspace_concurrency);
+    const worstCaseGib = (packages * workers * HEAVY_TOOL_HEAP_MB) / 1024;
+    expect(worstCaseGib).toBeLessThanOrEqual(62);
+  });
+});

--- a/packages/core/src/tasks/heavy-tool-env.ts
+++ b/packages/core/src/tasks/heavy-tool-env.ts
@@ -1,0 +1,150 @@
+/**
+ * Hard memory ceiling injected into every heavy tool CLEO spawns (T12096).
+ *
+ * ## Why a cap at the spawn point, and not just a semaphore
+ *
+ * T12091 bounded how many `tool:test` INVOCATIONS run at once. It counts an
+ * entire process tree as one slot — and in a workspace, one invocation is not
+ * one test run. Measured 2026-08-09 in `/mnt/projects/PepsVida`:
+ *
+ *     cleo verify T1046 --gate testsPassed --evidence tool:test
+ *       └─ npm test
+ *           └─ pnpm -r --if-present run test     ← fans out
+ *               └─ concurrent vitest in {apps,lib}/*   (15 packages have tests)
+ *
+ * CLEO's semaphore saw ONE slot in use. The project has 15 packages with a
+ * `test` script and **none of its three vitest configs cap `maxWorkers` or
+ * heap** — the memory-safe SSoT and its lint gate live in cleocode and protect
+ * only cleocode. So a single evidence atom could expand to 15 concurrent
+ * unbounded fork pools on a 62 GiB machine.
+ *
+ * A consuming project cannot be relied on to configure this. CLEO is the one
+ * spawning the process, so CLEO sets the ceiling — and the child inherits it
+ * whether or not the project has ever heard of `vitest.memory-safe.ts`.
+ *
+ * ## The three levers (each verified against the installed tool, not assumed)
+ *
+ * | Variable | Effect | Verified by |
+ * |---|---|---|
+ * | `NODE_OPTIONS=--max-old-space-size=N` | Heap ceiling for EVERY node process in the tree, inherited | node docs; appended, never clobbered |
+ * | `VITEST_MAX_WORKERS=N` | `if (process.env.VITEST_MAX_WORKERS) resolved.maxWorkers = parseInt(...)` — overrides the resolved config, so it binds projects that set their own | read out of vitest 4.1.4 `dist/chunks/coverage.*.js` |
+ * | `npm_config_workspace_concurrency=N` | Bounds `pnpm -r` fan-out across workspace packages | `npm_config_workspace_concurrency=1 pnpm config get workspace-concurrency` → `1` |
+ *
+ * Together these bound the product the semaphore could not see:
+ * `packages in flight × workers per run × heap per worker`.
+ *
+ * Applied ONLY to `test` / `build`. Capping `lint` or `typecheck` would
+ * serialise cheap single-process work for no benefit.
+ *
+ * A project that genuinely wants more can set any of these itself — an existing
+ * value is always respected, because a deliberate setting beats our default.
+ *
+ * @task T12096
+ */
+
+import { totalmem } from 'node:os';
+import type { CanonicalTool } from './tool-resolver.js';
+
+/**
+ * Heap ceiling per node process, in MiB.
+ *
+ * Matches `FORK_HEAP_MB` in `vitest.memory-safe.ts`. A worker that needs more
+ * than 4 GiB of JS heap for a unit test has a leak, and the whole point is to
+ * make that fail loudly in one worker rather than take the machine down.
+ */
+export const HEAVY_TOOL_HEAP_MB = 4096;
+
+/** RAM assumed consumable per concurrent worker, in GiB, when sizing the pool. */
+export const GIB_PER_WORKER = 6;
+
+/** Never grant more than this many workers, however large the machine. */
+export const MAX_HEAVY_WORKERS = 6;
+
+/** Never grant fewer than this many — one worker must always be able to run. */
+export const MIN_HEAVY_WORKERS = 1;
+
+/**
+ * Workspace packages allowed to run their test/build script concurrently.
+ *
+ * Deliberately 1. The fan-out is the multiplier the semaphore was blind to, and
+ * a serialised workspace sweep is slower but finishes; a parallel one on a
+ * memory-bound box does not finish at all.
+ */
+export const WORKSPACE_CONCURRENCY = 1;
+
+/** Environment overlay to merge into a heavy tool's spawn env. */
+export type HeavyToolEnv = Readonly<Record<string, string>>;
+
+/**
+ * Worker count this machine can hold, given {@link GIB_PER_WORKER}.
+ *
+ * @param totalRamGib - total RAM in GiB; defaults to a live reading.
+ * @returns a value in `[MIN_HEAVY_WORKERS, MAX_HEAVY_WORKERS]`.
+ */
+export function heavyToolWorkers(totalRamGib: number = totalmem() / 1024 ** 3): number {
+  const byRam = Math.floor(totalRamGib / GIB_PER_WORKER);
+  return Math.min(MAX_HEAVY_WORKERS, Math.max(MIN_HEAVY_WORKERS, byRam));
+}
+
+/**
+ * Append `--max-old-space-size` to an existing `NODE_OPTIONS`, or create it.
+ *
+ * Never clobbers: a project may legitimately set `--experimental-*` flags there,
+ * and dropping them would break the very command we are trying to run. An
+ * existing `--max-old-space-size` is left alone — an explicit choice outranks
+ * our default.
+ *
+ * @param existing - current `NODE_OPTIONS`, if any.
+ * @param heapMb - ceiling to apply.
+ * @returns the merged value.
+ */
+export function mergeNodeOptions(existing: string | undefined, heapMb: number): string {
+  const current = (existing ?? '').trim();
+  if (/--max-old-space-size[= ]/.test(current)) return current;
+  const flag = `--max-old-space-size=${heapMb}`;
+  return current.length > 0 ? `${current} ${flag}` : flag;
+}
+
+/**
+ * Build the environment overlay for a heavy tool spawn.
+ *
+ * Returns an empty object for non-heavy tools, so the caller can merge
+ * unconditionally.
+ *
+ * @param canonical - the canonical tool about to be spawned.
+ * @param env - the environment the child would otherwise inherit.
+ * @param totalRamGib - total RAM in GiB; injectable for deterministic tests.
+ * @returns variables to overlay; existing deliberate values are preserved.
+ *
+ * @example
+ * ```ts
+ * const overlay = heavyToolEnv('test', process.env, 62);
+ * // { NODE_OPTIONS: '--max-old-space-size=4096',
+ * //   VITEST_MAX_WORKERS: '6',
+ * //   npm_config_workspace_concurrency: '1' }
+ * heavyToolEnv('lint', process.env, 62); // → {}
+ * ```
+ *
+ * @task T12096
+ */
+export function heavyToolEnv(
+  canonical: CanonicalTool,
+  env: NodeJS.ProcessEnv = process.env,
+  totalRamGib: number = totalmem() / 1024 ** 3,
+): HeavyToolEnv {
+  if (canonical !== 'test' && canonical !== 'build') return {};
+
+  const overlay: Record<string, string> = {
+    NODE_OPTIONS: mergeNodeOptions(env.NODE_OPTIONS, HEAVY_TOOL_HEAP_MB),
+  };
+
+  // Respect a deliberate setting; supply one otherwise.
+  if (!env.VITEST_MAX_WORKERS) {
+    overlay.VITEST_MAX_WORKERS = String(heavyToolWorkers(totalRamGib));
+  }
+  if (!env.npm_config_workspace_concurrency) {
+    overlay.npm_config_workspace_concurrency = String(WORKSPACE_CONCURRENCY);
+  }
+
+  return overlay;
+}

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -170,6 +170,18 @@ export {
   type SignedGateAuditRecord,
   verifyAuditHistory,
 } from './gate-audit.js';
+// T12096 — hard memory ceiling injected into every heavy tool CLEO spawns.
+export type { HeavyToolEnv } from './heavy-tool-env.js';
+export {
+  GIB_PER_WORKER,
+  HEAVY_TOOL_HEAP_MB,
+  heavyToolEnv,
+  heavyToolWorkers,
+  MAX_HEAVY_WORKERS,
+  MIN_HEAVY_WORKERS,
+  mergeNodeOptions,
+  WORKSPACE_CONCURRENCY,
+} from './heavy-tool-env.js';
 // Pre-dispatch inference for cleo add (T1490)
 export {
   type InferAddParamsInput,

--- a/packages/core/src/tasks/tool-cache.ts
+++ b/packages/core/src/tasks/tool-cache.ts
@@ -46,6 +46,7 @@ import { join } from 'node:path';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
 import { withLock } from '../store/lock.js';
+import { heavyToolEnv } from './heavy-tool-env.js';
 import type { ResolvedToolCommand } from './tool-resolver.js';
 import { type AcquireSlotOptions, acquireGlobalSlot } from './tool-semaphore.js';
 
@@ -335,6 +336,7 @@ function spawnCmd(
   args: string[],
   cwd: string,
   spawnTimeoutMs?: number,
+  envOverlay?: Readonly<Record<string, string>>,
 ): Promise<CommandResult> {
   return new Promise((resolve) => {
     const stdoutBuf = new TailBuffer(STREAM_TAIL_CAP_BYTES);
@@ -342,7 +344,12 @@ function spawnCmd(
     const child = spawn(cmd, args, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
+      // T12096: the overlay carries a hard memory ceiling for heavy tools. It is
+      // applied HERE, at the one place CLEO starts a project's own toolchain,
+      // because a consuming project cannot be relied on to bound its own test
+      // runner — and CLEO's semaphore counts this whole tree as a single slot
+      // even when it fans out across a workspace.
+      env: envOverlay === undefined ? process.env : { ...process.env, ...envOverlay },
       // T12025: detached creates a new process group on POSIX so that
       // killProcessTree can signal every descendant. Without this a
       // tool like `pnpm test` that forks worker processes inheriting
@@ -614,7 +621,13 @@ export async function runToolCached(
 
         // Spawn the tool ourselves.
         const startedAt = Date.now();
-        const result = await spawnCmd(command.cmd, command.args, projectRoot, spawnTimeoutMs);
+        const result = await spawnCmd(
+          command.cmd,
+          command.args,
+          projectRoot,
+          spawnTimeoutMs,
+          heavyToolEnv(command.canonical),
+        );
         const durationMs = Date.now() - startedAt;
 
         // T12025: when the child exceeded its wall-clock deadline, do NOT

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -148,6 +148,36 @@ CLEO has **three distinct relationship systems**. Do not conflate them.
 Memory context: `cleo memory digest --brief` gives a live project memory summary (default mode). Legacy file mode: set `brain.memoryBridge.mode = "file"` in config to restore `@.cleo/memory-bridge.md` injection.
 <!-- /CLEO-INJECTION:section=memory -->
 
+<!-- CLEO-INJECTION:section=data-location -->
+## Where the data lives — do NOT read `.cleo/*.db` directly
+
+The project store is **`.cleo/cleo.db`**, and task rows live in PREFIXED tables
+(`tasks_tasks`, `tasks_sessions`, …). Ask the CLI, never the file.
+
+Two decoys will convince you the database is corrupt when it is not:
+
+| You will see | What it actually is |
+|--------------|---------------------|
+| `.cleo/tasks.db`, small and months old | The **pre-migration** store, superseded by `cleo.db` and left on disk under its old name |
+| `.cleo/backups/sqlite/tasks-<ts>.db`, ~100× larger | Snapshots **of `cleo.db`** — the `tasks-` prefix is a legacy label, not the source |
+| A bare `tasks` table in `cleo.db` with 0 rows | An empty relic beside the populated `tasks_tasks` |
+
+A 400 KB `tasks.db` next to 58 MB `tasks-*.db` snapshots is the NORMAL, healthy
+layout of a migrated project. It is not truncation, not rotation, and not
+`llmtxt.db`.
+
+**If you are wondering which database is real, run one command:**
+
+```bash
+cleo doctor superseded-store
+```
+
+It names every superseded file and proves which store holds the data by counting
+rows in both. Then go back to `cleo briefing` / `cleo focus` — those read the
+right store already. An agent that reasons about `.db` file sizes instead of
+asking the CLI will build a corruption theory out of a healthy project.
+<!-- /CLEO-INJECTION:section=data-location -->
+
 <!-- CLEO-INJECTION:section=nexus -->
 ## Nexus — when to use which scope
 

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -149,34 +149,22 @@ Memory context: `cleo memory digest --brief` gives a live project memory summary
 <!-- /CLEO-INJECTION:section=memory -->
 
 <!-- CLEO-INJECTION:section=data-location -->
-## Where the data lives — do NOT read `.cleo/*.db` directly
+## Where the data lives — never read `.cleo/*.db` directly
 
-The project store is **`.cleo/cleo.db`**, and task rows live in PREFIXED tables
-(`tasks_tasks`, `tasks_sessions`, …). Ask the CLI, never the file.
+Store = **`.cleo/cleo.db`**; task rows are in PREFIXED tables (`tasks_tasks`, …).
+Three decoys make a HEALTHY project look corrupt:
 
-Two decoys will convince you the database is corrupt when it is not:
+| Decoy | Reality |
+|-------|---------|
+| `.cleo/tasks.db`, small + months old | The pre-migration store, left under the old live name |
+| `.cleo/backups/sqlite/tasks-<ts>.db`, ~100× bigger | Snapshots **of `cleo.db`**; `tasks-` is a legacy label |
+| bare `tasks` table, 0 rows | Empty relic beside the populated `tasks_tasks` |
 
-| You will see | What it actually is |
-|--------------|---------------------|
-| `.cleo/tasks.db`, small and months old | The **pre-migration** store, superseded by `cleo.db` and left on disk under its old name |
-| `.cleo/backups/sqlite/tasks-<ts>.db`, ~100× larger | Snapshots **of `cleo.db`** — the `tasks-` prefix is a legacy label, not the source |
-| A bare `tasks` table in `cleo.db` with 0 rows | An empty relic beside the populated `tasks_tasks` |
-
-A 400 KB `tasks.db` next to 58 MB `tasks-*.db` snapshots is the NORMAL, healthy
-layout of a migrated project. It is not truncation, not rotation, and not
-`llmtxt.db`.
-
-**If you are wondering which database is real, run one command:**
-
-```bash
-cleo doctor superseded-store
-```
-
-It names every superseded file and proves which store holds the data by counting
-rows in both. Then go back to `cleo briefing` / `cleo focus` — those read the
-right store already. An agent that reasons about `.db` file sizes instead of
-asking the CLI will build a corruption theory out of a healthy project.
+A 400 KB `tasks.db` beside 58 MB `tasks-*.db` is the NORMAL migrated layout — not
+truncation, not rotation, not `llmtxt.db`. `cleo doctor superseded-store` proves
+which DB is real by counting rows in both; `briefing`/`focus` read it already.
 <!-- /CLEO-INJECTION:section=data-location -->
+
 
 <!-- CLEO-INJECTION:section=nexus -->
 ## Nexus — when to use which scope


### PR DESCRIPTION
## What happened

An agent working in `/mnt/projects/PepsVida` spent a session going in circles:

> "The current tasks.db may be a different format (maybe the llmtxt.db)… the current tasks.db is 417KB which is much smaller than the backups (58MB). Maybe the current tasks.db was rotated/rebuilt…"

**Nothing was wrong with that project.** Verified: 1,123 tasks, 106 sessions, an active session, 47 pending, `cleo current` → T1094, all readable through the CLI. The on-disk layout manufactured a corruption signal and the agent trusted it over the tool.

## The trap (three leftovers, each individually defensible)

Post-E6 (ADR-068) the store is `.cleo/cleo.db` with task rows in **prefixed** tables (`tasks_tasks`, …).

| Artefact | Reality |
|---|---|
| `.cleo/tasks.db`, 408 KB, last written June 11 | The **pre-migration** store. The migration doesn't delete it, so it survives under the name every doc — including `AGENTS.md` § Runtime Data Safety and `cleo restore backup --file tasks.db` — still uses for "live". |
| `.cleo/backups/sqlite/tasks-<ts>.db`, 58 MB | Snapshots **of `cleo.db`**. `openTasksDbForSnapshot` routes through the dual-scope chokepoint; the `tasks-` prefix is a legacy label kept for the rotation regex. This is the "417KB vs 58MB" read as truncation. |
| A bare `tasks` table inside `cleo.db`, **0 rows** | An empty relic beside the populated `tasks_tasks` (1,123 rows). Any direct SQL probe lands on the decoy. |

The trap is set in **3 projects on this machine**, including `cleocode` itself.

## The fix

`cleo doctor superseded-store` — read-only, deletes nothing — names each superseded file and **proves** which store is authoritative by counting rows in both. Run against the real project:

```
liveStore : /mnt/projects/PepsVida/.cleo/cleo.db
entries   : 1
  • tasks.db (408 KB, modified 2026-06-11)
    rows here: 0   rows live: 1123   safeToArchive: true
```

Two deliberate refusals to guess:

- **Silent when `cleo.db` is absent.** A pre-migration project's `tasks.db` *is* its live store; flagging it would advise deleting the only database.
- **Withholds the archive recommendation** when the legacy file still holds rows, is newer than `cleo.db`, or isn't valid SQLite.

`CLEO-INJECTION.md` — injected verbatim into every spawned agent — now states where the data lives, tabulates all three decoys, says plainly that 408 KB-beside-58 MB is the **normal** layout of a migrated project, and points at the one command. `AGENTS.md` § Runtime Data Safety is corrected from `tasks.db` to `cleo.db` with the same table.

## Verification

- Run against the actual project that triggered this (output above)
- `tsc -b` clean · `biome check` clean · `cleo check arch` **9/9**
- Gate 14 confirms the new command exists (`all 62 referenced commands exist`)
- 6 unit tests cover both directions — correctly flags a migrated leftover, and stays silent on an unmigrated project, garbage file, and newer file
- Suite runs in CI, not locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)