### PR TITLE
feat(T12103): CI phantom-cancel watchdog — auto-rerun runs cancelled after all-steps-success

### DIFF
--- a/.changeset/t12103-phantom-cancel-watchdog.md
+++ b/.changeset/t12103-phantom-cancel-watchdog.md
@@ -1,5 +1,8 @@
 ---
-"@cleocode/cleo": patch
+id: t12103-phantom-cancel-watchdog
+tasks: [T12103]
+kind: feat
+summary: "CI phantom-cancel watchdog — detects workflow runs cancelled after all steps succeeded and auto-reruns them (scripts/ci-phantom-cancel-watchdog.mjs + scheduled workflow)"
 ---
 
-T12103: add CI phantom-cancel watchdog — detects workflow runs cancelled after all steps succeeded and auto-reruns them (scripts/ci-phantom-cancel-watchdog.mjs + scheduled workflow).
+Hosted runners have cancelled jobs whose every step succeeded (5 occurrences in 2 days; logs show the orphan-process reaper firing right before cancellation), and each occurrence cost a manual re-run that blocked the merge queue. The watchdog scans recent completed runs for the all-steps-success-then-cancelled signature and re-runs them, guarded by latest-run-only per (workflow, branch, sha) and a 7-day age window. Runs on a 15-minute schedule plus workflow_dispatch; --dry-run previews without mutating.

--- a/.changeset/t12103-phantom-cancel-watchdog.md
+++ b/.changeset/t12103-phantom-cancel-watchdog.md
@@ -1,0 +1,5 @@
+---
+"@cleocode/cleo": patch
+---
+
+T12103: add CI phantom-cancel watchdog — detects workflow runs cancelled after all steps succeeded and auto-reruns them (scripts/ci-phantom-cancel-watchdog.mjs + scheduled workflow).

--- a/.changeset/t12109-docs-test-timeout.md
+++ b/.changeset/t12109-docs-test-timeout.md
@@ -1,0 +1,8 @@
+---
+id: t12109-docs-test-timeout
+tasks: [T12109]
+kind: test
+summary: "docs-canonical-surface integration test — raise the spawned-CLI timeout from 30s to 120s and retry once on a timeout kill, so a loaded CI runner no longer fails the whole shard"
+---
+
+The 30s `spawnSync` cap in `runCli` was exceeded on ubuntu CI under full-shard load (PR #1203, run 32334556443) — the spawned `docs fetch` CLI returned status null and failed the shard while main stayed green. The cap is now 120s with a single retry when the child was killed by the timeout.

--- a/.github/workflows/ci-phantom-cancel-watchdog.yml
+++ b/.github/workflows/ci-phantom-cancel-watchdog.yml
@@ -1,0 +1,41 @@
+name: CI Phantom-Cancel Watchdog
+
+# @task T12103
+# Owner-CI cron — scans recent completed runs for the phantom-cancel
+# signature (job conclusion `cancelled` while every step reported success)
+# and re-runs the affected runs automatically. We cannot fix the hosted
+# runner's orphan-process reaper; this eliminates the manual-recovery cost.
+
+on:
+  schedule:
+    # Every 15 minutes, offset from :00/:30 to dodge top-of-hour contention.
+    - cron: '7-59/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (detect and print, do not rerun anything)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: write # required for `gh run rerun`
+
+jobs:
+  watchdog:
+    name: Detect and rerun phantom cancels
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run phantom-cancel watchdog
+        run: |
+          ARGS="--json"
+          if [ "${DRY_RUN}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          node scripts/ci-phantom-cancel-watchdog.mjs $ARGS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}

--- a/scripts/__tests__/ci-phantom-cancel-watchdog.test.mjs
+++ b/scripts/__tests__/ci-phantom-cancel-watchdog.test.mjs
@@ -1,0 +1,231 @@
+/**
+ * Tests for scripts/ci-phantom-cancel-watchdog.mjs (T12103).
+ *
+ * Covers the phantom-cancel detection signature, the superseded-run guard,
+ * the 7-day age guard, and dry-run mutation safety. All `gh` interaction is
+ * dependency-injected via a fake exec function — no network, no CLI.
+ *
+ * @task T12103
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isLatestForTuple,
+  isPhantomCancelJob,
+  isPostJobCleanupStep,
+  isWithinAgeWindow,
+  MAX_AGE_DAYS,
+  runWatchdog,
+} from '../ci-phantom-cancel-watchdog.mjs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = new Date('2026-08-20T12:00:00Z');
+
+function makeRun(overrides = {}) {
+  return {
+    databaseId: 1001,
+    workflowName: 'CI',
+    workflowDatabaseId: 10,
+    headBranch: 'feat/x',
+    headSha: 'abc123',
+    conclusion: 'cancelled',
+    createdAt: '2026-08-20T10:00:00Z',
+    number: 5,
+    url: 'https://github.com/kryptobaseddev/cleo/actions/runs/1001',
+    ...overrides,
+  };
+}
+
+function makeStep(name, conclusion) {
+  return { name, conclusion };
+}
+
+function makeJob(name, conclusion, steps) {
+  return { databaseId: 1, name, conclusion, steps };
+}
+
+const ALL_SUCCESS_STEPS = [
+  makeStep('Checkout', 'success'),
+  makeStep('Install', 'success'),
+  makeStep('Test', 'success'),
+  makeStep('Complete job', 'success'),
+];
+
+/**
+ * Build a fake exec that serves `gh run list` from `runs` and `gh run view`
+ * from `jobsByRunId`, and records every invocation. Rerun calls record into
+ * `calls` but produce no output.
+ */
+function makeFakeExec({ runs, jobsByRunId }) {
+  const calls = [];
+  const exec = (argv) => {
+    calls.push(argv);
+    if (argv[0] === 'run' && argv[1] === 'list') return JSON.stringify(runs);
+    if (argv[0] === 'run' && argv[1] === 'view') {
+      const id = Number(argv[2]);
+      return JSON.stringify({ jobs: jobsByRunId[id] ?? [] });
+    }
+    if (argv[0] === 'run' && argv[1] === 'rerun') return '';
+    throw new Error(`unexpected argv: ${argv.join(' ')}`);
+  };
+  return { exec, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Phantom signature
+// ---------------------------------------------------------------------------
+
+describe('isPhantomCancelJob', () => {
+  it('flags a cancelled job whose steps all succeeded', () => {
+    expect(isPhantomCancelJob(makeJob('Reject Test', 'cancelled', ALL_SUCCESS_STEPS))).toBe(true);
+  });
+
+  it('treats skipped steps as benign', () => {
+    const steps = [...ALL_SUCCESS_STEPS, makeStep('Deploy', 'skipped')];
+    expect(isPhantomCancelJob(makeJob('CI', 'cancelled', steps))).toBe(true);
+  });
+
+  it('exempts post-job cleanup steps from the all-success rule', () => {
+    const steps = [...ALL_SUCCESS_STEPS, makeStep('Post Run actions/checkout@v4', 'cancelled')];
+    expect(isPhantomCancelJob(makeJob('CI', 'cancelled', steps))).toBe(true);
+  });
+
+  it('rejects a genuine mid-step cancel (failed step)', () => {
+    const steps = [makeStep('Checkout', 'success'), makeStep('Test', 'failure')];
+    expect(isPhantomCancelJob(makeJob('CI', 'cancelled', steps))).toBe(false);
+  });
+
+  it('rejects a genuine mid-step cancel (cancelled step)', () => {
+    const steps = [makeStep('Checkout', 'success'), makeStep('Test', 'cancelled')];
+    expect(isPhantomCancelJob(makeJob('CI', 'cancelled', steps))).toBe(false);
+  });
+
+  it('ignores jobs that did not conclude cancelled', () => {
+    expect(isPhantomCancelJob(makeJob('CI', 'success', ALL_SUCCESS_STEPS))).toBe(false);
+    expect(isPhantomCancelJob(makeJob('CI', 'failure', ALL_SUCCESS_STEPS))).toBe(false);
+  });
+});
+
+describe('isPostJobCleanupStep', () => {
+  it('matches GitHub post-step and complete-job names', () => {
+    expect(isPostJobCleanupStep('Post Run actions/checkout@v4')).toBe(true);
+    expect(isPostJobCleanupStep('Post Cache pnpm store')).toBe(true);
+    expect(isPostJobCleanupStep('Complete job')).toBe(true);
+    expect(isPostJobCleanupStep('Run tests')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+describe('isLatestForTuple', () => {
+  it('accepts the newest run for its (workflow, branch, sha) tuple', () => {
+    const older = makeRun({ databaseId: 1001, number: 5 });
+    const newer = makeRun({ databaseId: 1002, number: 6 });
+    expect(isLatestForTuple(newer, [older, newer])).toBe(true);
+  });
+
+  it('rejects a run superseded by a newer attempt of the same tuple', () => {
+    const older = makeRun({ databaseId: 1001, number: 5 });
+    const newer = makeRun({ databaseId: 1002, number: 6 });
+    expect(isLatestForTuple(older, [older, newer])).toBe(false);
+  });
+
+  it('does not treat a different sha or workflow as superseding', () => {
+    const run = makeRun({ databaseId: 1001, number: 5 });
+    const otherSha = makeRun({ databaseId: 1002, number: 6, headSha: 'def456' });
+    const otherWorkflow = makeRun({ databaseId: 1003, number: 7, workflowDatabaseId: 99 });
+    expect(isLatestForTuple(run, [run, otherSha, otherWorkflow])).toBe(true);
+  });
+});
+
+describe('isWithinAgeWindow', () => {
+  it('accepts a run inside the window and rejects one outside it', () => {
+    expect(isWithinAgeWindow(makeRun({ createdAt: '2026-08-19T00:00:00Z' }), NOW)).toBe(true);
+    expect(isWithinAgeWindow(makeRun({ createdAt: '2026-08-01T00:00:00Z' }), NOW)).toBe(false);
+  });
+
+  it(`window is ${MAX_AGE_DAYS} days`, () => {
+    const edge = new Date(NOW.getTime() - MAX_AGE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    expect(isWithinAgeWindow(makeRun({ createdAt: edge }), NOW)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runWatchdog integration (fake exec)
+// ---------------------------------------------------------------------------
+
+describe('runWatchdog', () => {
+  const phantomJobs = {
+    1001: [makeJob('Reject Test', 'cancelled', ALL_SUCCESS_STEPS)],
+  };
+
+  it('reruns a phantom-cancelled run in execute mode', async () => {
+    const runs = [makeRun({ databaseId: 1001 })];
+    const { exec, calls } = makeFakeExec({ runs, jobsByRunId: phantomJobs });
+    const summary = await runWatchdog({ exec, dryRun: false, limit: 30, now: NOW });
+
+    expect(summary.phantomRuns.map((p) => p.id)).toEqual([1001]);
+    expect(summary.phantomRuns[0].phantomJobs).toEqual(['Reject Test']);
+    expect(summary.rerun).toEqual([1001]);
+    expect(calls.some((c) => c[0] === 'run' && c[1] === 'rerun' && c[2] === '1001')).toBe(true);
+  });
+
+  it('produces no mutations in dry-run mode', async () => {
+    const runs = [makeRun({ databaseId: 1001 })];
+    const { exec, calls } = makeFakeExec({ runs, jobsByRunId: phantomJobs });
+    const summary = await runWatchdog({ exec, dryRun: true, limit: 30, now: NOW });
+
+    expect(summary.phantomRuns.map((p) => p.id)).toEqual([1001]);
+    expect(summary.rerun).toEqual([]);
+    expect(calls.some((c) => c[1] === 'rerun')).toBe(false);
+  });
+
+  it('skips a cancelled run with a genuine failed step', async () => {
+    const runs = [makeRun({ databaseId: 1001 })];
+    const jobsByRunId = {
+      1001: [makeJob('Test', 'cancelled', [makeStep('Test', 'failure')])],
+    };
+    const { exec, calls } = makeFakeExec({ runs, jobsByRunId });
+    const summary = await runWatchdog({ exec, dryRun: false, limit: 30, now: NOW });
+
+    expect(summary.phantomRuns).toEqual([]);
+    expect(summary.skippedNotPhantom).toEqual([1001]);
+    expect(calls.some((c) => c[1] === 'rerun')).toBe(false);
+  });
+
+  it('never resurrects a superseded run', async () => {
+    const older = makeRun({ databaseId: 1001, number: 5 });
+    const newer = makeRun({ databaseId: 1002, number: 6, conclusion: 'success' });
+    const runs = [older, newer];
+    const { exec, calls } = makeFakeExec({ runs, jobsByRunId: phantomJobs });
+    const summary = await runWatchdog({ exec, dryRun: false, limit: 30, now: NOW });
+
+    expect(summary.skippedSuperseded).toEqual([1001]);
+    expect(summary.rerun).toEqual([]);
+    expect(calls.some((c) => c[1] === 'rerun')).toBe(false);
+  });
+
+  it('skips runs older than the age window', async () => {
+    const runs = [makeRun({ databaseId: 1001, createdAt: '2026-08-01T00:00:00Z' })];
+    const { exec, calls } = makeFakeExec({ runs, jobsByRunId: phantomJobs });
+    const summary = await runWatchdog({ exec, dryRun: false, limit: 30, now: NOW });
+
+    expect(summary.skippedTooOld).toEqual([1001]);
+    expect(calls.some((c) => c[1] === 'rerun')).toBe(false);
+  });
+
+  it('ignores non-cancelled runs entirely (no run view call)', async () => {
+    const runs = [makeRun({ databaseId: 1001, conclusion: 'success' })];
+    const { exec, calls } = makeFakeExec({ runs, jobsByRunId: {} });
+    const summary = await runWatchdog({ exec, dryRun: false, limit: 30, now: NOW });
+
+    expect(summary.cancelledRuns).toBe(0);
+    expect(summary.phantomRuns).toEqual([]);
+    expect(calls.some((c) => c[1] === 'view')).toBe(false);
+  });
+});

--- a/scripts/ci-phantom-cancel-watchdog.mjs
+++ b/scripts/ci-phantom-cancel-watchdog.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * ci-phantom-cancel-watchdog.mjs — auto-recovery for phantom CI cancels (T12103).
+ *
+ * Observed failure mode: hosted runners cancel a job AFTER every step
+ * (including "Complete job") reports success. The PR check rollup reads the
+ * job conclusion `cancelled` as a failure and blocks the merge; each
+ * occurrence costs a manual re-run. Logs show "Cleaning up orphan processes /
+ * Terminate orphan process" right before cancellation — a runner-fleet issue
+ * we cannot fix, but we CAN eliminate the manual-recovery cost.
+ *
+ * Detection signature (phantom cancel):
+ *   - run conclusion is `cancelled`, AND
+ *   - for at least one job: job conclusion is `cancelled` while EVERY step
+ *     conclusion is `success` (post-job cleanup steps — names starting with
+ *     "Post " or "Complete job" — are exempt from the all-success rule).
+ * A job with a genuinely failed/cancelled mid-run step is NOT a phantom and
+ * is left alone.
+ *
+ * Rerun guard: a run is only re-run if it is the LATEST run for its
+ * (workflow, branch, sha) tuple — never resurrect a superseded run — and is
+ * no older than 7 days.
+ *
+ * Usage:
+ *   node scripts/ci-phantom-cancel-watchdog.mjs             # execute reruns
+ *   node scripts/ci-phantom-cancel-watchdog.mjs --dry-run   # print only
+ *   node scripts/ci-phantom-cancel-watchdog.mjs --json      # machine output
+ *   node scripts/ci-phantom-cancel-watchdog.mjs --limit 50  # scan 50 runs
+ *
+ * Exit codes: 0 always (automation, not a gate); 1 on API/usage errors.
+ *
+ * @task T12103
+ */
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Types (JSDoc — this is a plain .mjs script, no tsconfig)
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} GhRun
+ * @property {number} databaseId
+ * @property {string} workflowName
+ * @property {number} workflowDatabaseId
+ * @property {string} headBranch
+ * @property {string} headSha
+ * @property {string} conclusion
+ * @property {string} createdAt
+ * @property {number} number
+ * @property {string} url
+ */
+
+/**
+ * @typedef {object} GhStep
+ * @property {string} name
+ * @property {string | null} conclusion
+ */
+
+/**
+ * @typedef {object} GhJob
+ * @property {number} databaseId
+ * @property {string} name
+ * @property {string} conclusion
+ * @property {GhStep[]} steps
+ */
+
+/**
+ * Exec function signature — injectable for tests. Receives argv (no shell)
+ * and must return stdout as a string. Should throw on non-zero exit.
+ *
+ * @typedef {(argv: string[]) => string} ExecFn
+ */
+
+/** Maximum age of a run eligible for re-run, in days. */
+export const MAX_AGE_DAYS = 7;
+
+/** Step conclusions that never block the phantom signature. */
+const BENIGN_STEP_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
+
+/**
+ * A step name that denotes post-job cleanup machinery rather than real work.
+ * GitHub renders post-action steps as "Post Run <action>" and the final
+ * bookkeeping step as "Complete job"; these may legitimately report a
+ * non-success conclusion during a phantom cancel.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isPostJobCleanupStep(name) {
+  return /^post\b/i.test(name) || /^complete job$/i.test(name);
+}
+
+/**
+ * Decide whether a job is a PHANTOM cancel: job conclusion `cancelled` while
+ * every non-cleanup step concluded successfully (or was skipped/neutral).
+ *
+ * @param {GhJob} job
+ * @returns {boolean}
+ */
+export function isPhantomCancelJob(job) {
+  if (job.conclusion !== 'cancelled') return false;
+  for (const step of job.steps ?? []) {
+    const conclusion = step.conclusion ?? 'success';
+    if (BENIGN_STEP_CONCLUSIONS.has(conclusion)) continue;
+    if (isPostJobCleanupStep(step.name)) continue;
+    // A genuinely failed/cancelled mid-run step — not a phantom.
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Decide whether `run` is the latest run for its (workflow, branch, sha)
+ * tuple within `allRuns`. Never re-run a superseded run — a newer attempt of
+ * the same commit already exists.
+ *
+ * @param {GhRun} run
+ * @param {GhRun[]} allRuns
+ * @returns {boolean}
+ */
+export function isLatestForTuple(run, allRuns) {
+  for (const other of allRuns) {
+    if (other.databaseId === run.databaseId) continue;
+    if (
+      other.workflowDatabaseId === run.workflowDatabaseId &&
+      other.headBranch === run.headBranch &&
+      other.headSha === run.headSha &&
+      other.number > run.number
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Decide whether a run is within the re-run age window.
+ *
+ * @param {GhRun} run
+ * @param {Date} now
+ * @returns {boolean}
+ */
+export function isWithinAgeWindow(run, now) {
+  const createdMs = Date.parse(run.createdAt);
+  if (Number.isNaN(createdMs)) return false;
+  return now.getTime() - createdMs <= MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+}
+
+// ---------------------------------------------------------------------------
+// gh CLI wrappers
+// ---------------------------------------------------------------------------
+
+/**
+ * List recent completed workflow runs via `gh run list`.
+ *
+ * @param {ExecFn} exec
+ * @param {number} limit
+ * @returns {GhRun[]}
+ */
+function listRecentRuns(exec, limit) {
+  const out = exec([
+    'run',
+    'list',
+    '--status',
+    'completed',
+    '--limit',
+    String(limit),
+    '--json',
+    'databaseId,workflowName,workflowDatabaseId,headBranch,headSha,conclusion,createdAt,number,url',
+  ]);
+  return JSON.parse(out);
+}
+
+/**
+ * Fetch the jobs (with steps) for one run via `gh run view`.
+ *
+ * @param {ExecFn} exec
+ * @param {number} runId
+ * @returns {GhJob[]}
+ */
+function getRunJobs(exec, runId) {
+  const out = exec(['run', 'view', String(runId), '--json', 'jobs']);
+  const parsed = JSON.parse(out);
+  return parsed.jobs ?? [];
+}
+
+/**
+ * Re-run the failed/cancelled jobs of a run.
+ *
+ * @param {ExecFn} exec
+ * @param {number} runId
+ */
+function rerunRun(exec, runId) {
+  exec(['run', 'rerun', String(runId), '--failed']);
+}
+
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan recent completed runs, detect phantom cancels, and re-run the
+ * eligible ones (unless `dryRun`).
+ *
+ * @param {object} opts
+ * @param {ExecFn} opts.exec
+ * @param {boolean} opts.dryRun
+ * @param {number} opts.limit
+ * @param {Date} [opts.now] injectable clock for tests
+ * @returns {Promise<{
+ *   scanned: number,
+ *   cancelledRuns: number,
+ *   phantomRuns: Array<{ id: number, workflow: string, branch: string, url: string, phantomJobs: string[] }>,
+ *   rerun: number[],
+ *   skippedSuperseded: number[],
+ *   skippedTooOld: number[],
+ *   skippedNotPhantom: number[],
+ * }>}
+ */
+export async function runWatchdog({ exec, dryRun, limit, now = new Date() }) {
+  const runs = listRecentRuns(exec, limit);
+  const cancelled = runs.filter((r) => r.conclusion === 'cancelled');
+
+  const summary = {
+    scanned: runs.length,
+    cancelledRuns: cancelled.length,
+    phantomRuns: [],
+    rerun: [],
+    skippedSuperseded: [],
+    skippedTooOld: [],
+    skippedNotPhantom: [],
+  };
+
+  for (const run of cancelled) {
+    const jobs = getRunJobs(exec, run.databaseId);
+    const phantomJobs = jobs.filter(isPhantomCancelJob);
+    if (phantomJobs.length === 0) {
+      summary.skippedNotPhantom.push(run.databaseId);
+      continue;
+    }
+    if (!isLatestForTuple(run, runs)) {
+      summary.skippedSuperseded.push(run.databaseId);
+      continue;
+    }
+    if (!isWithinAgeWindow(run, now)) {
+      summary.skippedTooOld.push(run.databaseId);
+      continue;
+    }
+    summary.phantomRuns.push({
+      id: run.databaseId,
+      workflow: run.workflowName,
+      branch: run.headBranch,
+      url: run.url,
+      phantomJobs: phantomJobs.map((j) => j.name),
+    });
+    if (!dryRun) {
+      rerunRun(exec, run.databaseId);
+      summary.rerun.push(run.databaseId);
+    }
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Default exec: shell out to the `gh` CLI (argv, no shell interpolation).
+ *
+ * @type {ExecFn}
+ */
+function ghExec(argv) {
+  return execFileSync('gh', argv, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+/**
+ * Parse CLI args into an options object. Throws on unknown flags or a bad
+ * --limit value (usage error → exit 1).
+ *
+ * @param {string[]} argv
+ */
+function parseArgs(argv) {
+  const opts = { dryRun: false, json: false, limit: 30 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      opts.dryRun = true;
+    } else if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--limit') {
+      const value = Number(argv[++i]);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`--limit requires a positive integer, got "${argv[i]}"`);
+      }
+      opts.limit = value;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`[ci-phantom-cancel-watchdog] usage error: ${err.message}`);
+    process.exit(1);
+  }
+
+  let summary;
+  try {
+    summary = await runWatchdog({
+      exec: ghExec,
+      dryRun: opts.dryRun,
+      limit: opts.limit,
+    });
+  } catch (err) {
+    console.error(`[ci-phantom-cancel-watchdog] gh API error: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    const mode = opts.dryRun ? 'dry-run' : 'execute';
+    console.log(
+      `[ci-phantom-cancel-watchdog] (${mode}) scanned=${summary.scanned} ` +
+        `cancelled=${summary.cancelledRuns} phantom=${summary.phantomRuns.length}`,
+    );
+    for (const p of summary.phantomRuns) {
+      const action = opts.dryRun ? 'would rerun' : 'rerun triggered';
+      console.log(
+        `  ${action}: run ${p.id} (${p.workflow} @ ${p.branch}) — jobs: ${p.phantomJobs.join(', ')}`,
+      );
+    }
+    if (summary.skippedSuperseded.length > 0) {
+      console.log(`  skipped (superseded): ${summary.skippedSuperseded.join(', ')}`);
+    }
+    if (summary.skippedTooOld.length > 0) {
+      console.log(`  skipped (older than ${MAX_AGE_DAYS}d): ${summary.skippedTooOld.join(', ')}`);
+    }
+    if (summary.skippedNotPhantom.length > 0) {
+      console.log(`  skipped (genuine cancel): ${summary.skippedNotPhantom.join(', ')}`);
+    }
+  }
+  process.exit(0);
+}
+
+// Only run main() when invoked directly (not when imported by tests).
+const invokedDirectly =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) {
+  main();
+}


### PR DESCRIPTION
## Problem (T12103)

Hosted runners are cancelling CI jobs **after every step — including "Complete job" — reports SUCCESS** (runner image 20260729.566; logs show "Cleaning up orphan processes / Terminate orphan process" right before cancellation). The PR check rollup reads conclusion `cancelled` as fail and blocks merges; each occurrence costs a manual re-run. 5 occurrences in 2 days (runs 32271617195, 32280021642, 32283006489). We cannot fix GitHub's runner — this PR eliminates the manual-recovery cost.

## What this adds

- **`scripts/ci-phantom-cancel-watchdog.mjs`** — scans the last 30 completed runs via `gh`. Detection signature: run conclusion `cancelled` AND a job with conclusion `cancelled` while every step concluded `success`/`skipped`/`neutral` (post-job cleanup steps — `Post …` / `Complete job` — are exempt). A genuine mid-step failure/cancel is NOT rerun.
- **Rerun guard** — a run is only rerun (`gh run rerun <id> --failed`) if it is the LATEST run for its (workflow, branch, sha) tuple and is ≤ 7 days old. Superseded runs are never resurrected.
- Default mode executes reruns; `--dry-run` prints only; `--json` for machine output. Exit 0 always (automation, not a gate); non-zero only on API/usage errors.
- **`.github/workflows/ci-phantom-cancel-watchdog.yml`** — runs every 15 min (`7-59/15`, offset from :00/:30) + `workflow_dispatch` with a `dry_run` input. Permissions: `contents: read` + `actions: write`; uses `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
- Test: `scripts/__tests__/ci-phantom-cancel-watchdog.test.mjs` — 18 tests, `gh` fully dependency-injected (fake exec), covering phantom signature detection, genuine-cancel skip, superseded-run guard, age guard, and dry-run mutation safety.

## Gate compliance

- **Gate 7 (deployed-template parity, T9860):** PASS (`findings=0, baseline=0`). The gate only enforces entries in its `PARITY_MAP` (currently `release-prepare.yml` only); this watchdog workflow is cleocode-internal and not shipped via `cleo init --workflows`, so no template was added.
- **Gate 15 (workflow command existence, T12093):** PASS — the workflow calls no `cleo` verbs.
- **biome:** clean. Targeted vitest run only (18/18 pass); full suite intentionally not run.
- Changeset: `.changeset/t12103-phantom-cancel-watchdog.md` (`@cleocode/cleo: patch`).

## Verification

- `pnpm vitest run scripts/__tests__/ci-phantom-cancel-watchdog.test.mjs` — 18/18 pass
- `node scripts/lint-deployed-template-parity.mjs` — PASS
- `node scripts/lint-workflow-cleo-commands.mjs` — PASS
- Live smoke test: `node scripts/ci-phantom-cancel-watchdog.mjs --dry-run` — scanned=30 cancelled=0 phantom=0