### PR TITLE
fix(T12100): pr-atom missing-workflows error names the override tiers

### DIFF
--- a/.changeset/t12100-pr-atom-override-guidance.md
+++ b/.changeset/t12100-pr-atom-override-guidance.md
@@ -1,0 +1,8 @@
+---
+id: t12100-pr-atom-override-guidance
+tasks: [T12100]
+kind: fix
+summary: pr-atom missing-workflows error now names the CLEO_PR_REQUIRED_WORKFLOWS env var and release.prRequiredWorkflows config key
+---
+
+When a consuming repo's branch protection lacks the cleocode default gates (CI / Lockfile Check / Contracts Dep Lint), `pr:<num>` evidence failed with "required gates were skipped" and no hint of the override tiers added in T12014, leading users to conclude the list was hardcoded and work around it. The error now names both overrides.

--- a/packages/core/src/release/__tests__/evidence-pr-atom.test.ts
+++ b/packages/core/src/release/__tests__/evidence-pr-atom.test.ts
@@ -395,6 +395,10 @@ describe('resolvePrEvidenceAtom — failure paths', () => {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.reason).toMatch(/Required workflows did not run/);
+    // T12100: the error must point at the override tiers, or consumers conclude
+    // the cleocode gate list is hardcoded and invent workarounds.
+    expect(r.reason).toContain('CLEO_PR_REQUIRED_WORKFLOWS');
+    expect(r.reason).toContain('release.prRequiredWorkflows');
   });
 
   it('rejects invalid pr number (negative)', async () => {

--- a/packages/core/src/release/pr-evidence.ts
+++ b/packages/core/src/release/pr-evidence.ts
@@ -410,7 +410,11 @@ export function evaluateRollup(
       ok: false,
       reason:
         `Required workflows did not run for this PR: ${missing.join(', ')}. ` +
-        `Cannot accept pr atom — required gates were skipped.`,
+        `Cannot accept pr atom — required gates were skipped. ` +
+        `If this project's required checks differ from the cleocode defaults, override the list ` +
+        `via the ${PR_REQUIRED_WORKFLOWS_ENV_VAR} env var (comma-separated) or the ` +
+        `\`release.prRequiredWorkflows\` key in \`.cleo/project-context.json\` ` +
+        `(an empty array means no required workflows).`,
     };
   }
 


### PR DESCRIPTION
## Problem

In a consuming repo whose branch protection lacks the cleocode default gates (`CI`, `Lockfile Check`, `Contracts Dep Lint`), `pr:<num>` evidence fails with *"Required workflows did not run for this PR… required gates were skipped"* — with **no mention** of the two override tiers that have existed since T12014 (v2026.6.19):

- `CLEO_PR_REQUIRED_WORKFLOWS` env var
- `release.prRequiredWorkflows` in `.cleo/project-context.json`

A PepsVida agent/dev concluded the list was "baked into the binary" and burned a session working around it with a raw test-run JSON artifact.

## Fix

The missing-workflows error in `evaluateRollup` now names both overrides verbatim, including the empty-array semantics (explicit `[]` = no required workflows, any MERGED PR passes).

Test: the missing-workflows case now asserts both override names appear in the reason. 51/51 in `evidence-pr-atom.test.ts`.

## Downstream impact

PepsVida itself is already unblocked out-of-band: its `.cleo/project-context.json` now declares its real required contexts (`typecheck · lint · test · build` etc.) and `pr:104` resolves OK on the 2026.8.6 install. This PR is the never-again fix for the next consumer.

Task: T12100