### PR TITLE
chore(release): plan v2026.8.6 (T12099)

### DIFF
--- a/.cleo/release/v2026.8.6.plan.json
+++ b/.cleo/release/v2026.8.6.plan.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.8.6",
+  "resolvedVersion": "v2026.8.6",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T11249",
+  "releaseKind": "regular",
+  "createdAt": "2026-08-18T23:41:16.529Z",
+  "createdBy": "keatonhoskins",
+  "previousVersion": "v2026.8.5",
+  "previousTag": "v2026.8.5",
+  "previousShippedAt": "2026-08-11T05:16:30.251Z",
+  "tasks": [
+    {
+      "id": "T12099",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "doctor superseded-store misdiagnoses a 0-byte superseded DB (brain.db) as holding 'an unknown number of rows'",
+      "evidenceAtoms": [
+        "commit:506dbadd4a66ad4f3250141c41f23d211f6f8bda",
+        "files:packages/core/src/doctor/superseded-store.ts,packages/core/src/doctor/__tests__/superseded-store.test.ts,.changeset/t12099-superseded-store-empty-file.md",
+        "pr:1188"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    }
+  ],
+  "changelog": {
+    "features": [],
+    "fixes": [
+      "T12099"
+    ],
+    "chores": [],
+    "breaking": []
+  },
+  "gates": [
+    {
+      "name": "test",
+      "atom": "tool:test",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-18T23:41:16.529Z",
+      "resolvedCommand": "pnpm run test",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "build",
+      "atom": "tool:build",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-18T23:41:16.529Z",
+      "resolvedCommand": "pnpm run build",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "lint",
+      "atom": "tool:lint",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-18T23:41:16.529Z",
+      "resolvedCommand": "npx biome check .",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "typecheck",
+      "atom": "tool:typecheck",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-18T23:41:16.529Z",
+      "resolvedCommand": "npx tsc --noEmit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "audit",
+      "atom": "tool:audit",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-18T23:41:16.529Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "security-scan",
+      "atom": "tool:security-scan",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-18T23:41:16.529Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    }
+  ],
+  "platformMatrix": [
+    {
+      "platform": "any",
+      "publisher": "npm",
+      "package": "@cleocode/cleo"
+    }
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true,
+    "preflightWarnings": [
+      "Skipped 265 out-of-scope changeset entries whose task anchors are not part of this release plan"
+    ]
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned",
+  "meta": {
+    "firstEverRelease": false,
+    "archetype": "node",
+    "releaseNotes": "## v2026.8.6 — 2026-08-18\n\n### Fixed\n\n- doctor superseded-store reports a 0-byte legacy DB (brain.db) as provably empty instead of \"an unknown number of rows\" _(provenance: [T12099](https://github.com/kryptobaseddev/cleo/search?q=T12099&type=commits))_\n",
+    "changesetEntryCount": 1,
+    "changesetIds": [
+      "t12099-superseded-store-empty-file"
+    ],
+    "taskIds": [
+      "T12099"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2026.8.6] (2026-08-18)
+
+### Fixed
+
+- doctor superseded-store reports a 0-byte legacy DB (brain.db) as provably empty instead of "an unknown number of rows" _(provenance: [T12099](https://github.com/kryptobaseddev/cleo/search?q=T12099&type=commits))_
+
 ## [2026.8.5] (2026-08-11)
 
 ### Fixed


### PR DESCRIPTION
Release plan for v2026.8.6 — ships T12099 (superseded-store 0-byte misdiagnosis fix, merged in #1188).

Contains:
- `.cleo/release/v2026.8.6.plan.json` (plan commit, needed in the release-prepare workflow checkout for plan-hash verification)
- `CHANGELOG.md` entry

Mirrors the v2026.8.5 flow (#1183 → dispatch → #1184 bump PR). The earlier dispatch for v2026.8.6 (run 32198253595) was cancelled: it was fired before the plan commit reached main and would have failed at Prepare bump-PR after a full preflight.