### PR TITLE
fix(T12107,T12108): files: atom anchors to sibling commit: sha; show --field falls back to full projection

### DIFF
--- a/.changeset/t12107-t12108-files-commit-field-projection.md
+++ b/.changeset/t12107-t12108-files-commit-field-projection.md
@@ -2,7 +2,7 @@
 id: t12107-t12108-files-commit-field-projection
 tasks: [T12107, T12108]
 kind: fix
-summary: files: atom resolves against the sibling commit: sha first; cleo show --field transparently resolves full-projection fields like verification.gates
+summary: "files: atom resolves against the sibling commit: sha first; cleo show --field transparently resolves full-projection fields like verification.gates"
 ---
 
 gh#1195: a `files:` evidence atom was checked only against the worktree and git refs, rejecting files that exist on the merged commit named by the sibling `commit:` atom (common in shared checkouts). Resolution is now commit tree → worktree → git refs, consistently at verify and complete, with failure messages naming every location checked. gh#1197: `cleo show --field /data/task/verification/gates` 404'd with a fix string implying the field doesn't exist; `--field` now transparently falls back to the full projection for `tasks.show`, and the boundary text states which fields live only in `--full`.

--- a/.changeset/t12107-t12108-files-commit-field-projection.md
+++ b/.changeset/t12107-t12108-files-commit-field-projection.md
@@ -1,0 +1,8 @@
+---
+id: t12107-t12108-files-commit-field-projection
+tasks: [T12107, T12108]
+kind: fix
+summary: files: atom resolves against the sibling commit: sha first; cleo show --field transparently resolves full-projection fields like verification.gates
+---
+
+gh#1195: a `files:` evidence atom was checked only against the worktree and git refs, rejecting files that exist on the merged commit named by the sibling `commit:` atom (common in shared checkouts). Resolution is now commit tree → worktree → git refs, consistently at verify and complete, with failure messages naming every location checked. gh#1197: `cleo show --field /data/task/verification/gates` 404'd with a fix string implying the field doesn't exist; `--field` now transparently falls back to the full projection for `tasks.show`, and the boundary text states which fields live only in `--full`.

--- a/packages/cleo/src/cli/renderers/__tests__/field-remediation.test.ts
+++ b/packages/cleo/src/cli/renderers/__tests__/field-remediation.test.ts
@@ -100,6 +100,28 @@ describe('cliOutput --field remediation (T11762 ST-4 · DHQ-057)', () => {
     expect(fix).toContain('/data/task/title');
   });
 
+  it('states the MVI/full boundary honestly when a pointer genuinely does not exist (T12108 / gh#1197)', () => {
+    // The pointer addresses NOTHING in any projection — the fix must say that
+    // the listed pointers are the default (MVI) projection and name the fields
+    // that live only in --full, instead of implying the list is exhaustive.
+    const { envelope, exitCode } = captureFieldError(
+      { task: { id: 'T1', title: 'Hello' }, view: {}, attachments: [] },
+      '/data/task/verification/gates',
+      { command: 'show', operation: 'tasks.show' },
+    );
+
+    expect(exitCode).toBe(4);
+    const error = envelope['error'] as Record<string, unknown>;
+    expect(error['codeName']).toBe('E_FIELD_NOT_FOUND');
+    const fix = error['fix'] as string;
+    expect(fix).toContain('default (MVI) projection');
+    expect(fix).toContain('verification');
+    expect(fix).toContain('acceptance');
+    expect(fix).toContain('description');
+    expect(fix).toContain('evidence');
+    expect(fix).toContain('--full');
+  });
+
   it('emits alternatives as {action,command}[] re-runnable against the failing op', () => {
     const { envelope } = captureFieldError(
       { task: { id: 'T1', title: 'Hello' }, view: {}, attachments: [] },

--- a/packages/cleo/src/dispatch/middleware/__tests__/mvi-record-projection.test.ts
+++ b/packages/cleo/src/dispatch/middleware/__tests__/mvi-record-projection.test.ts
@@ -3,7 +3,8 @@
  * (T9922 / Saga T9855 / E8.3).
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { setFieldContext } from '../../../cli/field-context.js';
 import { resetProjectionOptOut, setProjectionOptOut } from '../../../cli/projection-context.js';
 import type { DispatchRequest, DispatchResponse } from '../../types.js';
 import { createMviRecordProjection } from '../mvi-record-projection.js';
@@ -152,5 +153,90 @@ describe('createMviRecordProjection middleware', () => {
     const response = await mw(req, async () => errResponse);
     expect(response.meta.projection).toBe('mvi');
     expect(response.success).toBe(false);
+  });
+});
+
+describe('--field pointer fallback to the full projection (T12108 / gh#1197)', () => {
+  const FULL_FIELD_CONTEXT = {
+    mvi: 'minimal',
+    mviSource: 'default',
+    expectsCustomMvi: false,
+  } as const;
+
+  beforeEach(() => {
+    resetProjectionOptOut();
+    setFieldContext({ ...FULL_FIELD_CONTEXT });
+  });
+
+  afterEach(() => {
+    setFieldContext({ ...FULL_FIELD_CONTEXT });
+  });
+
+  const TASK_WITH_GATES = {
+    ...FULL_TASK,
+    verification: { gates: { implemented: true, testsPassed: false } },
+  };
+
+  it('selects the full projection when the pointer only resolves there', async () => {
+    setFieldContext({ ...FULL_FIELD_CONTEXT, field: '/data/task/verification/gates' });
+    const mw = createMviRecordProjection();
+    const req = makeRequest('tasks', 'show', { taskId: 'T9922' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse({ task: TASK_WITH_GATES, view: null, attachments: [] }),
+    );
+    const data = response.data as { task: Record<string, unknown> };
+    // The MVI-stripped field survived because the --field pointer needs it.
+    expect(data.task['verification']).toEqual(TASK_WITH_GATES.verification);
+    expect(data.task['description']).toBe(TASK_WITH_GATES.description);
+    expect(response.meta.projection).toBe('full');
+  });
+
+  it('keeps the MVI projection when the pointer already resolves in it', async () => {
+    setFieldContext({ ...FULL_FIELD_CONTEXT, field: '/data/task/title' });
+    const mw = createMviRecordProjection();
+    const req = makeRequest('tasks', 'show', { taskId: 'T9922' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse({ task: TASK_WITH_GATES, view: null, attachments: [] }),
+    );
+    const data = response.data as { task: Record<string, unknown> };
+    expect(data.task['title']).toBe(TASK_WITH_GATES.title);
+    expect(data.task['verification']).toBeUndefined();
+    expect(response.meta.projection).toBe('mvi');
+  });
+
+  it('keeps the MVI projection when the pointer resolves nowhere (E_FIELD_NOT_FOUND path)', async () => {
+    setFieldContext({ ...FULL_FIELD_CONTEXT, field: '/data/task/nonexistent/deep' });
+    const mw = createMviRecordProjection();
+    const req = makeRequest('tasks', 'show', { taskId: 'T9922' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse({ task: TASK_WITH_GATES, view: null, attachments: [] }),
+    );
+    const data = response.data as { task: Record<string, unknown> };
+    expect(data.task['verification']).toBeUndefined();
+    expect(response.meta.projection).toBe('mvi');
+  });
+
+  it('does not fall back for ops other than tasks.show', async () => {
+    setFieldContext({ ...FULL_FIELD_CONTEXT, field: '/data/tasks/0/verification' });
+    const mw = createMviRecordProjection();
+    const req = makeRequest('tasks', 'list');
+    const response = await mw(req, async () =>
+      makeSuccessResponse({ tasks: [TASK_WITH_GATES], total: 1, filtered: 1 }),
+    );
+    const data = response.data as { tasks: Record<string, unknown>[] };
+    expect(data.tasks[0]?.['verification']).toBeUndefined();
+    expect(response.meta.projection).toBe('mvi');
+  });
+
+  it('ignores non-/data pointers (/meta/... resolves against envelope chrome)', async () => {
+    setFieldContext({ ...FULL_FIELD_CONTEXT, field: '/meta/operation' });
+    const mw = createMviRecordProjection();
+    const req = makeRequest('tasks', 'show', { taskId: 'T9922' });
+    const response = await mw(req, async () =>
+      makeSuccessResponse({ task: TASK_WITH_GATES, view: null, attachments: [] }),
+    );
+    const data = response.data as { task: Record<string, unknown> };
+    expect(data.task['verification']).toBeUndefined();
+    expect(response.meta.projection).toBe('mvi');
   });
 });

--- a/packages/cleo/src/dispatch/middleware/mvi-record-projection.ts
+++ b/packages/cleo/src/dispatch/middleware/mvi-record-projection.ts
@@ -13,6 +13,11 @@
  * middleware so consumers can distinguish a projected payload from a full
  * record without re-implementing the policy.
  *
+ * T12108 (gh#1197): for `tasks.show`, a `--field /data/...` JSON pointer that
+ * does not resolve in the MVI projection but does resolve in the full record
+ * transparently selects the full projection (see
+ * {@link fieldPointerNeedsFullData}).
+ *
  * This is distinct from `./projection.ts` (the tier-based domain-access gate)
  * and from `./field-filter.ts` (the LAFS `--fields` parameter). All three can
  * coexist on the same request.
@@ -21,14 +26,18 @@
  *
  * @epic T9855
  * @task T9922
+ * @task T12108
  */
 
 import {
   applyProjectionPlan,
+  extractByJsonPointer,
+  isJsonPointer,
   PROJECTION_PLANS,
   type ProjectionMode,
   resolveProjectionMode,
 } from '@cleocode/core';
+import { getFieldContext } from '../../cli/field-context.js';
 import { getProjectionOptOut } from '../../cli/projection-context.js';
 import type { DispatchRequest, DispatchResponse, Middleware } from '../types.js';
 
@@ -44,6 +53,34 @@ function resolveModeFor(req: DispatchRequest): ProjectionMode {
   const override = req.params?.['_projection'];
   if (override === 'full' || override === 'mvi') return override;
   return resolveProjectionMode(getProjectionOptOut() || undefined);
+}
+
+/**
+ * Decide whether the current `--field` JSON pointer needs the FULL record
+ * rather than the projected one (T12108 / gh#1197).
+ *
+ * `--field /data/...` pointers are resolved by `cliOutput` against the whole
+ * envelope AFTER this middleware ran, so a pointer into a field the MVI
+ * projection strips (`verification`, `acceptance`, `description`, `evidence`)
+ * used to fail with `E_FIELD_NOT_FOUND` even though the value exists. When
+ * the pointer misses in the projected data but resolves in the unprojected
+ * data, the caller asked for one scalar either way — select the fuller
+ * projection transparently.
+ *
+ * Only `/data/...` pointers are considered; `/meta/...` and `/page/...`
+ * pointers never address record fields.
+ *
+ * @internal
+ * @task T12108
+ */
+function fieldPointerNeedsFullData(fullData: unknown, projectedData: unknown): boolean {
+  const field = getFieldContext().field;
+  if (!field || !isJsonPointer(field) || !field.startsWith('/data/')) return false;
+  const pointer = field.slice('/data'.length);
+  return (
+    extractByJsonPointer(projectedData, pointer) === undefined &&
+    extractByJsonPointer(fullData, pointer) !== undefined
+  );
 }
 
 /**
@@ -73,13 +110,27 @@ export function createMviRecordProjection(): Middleware {
 
     if (!hasPlan) return response;
 
+    let appliedMode = mode;
     if (response.success && response.data !== undefined) {
-      response.data = applyProjectionPlan(response.data, opKey, mode);
+      const projected = applyProjectionPlan(response.data, opKey, mode);
+      // T12108 (gh#1197), scoped to tasks.show: a `--field /data/...` pointer
+      // that misses in the MVI projection but resolves in the full record
+      // transparently selects the fuller projection instead of failing with
+      // E_FIELD_NOT_FOUND (e.g. /data/task/verification/gates).
+      if (
+        mode === 'mvi' &&
+        opKey === 'tasks.show' &&
+        fieldPointerNeedsFullData(response.data, projected)
+      ) {
+        appliedMode = 'full';
+      } else {
+        response.data = projected;
+      }
     }
     // Stamp the choice on every response that ran through a planned op,
     // including errors — agents inspecting an error envelope can still see
     // which mode the request resolved to.
-    response.meta.projection = mode;
+    response.meta.projection = appliedMode;
     return response;
   };
 }

--- a/packages/contracts/src/operations/output-contracts-data.ts
+++ b/packages/contracts/src/operations/output-contracts-data.ts
@@ -66,7 +66,10 @@ const tasksShowOutputContract: OperationOutputContract = {
   operation: 'tasks.show',
   shapeNote:
     'The task record is nested under `task` — use /data/task/<field>, not /data/<field>. ' +
-    '`view` may be null. `acRows` and `relations` are conditional.',
+    '`view` may be null. `acRows` and `relations` are conditional. ' +
+    'The listed pointers are the default (MVI) projection — `verification`, `acceptance`, ' +
+    '`description`, and `evidence` live only in the full record (`cleo show <id> --full`); ' +
+    '`--field` resolves them transparently when they exist (T12108).',
   dataSchema: {
     type: 'object',
     required: ['task', 'view', 'attachments'],

--- a/packages/core/src/tasks/__tests__/evidence.test.ts
+++ b/packages/core/src/tasks/__tests__/evidence.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -125,6 +125,100 @@ describe('validateAtom - files (T832)', () => {
   it('rejects empty paths list', async () => {
     const r = await validateAtom({ kind: 'files', paths: [] }, tmpDir);
     expect(r.ok).toBe(false);
+  });
+});
+
+describe('validateAtom - files with sibling commit sha (T12107 / gh#1195)', () => {
+  let tmpDir: string;
+  let commitSha: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'evidence-files-commit-'));
+    initGitRepo(tmpDir);
+    mkdirSync(join(tmpDir, 'docs'));
+    commitSha = gitCommit(tmpDir, 'docs/ENVIRONMENTS.md', 'environments\n', 'add docs');
+    // Simulate the gh#1195 state: the file exists in the commit tree but NOT
+    // in the local checkout (local main not fast-forwarded after a remote merge).
+    unlinkSync(join(tmpDir, 'docs', 'ENVIRONMENTS.md'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('validates a file present in the commit tree but absent from the worktree', async () => {
+    const r = await validateAtom(
+      { kind: 'files', paths: ['docs/ENVIRONMENTS.md'] },
+      tmpDir,
+      undefined,
+      commitSha,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok && r.atom.kind === 'files') {
+      expect(r.atom.files).toHaveLength(1);
+      // sha256 is computed from the COMMIT-TREE content, not the worktree.
+      const { createHash } = await import('node:crypto');
+      const expected = createHash('sha256').update('environments\n').digest('hex');
+      expect(r.atom.files[0].sha256).toBe(expected);
+    }
+  });
+
+  it('fails honestly when the file is absent from the commit tree AND the worktree', async () => {
+    const r = await validateAtom(
+      { kind: 'files', paths: ['docs/NOPE.md'] },
+      tmpDir,
+      undefined,
+      commitSha,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/does not exist/);
+      // The message names WHERE it looked — commit tree first, then worktree.
+      expect(r.reason).toContain(`commit ${commitSha} tree`);
+      expect(r.reason).toContain('filesystem');
+    }
+  });
+
+  it('anchors the sha256 to the commit tree when worktree content differs', async () => {
+    // Re-create the file with DIFFERENT (uncommitted) content — the commit
+    // tree is the evidence anchor, so its bytes win.
+    writeFileSync(join(tmpDir, 'docs', 'ENVIRONMENTS.md'), 'dirty worktree\n');
+    const r = await validateAtom(
+      { kind: 'files', paths: ['docs/ENVIRONMENTS.md'] },
+      tmpDir,
+      undefined,
+      commitSha,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok && r.atom.kind === 'files') {
+      const { createHash } = await import('node:crypto');
+      const committed = createHash('sha256').update('environments\n').digest('hex');
+      expect(r.atom.files[0].sha256).toBe(committed);
+    }
+  });
+
+  it('revalidates OK at complete time when the file is still absent from the worktree', async () => {
+    const filesResult = await validateAtom(
+      { kind: 'files', paths: ['docs/ENVIRONMENTS.md'] },
+      tmpDir,
+      undefined,
+      commitSha,
+    );
+    expect(filesResult.ok).toBe(true);
+    if (!filesResult.ok) return;
+    const evidence = composeGateEvidence(
+      [{ kind: 'commit', sha: commitSha, shortSha: commitSha.slice(0, 7) }, filesResult.atom],
+      'test',
+    );
+    const r = await revalidateEvidence(evidence, tmpDir);
+    expect(r.stillValid).toBe(true);
+    expect(r.failedAtoms).toHaveLength(0);
+  });
+
+  it('still resolves from the worktree when no sibling commit sha is provided', async () => {
+    await writeFile(join(tmpDir, 'loose.txt'), 'on disk only\n');
+    const r = await validateAtom({ kind: 'files', paths: ['loose.txt'] }, tmpDir);
+    expect(r.ok).toBe(true);
   });
 });
 

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -281,10 +281,16 @@ export type AtomValidation =
  *   check (T9178), content-intersect check (T9245), worktree-aware HEAD
  *   resolution (T-WT-3), and git-show file fallback for branch-only files
  *   (T11959).
+ * @param siblingCommitSha - Optional sha of a sibling `commit:` atom from the
+ *   same evidence string. When provided, `files:` paths are resolved against
+ *   that commit's tree FIRST (T12107 / gh#1195) before falling back to the
+ *   worktree and git refs — covers a merged commit whose files are not yet
+ *   present in the local checkout.
  * @returns Validation outcome with canonicalised form on success
  *
  * @task T832
  * @task T11959
+ * @task T12107
  * @adr ADR-051 §3
  */
 export async function validateAtom(
@@ -292,12 +298,14 @@ export async function validateAtom(
   projectRoot: string,
   /** T9178: When provided, validates commit is on task/<taskId> branch. */
   taskId?: string,
+  /** T12107: sha of a sibling `commit:` atom in the same evidence string. */
+  siblingCommitSha?: string,
 ): Promise<AtomValidation> {
   switch (parsed.kind) {
     case 'commit':
       return validateCommit(parsed.sha, projectRoot, taskId);
     case 'files':
-      return validateFiles(parsed.paths, projectRoot, taskId);
+      return validateFiles(parsed.paths, projectRoot, taskId, siblingCommitSha);
     case 'test-run':
       return validateTestRun(parsed.path, projectRoot);
     case 'tool':
@@ -1036,34 +1044,77 @@ async function gitShowFileContent(
 }
 
 /**
+ * Read file content from a specific commit tree.
+ *
+ * Used as the FIRST resolution step for `files:` evidence when the same
+ * evidence string carries a `commit:` atom (T12107 / gh#1195): the evidence
+ * claims the file exists at that commit, so the commit tree is the anchor —
+ * the file may not exist in the local checkout at all (e.g. the commit was
+ * merged remotely and local main has not been fast-forwarded).
+ *
+ * Uses `git cat-file blob <sha>:<path>` (not `git show`) so a path that
+ * resolves to a TREE (directory) fails with a non-zero exit instead of
+ * pretty-printing a tree listing that would hash as fake file content.
+ *
+ * @param relPath - Repo-relative file path.
+ * @param sha - Commit sha (short or full) whose tree is inspected.
+ * @param projectRoot - Working directory for git operations.
+ * @returns Buffer of the file content, or `null` when the path is not a blob
+ *   in that commit's tree (or git fails).
+ *
+ * @internal
+ * @task T12107
+ */
+async function gitShowFileContentAtCommit(
+  relPath: string,
+  sha: string,
+  projectRoot: string,
+): Promise<Buffer | null> {
+  // Normalise the path: strip leading "./" so git pathspec works correctly.
+  const norm = relPath.replace(/^\.\//, '');
+  const r = await runCommand('git', ['cat-file', 'blob', `${sha}:${norm}`], projectRoot);
+  if (r.exitCode !== 0) return null;
+  return Buffer.from(r.stdout, 'binary');
+}
+
+/**
  * Validate a `files:` evidence atom.
  *
  * Resolution order for each path:
- *   1. Filesystem check — `existsSync(abs)` at `projectRoot`.
- *   2. Git-show fallback (T11959) — when `taskId` is provided and the file is
+ *   1. Commit-tree check (T12107 / gh#1195) — when `commitSha` is provided
+ *      (a sibling `commit:` atom in the same evidence string), read the file
+ *      from that commit's tree via `git cat-file blob <sha>:<path>`. The
+ *      commit is the evidence anchor; the file may be absent from the local
+ *      checkout (merged remotely, local main not fast-forwarded).
+ *   2. Filesystem check — `existsSync(abs)` at `projectRoot`.
+ *   3. Git-show fallback (T11959) — when `taskId` is provided and the file is
  *      absent at `projectRoot`, try reading it from `task/<taskId>` (or main /
  *      HEAD) via `git show <ref>:<path>`. This allows worktree agents to record
  *      `files:` evidence for files that exist only on their branch and have not
  *      yet been merged to main, without triggering `E_WT_DB_ISOLATION_VIOLATION`.
  *
- * When the file is read from git (fallback path) the sha256 is computed from
- * the git-object content rather than the on-disk content.  The re-validation at
- * `cleo complete` time uses the same fallback path so the checksums remain
- * consistent across verify → complete.
+ * When the file is read from git (commit tree or fallback refs) the sha256 is
+ * computed from the git-object content rather than the on-disk content. The
+ * re-validation at `cleo complete` time uses the same resolution order so the
+ * checksums remain consistent across verify → complete.
  *
  * @param paths - Repo-relative or absolute file paths.
  * @param projectRoot - Absolute path to project root.
  * @param taskId - Optional CLEO task ID; enables the git-show fallback (T11959).
+ * @param commitSha - Optional sibling `commit:` atom sha; enables the
+ *   commit-tree-first check (T12107).
  * @returns Validated atom on success, error on failure.
  *
  * @internal
  * @task T832
  * @task T11959
+ * @task T12107
  */
 async function validateFiles(
   paths: string[],
   projectRoot: string,
   taskId?: string,
+  commitSha?: string,
 ): Promise<AtomValidation> {
   if (paths.length === 0) {
     return {
@@ -1075,9 +1126,16 @@ async function validateFiles(
   const files: Array<{ path: string; sha256: string }> = [];
   for (const p of paths) {
     const abs = isAbsolute(p) ? p : resolvePath(projectRoot, p);
-    let content: Buffer;
+    let content: Buffer | null = null;
 
-    if (existsSync(abs)) {
+    // T12107 (gh#1195): the sibling commit is the evidence anchor — check its
+    // tree FIRST. A file merged remotely but not yet present locally validates
+    // here without waiting for a fast-forward.
+    if (commitSha) {
+      content = await gitShowFileContentAtCommit(p, commitSha, projectRoot);
+    }
+
+    if (content === null && existsSync(abs)) {
       // Happy path — file exists on disk.
       const st = await stat(abs);
       if (!st.isFile()) {
@@ -1088,24 +1146,24 @@ async function validateFiles(
         };
       }
       content = await readFile(abs);
-    } else if (taskId) {
+    }
+
+    if (content === null && taskId) {
       // T11959: Git-show fallback for branch-only files (worktree context).
       // The file exists on the task branch but not yet at the canonical root.
-      const fromGit = await gitShowFileContent(p, taskId, projectRoot);
-      if (!fromGit) {
-        return {
-          ok: false,
-          reason:
-            `File does not exist: ${p}` +
-            ` (checked filesystem at ${projectRoot} and git refs task/${taskId}, main, HEAD)`,
-          codeName: 'E_EVIDENCE_INVALID',
-        };
-      }
-      content = fromGit;
-    } else {
+      content = await gitShowFileContent(p, taskId, projectRoot);
+    }
+
+    if (content === null) {
+      // Honest failure: enumerate every location that was checked so the
+      // caller can tell a worktree-miss from a commit-tree-miss.
+      const looked: string[] = [];
+      if (commitSha) looked.push(`commit ${commitSha} tree`);
+      looked.push(`filesystem at ${projectRoot}`);
+      if (taskId) looked.push(`git refs task/${taskId}, main, HEAD`);
       return {
         ok: false,
-        reason: `File does not exist: ${p}`,
+        reason: `File does not exist: ${p} (checked ${looked.join(', ')})`,
         codeName: 'E_EVIDENCE_INVALID',
       };
     }
@@ -1883,6 +1941,7 @@ export function isHardAtom(atom: EvidenceAtom): boolean {
  * @task T832
  * @task T9245
  * @task T11959
+ * @task T12107
  * @adr ADR-051 §5 / §8 (Decision 8)
  */
 export async function revalidateEvidence(
@@ -1934,13 +1993,26 @@ export async function revalidateEvidence(
         break;
       }
       case 'files': {
+        // T12107 (gh#1195): mirror validateFiles' resolution order so the
+        // sha256 captured at verify time compares against the same bytes —
+        // when a sibling `commit:` atom anchors the evidence, its tree is
+        // checked FIRST (the file may still be absent from the local checkout
+        // at complete time when local main was never fast-forwarded).
+        const siblingCommit = evidence.atoms.find(
+          (a): a is Extract<EvidenceAtom, { kind: 'commit' }> => a.kind === 'commit',
+        );
+        const siblingCommitSha = siblingCommit?.sha;
         for (const f of atom.files) {
           const abs = isAbsolute(f.path) ? f.path : resolvePath(projectRoot, f.path);
           let content: Buffer | null = null;
 
-          if (existsSync(abs)) {
+          if (siblingCommitSha) {
+            content = await gitShowFileContentAtCommit(f.path, siblingCommitSha, projectRoot);
+          }
+          if (!content && existsSync(abs)) {
             content = await readFile(abs);
-          } else if (taskId) {
+          }
+          if (!content && taskId) {
             // T11959: git-show fallback — file may have been on task branch at
             // verify time and is now on main after merge, or it may still only
             // exist on the branch. Use the same resolution path as validateFiles.

--- a/packages/core/src/validation/engine-ops.ts
+++ b/packages/core/src/validation/engine-ops.ts
@@ -30,6 +30,7 @@ import {
   checkGateEvidenceMinimumDetailed,
   composeGateEvidence,
   isHardAtom,
+  type ParsedAtom,
   parseEvidence,
   validateAtom,
 } from '../tasks/evidence.js';
@@ -520,8 +521,13 @@ export async function validateGateVerify(
             const message = err instanceof Error ? err.message : String(err);
             return engineError('E_EVIDENCE_INVALID', message);
           }
+          // T12107 (gh#1195): a sibling `commit:` atom anchors `files:` paths —
+          // thread its sha so files are resolved against that commit's tree first.
+          const siblingCommitSha = parsed.atoms.find(
+            (a): a is Extract<ParsedAtom, { kind: 'commit' }> => a.kind === 'commit',
+          )?.sha;
           for (const atom of parsed.atoms) {
-            const check = await validateAtom(atom, projectRoot, taskId);
+            const check = await validateAtom(atom, projectRoot, taskId, siblingCommitSha);
             if (!check.ok) {
               return engineError(check.codeName, check.reason);
             }
@@ -560,9 +566,14 @@ export async function validateGateVerify(
           return engineError('E_EVIDENCE_INVALID', message);
         }
 
+        // T12107 (gh#1195): a sibling `commit:` atom anchors `files:` paths —
+        // thread its sha so files are resolved against that commit's tree first.
+        const siblingCommitSha = parsed.atoms.find(
+          (a): a is Extract<ParsedAtom, { kind: 'commit' }> => a.kind === 'commit',
+        )?.sha;
         for (const atom of parsed.atoms) {
           // T9178: pass taskId for branch-scope commit validation
-          const check = await validateAtom(atom, projectRoot, taskId);
+          const check = await validateAtom(atom, projectRoot, taskId, siblingCommitSha);
           if (!check.ok) {
             return engineError(check.codeName, check.reason);
           }


### PR DESCRIPTION
**Closes #1195** — `files:` evidence was validated only against the worktree and git refs, so `commit:<merged-sha>;files:<path>` was rejected whenever the shared checkout lagged `origin/main`. Resolution order is now **commit tree (`git cat-file blob`) → worktree → git refs**, threaded through `validateGateVerify` and mirrored in `revalidateEvidence` so `complete` checksums the same bytes. Failure messages enumerate every location checked.

**Closes #1197** — `cleo show --field /data/task/verification/gates` 404'd against the default (MVI) projection while `--full` returned the data, and the `fix` string implied the field doesn't exist (forces the jq-piping anti-pattern ADR-086 bans). The `tasks.show` MVI middleware now transparently keeps the full record when a `/data` pointer resolves only there, and the output-contract boundary text states that `verification`, `acceptance`, `description`, `evidence` live in `--full`.

## Verification (targeted suites only)

- evidence.test.ts 59/59 · mvi-record-projection 11/11 · field-remediation 5/5 · output-contracts 10/10
- Regression: field-flag 37 · evidence-t11959-t11960 · verification · gate-verify-hint 13/13
- `tsc --noEmit` clean (contracts, core, cleo) · biome clean

Tasks: T12107, T12108