### PR TITLE
fix(T12102,T12105): idempotent + instrumented complete; configurable tool: spawn deadline

### DIFF
--- a/.changeset/t12102-t12105-complete-revalidation-tool-timeout.md
+++ b/.changeset/t12102-t12105-complete-revalidation-tool-timeout.md
@@ -1,0 +1,8 @@
+---
+id: t12102-t12105-complete-revalidation-tool-timeout
+tasks: [T12102, T12105]
+kind: fix
+summary: "cleo complete caches commit-atom re-validation, emits stderr progress, and is idempotent on done tasks; CLEO_TOOL_TIMEOUT_<TOOL> makes the tool: evidence deadline configurable"
+---
+
+gh#1196: profiling showed evidence re-validation is ~60ms of a multi-second complete (bootstrap, hooks, and worktree tails dominate), but complete still re-ran immutable git checks and, worse, reported a timeout for operations that had already succeeded server-side. Commit-atom re-validation is now cached keyed on (commitSha, headSha) under `.cleo/cache/evidence/` (successes only); per-atom progress goes to stderr; and completing an already-done task exits 0 with `alreadyDone: true` so post-timeout recovery is just "run it again". `files:`/`test-run:` re-validation is deliberately NOT cached — the sha256 re-read is the E_EVIDENCE_STALE guarantee. gh#1193: the fixed ~300s `tool:` spawn deadline is now `CLEO_TOOL_TIMEOUT_<TOOL>` (same convention as the concurrency var), documented in CLEO-INJECTION.md.

--- a/packages/cleo/src/cli/commands/complete.ts
+++ b/packages/cleo/src/cli/commands/complete.ts
@@ -118,6 +118,14 @@ export const completeCommand = defineCommand({
     // Engine may return {task: {...}} or the task record directly
     const task = data?.task ?? data;
     const output: Record<string, unknown> = { task };
+    // T12102 (gh#1196) — idempotent complete: surface the no-op marker +
+    // note so the agent sees "already done, nothing to do" with exit 0.
+    if (data?.alreadyDone === true) {
+      output['alreadyDone'] = true;
+    }
+    if (typeof data?.note === 'string') {
+      output['note'] = data.note;
+    }
     const autoCompleted = data?.autoCompleted;
     if (Array.isArray(autoCompleted) && autoCompleted.length > 0) {
       output['autoCompleted'] = autoCompleted;

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1608,6 +1608,7 @@ export {
   type ParsedAtom,
   type ParsedEvidence,
   parseEvidence,
+  type RevalidateOptions,
   type RevalidationResult,
   revalidateEvidence,
   TOOL_COMMANDS,

--- a/packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts
+++ b/packages/core/src/tasks/__tests__/complete-saga-autoclose.test.ts
@@ -279,12 +279,12 @@ describe('completeTask — saga auto-close (T10116)', () => {
     expect(sagaAfterFirst?.status).toBe('done');
     const completedAtAfterFirst = sagaAfterFirst?.completedAt;
 
-    // Second attempt on the same task MUST raise 'already completed' —
-    // proving the saga auto-close path is not re-entered for a no-op
-    // call. The saga's completedAt stamp MUST be unchanged.
-    await expect(completeTask({ taskId: 'TM-I2' }, env.tempDir, accessor)).rejects.toThrow(
-      'already completed',
-    );
+    // Second attempt on the same task is an idempotent no-op success
+    // (T12102 / gh#1196) — the saga auto-close path is not re-entered and
+    // the saga's completedAt stamp MUST be unchanged.
+    const second = await completeTask({ taskId: 'TM-I2' }, env.tempDir, accessor);
+    expect(second.alreadyCompleted).toBe(true);
+    expect(second.autoCompleted).toBeUndefined();
     const sagaAfterSecond = await accessor.loadSingleTask('TS-IDEM');
     expect(sagaAfterSecond?.status).toBe('done');
     expect(sagaAfterSecond?.completedAt).toBe(completedAtAfterFirst);

--- a/packages/core/src/tasks/__tests__/complete.test.ts
+++ b/packages/core/src/tasks/__tests__/complete.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createTestDb, seedTasks, type TestDbEnv } from '../../store/__tests__/test-db-helper.js';
 import type { DataAccessor, TransactionAccessor } from '../../store/data-accessor.js';
 import { resetDbState } from '../../store/sqlite.js';
-import { completeTask, withTaskWriteTransaction } from '../complete.js';
+import { completeTask, completeTaskStrict, withTaskWriteTransaction } from '../complete.js';
 
 describe('completeTask', () => {
   let env: TestDbEnv;
@@ -65,7 +65,7 @@ describe('completeTask', () => {
     );
   });
 
-  it('throws if task already done', async () => {
+  it('is an idempotent no-op success when the task is already done (T12102 / gh#1196)', async () => {
     await seedTasks(accessor, [
       {
         id: 'T001',
@@ -77,9 +77,36 @@ describe('completeTask', () => {
       },
     ]);
 
-    await expect(completeTask({ taskId: 'T001' }, env.tempDir, accessor)).rejects.toThrow(
-      'already completed',
-    );
+    const result = await completeTask({ taskId: 'T001' }, env.tempDir, accessor);
+    expect(result.alreadyCompleted).toBe(true);
+    expect(result.task.status).toBe('done');
+    // No side effects on a no-op: no auto-completed parents, no unblocked list.
+    expect(result.autoCompleted).toBeUndefined();
+    expect(result.unblockedTasks).toBeUndefined();
+  });
+
+  it('completeTaskStrict returns success with alreadyDone for a done task in strict mode (T12102 / gh#1196)', async () => {
+    // Strict lifecycle mode would normally run the staleness/IVTR/verification
+    // pre-checks — the done short-circuit must fire BEFORE any of them so a
+    // post-timeout retry succeeds instead of failing on stale-state guards.
+    await writeConfig({ lifecycle: { mode: 'strict' } });
+    await seedTasks(accessor, [
+      {
+        id: 'T001',
+        title: 'Done task',
+        status: 'done',
+        priority: 'medium',
+        createdAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await completeTaskStrict(env.tempDir, 'T001');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data?.alreadyDone).toBe(true);
+      expect(result.data?.note).toContain('already done');
+    }
   });
 
   it('throws if dependencies are incomplete', async () => {

--- a/packages/core/src/tasks/__tests__/revalidation-cache.test.ts
+++ b/packages/core/src/tasks/__tests__/revalidation-cache.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the `cleo complete` commit-atom revalidation cache
+ * (T12102 / gh#1196).
+ *
+ * Covers:
+ *   - Key derivation: deterministic, case-insensitive, head-sensitive.
+ *   - Entry IO: write/read roundtrip, corrupt + foreign entries rejected.
+ *   - Integration via {@link revalidateEvidence}: first call validates and
+ *     caches; second call hits the cache (progress line says so); a HEAD
+ *     move invalidates; `files:` atoms are NEVER cached (staleness check
+ *     still re-reads content).
+ *
+ * @task T12102
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { revalidateEvidence } from '../evidence.js';
+import {
+  computeCommitRevalidationKey,
+  readCommitRevalidationEntry,
+  writeCommitRevalidationEntry,
+} from '../revalidation-cache.js';
+
+function git(dir: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: dir }).toString();
+}
+
+function initRepo(dir: string): string {
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  writeFileSync(join(dir, 'a.txt'), 'one\n');
+  git(dir, ['add', 'a.txt']);
+  git(dir, ['commit', '-q', '-m', 'first']);
+  return git(dir, ['rev-parse', 'HEAD']).trim();
+}
+
+describe('computeCommitRevalidationKey (T12102)', () => {
+  it('is deterministic and case-insensitive', () => {
+    const a = computeCommitRevalidationKey('ABC123', 'DEF456');
+    const b = computeCommitRevalidationKey('abc123', 'def456');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('changes when HEAD moves', () => {
+    const a = computeCommitRevalidationKey('abc123', 'head1');
+    const b = computeCommitRevalidationKey('abc123', 'head2');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('commit-revalidation entry IO (T12102)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'reval-cache-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a written entry', () => {
+    const key = computeCommitRevalidationKey('a'.repeat(40), 'b'.repeat(40));
+    writeCommitRevalidationEntry(tmpDir, {
+      schemaVersion: 1,
+      kind: 'commit-revalidation',
+      key,
+      sha: 'a'.repeat(40),
+      shortSha: 'aaaaaaa',
+      head: 'b'.repeat(40),
+      capturedAt: new Date().toISOString(),
+    });
+    const read = readCommitRevalidationEntry(tmpDir, key);
+    expect(read?.sha).toBe('a'.repeat(40));
+    expect(read?.shortSha).toBe('aaaaaaa');
+  });
+
+  it('returns null for a missing entry', () => {
+    expect(readCommitRevalidationEntry(tmpDir, 'f'.repeat(32))).toBeNull();
+  });
+
+  it('returns null for a corrupt entry', () => {
+    const key = 'e'.repeat(32);
+    // ensureCacheDir is only created by the writer — create it manually here.
+    const dir = join(tmpDir, '.cleo', 'cache', 'evidence');
+    execFileSync('mkdir', ['-p', dir]);
+    writeFileSync(join(dir, `reval-commit-${key}.json`), 'not json{');
+    expect(readCommitRevalidationEntry(tmpDir, key)).toBeNull();
+  });
+
+  it('returns null when the embedded key does not match the requested key', () => {
+    const key = computeCommitRevalidationKey('a'.repeat(40), 'b'.repeat(40));
+    writeCommitRevalidationEntry(tmpDir, {
+      schemaVersion: 1,
+      kind: 'commit-revalidation',
+      key,
+      sha: 'a'.repeat(40),
+      shortSha: 'aaaaaaa',
+      head: 'b'.repeat(40),
+      capturedAt: new Date().toISOString(),
+    });
+    expect(readCommitRevalidationEntry(tmpDir, '0'.repeat(32))).toBeNull();
+  });
+});
+
+describe('revalidateEvidence commit caching (T12102)', () => {
+  let tmpDir: string;
+  let headSha: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'reval-evidence-'));
+    headSha = initRepo(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function cacheFiles(): string[] {
+    const dir = join(tmpDir, '.cleo', 'cache', 'evidence');
+    return existsSync(dir) ? readdirSync(dir).filter((f) => f.startsWith('reval-commit-')) : [];
+  }
+
+  it('validates + caches on first call, hits cache on second (progress reports it)', async () => {
+    const evidence = {
+      atoms: [{ kind: 'commit' as const, sha: headSha, shortSha: headSha.slice(0, 7) }],
+      capturedAt: new Date().toISOString(),
+      capturedBy: 'test',
+    };
+
+    const first: string[] = [];
+    const r1 = await revalidateEvidence(evidence, tmpDir, undefined, undefined, {
+      onProgress: (m) => first.push(m),
+    });
+    expect(r1.stillValid).toBe(true);
+    expect(cacheFiles()).toHaveLength(1);
+    expect(first.join('\n')).toContain(`commit:${headSha.slice(0, 7)} ok`);
+    expect(first.join('\n')).not.toContain('(cached)');
+
+    const second: string[] = [];
+    const r2 = await revalidateEvidence(evidence, tmpDir, undefined, undefined, {
+      onProgress: (m) => second.push(m),
+    });
+    expect(r2.stillValid).toBe(true);
+    expect(second.join('\n')).toContain('(cached)');
+  });
+
+  it('re-validates when HEAD moves (key includes headSha)', async () => {
+    const evidence = {
+      atoms: [{ kind: 'commit' as const, sha: headSha, shortSha: headSha.slice(0, 7) }],
+      capturedAt: new Date().toISOString(),
+      capturedBy: 'test',
+    };
+    const r1 = await revalidateEvidence(evidence, tmpDir);
+    expect(r1.stillValid).toBe(true);
+    expect(cacheFiles()).toHaveLength(1);
+
+    // Move HEAD — the old entry's key no longer matches.
+    writeFileSync(join(tmpDir, 'b.txt'), 'two\n');
+    git(tmpDir, ['add', 'b.txt']);
+    git(tmpDir, ['commit', '-q', '-m', 'second']);
+
+    const progress: string[] = [];
+    const r2 = await revalidateEvidence(evidence, tmpDir, undefined, undefined, {
+      onProgress: (m) => progress.push(m),
+    });
+    expect(r2.stillValid).toBe(true);
+    expect(progress.join('\n')).not.toContain('(cached)');
+    expect(cacheFiles()).toHaveLength(2);
+  });
+
+  it('does not cache failures (a missing commit re-runs validation)', async () => {
+    const missing = 'f'.repeat(40);
+    const evidence = {
+      atoms: [{ kind: 'commit' as const, sha: missing, shortSha: missing.slice(0, 7) }],
+      capturedAt: new Date().toISOString(),
+      capturedBy: 'test',
+    };
+    const r1 = await revalidateEvidence(evidence, tmpDir);
+    expect(r1.stillValid).toBe(false);
+    expect(cacheFiles()).toHaveLength(0);
+  });
+
+  it('never caches files: atoms — content is re-read on every call', async () => {
+    const path = 'watched.txt';
+    writeFileSync(join(tmpDir, path), 'original');
+    const sha = createHash('sha256').update('original').digest('hex');
+    const evidence = {
+      atoms: [{ kind: 'files' as const, files: [{ path, sha256: sha }] }],
+      capturedAt: new Date().toISOString(),
+      capturedBy: 'test',
+    };
+    const ok = await revalidateEvidence(evidence, tmpDir);
+    expect(ok.stillValid).toBe(true);
+
+    // Tamper after "validation" — the very next revalidation MUST catch it.
+    // A cache would be exactly what lets this slip through.
+    writeFileSync(join(tmpDir, path), 'tampered');
+    const progress: string[] = [];
+    const stale = await revalidateEvidence(evidence, tmpDir, undefined, undefined, {
+      onProgress: (m) => progress.push(m),
+    });
+    expect(stale.stillValid).toBe(false);
+    expect(stale.failedAtoms[0]?.reason).toMatch(/modified/);
+    expect(progress.join('\n')).toContain('files:1 path(s) FAILED');
+  });
+});

--- a/packages/core/src/tasks/__tests__/task-complete-lifecycle-gate.test.ts
+++ b/packages/core/src/tasks/__tests__/task-complete-lifecycle-gate.test.ts
@@ -75,6 +75,8 @@ function makeAccessorMock(opts: {
     id: string;
     parentId: string | null | undefined;
     verification?: Record<string, unknown> | null;
+    /** Defaults to 'active' — pass 'done' for the T12102 idempotency tests. */
+    status?: string;
   };
   parent?: {
     id: string;
@@ -91,7 +93,7 @@ function makeAccessorMock(opts: {
           id: opts.child.id,
           title: 'Child task',
           description: '',
-          status: 'active',
+          status: opts.child.status ?? 'active',
           priority: 'medium',
           type: 'task',
           parentId: opts.child.parentId ?? null,
@@ -322,5 +324,34 @@ describe('taskCompleteStrict — parent-epic lifecycle gate (T788)', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('E_LIFECYCLE_GATE_FAILED');
     expect(result.error?.fix).toContain('lifecycle complete');
+  });
+
+  // -------------------------------------------------------------------------
+  // T12102 (gh#1196): idempotent complete — an already-done task must return
+  // success BEFORE any strict pre-check (staleness, IVTR, lifecycle gate),
+  // so the post-timeout recovery path is simply "run it again".
+  // -------------------------------------------------------------------------
+
+  it('strict mode: already-done task short-circuits to idempotent success (T12102)', async () => {
+    vi.mocked(loadConfig).mockResolvedValue({
+      lifecycle: { mode: 'strict' },
+    } as ReturnType<typeof loadConfig> extends Promise<infer T> ? T : never);
+
+    vi.mocked(getTaskAccessor).mockResolvedValue(
+      makeAccessorMock({
+        // Done task whose parent epic is STILL in a planning stage — without
+        // the short-circuit this fixture would fail E_LIFECYCLE_GATE_FAILED.
+        child: { id: CHILD_ID, parentId: EPIC_ID, status: 'done' },
+        parent: { id: EPIC_ID, type: 'epic', pipelineStage: 'research' },
+      }) as ReturnType<typeof getAccessor> extends Promise<infer T> ? T : never,
+    );
+
+    const result = await completeTaskStrict(PROJECT_ROOT, CHILD_ID);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data?.alreadyDone).toBe(true);
+      expect(result.data?.note).toContain('already done');
+    }
   });
 });

--- a/packages/core/src/tasks/__tests__/task-engine.test.ts
+++ b/packages/core/src/tasks/__tests__/task-engine.test.ts
@@ -265,6 +265,43 @@ describe('taskComplete', () => {
     }
   });
 
+  it('returns success with alreadyDone note for an already-done task (T12102 / gh#1196)', async () => {
+    // The real completeTask runs against this accessor (importActual spread);
+    // its early done-check must short-circuit BEFORE any session/enforcement
+    // work, and taskComplete must skip the provenance stamp + worktree hook.
+    const updateTaskFields = vi.fn().mockResolvedValue(undefined);
+    const doneAccessor = {
+      loadSingleTask: vi.fn(async (id: string) =>
+        id === 'T300'
+          ? {
+              id: 'T300',
+              title: 'Done task',
+              description: '',
+              status: 'done',
+              priority: 'medium',
+              type: 'task',
+              parentId: null,
+              pipelineStage: 'contribution',
+              completedAt: '2026-01-02T00:00:00.000Z',
+              updatedAt: '2026-01-02T00:00:00.000Z',
+            }
+          : null,
+      ),
+      updateTaskFields,
+    };
+    mockGetTaskAccessor.mockResolvedValue(
+      doneAccessor as ReturnType<typeof getAccessor> extends Promise<infer T> ? T : never,
+    );
+
+    const result = await taskComplete(projectRoot, 'T300');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.alreadyDone).toBe(true);
+    expect(result.data?.note).toContain('already done');
+    // No side effects on a no-op: provenance stamp must NOT fire.
+    expect(updateTaskFields).not.toHaveBeenCalled();
+  });
+
   it('populates session_id from active session on successful completion (T1222 · CLEO-VALID-27)', async () => {
     const mockUpdateTaskFields = vi.fn().mockResolvedValue(undefined);
     mockGetAccessor.mockResolvedValue(

--- a/packages/core/src/tasks/__tests__/tool-cache.test.ts
+++ b/packages/core/src/tasks/__tests__/tool-cache.test.ts
@@ -27,7 +27,9 @@ import {
   captureHead,
   clearToolCache,
   computeCacheKey,
+  DEFAULT_SPAWN_TIMEOUT_MS,
   readCacheEntry,
+  resolveSpawnTimeoutMs,
   runToolCached,
 } from '../tool-cache.js';
 import type { ResolvedToolCommand } from '../tool-resolver.js';
@@ -693,5 +695,65 @@ describe('runToolCached — lock contention fail-fast (T12025)', () => {
     const r = await runToolCached(cmd, dir, { skipGlobalSemaphore: true });
     expect(r.cacheHit).toBe(true);
     expect(r.lockBusy).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLEO_TOOL_TIMEOUT_<TOOL> — wall-clock deadline resolution (T12105 / gh#1193)
+// ---------------------------------------------------------------------------
+
+describe('resolveSpawnTimeoutMs (T12105)', () => {
+  it('returns the 300s default when the env var is unset', () => {
+    expect(resolveSpawnTimeoutMs('typecheck', {})).toBe(DEFAULT_SPAWN_TIMEOUT_MS);
+    expect(DEFAULT_SPAWN_TIMEOUT_MS).toBe(300_000);
+  });
+
+  it('returns the default when the env var is empty', () => {
+    expect(resolveSpawnTimeoutMs('typecheck', { CLEO_TOOL_TIMEOUT_TYPECHECK: '' })).toBe(
+      DEFAULT_SPAWN_TIMEOUT_MS,
+    );
+    expect(resolveSpawnTimeoutMs('typecheck', { CLEO_TOOL_TIMEOUT_TYPECHECK: '   ' })).toBe(
+      DEFAULT_SPAWN_TIMEOUT_MS,
+    );
+  });
+
+  it('honours a valid positive-integer override', () => {
+    expect(resolveSpawnTimeoutMs('typecheck', { CLEO_TOOL_TIMEOUT_TYPECHECK: '600000' })).toBe(
+      600_000,
+    );
+  });
+
+  it('follows the concurrency-var naming convention (uppercase, dashes → underscores)', () => {
+    expect(
+      resolveSpawnTimeoutMs('security-scan', { CLEO_TOOL_TIMEOUT_SECURITY_SCAN: '900000' }),
+    ).toBe(900_000);
+    // The dashed spelling is NOT consulted — same convention as CLEO_TOOL_CONCURRENCY_*.
+    expect(
+      resolveSpawnTimeoutMs('security-scan', { 'CLEO_TOOL_TIMEOUT_SECURITY-SCAN': '900000' }),
+    ).toBe(DEFAULT_SPAWN_TIMEOUT_MS);
+  });
+
+  it('rejects non-numeric values with a clear error (no silent fallback)', () => {
+    expect(() =>
+      resolveSpawnTimeoutMs('typecheck', { CLEO_TOOL_TIMEOUT_TYPECHECK: 'ten-minutes' }),
+    ).toThrow(/CLEO_TOOL_TIMEOUT_TYPECHECK must be a positive integer/);
+  });
+
+  it('rejects zero and negative values with a clear error', () => {
+    expect(() => resolveSpawnTimeoutMs('test', { CLEO_TOOL_TIMEOUT_TEST: '0' })).toThrow(
+      /CLEO_TOOL_TIMEOUT_TEST must be greater than zero/,
+    );
+    expect(() => resolveSpawnTimeoutMs('test', { CLEO_TOOL_TIMEOUT_TEST: '-5000' })).toThrow(
+      /CLEO_TOOL_TIMEOUT_TEST/,
+    );
+  });
+
+  it('rejects fractional and unit-suffixed values', () => {
+    expect(() => resolveSpawnTimeoutMs('lint', { CLEO_TOOL_TIMEOUT_LINT: '1.5' })).toThrow(
+      /CLEO_TOOL_TIMEOUT_LINT/,
+    );
+    expect(() => resolveSpawnTimeoutMs('lint', { CLEO_TOOL_TIMEOUT_LINT: '600000ms' })).toThrow(
+      /CLEO_TOOL_TIMEOUT_LINT/,
+    );
   });
 });

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -133,6 +133,15 @@ export interface CompleteTaskResult {
   autoCompleted?: string[];
   unblockedTasks?: Array<Pick<TaskRef, 'id' | 'title'>>;
   /**
+   * `true` when the task was already `done` and the call was an idempotent
+   * no-op (T12102 / gh#1196). No gates re-ran, no writes occurred, and the
+   * caller should surface success with an `already done` note so the
+   * recovery path after a timed-out complete is simply "run it again".
+   *
+   * @task T12102
+   */
+  alreadyCompleted?: boolean;
+  /**
    * llmtxt ContributionReceipt correlation (T947). Absent when the
    * AgentSession adapter degraded to a no-op (peer deps missing) or
    * when running in VITEST with no audit layer.
@@ -414,17 +423,25 @@ export async function completeTask(
     });
   }
 
+  // ---- T12102 (gh#1196): idempotent complete ----
+  // Re-running `cleo complete` on an already-done task is a no-op SUCCESS,
+  // not E_CLEO_TASK_COMPLETED. The reported failure mode was a complete that
+  // committed `status='done'` server-side and then kept running until the
+  // agent's tool timeout killed the client — the agent saw a failure for an
+  // operation that actually succeeded. Making the retry exit 0 with a clear
+  // note turns the recovery path into simply "run it again".
+  //
+  // This check runs BEFORE requireActiveSession: the no-op mutates nothing,
+  // so the mutation guard does not apply, and recovery must work even from a
+  // fresh shell. The `cleo verify` E_ALREADY_DONE guard (ADR-051 §11.1
+  // evidence immutability) is a different path and is NOT loosened.
+  if (task.status === 'done') {
+    return { task, alreadyCompleted: true };
+  }
+
   await requireActiveSession('tasks.complete', cwd);
 
   const enforcement = await loadCompletionEnforcement(cwd);
-
-  // Already done
-  if (task.status === 'done') {
-    throw new CleoError(ExitCode.TASK_COMPLETED, `Task ${options.taskId} is already completed`, {
-      fix: `To reopen, run cleo update ${options.taskId} --status active`,
-      details: { field: 'status', expected: 'not done', actual: 'done' },
-    });
-  }
 
   // ---- Dependency gate (T11954 / DHQ-071) ----
   // A task whose OWN work is done can still be blocked here by `depends` edges
@@ -1241,6 +1258,21 @@ interface CompleteEngineSuccess {
   autoCompleted?: string[];
   unblockedTasks?: Array<{ id: string; title: string }>;
   /**
+   * `true` when the task was already `done` and the complete call was an
+   * idempotent no-op (T12102 / gh#1196). Accompanies {@link note}; exit
+   * code is 0 so a post-timeout retry is the canonical recovery path.
+   *
+   * @task T12102
+   */
+  alreadyDone?: boolean;
+  /**
+   * Human-readable note surfaced on the payload — currently used for the
+   * idempotent `already done` case (T12102).
+   *
+   * @task T12102
+   */
+  note?: string;
+  /**
    * T9548 — Auto-invoke worktree-complete diagnostic envelope.
    *
    * Populated when `cleo complete <taskId>` runs and the auto-invoke hook
@@ -1342,6 +1374,19 @@ export async function taskComplete(
       accessor,
     );
 
+    // T12102 (gh#1196): idempotent no-op — the task was already done before
+    // this call. Skip every post-completion side effect (provenance stamp,
+    // worktree auto-complete) and return success with a clear note so an
+    // agent recovering from a timed-out complete can confirm state by
+    // simply re-running the command.
+    if (result.alreadyCompleted) {
+      return engineSuccess({
+        task: result.task as TaskRecord,
+        alreadyDone: true,
+        note: `Task ${taskId} is already done — complete was a no-op (idempotent).`,
+      });
+    }
+
     // T1222 / CLEO-VALID-27: stamp modified_by + session_id on every successful completion.
     // Best-effort — failure here must not roll back the completion that already landed.
     try {
@@ -1427,6 +1472,13 @@ export async function completeTaskStrict(
     if (lifecycleMode === 'strict') {
       const accessor = await getTaskAccessor(projectRoot);
       const task = await accessor.loadSingleTask(taskId);
+      // T12102 (gh#1196): an already-done task short-circuits to the
+      // idempotent success path BEFORE any strict pre-check. Without this a
+      // post-timeout retry could spuriously fail on E_EVIDENCE_STALE /
+      // E_IVTR_INCOMPLETE for a task that is legitimately finished.
+      if (task?.status === 'done') {
+        return taskComplete(projectRoot, taskId, opts);
+      }
       if (task?.verification?.evidence) {
         const evidenceEntries = Object.entries(task.verification.evidence);
         const staleGates: Array<{ gate: string; failures: string[] }> = [];
@@ -1434,7 +1486,24 @@ export async function completeTaskStrict(
           if (!ev) continue;
           // T9245: pass gate so revalidate can enforce the
           // critical-gate override-rejection rule.
-          const check = await revalidateEvidence(ev, projectRoot, gate as VerificationGate);
+          // T12102: progress lines go to stderr (console.warn) so a slow
+          // re-validation is observable while stdout stays pure JSON.
+          const gateStartedAt = Date.now();
+          console.warn(
+            `[complete] re-validating evidence for gate '${gate}' (${ev.atoms.length} atom(s))…`,
+          );
+          const check = await revalidateEvidence(
+            ev,
+            projectRoot,
+            gate as VerificationGate,
+            undefined,
+            {
+              onProgress: (message) => console.warn(`[complete]   ${message}`),
+            },
+          );
+          console.warn(
+            `[complete] gate '${gate}' re-validated: ${check.stillValid ? 'ok' : 'STALE'} (${Date.now() - gateStartedAt}ms)`,
+          );
           if (!check.stillValid) {
             staleGates.push({
               gate,

--- a/packages/core/src/tasks/evidence.ts
+++ b/packages/core/src/tasks/evidence.ts
@@ -42,6 +42,11 @@ import {
 
 import { CleoError } from '../errors.js';
 import { getEffectiveHead } from '../worktree/effective-head.js';
+import {
+  computeCommitRevalidationKey,
+  readCommitRevalidationEntry,
+  writeCommitRevalidationEntry,
+} from './revalidation-cache.js';
 import { runToolCached } from './tool-cache.js';
 import {
   CANONICAL_TOOLS,
@@ -1822,6 +1827,24 @@ export interface RevalidationResult {
 }
 
 /**
+ * Options for {@link revalidateEvidence}.
+ *
+ * @task T12102
+ */
+export interface RevalidateOptions {
+  /**
+   * Progress sink invoked once per hard atom as it is re-validated, with a
+   * short human-readable line (e.g. `commit:abc1234 ok (cached) 3ms`). The
+   * `cleo complete` path forwards this to stderr so a long re-validation is
+   * observable; stdout stays pure JSON per the output contract. Other
+   * callers omit it and see no behavioural change.
+   *
+   * @task T12102 (gh#1196)
+   */
+  onProgress?: (message: string) => void;
+}
+
+/**
  * Critical gates for which `override`-only evidence is NEVER accepted. Closes
  * the override-loophole proven 2026-05-12 — 13 mis-completed tasks in the
  * 2026-05-11 campaign passed `implemented`/`testsPassed` with override-only
@@ -1878,11 +1901,13 @@ export function isHardAtom(atom: EvidenceAtom): boolean {
  *   that were on the task branch at verify time but are now on main after
  *   merge (T11959). When provided, sha256 comparison uses the same git-show
  *   resolution path as validate time so the checksums remain consistent.
+ * @param options - Optional {@link RevalidateOptions} progress sink (T12102).
  * @returns Revalidation outcome
  *
  * @task T832
  * @task T9245
  * @task T11959
+ * @task T12102
  * @adr ADR-051 §5 / §8 (Decision 8)
  */
 export async function revalidateEvidence(
@@ -1890,6 +1915,7 @@ export async function revalidateEvidence(
   projectRoot: string,
   gate?: VerificationGate,
   taskId?: string,
+  options?: RevalidateOptions,
 ): Promise<RevalidationResult> {
   // T9245: critical-gate override rejection.
   // When the gate is `implemented` or `testsPassed`, evidence that has no
@@ -1929,11 +1955,22 @@ export async function revalidateEvidence(
       case 'override':
         break;
       case 'commit': {
-        const check = await validateCommit(atom.sha, projectRoot);
-        if (!check.ok) failed.push({ atom, reason: check.reason });
+        // T12102 (gh#1196): routed through the revalidation cache — keyed on
+        // (commitSha, headSha), both immutable git facts, so a hit is exactly
+        // as sound as re-running the git spawns. See revalidation-cache.ts.
+        const startedAt = Date.now();
+        const cached = await revalidateCommitAtom(atom.sha, projectRoot);
+        if (!cached.check.ok) failed.push({ atom, reason: cached.check.reason });
+        options?.onProgress?.(
+          `commit:${atom.sha.slice(0, 7)} ${cached.check.ok ? 'ok' : 'FAILED'}` +
+            `${cached.fromCache ? ' (cached)' : ''} ${Date.now() - startedAt}ms`,
+        );
         break;
       }
       case 'files': {
+        // Deliberately NOT cached (T12102): the read-and-compare-sha256 below
+        // IS the staleness guarantee; a cheaper key would weaken it.
+        const startedAt = Date.now();
         for (const f of atom.files) {
           const abs = isAbsolute(f.path) ? f.path : resolvePath(projectRoot, f.path);
           let content: Buffer | null = null;
@@ -1960,12 +1997,20 @@ export async function revalidateEvidence(
             break;
           }
         }
+        options?.onProgress?.(
+          `files:${atom.files.length} path(s) ` +
+            `${failed.some((x) => x.atom === atom) ? 'FAILED' : 'ok'} ${Date.now() - startedAt}ms`,
+        );
         break;
       }
       case 'test-run': {
+        // Deliberately NOT cached (T12102): same reasoning as files: — the
+        // content hash comparison IS the staleness guarantee.
+        const startedAt = Date.now();
         const abs = isAbsolute(atom.path) ? atom.path : resolvePath(projectRoot, atom.path);
         if (!existsSync(abs)) {
           failed.push({ atom, reason: `test-run file removed since verify: ${atom.path}` });
+          options?.onProgress?.(`test-run:${atom.path} FAILED ${Date.now() - startedAt}ms`);
           break;
         }
         const content = await readFile(abs);
@@ -1973,6 +2018,9 @@ export async function revalidateEvidence(
         if (sha256 !== atom.sha256) {
           failed.push({ atom, reason: `test-run output modified since verify: ${atom.path}` });
         }
+        options?.onProgress?.(
+          `test-run:${atom.path} ${sha256 === atom.sha256 ? 'ok' : 'FAILED'} ${Date.now() - startedAt}ms`,
+        );
         break;
       }
       case 'tool': {
@@ -2016,6 +2064,65 @@ export async function revalidateEvidence(
   }
 
   return { stillValid: failed.length === 0, failedAtoms: failed };
+}
+
+/**
+ * Re-validate a `commit:` atom at complete time, consulting the T12102
+ * revalidation cache first.
+ *
+ * The cache key is `(commitSha, headSha)` — every check
+ * {@link validateCommit} performs on this path (no `taskId`, so
+ * `getEffectiveHead` resolves to `HEAD`) is an immutable fact of the git
+ * DAG once both SHAs are fixed, so a cache hit is exactly as sound as
+ * re-running the git spawns. Only successful validations are cached: a
+ * "commit not found" failure is NOT immutable (a later `git fetch` can
+ * make the object appear), so failures always re-run.
+ *
+ * When `HEAD` cannot be resolved (not a git checkout, bare failure), the
+ * cache is bypassed entirely and behaviour matches the pre-T12102 path.
+ *
+ * @param sha - Commit SHA recorded at verify time.
+ * @param projectRoot - Absolute path used as cwd for git operations.
+ * @returns The {@link AtomValidation} plus whether it came from cache.
+ *
+ * @internal
+ * @task T12102 (gh#1196)
+ */
+async function revalidateCommitAtom(
+  sha: string,
+  projectRoot: string,
+): Promise<{ check: AtomValidation; fromCache: boolean }> {
+  const headResult = await runCommand('git', ['rev-parse', 'HEAD'], projectRoot);
+  const head = headResult.exitCode === 0 ? headResult.stdout.trim() : null;
+  if (!head) {
+    return { check: await validateCommit(sha, projectRoot), fromCache: false };
+  }
+  const key = computeCommitRevalidationKey(sha, head);
+  const hit = readCommitRevalidationEntry(projectRoot, key);
+  if (hit) {
+    return {
+      check: { ok: true, atom: { kind: 'commit', sha: hit.sha, shortSha: hit.shortSha } },
+      fromCache: true,
+    };
+  }
+  const check = await validateCommit(sha, projectRoot);
+  if (check.ok && check.atom.kind === 'commit') {
+    try {
+      writeCommitRevalidationEntry(projectRoot, {
+        schemaVersion: 1,
+        kind: 'commit-revalidation',
+        key,
+        sha: check.atom.sha,
+        shortSha: check.atom.shortSha,
+        head,
+        capturedAt: new Date().toISOString(),
+      });
+    } catch {
+      // Cache writes are advisory — a read-only .cleo dir must not fail a
+      // legitimate completion.
+    }
+  }
+  return { check, fromCache: false };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/tasks/revalidation-cache.ts
+++ b/packages/core/src/tasks/revalidation-cache.ts
@@ -1,0 +1,143 @@
+/**
+ * Revalidation cache for the `cleo complete` evidence staleness check
+ * (T12102 / gh#1196).
+ *
+ * `cleo complete` re-validates every hard evidence atom recorded at
+ * `cleo verify` time (ADR-051 Decision 8 — `E_EVIDENCE_STALE` catches
+ * post-verify tampering). On large repos the per-atom git spawns make a
+ * loop of completes slow enough to blow agent tool timeouts.
+ *
+ * ## What is cached, and why it is safe
+ *
+ * Only `commit:` atom revalidation is cached, keyed on
+ * `(commitSha, headSha)`. Every check {@link validateCommit} performs on
+ * the complete-time path (no `taskId`) is an IMMUTABLE fact of the git
+ * object DAG once both SHAs are fixed:
+ *
+ *   - `git cat-file -e <sha>^{commit}` — object existence is immutable
+ *     (objects are never removed from a live repo by ordinary work).
+ *   - `git merge-base --is-ancestor <sha> <headSha>` — reachability
+ *     between two fixed commits can never change.
+ *   - `git rev-parse [--short] <sha>` — canonicalisation is immutable.
+ *
+ * A new commit moves `HEAD`, which changes the key, so post-verify
+ * commits always force a fresh validation. Only successful validations
+ * are cached: a "commit not found" failure is NOT immutable (a later
+ * `git fetch` can make the object appear), so failures always re-run.
+ *
+ * ## What is deliberately NOT cached
+ *
+ *   - `files:` / `test-run:` — the staleness guarantee IS the
+ *     read-the-file-and-compare-sha256 step. Any cheaper key (mtime +
+ *     size) is forgeable and would silently weaken `E_EVIDENCE_STALE`,
+ *     which is the entire point of re-validation. These atoms stay
+ *     uncached; their cost is one read + one hash per path.
+ *   - `tool:` — never re-executed at complete time by design (see
+ *     {@link revalidateEvidence}); verify-time results are already
+ *     memoised by the ADR-061 cache in tool-cache.ts.
+ *
+ * Entries live beside the ADR-061 tool cache under
+ * `.cleo/cache/evidence/reval-commit-<key>.json` so `clearToolCache`
+ * wipes them too — the cache is purely advisory.
+ *
+ * @task T12102 (gh#1196)
+ * @adr ADR-051
+ * @adr ADR-061
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * One cached `commit:` atom revalidation. Success-only by design — see
+ * the module docstring for the immutability argument.
+ *
+ * @task T12102
+ */
+export interface CommitRevalidationEntry {
+  /** Schema version for forwards compatibility. */
+  schemaVersion: 1;
+  /** Discriminator so a foreign JSON blob is never trusted. */
+  kind: 'commit-revalidation';
+  /** Cache key (also encoded in the filename). */
+  key: string;
+  /** Canonical full commit SHA that validated successfully. */
+  sha: string;
+  /** Abbreviated SHA captured at validation time. */
+  shortSha: string;
+  /** `HEAD` SHA the reachability check ran against. */
+  head: string;
+  /** ISO 8601 wall-clock timestamp of the validation. */
+  capturedAt: string;
+}
+
+/**
+ * Compute the cache key for a `(commitSha, headSha)` pair.
+ *
+ * Mirrors the ADR-061 key style: sha256 of the JSON payload, truncated
+ * to 32 hex chars — collision-resistant and bounded regardless of input.
+ *
+ * @task T12102
+ */
+export function computeCommitRevalidationKey(commitSha: string, headSha: string): string {
+  const payload = JSON.stringify({
+    kind: 'commit-revalidation',
+    sha: commitSha.toLowerCase(),
+    head: headSha.toLowerCase(),
+  });
+  return createHash('sha256').update(payload).digest('hex').slice(0, 32);
+}
+
+/**
+ * Absolute path for a revalidation cache entry by key.
+ *
+ * @task T12102
+ */
+export function commitRevalidationPath(projectRoot: string, key: string): string {
+  return join(projectRoot, '.cleo', 'cache', 'evidence', `reval-commit-${key}.json`);
+}
+
+/**
+ * Read a cached commit-revalidation entry. Returns `null` when the entry
+ * is missing, unreadable, schema-incompatible, or keyed differently
+ * (defence against a poisoned cache directory).
+ *
+ * @task T12102
+ */
+export function readCommitRevalidationEntry(
+  projectRoot: string,
+  key: string,
+): CommitRevalidationEntry | null {
+  const path = commitRevalidationPath(projectRoot, key);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<CommitRevalidationEntry>;
+    if (parsed.schemaVersion !== 1 || parsed.kind !== 'commit-revalidation') return null;
+    if (parsed.key !== key) return null;
+    if (typeof parsed.sha !== 'string' || typeof parsed.head !== 'string') return null;
+    return parsed as CommitRevalidationEntry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Atomically write a cache entry: tmp-then-rename so concurrent readers
+ * never observe a half-written file (same discipline as tool-cache.ts).
+ *
+ * @task T12102
+ */
+export function writeCommitRevalidationEntry(
+  projectRoot: string,
+  entry: CommitRevalidationEntry,
+): void {
+  const dir = join(projectRoot, '.cleo', 'cache', 'evidence');
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const finalPath = commitRevalidationPath(projectRoot, entry.key);
+  const tmpPath = `${finalPath}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(entry, null, 2), 'utf-8');
+  renameSync(tmpPath, finalPath);
+}

--- a/packages/core/src/tasks/tool-cache.ts
+++ b/packages/core/src/tasks/tool-cache.ts
@@ -171,13 +171,84 @@ export interface RunToolOptions {
    * Wall-clock deadline for the child process (ms). When exceeded the
    * process is SIGTERM'd, then SIGKILL'd after a 5 s grace period.
    * The lock and semaphore slot are always released so a subsequent
-   * retry can proceed. Default covers a full monorepo test suite;
-   * tests inject shorter values for determinism.
+   * retry can proceed. When omitted, the deadline resolves via
+   * {@link resolveSpawnTimeoutMs} (`CLEO_TOOL_TIMEOUT_<CANONICAL>` env
+   * override over {@link DEFAULT_SPAWN_TIMEOUT_MS}); tests inject shorter
+   * values for determinism.
    *
    * @defaultValue `300_000` (5 min)
    * @task T12025
+   * @task T12105
    */
   spawnTimeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Wall-clock deadline resolution (T12105 / gh#1193)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default wall-clock deadline for one evidence-tool child process, in ms.
+ *
+ * 5 minutes covers a full monorepo test suite on an idle machine. Loaded
+ * CI runners sharing the box can push a suite past this — raise it per
+ * tool with `CLEO_TOOL_TIMEOUT_<CANONICAL>` rather than weakening the
+ * deadline globally in code.
+ *
+ * @task T12025
+ * @task T12105
+ */
+export const DEFAULT_SPAWN_TIMEOUT_MS = 300_000;
+
+/**
+ * Resolve the wall-clock child-process deadline for a canonical tool.
+ *
+ * Precedence:
+ *   1. `CLEO_TOOL_TIMEOUT_<CANONICAL>` env var (canonical name uppercased,
+ *      dashes → underscores — the same convention as
+ *      `CLEO_TOOL_CONCURRENCY_<CANONICAL>` in tool-semaphore.ts). Value is
+ *      milliseconds, digits only, strictly positive.
+ *   2. {@link DEFAULT_SPAWN_TIMEOUT_MS}.
+ *
+ * A set-but-invalid value (non-numeric, zero, negative) is a configuration
+ * ERROR, not a fallback: silently ignoring it would let an operator believe
+ * they raised the deadline while the old one still fires (gh#1193).
+ *
+ * @param canonical - Canonical tool name from the resolver.
+ * @param env - Environment to read (injectable for tests).
+ * @returns Deadline in milliseconds.
+ * @throws CleoError(VALIDATION_ERROR) when the env var is set but invalid.
+ *
+ * @task T12105 (gh#1193)
+ */
+export function resolveSpawnTimeoutMs(
+  canonical: string,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const envKey = `CLEO_TOOL_TIMEOUT_${canonical.toUpperCase().replace(/-/g, '_')}`;
+  const raw = env[envKey];
+  if (raw === undefined || raw.trim() === '') return DEFAULT_SPAWN_TIMEOUT_MS;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new CleoError(
+      ExitCode.VALIDATION_ERROR,
+      `${envKey} must be a positive integer (milliseconds), got "${raw}".`,
+      {
+        fix: `Set ${envKey} to a millisecond value such as 600000 (10 min), or unset it to use the ${DEFAULT_SPAWN_TIMEOUT_MS}ms default.`,
+      },
+    );
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (parsed <= 0) {
+    throw new CleoError(
+      ExitCode.VALIDATION_ERROR,
+      `${envKey} must be greater than zero, got ${parsed}.`,
+      {
+        fix: `Set ${envKey} to a positive millisecond value such as 600000 (10 min), or unset it to use the ${DEFAULT_SPAWN_TIMEOUT_MS}ms default.`,
+      },
+    );
+  }
+  return parsed;
 }
 
 // ---------------------------------------------------------------------------
@@ -551,7 +622,9 @@ export async function runToolCached(
 ): Promise<ToolRunResult> {
   const tailBytes = opts.tailBytes ?? 512;
   const lockStaleMs = opts.lockStaleMs ?? 600_000;
-  const spawnTimeoutMs = opts.spawnTimeoutMs ?? 300_000;
+  // T12105 / gh#1193: an explicit opts value (tests) wins; otherwise the
+  // CLEO_TOOL_TIMEOUT_<CANONICAL> env override, else the 5 min default.
+  const spawnTimeoutMs = opts.spawnTimeoutMs ?? resolveSpawnTimeoutMs(command.canonical);
 
   const head = await captureHead(projectRoot);
   const dirtyFingerprint = await captureDirtyFingerprint(projectRoot);

--- a/packages/core/templates/CLEO-INJECTION.md
+++ b/packages/core/templates/CLEO-INJECTION.md
@@ -355,7 +355,7 @@ All overrides append a line to `.cleo/audit/force-bypass.jsonl`. Use sparingly.
 
 ### Tool resolution + result cache (ADR-061)
 
-`tool:<name>` evidence resolves via `.cleo/project-context.json` with per-`primaryType` fallbacks. Results cached under `.cleo/cache/evidence/<key>.json`, keyed on `(canonical, cmd, args, HEAD, dirty-tree fingerprint)`. Parallel verifies coalesce; cross-worktree bounded by per-tool semaphore at `~/.local/share/cleo/locks/tool-<canonical>/`. Tune with `CLEO_TOOL_CONCURRENCY_<TOOL>=<n>`.
+`tool:<name>` evidence resolves via `.cleo/project-context.json` with per-`primaryType` fallbacks. Results cached under `.cleo/cache/evidence/<key>.json`, keyed on `(canonical, cmd, args, HEAD, dirty-tree fingerprint)`. Parallel verifies coalesce; cross-worktree bounded by per-tool semaphore at `~/.local/share/cleo/locks/tool-<canonical>/`. Tune with `CLEO_TOOL_CONCURRENCY_<TOOL>=<n>`. The wall-clock deadline per tool run defaults to 300000 ms; override with `CLEO_TOOL_TIMEOUT_<TOOL>=<ms>` (positive integer; invalid values are rejected with a clear error, never silently ignored).
 
 ### `pr:<number>` retroactive atom (T9764)
 

--- a/packages/skills/skills/ct-task-executor/references/evidence-and-gates.md
+++ b/packages/skills/skills/ct-task-executor/references/evidence-and-gates.md
@@ -155,6 +155,11 @@ semaphore at `~/.local/share/cleo/locks/tool-<canonical>/`.
 Tune with `CLEO_TOOL_CONCURRENCY_<TOOL>=<n>` (`0` disables). For most
 worker agents this is set-and-forget; the orchestrator handles tuning.
 
+The wall-clock deadline per tool run defaults to 300000 ms (5 min). On
+loaded CI runners a suite can legitimately exceed that; raise it per tool
+with `CLEO_TOOL_TIMEOUT_<TOOL>=<ms>` (positive integer — invalid values
+are rejected with a clear error, not silently ignored).
+
 ## The Emergency Override
 
 In rare incident-response scenarios, the override exists:


### PR DESCRIPTION
**Closes #1196** — profiled the complete path first: evidence re-validation is only ~60 ms of a 6–15 s complete (bootstrap ~3 s, PostToolUse hooks ~1 s, worktree tail ~0.6 s dominate), and the 5-minute zero-CPU repro is lock/contention-shaped (follow-up noted). Implemented the issue's four asks:

1. **Commit-atom re-validation cached** keyed on `(commitSha, headSha)` under `.cleo/cache/evidence/` — sound because every check is an immutable fact of the git DAG once both SHAs are fixed; only successes cached. `files:`/`test-run:` deliberately NOT cached — the sha256 re-read is the `E_EVIDENCE_STALE` guarantee (tamper test included).
2. **Progress to stderr** per atom (with `(cached)` markers); stdout JSON untouched.
3. **Flush/ordering verified** — the write transaction commits *before* the slow tail already; profile included.
4. **Idempotent complete** — re-completing a done task exits 0 with `alreadyDone: true`, short-circuiting before staleness/session pre-checks so post-timeout recovery is "run it again". `verify`'s `E_ALREADY_DONE` evidence-immutability guard (ADR-051 §11.1) untouched.

**Closes #1193** — the fixed ~300 s `tool:` spawn deadline is now `CLEO_TOOL_TIMEOUT_<TOOL>` (same convention as `CLEO_TOOL_CONCURRENCY_<TOOL>`), loud validation on bad values, documented in CLEO-INJECTION.md + ct-task-executor.

## Verification (targeted only)

- 240 passed across 11 task/evidence test files · 249 in validation/__tests__ · 22 engine/lifecycle
- `tsc --noEmit` clean · biome clean · injection-commands + cli-boundary gates PASS

Tasks: T12102, T12105