### PR TITLE
chore(release): plan v2026.8.5 (T12090, T12094, T12097)

### DIFF
--- a/.cleo/release/v2026.8.5.plan.json
+++ b/.cleo/release/v2026.8.5.plan.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.8.5",
+  "resolvedVersion": "v2026.8.5",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T11396",
+  "releaseKind": "regular",
+  "createdAt": "2026-08-11T03:40:36.556Z",
+  "createdBy": "keatonhoskins",
+  "previousVersion": "v2026.8.4",
+  "previousTag": "v2026.8.4",
+  "previousShippedAt": "2026-08-10T22:06:48.323Z",
+  "tasks": [
+    {
+      "id": "T12090",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "macOS-only flake: docs-memory-observation leaks slug reservations (E_SLUG_RESERVED) — CLEO_DIR isolation vs cwd-resolved store",
+      "evidenceAtoms": [
+        "pr:1182",
+        "files:AGENTS.md,docs/release/merge-queue-runbook.md"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12094",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "bump-PR opens with ZERO checks — a branch pushed with GITHUB_TOKEN does not trigger workflows, so branch protection can never be satisfied",
+      "evidenceAtoms": [
+        "pr:1182",
+        "files:AGENTS.md,docs/release/merge-queue-runbook.md"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12097",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "tests invoked DIRECTLY by an agent (pnpm test / npx vitest) bypass every CLEO memory ceiling — only cleo verify --evidence tool:test is bounded",
+      "evidenceAtoms": [
+        "pr:1182",
+        "files:AGENTS.md,docs/release/merge-queue-runbook.md"
+      ],
+      "epicAncestor": "T11396",
+      "ivtrPhaseAtPlan": "contribution"
+    }
+  ],
+  "changelog": {
+    "features": [],
+    "fixes": [
+      "T12090",
+      "T12094",
+      "T12097"
+    ],
+    "chores": [],
+    "breaking": []
+  },
+  "gates": [
+    {
+      "name": "test",
+      "atom": "tool:test",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-11T03:40:36.556Z",
+      "resolvedCommand": "pnpm run test",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "build",
+      "atom": "tool:build",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-11T03:40:36.556Z",
+      "resolvedCommand": "pnpm run build",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "lint",
+      "atom": "tool:lint",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-11T03:40:36.556Z",
+      "resolvedCommand": "npx biome check .",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "typecheck",
+      "atom": "tool:typecheck",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-11T03:40:36.556Z",
+      "resolvedCommand": "npx tsc --noEmit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "audit",
+      "atom": "tool:audit",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-11T03:40:36.556Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "security-scan",
+      "atom": "tool:security-scan",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-11T03:40:36.556Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    }
+  ],
+  "platformMatrix": [
+    {
+      "platform": "any",
+      "publisher": "npm",
+      "package": "@cleocode/cleo"
+    }
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true,
+    "preflightWarnings": [
+      "Skipped 265 out-of-scope changeset entries whose task anchors are not part of this release plan"
+    ]
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned",
+  "meta": {
+    "firstEverRelease": false,
+    "archetype": "node",
+    "releaseNotes": "## v2026.8.5 — 2026-08-11\n\n### Fixed\n\n- the macOS-only E_SLUG_RESERVED flake was a process-global reservation set — keyed by slug alone, so CLEO_DIR isolation never isolated it _(provenance: [T12090](https://github.com/kryptobaseddev/cleo/search?q=T12090&type=commits))_\n- bump-PRs opened with zero checks and could never merge; and tests an agent runs itself bypassed every CLEO memory ceiling _(provenance: [T12094](https://github.com/kryptobaseddev/cleo/search?q=T12094&type=commits), [T12097](https://github.com/kryptobaseddev/cleo/search?q=T12097&type=commits))_\n",
+    "changesetEntryCount": 2,
+    "changesetIds": [
+      "t12090-slug-reservation-scoping",
+      "t12094-t12097-ci-dispatch-and-memory-guard"
+    ],
+    "taskIds": [
+      "T12090",
+      "T12094",
+      "T12097"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2026.8.5] (2026-08-11)
+
+### Fixed
+
+- the macOS-only E_SLUG_RESERVED flake was a process-global reservation set — keyed by slug alone, so CLEO_DIR isolation never isolated it _(provenance: [T12090](https://github.com/kryptobaseddev/cleo/search?q=T12090&type=commits))_
+- bump-PRs opened with zero checks and could never merge; and tests an agent runs itself bypassed every CLEO memory ceiling _(provenance: [T12094](https://github.com/kryptobaseddev/cleo/search?q=T12094&type=commits), [T12097](https://github.com/kryptobaseddev/cleo/search?q=T12097&type=commits))_
+
 ## [2026.8.4] (2026-08-10)
 
 ### Fixed


### PR DESCRIPTION
Plan + CHANGELOG for **v2026.8.5**, carrying the three fixes merged in #1182:

- **T12090** — the macOS-only `E_SLUG_RESERVED` flake. Two defects: a process-global reservation set keyed by slug alone, and `os.tmpdir()` on macOS being a symlink so the write and the read resolved different `.cleo` directories. The macOS shard that had failed twice is now green.
- **T12094** — bump-PRs opened with zero checks (a `GITHUB_TOKEN` push doesn't trigger workflows) and could never satisfy branch protection. `release-prepare` now dispatches CI itself. **This release is the first test of that.**
- **T12097** — tests an agent runs itself bypassed every CLEO ceiling. `cleo doctor memory-guard` audits the only layer that can bound them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)