### PR TITLE
fix(T12099): superseded-store treats a 0-byte legacy DB as provably empty

### DIFF
--- a/.changeset/t12099-superseded-store-empty-file.md
+++ b/.changeset/t12099-superseded-store-empty-file.md
@@ -1,0 +1,8 @@
+---
+id: t12099-superseded-store-empty-file
+tasks: [T12099]
+kind: fix
+summary: doctor superseded-store reports a 0-byte legacy DB (brain.db) as provably empty instead of "an unknown number of rows"
+---
+
+`cleo doctor superseded-store` treated a 0-byte superseded store file the same as a corrupt one: `rowsInSuperseded: null`, `safeToArchive: false`, and a reason telling the user to "reconcile the contents first" of a file that holds nothing by definition. A 0-byte file now bypasses `countRows`, reports 0 rows, and gets the normal safe-to-archive verdict; corrupt nonzero files keep the conservative `null` path.

--- a/packages/core/src/doctor/__tests__/superseded-store.test.ts
+++ b/packages/core/src/doctor/__tests__/superseded-store.test.ts
@@ -104,6 +104,28 @@ describe('scanSupersededStores (T12095)', () => {
     expect(scanSupersededStores(root).entries).toEqual([]);
   });
 
+  it('reports a 0-byte legacy file as provably empty and safe to archive (T12099)', () => {
+    // The measured PepsVida shape: brain.db is 0 bytes. A 0-byte file holds
+    // zero rows BY DEFINITION — reporting "an unknown number of rows" and
+    // withholding the verdict manufactures the corruption signal this check
+    // exists to eliminate.
+    writeFileSync(join(cleoDir, 'brain.db'), '');
+    seed(join(cleoDir, LIVE_STORE_FILENAME), 'brain_observations', 1309);
+    backdate(join(cleoDir, 'brain.db'), 7);
+    backdate(join(cleoDir, LIVE_STORE_FILENAME), 0);
+
+    const { entries } = scanSupersededStores(root);
+    expect(entries).toHaveLength(1);
+    const [e] = entries;
+    expect(e?.name).toBe('brain.db');
+    expect(e?.sizeBytes).toBe(0);
+    expect(e?.rowsInSuperseded).toBe(0);
+    expect(e?.rowsInLive).toBe(1309);
+    expect(e?.safeToArchive).toBe(true);
+    expect(e?.reason).toContain('0 bytes');
+    expect(e?.reason).not.toContain('unknown number');
+  });
+
   it('survives a legacy file that is not valid SQLite', () => {
     // A truncated or garbage file must degrade to "unreadable", not throw and
     // take the whole doctor run down.

--- a/packages/core/src/doctor/superseded-store.ts
+++ b/packages/core/src/doctor/superseded-store.ts
@@ -55,7 +55,9 @@ export interface SupersededStoreEntry {
   readonly modifiedAt: string;
   /**
    * Rows found in the superseded file's own task table, if it has one.
-   * `null` when the file has no such table or could not be read.
+   * `null` when the file has no such table or could not be read. A 0-byte
+   * file yields `0`, never `null` — an empty file holds zero rows by
+   * definition (T12099).
    */
   readonly rowsInSuperseded: number | null;
   /** Rows found in the LIVE store's prefixed table. */
@@ -172,7 +174,11 @@ export function scanSupersededStores(projectRoot: string): SupersededStoreScanRe
     // risk advising removal of something still being written.
     if (stat.mtimeMs >= liveMtimeMs) continue;
 
-    const rowsInSuperseded = countRows(path, bareTable);
+    // A 0-byte file holds zero rows BY DEFINITION — bypass countRows, which
+    // would return null (nothing to open) and manufacture the "unknown number
+    // of rows" corruption signal this check exists to kill (T12099). `null`
+    // remains reserved for a NONZERO file that could not be read.
+    const rowsInSuperseded = stat.size === 0 ? 0 : countRows(path, bareTable);
     const rowsInLive = countRows(liveStorePath, liveTable);
     // `rowsInSuperseded === 0` must be EXPLICIT, never `?? 0`. `null` means the
     // file could not be read — corrupt, locked, truncated, or not SQLite — and
@@ -181,17 +187,27 @@ export function scanSupersededStores(projectRoot: string): SupersededStoreScanRe
     // is the one case where being wrong loses data.
     const safeToArchive = (rowsInLive ?? 0) > 0 && rowsInSuperseded === 0;
 
-    const reason = safeToArchive
-      ? `superseded by ${LIVE_STORE_FILENAME}: ${rowsInSuperseded ?? 0} rows in ${file}#${bareTable} ` +
+    let reason: string;
+    if (stat.size === 0 && safeToArchive) {
+      reason =
+        `${file} is 0 bytes — an empty file holds zero rows by definition, so there is ` +
+        `nothing to reconcile. The live store ${LIVE_STORE_FILENAME}#${liveTable} holds ` +
+        `${rowsInLive} rows. Safe to archive.`;
+    } else if (safeToArchive) {
+      reason =
+        `superseded by ${LIVE_STORE_FILENAME}: ${rowsInSuperseded ?? 0} rows in ${file}#${bareTable} ` +
         `vs ${rowsInLive} in ${LIVE_STORE_FILENAME}#${liveTable}. Last written ` +
         `${stat.mtime.toISOString().slice(0, 10)}, while ${LIVE_STORE_FILENAME} was written ` +
         `${new Date(liveMtimeMs).toISOString().slice(0, 10)}. Its name is the one the docs and ` +
         `\`cleo restore backup --file tasks.db\` still say, and snapshots are named ` +
         `\`tasks-<ts>.db\` even though they snapshot ${LIVE_STORE_FILENAME} — so this file reads ` +
-        `as a truncated live DB when it is simply the pre-migration one.`
-      : `predates ${LIVE_STORE_FILENAME} but still holds ${rowsInSuperseded ?? 'an unknown number of'} ` +
+        `as a truncated live DB when it is simply the pre-migration one.`;
+    } else {
+      reason =
+        `predates ${LIVE_STORE_FILENAME} but still holds ${rowsInSuperseded ?? 'an unknown number of'} ` +
         `rows in ${bareTable} (live ${liveTable}: ${rowsInLive ?? 'unreadable'}). NOT recommended for ` +
         `removal — reconcile the contents first.`;
+    }
 
     entries.push({
       path,


### PR DESCRIPTION
## Problem

`cleo doctor superseded-store` treated a **0-byte** superseded store file the same as a corrupt/unreadable one:

- `countRows` returned `null` → `rowsInSuperseded: null` → `safeToArchive: false`
- Reason text: *"still holds an unknown number of rows… NOT recommended for removal — reconcile the contents first"*

Measured on the real `/mnt/projects/PepsVida` project: `.cleo/brain.db` is 0 bytes while `cleo.db` holds 1,309 `brain_observations` rows — and the doctor told the user to reconcile the contents of a file that holds nothing by definition. This is the same false-corruption-signal failure class T12095 was built to kill.

## Fix

`packages/core/src/doctor/superseded-store.ts`: `stat.size === 0` now bypasses `countRows` (`rowsInSuperseded: 0`), gets the normal `safeToArchive` verdict, and a dedicated reason: *"…is 0 bytes — an empty file holds zero rows by definition, so there is nothing to reconcile… Safe to archive."*

Corrupt **nonzero** files keep the conservative `null` / "NOT recommended" path unchanged.

## Verification

- Regression test reproduces the PepsVida shape (0-byte `brain.db` + populated `cleo.db#brain_observations`) — red before, green after; 7/7 in `superseded-store.test.ts`
- `cleo check arch` — 10/10 gates pass
- Ran the built CLI against the real PepsVida project: `brain.db` now reports `safeToArchive: true` with the empty-file reason

Task: T12099