### PR TITLE
chore(release): plan v2026.8.9

### DIFF
--- a/.cleo/release/v2026.8.9.plan.json
+++ b/.cleo/release/v2026.8.9.plan.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://cleocode.io/schemas/release-plan/v1.json",
+  "version": "v2026.8.9",
+  "resolvedVersion": "v2026.8.9",
+  "suffixApplied": false,
+  "scheme": "calver",
+  "channel": "latest",
+  "epicId": "T11249",
+  "releaseKind": "regular",
+  "createdAt": "2026-08-20T14:50:30.803Z",
+  "createdBy": "keatonhoskins",
+  "previousVersion": "v2026.8.8",
+  "previousTag": "v2026.8.8",
+  "previousShippedAt": "2026-08-20T07:26:05.728Z",
+  "tasks": [
+    {
+      "id": "T12109",
+      "kind": "feat",
+      "impact": "minor",
+      "userFacingSummary": "docs-canonical-surface integration test flakes under CI load — 30s spawnSync timeout too tight",
+      "evidenceAtoms": [
+        "pr:1209"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    },
+    {
+      "id": "T12103",
+      "kind": "fix",
+      "impact": "patch",
+      "userFacingSummary": "CI jobs cancelled by the runner AFTER all steps succeed — 5 occurrences in 2 days block PR merges",
+      "evidenceAtoms": [
+        "pr:1210"
+      ],
+      "epicAncestor": "T11249",
+      "ivtrPhaseAtPlan": "contribution"
+    }
+  ],
+  "changelog": {
+    "features": [
+      "T12109"
+    ],
+    "fixes": [
+      "T12103"
+    ],
+    "chores": [],
+    "breaking": []
+  },
+  "gates": [
+    {
+      "name": "test",
+      "atom": "tool:test",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-20T14:50:30.803Z",
+      "resolvedCommand": "pnpm run test",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "build",
+      "atom": "tool:build",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-20T14:50:30.803Z",
+      "resolvedCommand": "pnpm run build",
+      "resolvedSource": "project-context"
+    },
+    {
+      "name": "lint",
+      "atom": "tool:lint",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-20T14:50:30.803Z",
+      "resolvedCommand": "npx biome check .",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "typecheck",
+      "atom": "tool:typecheck",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-20T14:50:30.803Z",
+      "resolvedCommand": "npx tsc --noEmit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "audit",
+      "atom": "tool:audit",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-20T14:50:30.803Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    },
+    {
+      "name": "security-scan",
+      "atom": "tool:security-scan",
+      "status": "unresolved",
+      "lastVerifiedAt": "2026-08-20T14:50:30.803Z",
+      "resolvedCommand": "npm audit",
+      "resolvedSource": "language-default"
+    }
+  ],
+  "platformMatrix": [
+    {
+      "platform": "any",
+      "publisher": "npm",
+      "package": "@cleocode/cleo"
+    }
+  ],
+  "preflightSummary": {
+    "esbuildExternalsDrift": false,
+    "lockfileDrift": false,
+    "epicCompletenessClean": true,
+    "doubleListingClean": true,
+    "preflightWarnings": [
+      "Skipped 265 out-of-scope changeset entries whose task anchors are not part of this release plan"
+    ]
+  },
+  "workflowRunUrl": null,
+  "prUrl": null,
+  "mergeCommitSha": null,
+  "status": "planned",
+  "meta": {
+    "firstEverRelease": false,
+    "archetype": "node",
+    "releaseNotes": "## v2026.8.9 — 2026-08-20\n\n### Added\n\n- CI phantom-cancel watchdog — detects workflow runs cancelled after all steps succeeded and auto-reruns them (scripts/ci-phantom-cancel-watchdog.mjs + scheduled workflow) _(provenance: [T12103](https://github.com/kryptobaseddev/cleo/search?q=T12103&type=commits))_\n\n### Changed\n\n- docs-canonical-surface integration test — raise the spawned-CLI timeout from 30s to 120s and retry once on a timeout kill, so a loaded CI runner no longer fails the whole shard _(provenance: [T12109](https://github.com/kryptobaseddev/cleo/search?q=T12109&type=commits))_\n",
+    "changesetEntryCount": 2,
+    "changesetIds": [
+      "t12103-phantom-cancel-watchdog",
+      "t12109-docs-test-timeout"
+    ],
+    "taskIds": [
+      "T12109",
+      "T12103"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2026.8.9] (2026-08-20)
+
+### Added
+
+- CI phantom-cancel watchdog — detects workflow runs cancelled after all steps succeeded and auto-reruns them (scripts/ci-phantom-cancel-watchdog.mjs + scheduled workflow) _(provenance: [T12103](https://github.com/kryptobaseddev/cleo/search?q=T12103&type=commits))_
+
+### Changed
+
+- docs-canonical-surface integration test — raise the spawned-CLI timeout from 30s to 120s and retry once on a timeout kill, so a loaded CI runner no longer fails the whole shard _(provenance: [T12109](https://github.com/kryptobaseddev/cleo/search?q=T12109&type=commits))_
+
 ## [2026.8.8] (2026-08-20)
 
 ### Fixed


### PR DESCRIPTION
Release plan for v2026.8.9 (T12109 docs-test timeout hardening, T12103 phantom-cancel watchdog).