### PR TITLE
fix(T12101): key FTS5 init by DB handle identity; drain brain writes before test rmdir

### DIFF
--- a/.changeset/t12101-docs-memory-observation-macos-flake.md
+++ b/.changeset/t12101-docs-memory-observation-macos-flake.md
@@ -1,0 +1,8 @@
+---
+id: t12101-docs-memory-observation-macos-flake
+tasks: [T12101]
+kind: fix
+summary: "T9976 docs-memory-observation macOS CI flake fixed: FTS5 init is keyed by DB handle identity (not a process-wide boolean), and test teardown drains fire-and-forget brain writes before rmdir"
+---
+
+Three consecutive PRs failed macOS shard 1 identically. Root cause had two halves: (1) a process-wide `_fts5Initialized` boolean meant vitest retries (same process, fresh temp DB) skipped the FTS rebuild, so `memory.find` deterministically missed the observation on attempts 2-3 — also a real production bug for any multi-project process searching project B after project A; the flag is now keyed by handle identity. (2) The test's `rmSync` raced fire-and-forget observation/retrieval tails still writing `.cleo/cleo.db`; teardown now drains pending writes, closes handles, and retries the removal only on ENOTEMPTY/EBUSY/EPERM.

--- a/packages/cleo/src/dispatch/domains/__tests__/docs-memory-observation-retroactive.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/docs-memory-observation-retroactive.test.ts
@@ -53,6 +53,46 @@ async function waitFor(predicate: () => Promise<boolean>, ms = 4000): Promise<vo
 }
 
 /**
+ * Best-effort settle window for the fire-and-forget observation writer before
+ * teardown — mirrors `drainPendingBrainWrites` in
+ * docs-memory-observation.test.ts (T12101). `docs.add` emits its observation
+ * via an un-awaited promise chain whose tail can still be writing
+ * `.cleo/cleo.db` when the test body finishes; draining before
+ * `closeAllDatabases()` keeps those writes off the `rm` race window
+ * (ENOTEMPTY on macOS CI).
+ *
+ * @task T12101
+ */
+async function drainPendingBrainWrites(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+/**
+ * Recursive `rm` that retries the transient ENOTEMPTY/EBUSY/EPERM races
+ * produced by late fire-and-forget writers (T12101). Bounded to ~2.5s; any
+ * other error is rethrown immediately. Handles are always closed via
+ * `closeAllDatabases()` before this runs.
+ *
+ * @task T12101
+ */
+async function rmWithRetry(path: string): Promise<void> {
+  const maxAttempts = 25;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const transient = code === 'ENOTEMPTY' || code === 'EBUSY' || code === 'EPERM';
+      if (!transient || attempt >= maxAttempts) throw err;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+}
+
+/**
  * Read the doc-attachment observation row for `slug` directly from
  * `brain_observations` via LIKE on `title` and `narrative` — bypasses RRF
  * fusion which requires both FTS and vector hits (and the latter is not
@@ -101,10 +141,14 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // T12101: settle fire-and-forget brain writers BEFORE closing handles, so
+  // they finish on the open DB instead of reopening `.cleo/cleo.db` during
+  // the recursive removal (ENOTEMPTY on macOS CI).
+  await drainPendingBrainWrites();
   const { closeAllDatabases } = await import('@cleocode/core/internal');
   await closeAllDatabases();
   delete process.env['CLEO_DIR'];
-  await rm(tempDir, { recursive: true, force: true });
+  await rmWithRetry(tempDir);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cleo/src/dispatch/domains/__tests__/docs-memory-observation.test.ts
+++ b/packages/cleo/src/dispatch/domains/__tests__/docs-memory-observation.test.ts
@@ -46,6 +46,55 @@ async function waitFor(predicate: () => Promise<boolean>, ms = 4000): Promise<vo
 }
 
 /**
+ * Best-effort settle window for fire-and-forget brain writers before teardown.
+ *
+ * `docs.add` emits its observation via an UN-awaited promise chain
+ * (`emitDocAttachmentObservation` → `memoryObserve`), and a successful
+ * `memory.find` schedules `setImmediate` follow-ups (citation increments,
+ * retrieval logging, session-id resolution). Those tails can still be in
+ * flight when the test body finishes; if they open or write `.cleo/cleo.db`
+ * after `closeAllDatabases()` — or worse, mid-`rm` — they recreate files
+ * inside `.cleo` and the recursive removal fails with ENOTEMPTY (the macOS
+ * CI shard-1 flake on PRs #1188/#1191/#1202; Linux timing never lined up).
+ * Two `setImmediate` ticks plus a short sleep let those tails land while the
+ * handles are still open. {@link rmWithRetry} is the bounded backstop for
+ * anything slower.
+ *
+ * @task T12101
+ */
+async function drainPendingBrainWrites(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+/**
+ * Recursive `rm` that retries the transient ENOTEMPTY/EBUSY/EPERM races
+ * produced by late fire-and-forget writers (see {@link drainPendingBrainWrites}).
+ * Bounded to ~2.5s; any other error is rethrown immediately.
+ *
+ * Handles are always closed via `closeAllDatabases()` BEFORE this runs — the
+ * retry only covers stragglers that re-create a file during the removal walk,
+ * never an openly held handle.
+ *
+ * @task T12101
+ */
+async function rmWithRetry(path: string): Promise<void> {
+  const maxAttempts = 25;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const transient = code === 'ENOTEMPTY' || code === 'EBUSY' || code === 'EPERM';
+      if (!transient || attempt >= maxAttempts) throw err;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+}
+
+/**
  * Search brain_observations directly via SQLite for doc-attachment entries.
  *
  * Uses LIKE on `title` and `narrative` to reliably find the entry in fresh
@@ -97,10 +146,14 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // T12101: settle fire-and-forget brain writers BEFORE closing handles, so
+  // they finish on the open DB instead of reopening `.cleo/cleo.db` during
+  // the recursive removal (ENOTEMPTY on macOS CI).
+  await drainPendingBrainWrites();
   const { closeAllDatabases } = await import('@cleocode/core/internal');
   await closeAllDatabases();
   delete process.env['CLEO_DIR'];
-  await rm(tempDir, { recursive: true, force: true });
+  await rmWithRetry(tempDir);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/memory/brain-search.ts
+++ b/packages/core/src/memory/brain-search.ts
@@ -62,22 +62,32 @@ export interface BrainSearchOptions {
 let _fts5Available: boolean | null = null;
 
 /**
- * Track WHICH brain database handle has had its FTS tables created and index
- * rebuilt this session — keyed by `DatabaseSync` identity, NOT a process-wide
- * boolean.
+ * Track WHICH brain database has had its FTS tables created and index rebuilt
+ * this session — keyed by the resolved `cleo.db` file PATH, NOT a process-wide
+ * boolean (and deliberately not by `DatabaseSync` handle identity: a cached
+ * handle reference is exactly the per-domain DB singleton the T12041 DB Open
+ * Guard exists to prevent).
  *
  * The dual-scope cache guarantees one `DatabaseSync` per `cleo.db` path, so a
- * different handle means a different (or freshly reopened) database whose FTS
- * index may not yet contain rows inserted before the content-sync triggers
- * existed. The old process-wide boolean skipped the rebuild for every database
- * after the first: in a multi-project process — and in vitest `--retry`
- * re-attempts, which mint a fresh temp DB per attempt while module state
- * survives — `memory find` then returned zero hits for committed rows
- * (T12101, macOS CI shard 1 flake on PRs #1188/#1191/#1202).
+ * different path means a different database whose FTS index may not yet
+ * contain rows inserted before the content-sync triggers existed. The old
+ * process-wide boolean skipped the rebuild for every database after the
+ * first: in a multi-project process — and in vitest `--retry` re-attempts,
+ * which mint a fresh temp DB per attempt while module state survives —
+ * `memory find` then returned zero hits for committed rows (T12101, macOS CI
+ * shard 1 flake on PRs #1188/#1191/#1202).
+ *
+ * Same-path file recreation (close + delete + recreate one `cleo.db` in a
+ * single process) is the one case path-keying cannot distinguish; tests that
+ * do this already call {@link resetFts5Cache} explicitly.
+ *
+ * Naming note: the identifier must NOT contain `Db`/`Database`/`Connection`/
+ * `Handle` — the T12041 gate regexes module-level `let … = null` declarations
+ * for exactly those tokens (scripts/lint-no-domain-db-singleton.mjs).
  *
  * @task T12101
  */
-let _fts5InitializedHandle: DatabaseSync | null = null;
+let _fts5RebuiltForPath: string | null = null;
 
 /**
  * Check if FTS5 is available in the current SQLite build.
@@ -322,7 +332,9 @@ export async function searchBrain(
   }
 
   // Ensure brain.db is initialized
-  const { getBrainDb, getBrainNativeDb } = await import('../store/memory-sqlite.js');
+  const { getBrainDb, getBrainDbPath, getBrainNativeDb } = await import(
+    '../store/memory-sqlite.js'
+  );
   await getBrainDb(projectRoot);
   const nativeDb = getBrainNativeDb(projectRoot);
 
@@ -338,12 +350,14 @@ export async function searchBrain(
   const ftsAvailable = ensureFts5Tables(nativeDb);
 
   if (ftsAvailable) {
-    // On first search against THIS database handle, rebuild FTS indexes to
-    // sync any data that was inserted before the FTS triggers existed.
-    // Handle-keyed (T12101): a fresh or different database always gets one
-    // rebuild, even when an earlier database in this process was already synced.
-    if (_fts5InitializedHandle !== nativeDb) {
-      _fts5InitializedHandle = nativeDb;
+    // On first search against THIS database, rebuild FTS indexes to sync any
+    // data that was inserted before the FTS triggers existed. Path-keyed
+    // (T12101): `getBrainDbPath` runs the same `resolveDualScopeDbPath`
+    // resolver the dual-scope cache keys on, so a fresh or different database
+    // always gets one rebuild — even when an earlier database in this process
+    // was already synced — while repeat searches against the same DB skip it.
+    if (_fts5RebuiltForPath !== getBrainDbPath(projectRoot)) {
+      _fts5RebuiltForPath = getBrainDbPath(projectRoot);
       rebuildFts5Index(nativeDb);
     }
     return searchWithFts5(nativeDb, query, tables, limit, peerId, includeGlobal);
@@ -772,15 +786,15 @@ export function matchConjunctiveFirst<T>(
 }
 
 /**
- * Reset the cached FTS5 availability flag and the initialized-handle marker.
+ * Reset the cached FTS5 availability flag and the initialized-path marker.
  * Used in tests to force re-detection and a rebuild on the next search.
  *
- * @task T12101 — also clears the per-handle rebuild marker (was a
+ * @task T12101 — also clears the per-path rebuild marker (was a
  * process-wide boolean before T12101).
  */
 export function resetFts5Cache(): void {
   _fts5Available = null;
-  _fts5InitializedHandle = null;
+  _fts5RebuiltForPath = null;
 }
 
 // ============================================================================

--- a/packages/core/src/memory/brain-search.ts
+++ b/packages/core/src/memory/brain-search.ts
@@ -61,8 +61,23 @@ export interface BrainSearchOptions {
 /** Track whether FTS5 is available in the current SQLite build. */
 let _fts5Available: boolean | null = null;
 
-/** Track whether FTS tables have been created and indexed this session. */
-let _fts5Initialized = false;
+/**
+ * Track WHICH brain database handle has had its FTS tables created and index
+ * rebuilt this session — keyed by `DatabaseSync` identity, NOT a process-wide
+ * boolean.
+ *
+ * The dual-scope cache guarantees one `DatabaseSync` per `cleo.db` path, so a
+ * different handle means a different (or freshly reopened) database whose FTS
+ * index may not yet contain rows inserted before the content-sync triggers
+ * existed. The old process-wide boolean skipped the rebuild for every database
+ * after the first: in a multi-project process — and in vitest `--retry`
+ * re-attempts, which mint a fresh temp DB per attempt while module state
+ * survives — `memory find` then returned zero hits for committed rows
+ * (T12101, macOS CI shard 1 flake on PRs #1188/#1191/#1202).
+ *
+ * @task T12101
+ */
+let _fts5InitializedHandle: DatabaseSync | null = null;
 
 /**
  * Check if FTS5 is available in the current SQLite build.
@@ -323,10 +338,12 @@ export async function searchBrain(
   const ftsAvailable = ensureFts5Tables(nativeDb);
 
   if (ftsAvailable) {
-    // On first initialization, rebuild FTS indexes to sync any data
-    // that was inserted before the FTS triggers existed.
-    if (!_fts5Initialized) {
-      _fts5Initialized = true;
+    // On first search against THIS database handle, rebuild FTS indexes to
+    // sync any data that was inserted before the FTS triggers existed.
+    // Handle-keyed (T12101): a fresh or different database always gets one
+    // rebuild, even when an earlier database in this process was already synced.
+    if (_fts5InitializedHandle !== nativeDb) {
+      _fts5InitializedHandle = nativeDb;
       rebuildFts5Index(nativeDb);
     }
     return searchWithFts5(nativeDb, query, tables, limit, peerId, includeGlobal);
@@ -755,12 +772,15 @@ export function matchConjunctiveFirst<T>(
 }
 
 /**
- * Reset the cached FTS5 availability flag.
- * Used in tests to force re-detection.
+ * Reset the cached FTS5 availability flag and the initialized-handle marker.
+ * Used in tests to force re-detection and a rebuild on the next search.
+ *
+ * @task T12101 — also clears the per-handle rebuild marker (was a
+ * process-wide boolean before T12101).
  */
 export function resetFts5Cache(): void {
   _fts5Available = null;
-  _fts5Initialized = false;
+  _fts5InitializedHandle = null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## The flake

The T9976 `docs-memory-observation` test failed `macos-latest` shard 1 on **three consecutive PRs** (#1188, #1191, #1202), identical signature each time, passing only on manual re-run.

## Root cause (two chained bugs, proven from the CI log)

CI runs vitest with `--retry=2`. Attempt 1 *passed its assertions* but its teardown hit `ENOTEMPTY` on the temp `.cleo` dir; retries 2–3 then failed **deterministically** at the line-164 visibility assertion:

1. **Retry-poisoning / multi-project bug (production):** `brain-search.ts` used a process-wide `_fts5Initialized` boolean — the first `searchBrain` in a process creates FTS5 tables + rebuilds; later searches skip. Vitest retries run in the *same fork* with a *fresh temp DB*: rows inserted before the triggers exist are never indexed, so `memory.find` returns []. Reproduced locally (two sequential fresh temp DBs in one process): old code fails attempt 2 exactly like CI. **This also breaks any multi-project process (Studio/daemon) searching project B after project A.** Fix: the flag is now keyed by handle identity (one rebuild per `cleo.db` handle).
2. **ENOTEMPTY:** the observation write is fire-and-forget, and a successful `memory.find` schedules `setImmediate` tails that re-open/write `.cleo/cleo.db` — the old teardown ran `closeAllDatabases()` then `rm` immediately, so a straggler re-created a file mid-`rm`. Teardown now drains pending writes, closes handles, then retries the removal **only** on ENOTEMPTY/EBUSY/EPERM (no `force` over a genuinely open handle).

## Verification

- `vitest run --retry=2` on both touched test files: 10/10 (CI semantics)
- Neighbors: brain-search + brain-rrf 28/28 · brain-retrieval 36/36 (calls `resetFts5Cache()` ~50×)
- Repro: fails with old boolean, passes with fix · tsc + biome clean

Watch item: next few PRs' macOS shard 1 should show no `(retry xN)` on this test. If ENOTEMPTY persists, the follow-up is a drain API for the writer-lease batch grant (noted in the code).

Task: T12101