### PR TITLE
chore(release): plan v2026.8.4 (T12095, T12096)

### DIFF
--- a/.cleo/release/v2026.8.4.plan.json
+++ b/.cleo/release/v2026.8.4.plan.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.8.4",
+  "resolvedVersion": "v2026.8.4",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T11396",
+  "releaseKind": "regular",
+  "createdAt": "2026-08-10T21:04:36.762Z",
+  "createdBy": "keatonhoskins",
+  "previousVersion": "v2026.8.3",
+  "previousTag": "v2026.8.3",
+  "previousShippedAt": "2026-08-09T08:36:47.257Z",
+  "tasks": [
+    {
+      "id": "T12095",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "a healthy migrated project reads as CORRUPT: leftover .cleo/tasks.db + tasks-* snapshot naming + empty bare tasks table sent an agent in circles",
+      "evidenceAtoms": [
+        "pr:1178",
+        "files:AGENTS.md,packages/core/templates/CLEO-INJECTION.md"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12096",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "one tool:test atom fans out to N unbounded vitest pools in a consuming project — CLEO's semaphore counts the whole tree as ONE slot",
+      "evidenceAtoms": [
+        "pr:1178",
+        "files:AGENTS.md,packages/core/templates/CLEO-INJECTION.md"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    }
+  ],
+  "changelog": {
+    "features": [],
+    "fixes": [
+      "T12095",
+      "T12096"
+    ],
+    "chores": [],
+    "breaking": []
+  },
+  "gates": [
+    {
+      "name": "test",
+      "atom": "tool:test",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-10T21:04:36.762Z",
+      "resolvedCommand": "pnpm run test",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "build",
+      "atom": "tool:build",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-10T21:04:36.762Z",
+      "resolvedCommand": "pnpm run build",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "lint",
+      "atom": "tool:lint",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-10T21:04:36.762Z",
+      "resolvedCommand": "npx biome check .",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "typecheck",
+      "atom": "tool:typecheck",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-10T21:04:36.762Z",
+      "resolvedCommand": "npx tsc --noEmit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "audit",
+      "atom": "tool:audit",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-10T21:04:36.762Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "security-scan",
+      "atom": "tool:security-scan",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-10T21:04:36.762Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    }
+  ],
+  "platformMatrix": [
+    {
+      "platform": "any",
+      "publisher": "npm",
+      "package": "@cleocode/cleo"
+    }
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true,
+    "preflightWarnings": [
+      "Skipped 264 out-of-scope changeset entries whose task anchors are not part of this release plan"
+    ]
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned",
+  "meta": {
+    "firstEverRelease": false,
+    "archetype": "node",
+    "releaseNotes": "## v2026.8.4 — 2026-08-10\n\n### Fixed\n\n- a healthy migrated project read as CORRUPT — three leftovers from the cleo.db migration sent an agent in circles over a 1123-task database that was completely intact _(provenance: [T12095](https://github.com/kryptobaseddev/cleo/search?q=T12095&type=commits))_\n- one tool:test atom could fan out to 15 unbounded vitest pools in a consuming project — CLEO now sets a hard memory ceiling at the spawn point _(provenance: [T12096](https://github.com/kryptobaseddev/cleo/search?q=T12096&type=commits))_\n",
+    "changesetEntryCount": 2,
+    "changesetIds": [
+      "t12095-superseded-store-diagnosis",
+      "t12096-heavy-tool-spawn-ceiling"
+    ],
+    "taskIds": [
+      "T12095",
+      "T12096"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2026.8.4] (2026-08-10)
+
+### Fixed
+
+- a healthy migrated project read as CORRUPT — three leftovers from the cleo.db migration sent an agent in circles over a 1123-task database that was completely intact _(provenance: [T12095](https://github.com/kryptobaseddev/cleo/search?q=T12095&type=commits))_
+- one tool:test atom could fan out to 15 unbounded vitest pools in a consuming project — CLEO now sets a hard memory ceiling at the spawn point _(provenance: [T12096](https://github.com/kryptobaseddev/cleo/search?q=T12096&type=commits))_
+
 ## [2026.8.3] (2026-08-09)
 
 ### Fixed


### PR DESCRIPTION
Plan + CHANGELOG for **v2026.8.4**, carrying the two fixes merged in #1178:

- **T12095** — a healthy migrated project read as CORRUPT. `cleo doctor superseded-store` now names each superseded store file and proves which one holds the data by counting rows in both.
- **T12096** — one `tool:test` atom could fan out to 15 unbounded vitest pools in a consuming project. CLEO now sets a hard heap/worker/workspace-concurrency ceiling at the spawn point, so a project with no memory-safe config of its own is still bounded.

**T12094 excluded on purpose.** `cleo release plan` rejected it with `missingAtoms: [implemented, testsPassed, qaPassed]` — correct, it is filed but not fixed. Shipping it in the notes would have been a lie the gate caught.

Getting this published matters more than usual: the OOM protection in T12096 only takes effect once each project's installed `cleo` is ≥ 2026.8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)