### PR TITLE
fix(T12106): verify warns when session-free; complete's session error names the remedy

### DIFF
--- a/.changeset/t12106-verify-no-session-warning.md
+++ b/.changeset/t12106-verify-no-session-warning.md
@@ -1,0 +1,8 @@
+---
+id: t12106-verify-no-session-warning
+tasks: [T12106]
+kind: fix
+summary: "cleo verify without an active session now warns via the envelope diagnostics channel, and complete's session error names the remedy and confirms gates are preserved"
+---
+
+gh#1194: verify intentionally accepts evidence session-free (crash-recovery re-attestation), but nothing signalled that complete would then refuse with E_CLEO_SESSION_REQUIRED — agents re-checked gate state thinking the evidence was at fault. Verify now emits a W_NO_ACTIVE_SESSION warning through the canonical meta.warnings[] channel (stdout JSON stays pure), and complete's session error names `cleo session start` and states recorded gates do not need re-verification.

--- a/packages/core/src/sessions/__tests__/session-enforcement.test.ts
+++ b/packages/core/src/sessions/__tests__/session-enforcement.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for session enforcement (gh#1194 / T12106).
+ *
+ * Covers the verify/complete session asymmetry reported in gh#1194:
+ * - `requireActiveSession` (strict mode) throws E_CLEO_SESSION_REQUIRED whose
+ *   `fix` names the exact remedy (`cleo session start`) and — for
+ *   `tasks.complete` — states that gates already recorded via `cleo verify`
+ *   are preserved and do NOT need re-verification.
+ * - `warnIfNoActiveSession` emits a loud NON-fatal W_NO_ACTIVE_SESSION warning
+ *   (envelope meta.warnings channel) for session-free writes under strict
+ *   enforcement, and stays silent when a session is active.
+ *
+ * These tests NEED strict enforcement active — `getEnforcementMode`
+ * short-circuits to 'none' while `process.env.VITEST` is set, so it is
+ * temporarily cleared (same pattern as tasks/__tests__/epic-enforcement.test.ts).
+ *
+ * @task T12106
+ * @gh 1194
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ExitCode } from '@cleocode/contracts';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { CleoError } from '../../errors.js';
+import { drainWarnings } from '../../output.js';
+import { seedTasks } from '../../store/__tests__/test-db-helper.js';
+import { resetDbState } from '../../store/sqlite.js';
+import { createSqliteDataAccessor } from '../../store/sqlite-data-accessor.js';
+import { completeTask } from '../../tasks/complete.js';
+import { startSession } from '../index.js';
+import { requireActiveSession, warnIfNoActiveSession } from '../session-enforcement.js';
+
+const savedVitest = process.env.VITEST;
+beforeAll(() => {
+  delete process.env.VITEST;
+});
+afterAll(() => {
+  if (savedVitest) process.env.VITEST = savedVitest;
+});
+
+/** Absolute project root for each test — recreated per test. */
+let TEST_ROOT: string;
+
+beforeEach(async () => {
+  resetDbState();
+  drainWarnings();
+  TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-session-enforcement-'));
+  await mkdir(join(TEST_ROOT, '.cleo'), { recursive: true });
+});
+
+afterEach(async () => {
+  resetDbState();
+  await rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('requireActiveSession — E_CLEO_SESSION_REQUIRED remedy text (gh#1194)', () => {
+  it('throws SESSION_REQUIRED naming cleo session start as the remedy', async () => {
+    const err = await requireActiveSession('tasks.complete', TEST_ROOT).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(CleoError);
+    const cleoErr = err as CleoError;
+    expect(cleoErr.code).toBe(ExitCode.SESSION_REQUIRED);
+    expect(cleoErr.message).toContain("Operation 'tasks.complete' requires an active session");
+    expect(cleoErr.fix).toContain('cleo session start');
+  });
+
+  it('appends the operation-specific remedy note to the fix text', async () => {
+    const note =
+      'Verification gates already recorded via cleo verify are preserved — do NOT re-verify them.';
+    const err = await requireActiveSession('tasks.complete', TEST_ROOT, note).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(CleoError);
+    const cleoErr = err as CleoError;
+    expect(cleoErr.code).toBe(ExitCode.SESSION_REQUIRED);
+    expect(cleoErr.fix).toContain('cleo session start');
+    expect(cleoErr.fix).toContain(note);
+  });
+
+  it('does not throw when a session is active', async () => {
+    await startSession(TEST_ROOT, { name: 'Active work', scope: 'global' });
+    resetDbState();
+    const result = await requireActiveSession('tasks.complete', TEST_ROOT);
+    expect(result.allowed).toBe(true);
+    expect(result.session).not.toBeNull();
+  });
+});
+
+describe('completeTask — session guard names remedy, gates preserved (gh#1194)', () => {
+  it('rejects with SESSION_REQUIRED whose fix says gates are preserved, re-run complete', async () => {
+    const accessor = await createSqliteDataAccessor(TEST_ROOT);
+    await seedTasks(accessor, [
+      {
+        id: 'T300',
+        title: 'Task completed without a session',
+        type: 'task',
+        status: 'active',
+        priority: 'medium',
+      },
+    ]);
+    await accessor.close();
+    resetDbState();
+
+    const err = await completeTask({ taskId: 'T300' }, TEST_ROOT).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(CleoError);
+    const cleoErr = err as CleoError;
+    expect(cleoErr.code).toBe(ExitCode.SESSION_REQUIRED);
+    // The recovery must be obvious: start a session, re-run complete.
+    expect(cleoErr.fix).toContain('cleo session start');
+    // And it must be clear this is NOT an evidence problem: recorded gates
+    // survive and do not need re-verification.
+    expect(cleoErr.fix).toContain('preserved');
+    expect(cleoErr.fix).toContain('do NOT re-verify');
+    expect(cleoErr.fix).toContain('re-run this cleo complete command');
+  });
+});
+
+describe('warnIfNoActiveSession — loud non-fatal warning (gh#1194)', () => {
+  it('returns true and pushes W_NO_ACTIVE_SESSION when no session is active', async () => {
+    const warned = await warnIfNoActiveSession('check.gate.set', TEST_ROOT);
+    expect(warned).toBe(true);
+
+    const warnings = drainWarnings() ?? [];
+    const hit = warnings.find((w) => w.code === 'W_NO_ACTIVE_SESSION');
+    expect(hit).toBeDefined();
+    expect(hit?.message).toContain('check.gate.set');
+    expect(hit?.message).toContain('E_CLEO_SESSION_REQUIRED');
+    expect(hit?.message).toContain('cleo session start');
+    expect(hit?.message).toContain('preserved');
+  });
+
+  it('returns false and pushes nothing when a session is active', async () => {
+    await startSession(TEST_ROOT, { name: 'Active work', scope: 'global' });
+    resetDbState();
+    drainWarnings();
+
+    const warned = await warnIfNoActiveSession('check.gate.set', TEST_ROOT);
+    expect(warned).toBe(false);
+
+    const warnings = drainWarnings() ?? [];
+    expect(warnings.find((w) => w.code === 'W_NO_ACTIVE_SESSION')).toBeUndefined();
+  });
+});

--- a/packages/core/src/sessions/session-enforcement.ts
+++ b/packages/core/src/sessions/session-enforcement.ts
@@ -12,6 +12,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ExitCode } from '@cleocode/contracts';
 import { CleoError } from '../errors.js';
+import { pushWarning } from '../output.js';
 import { getCleoDir } from '../paths.js';
 import { sessionStatus } from './index.js';
 
@@ -96,10 +97,19 @@ export interface EnforcementResult {
  * In strict mode, throws if no session is active.
  * In warn mode, returns a warning but allows the operation.
  * In none mode, always allows.
+ *
+ * @param operation - Dot-delimited operation identifier (e.g. `"tasks.complete"`).
+ * @param cwd - Project root override for config + session resolution.
+ * @param remedyNote - Optional operation-specific remediation sentence appended
+ *   to the thrown error's `fix` text (gh#1194 / T12106). Used by
+ *   `tasks.complete` to make clear that gates already recorded via
+ *   `cleo verify` are preserved and do NOT need re-verification — the recovery
+ *   is "start a session, re-run complete", not "fix the evidence".
  */
 export async function requireActiveSession(
   operation: string,
   cwd?: string,
+  remedyNote?: string,
 ): Promise<EnforcementResult> {
   const mode = getEnforcementMode(cwd);
 
@@ -119,7 +129,9 @@ export async function requireActiveSession(
       ExitCode.SESSION_REQUIRED,
       `Operation '${operation}' requires an active session`,
       {
-        fix: 'Start a session with \'cleo session start --scope epic:T### --auto-start --name "Work"\'',
+        fix:
+          `Start a session with 'cleo session start --scope epic:T### --auto-start --name "Work"'` +
+          (remedyNote ? ` ${remedyNote}` : ''),
         alternatives: [
           {
             action: 'Start session',
@@ -138,6 +150,47 @@ export async function requireActiveSession(
     session: null,
     warning: `No active session for operation '${operation}'. Consider starting one.`,
   };
+}
+
+/**
+ * Emit a loud NON-fatal warning when a session-free write operation (e.g.
+ * `cleo verify`) records state without an active session while strict session
+ * enforcement is in effect (gh#1194 / T12106).
+ *
+ * Session-free writes are intentional: T9505 keeps `cleo verify` usable
+ * without a session so crash-recovery re-attestation works before a new
+ * session is started — the write is NEVER blocked here. But `cleo complete`
+ * DOES require an active session, so an agent that ended its session
+ * mid-turn would otherwise discover the asymmetry only at complete time
+ * (E_CLEO_SESSION_REQUIRED) after every gate already read green. Pushing the
+ * warning into the envelope `meta.warnings[]` diagnostics channel keeps the
+ * stdout JSON contract pure while surfacing the mismatch at verify time.
+ *
+ * Only fires under `strict` enforcement — in `warn`/`none` modes complete
+ * will not reject the missing session, so the warning would be misleading.
+ *
+ * @param operation - Dot-delimited operation identifier (e.g. `"check.gate.set"`).
+ * @param cwd - Project root override for config + session resolution.
+ * @returns `true` when the warning was emitted (strict mode + no active session).
+ *
+ * @task T12106
+ * @gh 1194
+ */
+export async function warnIfNoActiveSession(operation: string, cwd?: string): Promise<boolean> {
+  if (getEnforcementMode(cwd) !== 'strict') return false;
+
+  const session = await getActiveSessionInfo(cwd);
+  if (session) return false;
+
+  pushWarning({
+    code: 'W_NO_ACTIVE_SESSION',
+    message:
+      `No active session: '${operation}' was recorded anyway (session-free by design, T9505), ` +
+      `but 'cleo complete' requires an active session and will fail with E_CLEO_SESSION_REQUIRED. ` +
+      `Start one with 'cleo session start --scope epic:T### --auto-start --name "Work"' before completing — ` +
+      `gates recorded now are preserved and do NOT need re-verification.`,
+  });
+  return true;
 }
 
 /**

--- a/packages/core/src/tasks/complete.ts
+++ b/packages/core/src/tasks/complete.ts
@@ -414,7 +414,15 @@ export async function completeTask(
     });
   }
 
-  await requireActiveSession('tasks.complete', cwd);
+  // gh#1194 / T12106 — name the exact recovery so an agent that recorded
+  // gates via `cleo verify` without an active session does not misread this
+  // as an evidence problem: gates are preserved; start a session, re-run
+  // complete. Verify stays session-free by design (T9505) for crash recovery.
+  await requireActiveSession(
+    'tasks.complete',
+    cwd,
+    'Verification gates already recorded via cleo verify are preserved — do NOT re-verify them. Recovery: start a session, then re-run this cleo complete command.',
+  );
 
   const enforcement = await loadCompletionEnforcement(cwd);
 

--- a/packages/core/src/validation/__tests__/gate-verify-no-session-warning.test.ts
+++ b/packages/core/src/validation/__tests__/gate-verify-no-session-warning.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the no-active-session warning in validateGateVerify (gh#1194 / T12106).
+ *
+ * `cleo verify` is intentionally session-free (T9505) so crash-recovery
+ * re-attestation works before a new session is started — the gate write MUST
+ * succeed without a session. But `cleo complete` requires an active session,
+ * so a write under strict enforcement with no active session MUST emit a loud
+ * NON-fatal W_NO_ACTIVE_SESSION warning on the envelope meta.warnings channel
+ * (stdout JSON contract stays pure), telling the agent that complete will
+ * require a session and that recorded gates are preserved.
+ *
+ * Test matrix:
+ * - Gate write with NO active session → success + W_NO_ACTIVE_SESSION warning
+ * - Gate write WITH an active session → success + no warning
+ * - View mode (no write) with no session → no warning
+ *
+ * These tests NEED strict session enforcement — `getEnforcementMode`
+ * short-circuits to 'none' while `process.env.VITEST` is set, so it is
+ * temporarily cleared (same pattern as tasks/__tests__/epic-enforcement.test.ts).
+ *
+ * @task T12106
+ * @gh 1194
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createSqliteDataAccessor,
+  resetDbState,
+  validateGateVerify,
+} from '@cleocode/core/internal';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { drainWarnings } from '../../output.js';
+import { startSession } from '../../sessions/index.js';
+import { seedTasks } from '../../store/__tests__/test-db-helper.js';
+
+const savedVitest = process.env.VITEST;
+beforeAll(() => {
+  delete process.env.VITEST;
+});
+afterAll(() => {
+  if (savedVitest) process.env.VITEST = savedVitest;
+});
+
+/** Absolute project root for each test — recreated per test. */
+let TEST_ROOT: string;
+
+/** Real commit SHA used as `commit:` evidence for the implemented gate (T9245). */
+let SEED_COMMIT_SHA: string;
+
+/**
+ * Minimal config that limits required gates to just `implemented` so tests
+ * can write a single gate. Session enforcement is deliberately NOT disabled
+ * (unlike gate-verify-hint.test.ts) — these tests exercise it.
+ */
+const MINIMAL_CONFIG = {
+  enforcement: {
+    acceptance: { mode: 'off' },
+  },
+  verification: {
+    enabled: true,
+    requiredGates: ['implemented'],
+  },
+  lifecycle: { mode: 'off' },
+};
+
+function initGitRepoWithCommit(taskFile: string): void {
+  const git = (args: string[]): string => execFileSync('git', args, { cwd: TEST_ROOT }).toString();
+  git(['init', '-q']);
+  git(['config', 'user.name', 'gate-verify-no-session test']);
+  git(['config', 'user.email', 'nosession@example.com']);
+  git(['config', 'commit.gpgsign', 'false']);
+  writeFileSync(join(TEST_ROOT, taskFile), 'seed\n');
+  git(['add', taskFile]);
+  git(['commit', '-q', '-m', 'seed']);
+  SEED_COMMIT_SHA = git(['rev-parse', 'HEAD']).trim();
+}
+
+async function seedTask(taskId: string): Promise<void> {
+  const accessor = await createSqliteDataAccessor(TEST_ROOT);
+  await seedTasks(accessor, [
+    {
+      id: taskId,
+      title: `Test task ${taskId}`,
+      type: 'task',
+      status: 'active',
+      priority: 'medium',
+      acceptance: ['AC1'],
+      // T9245: declare an AC file so commit content-intersect can validate.
+      files: ['seed.ts'],
+    },
+  ]);
+  await accessor.close();
+  resetDbState();
+}
+
+describe('validateGateVerify — no-active-session warning (gh#1194 / T12106)', () => {
+  beforeEach(async () => {
+    resetDbState();
+    drainWarnings();
+    TEST_ROOT = await mkdtemp(join(tmpdir(), 'cleo-gate-nosession-'));
+    await mkdir(join(TEST_ROOT, '.cleo'), { recursive: true });
+    await writeFile(join(TEST_ROOT, '.cleo', 'config.json'), JSON.stringify(MINIMAL_CONFIG));
+    initGitRepoWithCommit('seed.ts');
+  });
+
+  afterEach(async () => {
+    resetDbState();
+    drainWarnings();
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it('records the gate AND warns when no session is active (verify stays session-free)', async () => {
+    await seedTask('T400');
+    drainWarnings();
+
+    const result = await validateGateVerify(TEST_ROOT, {
+      taskId: 'T400',
+      gate: 'implemented',
+      value: true,
+      evidence: `commit:${SEED_COMMIT_SHA};files:seed.ts`,
+    });
+
+    // The write succeeds — verify is session-free by design (T9505).
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('set_gate');
+
+    // …but a loud non-fatal warning is pushed onto the envelope channel.
+    const warnings = drainWarnings() ?? [];
+    const hit = warnings.find((w) => w.code === 'W_NO_ACTIVE_SESSION');
+    expect(hit).toBeDefined();
+    expect(hit?.message).toContain('E_CLEO_SESSION_REQUIRED');
+    expect(hit?.message).toContain('cleo session start');
+    expect(hit?.message).toContain('preserved');
+    expect(hit?.message).toContain('do NOT need re-verification');
+  });
+
+  it('emits NO warning when a session is active', async () => {
+    await seedTask('T401');
+    await startSession(TEST_ROOT, { name: 'Active work', scope: 'global' });
+    resetDbState();
+    drainWarnings();
+
+    const result = await validateGateVerify(TEST_ROOT, {
+      taskId: 'T401',
+      gate: 'implemented',
+      value: true,
+      evidence: `commit:${SEED_COMMIT_SHA};files:seed.ts`,
+    });
+
+    expect(result.success).toBe(true);
+    const warnings = drainWarnings() ?? [];
+    expect(warnings.find((w) => w.code === 'W_NO_ACTIVE_SESSION')).toBeUndefined();
+  });
+
+  it('emits NO warning in view mode even without a session', async () => {
+    await seedTask('T402');
+    drainWarnings();
+
+    const result = await validateGateVerify(TEST_ROOT, { taskId: 'T402' });
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('view');
+    const warnings = drainWarnings() ?? [];
+    expect(warnings.find((w) => w.code === 'W_NO_ACTIVE_SESSION')).toBeUndefined();
+  });
+});

--- a/packages/core/src/validation/engine-ops.ts
+++ b/packages/core/src/validation/engine-ops.ts
@@ -23,6 +23,7 @@ import { loadConfig } from '../config.js';
 import { type EngineResult, engineError, engineSuccess } from '../engine-result.js';
 import { checkAndIncrementOverrideCap } from '../security/override-cap.js';
 import { enforceSharedEvidence } from '../security/shared-evidence-tracker.js';
+import { warnIfNoActiveSession } from '../sessions/session-enforcement.js';
 import { getTaskAccessor } from '../store/data-accessor.js';
 import {
   checkCallsiteCoverageAtom,
@@ -334,6 +335,7 @@ function protocolCatch(err: unknown): EngineResult {
  *
  * @task T5327
  * @task T832
+ * @task T12106
  * @adr ADR-051
  */
 export async function validateGateVerify(
@@ -772,6 +774,17 @@ export async function validateGateVerify(
       missing.length === 0
     ) {
       result.hint = `All gates green. Run: cleo complete ${taskId}`;
+    }
+
+    // gh#1194 / T12106 — verify is session-free by design (T9505), but
+    // complete is not. When a gate write lands WITHOUT an active session
+    // under strict enforcement, emit a loud non-fatal warning (envelope
+    // meta.warnings channel — stdout JSON contract stays pure) so the agent
+    // learns about the verify/complete session asymmetry NOW instead of at
+    // complete time, where E_CLEO_SESSION_REQUIRED otherwise reads like an
+    // evidence problem after every gate already returned true.
+    if (action !== 'view') {
+      await warnIfNoActiveSession('check.gate.set', projectRoot);
     }
 
     return engineSuccess(result);


### PR DESCRIPTION
**Closes #1194** — `cleo verify` accepts evidence with no active session **by design** (T9505 crash-recovery re-attestation: the override-cap block explicitly falls back to a `'global'` bucket for session-less callers), but nothing signalled that `cleo complete` would then refuse with `E_CLEO_SESSION_REQUIRED`. The reporter burned a cycle re-checking gate state, misreading a session problem as an evidence problem.

Kept verify session-free; fixed the signaling on both sides:

- **Verify side:** `warnIfNoActiveSession` pushes a `W_NO_ACTIVE_SESSION` warning through the canonical envelope `meta.warnings[]` channel (stdout JSON stays pure) — strict-enforcement mode only, naming the remedy and that gates are preserved.
- **Complete side:** `requireActiveSession` gained an optional remedy note; complete's error now names `cleo session start` and states recorded gates do **not** need re-verification — recovery is "start a session, re-run complete" (idempotent per T12102).

## Verification (targeted only)

- session-enforcement.test.ts 6/6 · gate-verify-no-session-warning.test.ts 3/3
- Regression: gate-verify-hint + parent-matrix + sessions 27/27 · dispatch check.test 2/2
- `tsc --noEmit` clean · biome clean

Task: T12106